### PR TITLE
Fix a couple of warnings under gcc 4.7.2

### DIFF
--- a/include/geos/geom/BinaryOp.h
+++ b/include/geos/geom/BinaryOp.h
@@ -188,6 +188,8 @@ fix_self_intersections(std::auto_ptr<Geometry> g, const std::string& label)
   ::geos::ignore_unused_variable_warning(label);
 #ifdef GEOS_DEBUG_BINARYOP
 	std::cerr << label << " fix_self_intersection (UnaryUnion)" << std::endl;
+#else
+    (void)(label);
 #endif
 
   // Only multi-components can be fixed by UnaryUnion

--- a/include/geos/geom/prep/PreparedPoint.h
+++ b/include/geos/geom/prep/PreparedPoint.h
@@ -7,7 +7,7 @@
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU Lesser General Public Licence as published
- * by the Free Software Foundation. 
+ * by the Free Software Foundation.
  * See the COPYING file for more information.
  *
  *
@@ -29,26 +29,26 @@ namespace prep { // geos::geom::prep
 /**
  * \brief
  * A prepared version of {@link Point} or {@link MultiPoint} geometries.
- * 
+ *
  * @author Martin Davis
  *
  */
-class PreparedPoint: public BasicPreparedGeometry 
+class PreparedPoint: public BasicPreparedGeometry
 {
 private:
 protected:
 public:
-	PreparedPoint(const Geometry * geom) 
-		: BasicPreparedGeometry( geom) 
+	PreparedPoint(const Geometry * geom)
+		: BasicPreparedGeometry( geom)
 	{ }
 
 	/**
 	 * Tests whether this point intersects a {@link Geometry}.
-	 * 
+	 *
 	 * The optimization here is that computing topology for the test
 	 * geometry is avoided. This can be significant for large geometries.
 	 */
-	bool intersects(const geom::Geometry* g);
+	bool intersects(const geom::Geometry* g) const;
 
 };
 

--- a/include/geos/noding/MCIndexNoder.h
+++ b/include/geos/noding/MCIndexNoder.h
@@ -7,7 +7,7 @@
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU Lesser General Public Licence as published
- * by the Free Software Foundation. 
+ * by the Free Software Foundation.
  * See the COPYING file for more information.
  *
  **********************************************************************
@@ -102,7 +102,7 @@ public:
 			index::chain::MonotoneChainOverlapAction(),
 			si(newSi)
 		{}
-
+		using index::chain::MonotoneChainOverlapAction::overlap;
 		void overlap(index::chain::MonotoneChain& mc1, std::size_t start1,
             index::chain::MonotoneChain& mc2, std::size_t start2);
     private:
@@ -112,7 +112,7 @@ public:
         SegmentOverlapAction(const SegmentOverlapAction& other);
         SegmentOverlapAction& operator=(const SegmentOverlapAction& rhs);
 	};
-	
+
 };
 
 } // namespace geos.noding

--- a/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
+++ b/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
@@ -88,6 +88,7 @@ public:
         SegmentOverlapAction& operator=(const SegmentOverlapAction& rhs);
 
     public:
+        using index::chain::MonotoneChainOverlapAction::overlap;
         SegmentOverlapAction(SegmentIntersector & si) :
           index::chain::MonotoneChainOverlapAction(), si(si)
           {}

--- a/include/geos/noding/SegmentIntersectionDetector.h
+++ b/include/geos/noding/SegmentIntersectionDetector.h
@@ -122,7 +122,7 @@ public:
 	* 
 	* @return the coordinate for the intersection location
 	*/
-	const geom::Coordinate * const getIntersection()  const
+	const geom::Coordinate * getIntersection()  const
 	{    
 		return intPt;  
 	}

--- a/include/geos/triangulate/quadedge/Vertex.h
+++ b/include/geos/triangulate/quadedge/Vertex.h
@@ -79,6 +79,9 @@ public:
 
 	Vertex();
 
+	virtual ~Vertex() {
+	}
+
 	inline double getX() const {
 		return p.x;
 	}

--- a/src/geom/prep/PreparedPoint.cpp
+++ b/src/geom/prep/PreparedPoint.cpp
@@ -24,7 +24,7 @@ namespace geom { // geos.geom
 namespace prep { // geos.geom.prep
 
 bool 
-PreparedPoint::intersects(const geom::Geometry* g)
+PreparedPoint::intersects(const geom::Geometry* g) const
 {
 	if (! envelopesIntersect( g)) return false;
 

--- a/src/linearref/LinearLocation.cpp
+++ b/src/linearref/LinearLocation.cpp
@@ -88,7 +88,8 @@ LinearLocation::normalize()
 	{
 		segmentFraction = 1.0;
 	}
-
+// componentIndex has type unsigned int, so it cannot be negative
+#if 0
 	if (componentIndex < 0)
 	{
 		componentIndex = 0;
@@ -100,6 +101,7 @@ LinearLocation::normalize()
 		segmentIndex = 0;
 		segmentFraction = 0.0;
 	}
+#endif
 	if (segmentFraction == 1.0)
 	{
 		segmentFraction = 0.0;
@@ -204,7 +206,7 @@ LinearLocation::getCoordinate(const Geometry* linearGeom) const
 	const LineString* lineComp = dynamic_cast<const LineString *> (linearGeom->getGeometryN(componentIndex));
 	if ( ! lineComp ) {
 		throw util::IllegalArgumentException("LinearLocation::getCoordinate only works with LineString geometries");
-	}  
+	}
 	Coordinate p0 = lineComp->getCoordinateN(segmentIndex);
 	if (segmentIndex >= lineComp->getNumPoints() - 1)
 		return p0;
@@ -232,11 +234,13 @@ LinearLocation::getSegment(const Geometry* linearGeom) const
 bool
 LinearLocation::isValid(const Geometry* linearGeom) const
 {
-	if (componentIndex < 0 || componentIndex >= linearGeom->getNumGeometries())
+	// componentIndex is unsigned
+	if (/*componentIndex < 0 || */componentIndex >= linearGeom->getNumGeometries())
 		return false;
 
 	const LineString* lineComp = dynamic_cast<const LineString*> (linearGeom->getGeometryN(componentIndex));
-	if (segmentIndex < 0 || segmentIndex > lineComp->getNumPoints())
+	// segmentIndex is unsigned
+	if (/*segmentIndex < 0 || */segmentIndex > lineComp->getNumPoints())
 		return false;
 	if (segmentIndex == lineComp->getNumPoints() && segmentFraction != 0.0)
 		return false;


### PR DESCRIPTION
During compilation using `gcc 4.7.2` compiler we noticed a couple of warnings.
1. `-Woverloaded-virtual`: it warns about functions that might not be overloaded because of a typo in their signature
2. Unsigned variables cannot be less than zero.
3. Unused parameters produce warnings.

Also we add some `const` to `intersects` methods, because they are constant.
