### PR TITLE
Fix #924: Geometries returned by getGeometryN() now have the same SRID as collection.

### DIFF
--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -78,6 +78,8 @@ public:
 
 	~GeometryCollection() override;
 
+	void setSRID(int) override;
+
 	/**
 	 * \brief
 	 * Collects all coordinates of all subgeometries into a

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -53,8 +53,6 @@ GeometryCollection::GeometryCollection(const GeometryCollection &gc)
 	for(size_t i=0; i<ngeoms; ++i)
 	{
 		(*geometries)[i]=(*gc.geometries)[i]->clone();
-    // Drop SRID from inner geoms
-		(*geometries)[i]->setSRID(0);
 	}
 }
 
@@ -72,11 +70,21 @@ GeometryCollection::GeometryCollection(vector<Geometry *> *newGeoms, const Geome
 	}
 	geometries=newGeoms;
 
-  // Drop SRID from inner geoms
+	// Set SRID for inner geoms
 	size_t ngeoms=geometries->size();
 	for(size_t i=0; i<ngeoms; ++i)
 	{
-		(*geometries)[i]->setSRID(0);
+		(*geometries)[i]->setSRID(getSRID());
+	}
+}
+
+void
+GeometryCollection::setSRID(int newSRID)
+{
+	Geometry::setSRID(newSRID);
+	for (size_t i = 0; i < geometries->size(); i++)
+	{
+		(*geometries)[i]->setSRID(newSRID);
 	}
 }
 

--- a/src/io/WKBWriter.cpp
+++ b/src/io/WKBWriter.cpp
@@ -203,6 +203,8 @@ WKBWriter::writeGeometryCollection(const GeometryCollection &g,
 
 	auto ngeoms = g.getNumGeometries();
 	writeInt(static_cast<int>(ngeoms));
+	auto orig_includeSRID = includeSRID;
+	includeSRID = false;
 
 	assert(outStream);
 	for (std::size_t i=0; i<ngeoms; i++)
@@ -212,6 +214,7 @@ WKBWriter::writeGeometryCollection(const GeometryCollection &g,
 
 		write(*elem, *outStream);
 	}
+	includeSRID = orig_includeSRID;
 }
 
 void

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -58,6 +58,7 @@ geos_unit_SOURCES = \
 	geom/CoordinateTest.cpp \
 	geom/DimensionTest.cpp \
 	geom/EnvelopeTest.cpp \
+	geom/GeometryCollectionTest.cpp \
 	geom/Geometry/clone.cpp \
 	geom/Geometry/coversTest.cpp \
 	geom/Geometry/equalsTest.cpp \

--- a/tests/unit/geom/GeometryCollectionTest.cpp
+++ b/tests/unit/geom/GeometryCollectionTest.cpp
@@ -1,0 +1,56 @@
+//
+// Test Suite for geos::geom::GeometryCollection class.
+
+// tut
+#include <tut/tut.hpp>
+#include <utility.h>
+// geos
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/GeometryCollection.h>
+// std
+#include <vector>
+
+namespace tut
+{
+	//
+	// Test Group
+	//
+
+	// Common data used by tests
+	struct test_geometrycollection_data {};
+
+	typedef test_group<test_geometrycollection_data> group;
+	typedef group::object object;
+
+	group test_geometrycollection_group("geos::geom::GeometryCollection");
+
+	//
+	// Test Cases
+	//
+
+	// Test of default constructor
+	template<>
+	template<>
+	void object::test<1>()
+	{
+		using geos::geom::GeometryFactory;
+		geos::geom::PrecisionModel pm;
+		auto gf = GeometryFactory::create(&pm, 1);
+		auto g = gf->createEmptyGeometry();
+
+		g->setSRID(0);
+		std::vector<decltype(g)> v = {g};
+		auto geom_col = gf->createGeometryCollection(v);
+		ensure_equals(geom_col->getGeometryN(0)->getSRID(), 1);
+
+		geom_col->setSRID(2);
+		ensure_equals(geom_col->getGeometryN(0)->getSRID(), 2);
+
+		auto clone = geom_col->clone();
+		ensure_equals(clone->getGeometryN(0)->getSRID(), 2);
+
+		// FREE MEMORY
+		gf->destroyGeometry(geom_col);
+		gf->destroyGeometry(clone);
+	}
+} // namespace tut


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/924