### PR TITLE
Make GEOSException inherit from std::runtime_error

### DIFF
--- a/include/geos/util/GEOSException.h
+++ b/include/geos/util/GEOSException.h
@@ -33,8 +33,7 @@ namespace util { // geos.util
  *
  * \brief Base class for all GEOS exceptions.
  *
- * Exceptions are thrown as pointers to this type.
- * Use toString() to get a readable message.
+ * Use what() to get a readable message.
  */
 class GEOS_DLL GEOSException: public std::runtime_error {
 

--- a/include/geos/util/GEOSException.h
+++ b/include/geos/util/GEOSException.h
@@ -36,34 +36,24 @@ namespace util { // geos.util
  * Exceptions are thrown as pointers to this type.
  * Use toString() to get a readable message.
  */
-class GEOS_DLL GEOSException: public std::exception {
-
-	std::string _msg;
+class GEOS_DLL GEOSException: public std::runtime_error {
 
 public:
 
 	GEOSException()
 		:
-		_msg("Unknown error")
+		std::runtime_error("Unknown error")
 	{}
 
 	GEOSException(std::string const& msg)
 		:
-		_msg(msg)
+		std::runtime_error(msg)
 	{}
 
 	GEOSException(std::string const& name, std::string const& msg)
 		:
-		_msg(name+": "+msg)
+		std::runtime_error(name + ": "+msg)
 	{}
-
-	~GEOSException() throw() override
-	{}
-
-	const char* what() const throw() override
-	{
-		return _msg.c_str();
-	}
 
 };
 


### PR DESCRIPTION
This avoids a bunch of "thrown exception is not nothrow
copy-constructible" warnings from clang-tidy.

A description of the issue is available at
https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible