### PR TITLE
Fix #927 -- Fixed crash in GEOSCoordSeq_isCCW() when used with empty coordseq.

### DIFF
--- a/src/algorithm/CGAlgorithms.cpp
+++ b/src/algorithm/CGAlgorithms.cpp
@@ -99,14 +99,14 @@ CGAlgorithms::isOnLine(const Coordinate& p, const CoordinateSequence* pt)
 bool
 CGAlgorithms::isCCW(const CoordinateSequence* ring)
 {
-	// # of points without closing endpoint
-	const std::size_t nPts=ring->getSize()-1;
-
 	// sanity check
-	if (nPts < 3)
+	if (ring->getSize() < 4)
 	{
 		throw util::IllegalArgumentException("Ring has fewer than 3 points, so orientation cannot be determined");
 	}
+
+	// # of points without closing endpoint
+	const std::size_t nPts=ring->getSize()-1;
 
 	// find highest point
 	const Coordinate *hiPt=&ring->getAt(0);

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -322,5 +322,15 @@ namespace tut
         ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 0);
     }
 
+    template<>
+    template<>
+    void object::test<10>() {
+        // no orientation
+        cs_ = GEOSCoordSeq_create(0, 0);
+        char ccw;
+
+        ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 0);
+    }
+
 } // namespace tut
 


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/927