### PR TITLE
Voronoi Diagram:The userData of each polygon is NOT set to be the Coordinate  of the cell site

### DIFF
--- a/src/triangulate/VoronoiDiagramBuilder.cpp
+++ b/src/triangulate/VoronoiDiagramBuilder.cpp
@@ -137,11 +137,11 @@ VoronoiDiagramBuilder::clipGeometryCollection(const geom::GeometryCollection& ge
 		else if(clipEnv.intersects(g->getEnvelopeInternal()))
 		{
 			result.reset( clipPoly->intersection(g) );
-			result->setUserData(((Geometry*)g)->getUserData()); // TODO: needed ?
 		}
 
 		if(result.get() && !result->isEmpty() )
-		{
+		{			result->setUserData(((Geometry*)g)->getUserData()); // TODO: needed ?
+
 			clipped->push_back(result.release());
 		}
 	}

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -47,7 +47,7 @@ using namespace std;
 namespace geos {
 namespace triangulate { //geos.triangulate
 namespace quadedge { //geos.triangulate.quadedge
-
+		stack<Coordinate> coords;
 void
 QuadEdgeSubdivision::getTriangleEdges(const QuadEdge &startQE,
         const QuadEdge* triEdge[3])
@@ -582,9 +582,12 @@ QuadEdgeSubdivision::getVoronoiCellPolygon(QuadEdge* qe ,const geom::GeometryFac
 		geomFact.createPolygon(geomFact.createLinearRing(new geom::CoordinateArraySequence(pts.release())),nullptr));
 
 	Vertex v = startQE->orig();
-	Coordinate c(0,0);
+	Coordinate c(0,0),*pc;
 	c = v.getCoordinate();
-	cellPoly->setUserData(reinterpret_cast<void*>(&c));
+
+	coords.push(c);
+	pc = &coords.top();
+	cellPoly->setUserData(reinterpret_cast<void*>(pc));
 	return cellPoly;
 }
 
@@ -614,7 +617,8 @@ QuadEdgeSubdivision::getVoronoiCellEdge(QuadEdge* qe ,const geom::GeometryFactor
 	Vertex v = startQE->orig();
 	Coordinate c(0,0);
 	c = v.getCoordinate();
-	cellEdge->setUserData(reinterpret_cast<void*>(&c));
+	coords.push(c);
+	cellEdge->setUserData(reinterpret_cast<void*>(&coords.top()));
 	return cellEdge;
 }
 

--- a/tests/unit/triangulate/VoronoiTest.cpp
+++ b/tests/unit/triangulate/VoronoiTest.cpp
@@ -14,7 +14,7 @@
 #include <geos/io/WKTReader.h>
 #include <geos/geom/GeometryCollection.h>
 #include <geos/geom/GeometryFactory.h>
-
+#include<geos/geom/Point.h>
 #include <geos/geom/CoordinateArraySequence.h>
 //#include <stdio.h>
 #include <iostream>
@@ -71,6 +71,44 @@ namespace tut
 			cout << " Obtained: " << writer.write(results.get()) << endl;
 		}
 		ensure(eq);
+		//should be One-to-one correspondence?
+		const size_t nOne = 1;
+		size_t numResults = results->getNumGeometries(),
+			numSites = sites->getNumGeometries(),i,j,nCount;
+		if (numSites < 2 || fabs(tolerance)>1e-7) return;
+		ensure_equals(numSites, numResults);
+		for (i = 0; i < numResults; i++)
+		{
+			Coordinate *poPt= static_cast<Coordinate*>(results->getGeometryN(i)->getUserData());
+			Point *poPoint= geomFact.createPoint(*poPt);
+			nCount = 0;
+			for (j=0;j<numSites;j++)
+			{
+				const Point *poExpPt = dynamic_cast<const Point*>(sites->getGeometryN(j));
+				if (poExpPt->equalsExact(poPoint))
+				{
+					nCount++;
+				}
+			}
+			geomFact.destroyGeometry(poPoint);
+			ensure_equals(nOne, nCount);
+		}
+		for (i = 0; i < numSites; i++)
+		{
+			const Point *poExpPt = dynamic_cast<const Point*>(sites->getGeometryN(i));
+			nCount = 0;
+			for (j = 0; j<numResults; j++)
+			{
+				Coordinate *poPt = static_cast<Coordinate*>(results->getGeometryN(j)->getUserData());
+				Point *poPoint = geomFact.createPoint(*poPt);
+				if (poPoint->equalsExact(poExpPt))
+				{
+					nCount++;
+				}
+				geomFact.destroyGeometry(poPoint);
+			}
+			ensure_equals(nOne, nCount);
+		}
 
 	}
 


### PR DESCRIPTION
hi,

 QuadEdgeSubdivision.h  line 400, i read
```
	/**
	 * Gets the cells in the Voronoi diagram for this triangulation.
	 * The cells are returned as a {@link GeometryCollection} of {@link Polygon}s
	 * The userData of each polygon is set to be the {@link Coordinate}
	 * of the cell site.  This allows easily associating external
	 * data associated with the sites to the cells.
	 *
	 * @param geomFact a geometry factory
	 * @return a GeometryCollection of Polygons
	 */
	std::unique_ptr<geom::GeometryCollection> getVoronoiDiagram(const geom::GeometryFactory& geomFact); 
```

The userData of each polygon is set,But different from the expected value.
 do as promised,please
modified 2 files and add a test
