### PR TITLE
ENH: add GenerateSourceGroups.cmake to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ BUILT_SOURCES = geos_revision.h
 EXTRA_DIST = acsite.m4 makefile.vc nmake.opt autogen.bat CMakeLists.txt \
   cmake/modules/CheckPrototypeExists.cmake \
   cmake/modules/COPYING-CMAKE-SCRIPTS \
+  cmake/modules/GenerateSourceGroups.cmake \
   cmake/cmake_uninstall.cmake.in geos_revision.h
 
 ACLOCAL_AMFLAGS = -I macros


### PR DESCRIPTION
Backport PR #85 to branch svn-3.6 
Allow to compile geos source tarball using cmake.

See discussion here: https://trac.osgeo.org/geos/ticket/753#comment:22

