### PR TITLE
[CMake] Build the C API into static libs (svn-3.6 backport)

### DIFF
--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -21,8 +21,8 @@ set(geos_c_SOURCES
 
 file(GLOB geos_capi_HEADERS ${CMAKE_BINARY_DIR}/capi/*.h) # fix source_group issue
 
-if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK) 
-  # if building OS X framework, CAPI built into C++ library 
+if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK AND GEOS_BUILD_SHARED)
+  # if building OS X framework or only building static libs, CAPI built into C++ library
   add_library(geos_c SHARED ${geos_c_SOURCES}) 
 
   target_link_libraries(geos_c geos)
@@ -55,7 +55,7 @@ else()
     DESTINATION include)
 endif()
 
-if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK) 
+if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK AND GEOS_BUILD_SHARED)
   install(TARGETS geos_c
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,14 +14,15 @@
 file(GLOB_RECURSE geos_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE geos_ALL_HEADERS ${CMAKE_SOURCE_DIR}/include/*.h) # fix source_group issue
 
+# Include CAPI in OS X framework binary and in static libs
+set(geos_c_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_c.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_ts_c.cpp)
+
 if(GEOS_ENABLE_MACOSX_FRAMEWORK)
   # OS X frameworks don't have static libs
   # also 1 binary, so include CAPI here
   # and, make name all caps
-
-  set(geos_c_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_c.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_ts_c.cpp)
 
   add_library(GEOS SHARED ${geos_SOURCES} ${geos_c_SOURCES})
 
@@ -77,7 +78,8 @@ else()
   endif()
 
   if(GEOS_BUILD_STATIC)
-    add_library(geos-static STATIC ${geos_SOURCES} ${geos_ALL_HEADERS})
+    file(GLOB geos_capi_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../capi/*.h) # fix source_group issue
+    add_library(geos-static STATIC ${geos_SOURCES} ${geos_c_SOURCES} ${geos_ALL_HEADERS} ${geos_capi_HEADERS})
 
     set_target_properties(geos-static
       PROPERTIES


### PR DESCRIPTION
To support building (e.g., GDAL) against static libs only, add the C API
to the static target.

Otherwise, if building with CMake, the C API is only available in a
dynamic library.

In the future, this could be a lot cleaner -- e.g. with more idiomatic
CMake configuration of shared vs. static builds -- but for the time
being I hope this will be acceptable.