### PR TITLE
Fix #928: Fixed crash in GEOSUnaryUnion() when used with empty linestring.

### DIFF
--- a/src/operation/union/UnaryUnionOp.cpp
+++ b/src/operation/union/UnaryUnionOp.cpp
@@ -93,7 +93,9 @@ UnaryUnionOp::Union()
        */
       unionLines.reset( CascadedUnion::Union( lines.begin(),
                                               lines.end()   ) );
-      unionLines = unionNoOpt(*unionLines);
+      if (unionLines.get()) {
+          unionLines = unionNoOpt(*unionLines);
+      }
   }
 
   GeomPtr unionPolygons;

--- a/tests/unit/capi/GEOSUnaryUnionTest.cpp
+++ b/tests/unit/capi/GEOSUnaryUnionTest.cpp
@@ -207,5 +207,18 @@ namespace tut
 
     }
 
+    // Self-union an empty linestring
+    template<>
+    template<>
+    void object::test<10>()
+    {
+        geom1_ = GEOSGeomFromWKT("LINESTRING EMPTY");
+        ensure( nullptr != geom1_ );
+
+        geom2_ = GEOSUnaryUnion(geom1_);
+        ensure( nullptr != geom2_ );
+
+        ensure_equals(toWKT(geom2_), std::string("GEOMETRYCOLLECTION EMPTY"));
+    }
 } // namespace tut
 

--- a/tests/unit/operation/union/UnaryUnionOpTest.cpp
+++ b/tests/unit/operation/union/UnaryUnionOpTest.cpp
@@ -179,5 +179,17 @@ namespace tut
         doTest(geoms, "MULTILINESTRING ((0 0, 5 0), (5 0, 10 0, 5 -5, 5 0), (5 0, 5 5))");
     }
 
+    template<>
+    template<>
+    void object::test<7>()
+    {
+        static char const* const geoms[] =
+        {
+            "LINESTRING EMPTY",
+            nullptr
+        };
+        doTest(geoms, "GEOMETRYCOLLECTION EMPTY");
+    }
+
 } // namespace tut
 


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/928