### PR TITLE
Fix compilation against thread-safe PHP (ZTS)

### DIFF
--- a/php/geos.c
+++ b/php/geos.c
@@ -78,6 +78,7 @@ ZEND_GET_MODULE(geos)
 
 static void noticeHandler(const char *fmt, ...)
 {
+    TSRMLS_FETCH();
     char message[256];
     va_list args;
     va_start(args, fmt);
@@ -89,6 +90,7 @@ static void noticeHandler(const char *fmt, ...)
 
 static void errorHandler(const char *fmt, ...)
 {
+    TSRMLS_FETCH();
     char message[256];
     va_list args;
     va_start(args, fmt);
@@ -96,7 +98,7 @@ static void errorHandler(const char *fmt, ...)
     va_end(args);
 
     /* TODO: use a GEOSException ? */
-    zend_throw_exception_ex(zend_exception_get_default(TSRMLS_CC),
+    zend_throw_exception_ex(zend_exception_get_default(TSRMLS_C),
         1 TSRMLS_CC, "%s", message); 
 
 }
@@ -108,12 +110,14 @@ typedef struct Proxy_t {
 
 static void 
 setRelay(zval* val, void* obj) {
+    TSRMLS_FETCH();
     Proxy* proxy = (Proxy*)zend_object_store_get_object(val TSRMLS_CC);
     proxy->relay = obj;
 }
 
 static inline void *
 getRelay(zval* val, zend_class_entry* ce) {
+    TSRMLS_FETCH();
     Proxy *proxy =  (Proxy*)zend_object_store_get_object(val TSRMLS_CC);
     if ( proxy->std.ce != ce ) {
         php_error_docref(NULL TSRMLS_CC, E_ERROR,
@@ -153,9 +157,10 @@ static long getZvalAsDouble(zval* val)
 }
 
 static zend_object_value
-Gen_create_obj (zend_class_entry *type TSRMLS_DC,
+Gen_create_obj (zend_class_entry *type,
     zend_objects_free_object_storage_t st, zend_object_handlers* handlers)
 {
+    TSRMLS_FETCH();
     zend_object_value retval;
 
     Proxy *obj = (Proxy *)emalloc(sizeof(Proxy));
@@ -414,6 +419,7 @@ Geometry_deserialize(zval **object, zend_class_entry *ce, const unsigned char *b
 static void
 dumpGeometry(GEOSGeometry* g, zval* array)
 {
+    TSRMLS_FETCH();
     int ngeoms, i;
 
     /*


### PR DESCRIPTION
This (hopefully) fixes [bug 541](http://trac.osgeo.org/geos/ticket/541).

I found the root cause of the build errors in the [PHP manual](http://php.net/manual/en/internals2.memory.tsrm.php):

> While developing extensions, build errors that contain "tsrm_ls is undefined" or errors to that effect stem from the fact that TSRMLS is undefined in the current scope, to fix this, declare the function to accept TSRMLS with the appropriate macro, if the prototype of the function in question cannot be changed, you must call TSRMLS_FETCH within the function body.

Adding missing `TSRMLS_FETCH()` macros, fixing a confusion between `TSRMLS_C` and `TSRMLS_CC` (the latter is prepended with a comma), and removing a seemingly misplaced `TSRMLS_DC` fixed the build on ZTS. Needless to say, it still works on non-thread safe.
