### PR TITLE
fix ruby extension link error

### DIFF
--- a/macros/ruby.m4
+++ b/macros/ruby.m4
@@ -38,7 +38,7 @@ AC_DEFUN([AC_RUBY_DEVEL],
 		RUBY_EXTENSION_DIR=`$RUBY -rrbconfig -e 'puts RbConfig::CONFIG[["sitearchdir"]] || Config::CONFIG[["sitearchdir"]]'`
 
 		dnl Get Ruby shared library name, this does not include the lib prefix or extension name
-		RUBY_SO_NAME=`$RUBY -rrbconfig -e 'puts RbConfig::CONFIG[["LIBRUBY_SO"]] || Config::CONFIG[["RUBY_SO_NAME"]]'`
+		RUBY_SO_NAME=`$RUBY -rrbconfig -e 'puts RbConfig::CONFIG[["RUBY_SO_NAME"]] || Config::CONFIG[["RUBY_SO_NAME"]]'`
 		
 		dnl Get Ruby shared libary name
 		RUBY_SHARED_LIB=`$RUBY -rrbconfig -e 'puts RbConfig::CONFIG[["LIBRUBY"]] || Config::CONFIG[["LIBRUBY"]]'`


### PR DESCRIPTION
fix following build bug.

```
  /bin/bash ../../libtool --tag=CXX   --mode=link g++ -fpermissive -DGEOS_INLINE  -pedantic -Wall -ansi -Wno-long-long  -ffloat-store -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -no-undefined  -module -avoid-version -L/usr/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o geos.la -rpath /usr/local/lib/site_ruby/1.8/x86_64-linux geos_la-geos_wrap.lo ../../capi/libgeos_c.la -llibruby1.8.so.1.8.7 
  libtool: link: g++ -fpermissive  -fPIC -DPIC -shared -nostdlib /usr/lib/gcc/x86_64-linux-gnu/4.6/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/4.6/crtbeginS.o  .libs/geos_la-geos_wrap.o   -Wl,-rpath -Wl,/build/buildd/geos-3.4.99~3.5.0dev~20130922/capi/.libs -L/usr/lib ../../capi/.libs/libgeos_c.so -llibruby1.8.so.1.8.7 -L/usr/lib/gcc/x86_64-linux-gnu/4.6 -L/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/4.6/../../.. -lstdc++ -lm -lc -lgcc_s /usr/lib/gcc/x86_64-linux-gnu/4.6/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/4.6/../../../x86_64-linux-gnu/crtn.o  -O2 -Wl,-Bsymbolic-functions -Wl,-z -Wl,relro   -Wl,-soname -Wl,geos.so -o .libs/geos.so
  /usr/bin/ld: cannot find -llibruby1.8.so.1.8.7
  collect2: ld returned 1 exit status
```
