### PR TITLE
size() == 0 -> empty() (#849)

### DIFF
--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -95,7 +95,7 @@ CoordinateArraySequence::getDimension() const
     if( dimension != 0 )
         return dimension;
 
-    if( vect->size() == 0 )
+    if( vect->empty() )
         return 3;
 
     if( ISNAN((*vect)[0].z) )

--- a/src/geomgraph/EdgeEndStar.cpp
+++ b/src/geomgraph/EdgeEndStar.cpp
@@ -56,7 +56,7 @@ Coordinate&
 EdgeEndStar::getCoordinate()
 {
 	static Coordinate nullCoord(DoubleNotANumber, DoubleNotANumber, DoubleNotANumber);
-	if (edgeMap.size()==0) return nullCoord;
+	if (edgeMap.empty()) return nullCoord;
 
 	EdgeEndStar::iterator it=begin();
 	EdgeEnd *e=*it;
@@ -215,7 +215,7 @@ EdgeEndStar::checkAreaLabelsConsistent(int geomIndex)
 	// the left side of the edge
 
 	// if no edges, trivially consistent
-	if (edgeMap.size()==0) return true;
+	if (edgeMap.empty()) return true;
 
 	// initialize startLoc to location of last L side (if any)
 	assert(*rbegin());
@@ -366,4 +366,3 @@ operator<< (std::ostream& os, const EdgeEndStar& es)
 
 } // namespace geos.geomgraph
 } // namespace geos
-

--- a/src/operation/buffer/SubgraphDepthLocater.cpp
+++ b/src/operation/buffer/SubgraphDepthLocater.cpp
@@ -148,7 +148,7 @@ SubgraphDepthLocater::getDepth(const Coordinate& p)
 	findStabbedSegments(p, stabbedSegments);
 
 	// if no segments on stabbing line subgraph must be outside all others
-	if (stabbedSegments.size()==0) return 0;
+	if (stabbedSegments.empty()) return 0;
 
 	sort(stabbedSegments.begin(), stabbedSegments.end(), DepthSegmentLessThen());
 

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -232,7 +232,7 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
 		}
 	}
 
-	if ( lines->size() == 0 ) {
+	if ( lines->empty() ) {
 		return nullptr;
 	} else {
 		Geometry::NonConstVect *l=lines.get();

--- a/src/operation/overlay/LineBuilder.cpp
+++ b/src/operation/overlay/LineBuilder.cpp
@@ -225,7 +225,7 @@ LineBuilder::propagateZ(CoordinateSequence *cs)
 	cerr<<"  found "<<v3d.size()<<" 3d vertexes"<<endl;
 #endif
 
-	if ( v3d.size() == 0 )
+	if ( v3d.empty() )
 	{
 #if GEOS_DEBUG
 		cerr<<"  nothing to do"<<endl;
@@ -318,4 +318,3 @@ LineBuilder::labelIsolatedLine(Edge *e, int targetIndex)
 } // namespace geos.operation.overlay
 } // namespace geos.operation
 } // namespace geos
-


### PR DESCRIPTION
clang-tidy: readability-container-size-empty size() == 0 can be replaced with empty()

​https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html