### PR TITLE
Fix #926: Fixed crash in GEOSInterpolate() when used with empty LineString.

### DIFF
--- a/src/linearref/LinearLocation.cpp
+++ b/src/linearref/LinearLocation.cpp
@@ -194,6 +194,9 @@ LinearLocation::getCoordinate(const Geometry* linearGeom) const
 	if ( ! lineComp ) {
 		throw util::IllegalArgumentException("LinearLocation::getCoordinate only works with LineString geometries");
 	}
+	if (linearGeom->isEmpty()) {
+		return Coordinate::getNull();
+	}
 	Coordinate p0 = lineComp->getCoordinateN(segmentIndex);
 	if (segmentIndex >= lineComp->getNumPoints() - 1)
 		return p0;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -168,7 +168,8 @@ geos_unit_SOURCES = \
 	capi/GEOSReverseTest.cpp \
 	capi/GEOSUnaryUnionTest.cpp \
 	capi/GEOSisValidDetailTest.cpp \
-	capi/GEOSisClosedTest.cpp
+	capi/GEOSisClosedTest.cpp \
+	capi/GEOSInterpolateTest.cpp
 
 noinst_HEADERS = \
 	utility.h

--- a/tests/unit/capi/GEOSInterpolateTest.cpp
+++ b/tests/unit/capi/GEOSInterpolateTest.cpp
@@ -1,0 +1,68 @@
+// Test Suite for C-API LineString interpolate functions
+
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+// std
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+
+namespace tut
+{
+    //
+    // Test Group
+    //
+
+    // Common data used in test cases.
+    struct test_capiinterpolate_data
+    {
+        GEOSGeometry* geom1_;
+
+        static void notice(const char *fmt, ...)
+        {
+            std::fprintf( stdout, "NOTICE: ");
+
+            va_list ap;
+            va_start(ap, fmt);
+            std::vfprintf(stdout, fmt, ap);
+            va_end(ap);
+
+            std::fprintf(stdout, "\n");
+        }
+
+        test_capiinterpolate_data()
+            : geom1_(nullptr)
+        {
+            initGEOS(notice, notice);
+        }
+
+        ~test_capiinterpolate_data()
+        {
+            GEOSGeom_destroy(geom1_);
+            geom1_ = nullptr;
+            finishGEOS();
+        }
+
+    };
+
+    typedef test_group<test_capiinterpolate_data> group;
+    typedef group::object object;
+
+    group test_capiinterpolate_group("capi::GEOSInterpolate");
+
+    //
+    // Test Cases
+    //
+
+    template<>
+    template<>
+    void object::test<1>()
+    {
+        geom1_ = GEOSGeomFromWKT("LINESTRING EMPTY");
+        GEOSGeometry *geom2 = GEOSInterpolate(geom1_, 1);
+        ensure_equals(GEOSisEmpty(geom2), 1);
+        GEOSGeom_destroy(geom2);
+    }
+} // namespace tut

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -470,5 +470,15 @@ void object::test<28>()
 }
 #endif
 
+template<>
+template<>
+void object::test<29>()
+{
+    GeomPtr linearGeom(reader.read("LINESTRING EMPTY"));
+    LengthIndexedLine indexedLine(linearGeom.get());
+    Coordinate pt = indexedLine.extractPoint(100);
+    ensure(pt.isNull());
+}
+
 } // namespace tut
 


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/926