### PR TITLE
fix Interval::Interval(Interval *other) constructor

### DIFF
--- a/include/geos/index/strtree/Interval.h
+++ b/include/geos/index/strtree/Interval.h
@@ -29,6 +29,7 @@ class GEOS_DLL Interval {
 public:
 	Interval(Interval *other);
 	Interval(double newMin, double newMax);
+	void init(double newMin, double newMax);
 	double getCentre();
 	Interval* expandToInclude(Interval *other);
 	bool intersects(Interval *other);

--- a/src/index/strtree/Interval.cpp
+++ b/src/index/strtree/Interval.cpp
@@ -28,10 +28,16 @@ namespace strtree { // geos.index.strtree
 
 Interval::Interval(Interval *other)
 {
-	Interval(other->imin,other->imax);
+	init(other->imin, other->imax);
 }
 
 Interval::Interval(double newMin,double newMax)
+{
+	init(newMin, newMax);
+}
+
+void
+Interval::init(double newMin, double newMax)
 {
 	assert(newMin<=newMax);
 	imin=newMin;


### PR DESCRIPTION
"Interval(other->imin,other->imax);" create new unnamed object and gets destroyed without call other constructor
