### PR TITLE
Memory sanitizer warnings in GeometryFactory.cpp

### DIFF
--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -653,7 +653,7 @@ GeometryFactory::createLineString(const CoordinateSequence &fromCoords)
 Geometry*
 GeometryFactory::buildGeometry(vector<Geometry *> *newGeoms) const
 {
-	string geomClass("NULL");
+	string geomClass;
 	bool isHeterogeneous=false;
 	bool hasGeometryCollection=false;
 
@@ -661,7 +661,7 @@ GeometryFactory::buildGeometry(vector<Geometry *> *newGeoms) const
 	{
 		Geometry* geom = (*newGeoms)[i];
 		string partClass(typeid(*geom).name());
-		if (geomClass=="NULL")
+		if (geomClass.empty())
 		{
 			geomClass=partClass;
 		}
@@ -676,7 +676,7 @@ GeometryFactory::buildGeometry(vector<Geometry *> *newGeoms) const
 	}
 
 	// for the empty geometry, return an empty GeometryCollection
-	if (geomClass=="NULL")
+	if (geomClass.empty())
 	{
 		// we do not need the vector anymore
 		delete newGeoms;
@@ -717,7 +717,7 @@ GeometryFactory::buildGeometry(vector<Geometry *> *newGeoms) const
 Geometry*
 GeometryFactory::buildGeometry(const vector<Geometry *> &fromGeoms) const
 {
-	string geomClass("NULL");
+	string geomClass;
 	bool isHeterogeneous=false;
 	bool isCollection=fromGeoms.size()>1;
 	size_t i;
@@ -725,7 +725,7 @@ GeometryFactory::buildGeometry(const vector<Geometry *> &fromGeoms) const
 	for (i=0; i<fromGeoms.size(); i++) {
 		Geometry *geom = fromGeoms[i];
 		string partClass(typeid(*geom).name());
-		if (geomClass=="NULL") {
+		if (geomClass.empty()) {
 			geomClass=partClass;
 		} else if (geomClass!=partClass) {
 			isHeterogeneous = true;
@@ -733,7 +733,7 @@ GeometryFactory::buildGeometry(const vector<Geometry *> &fromGeoms) const
 	}
 
 	// for the empty geometry, return an empty GeometryCollection
-	if (geomClass=="NULL") {
+	if (geomClass.empty()) {
 		return createGeometryCollection();
 	}
 	if (isHeterogeneous) {


### PR DESCRIPTION
This gets rids of a memory sanitizer warning when running Postgis unit tests (trunk) against Geos 3.7.

```
Suite: buildarea
  Test: buildarea1 ...Uninitialized bytes in __interceptor_memcmp at offset 0 inside [0x7fffae24fa80, 4)
==19345==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f5ed6768c5f in std::char_traits<char>::compare(char const*, char const*, unsigned long) /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/char_traits.h:310:25
    #1 0x7f5ed6768c5f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::compare(char const*) const /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.tcc:1424:37
    #2 0x7f5ed6892f40 in bool std::operator==<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*) /usr/include/c++/8.2.1/bits/basic_string.h:6075:35
    #3 0x7f5ed6892f40 in geos::geom::GeometryFactory::buildGeometry(std::vector<geos::geom::Geometry*, std::allocator<geos::geom::Geometry*> >*) const /usr/src/debug/geos/src/geom/GeometryFactory.cpp:664:16
    #4 0x7f5ed690dd48 in geos::operation::overlay::OverlayOp::computeOverlay(geos::operation::overlay::OverlayOp::OpCode) /usr/src/debug/geos/src/operation/overlay/OverlayOp.cpp:839:28
    #5 0x7f5ed690dee1 in geos::operation::overlay::OverlayOp::getResultGeometry(geos::operation::overlay::OverlayOp::OpCode) /usr/src/debug/geos/src/operation/overlay/OverlayOp.cpp:187:16
    #6 0x7f5ed690e281 in geos::operation::overlay::OverlayOp::overlayOp(geos::geom::Geometry const*, geos::geom::Geometry const*, geos::operation::overlay::OverlayOp::OpCode) /usr/src/debug/geos/src/operation/overlay/OverlayOp.cpp:93:30
    #7 0x7f5ed688d11f in geos::operation::overlay::overlayOp::operator()(geos::geom::Geometry const*, geos::geom::Geometry const*) /usr/src/debug/geos/src/geom/../../include/geos/operation/overlay/OverlayOp.h:388:44
    #8 0x7f5ed688d11f in std::unique_ptr<geos::geom::Geometry, std::default_delete<geos::geom::Geometry> > geos::geom::BinaryOp<geos::operation::overlay::overlayOp>(geos::geom::Geometry const*, geos::geom::Geometry const*, geos::operation::overlay::overlayOp) /usr/src/debug/geos/src/geom/../../include/geos/geom/BinaryOp.h:357:3
    #9 0x7f5ed688b16f in geos::geom::Geometry::Union(geos::geom::Geometry const*) const /usr/src/debug/geos/src/geom/Geometry.cpp:586:17
    #10 0x7f5ed691885d in geos::operation::geounion::CascadedPolygonUnion::unionActual(geos::geom::Geometry*, geos::geom::Geometry*) /usr/src/debug/geos/src/operation/union/CascadedPolygonUnion.cpp:370:36
    #11 0x7f5ed6919080 in geos::operation::geounion::CascadedPolygonUnion::unionOptimized(geos::geom::Geometry*, geos::geom::Geometry*) /usr/src/debug/geos/src/operation/union/CascadedPolygonUnion.cpp:236:27
    #12 0x7f5ed6919252 in geos::operation::geounion::CascadedPolygonUnion::unionTree(geos::index::strtree::ItemsList*) /usr/src/debug/geos/src/operation/union/CascadedPolygonUnion.cpp:162:23
    #13 0x7f5ed6919630 in geos::operation::geounion::CascadedPolygonUnion::Union() /usr/src/debug/geos/src/operation/union/CascadedPolygonUnion.cpp:151:21
    #14 0x7f5ed691983d in geos::operation::geounion::CascadedPolygonUnion::Union(geos::geom::MultiPolygon const*) /usr/src/debug/geos/src/operation/union/CascadedPolygonUnion.cpp:124:20
    #15 0x7f5ed71db6a8 in GEOSUnionCascaded_r /usr/src/debug/geos/capi/geos_ts_c.cpp:2497:43
    #16 0x7f5ed7332ed6 in LWGEOM_GEOS_buildArea /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:1124:8
    #17 0x7f5ed7333164 in lwgeom_buildarea /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:1155:7
    #18 0x55b755e00bfa in buildarea1 /un/dev_public/postgis/liblwgeom/cunit/cu_buildarea.c:66:9
    #19 0x7f5ed6fb1117  (/usr/lib/libcunit.so.1+0x4117)
    #20 0x7f5ed6fb13b1  (/usr/lib/libcunit.so.1+0x43b1)
    #21 0x7f5ed6fb17b6 in CU_run_all_tests (/usr/lib/libcunit.so.1+0x47b6)
    #22 0x55b755e7f6b7 in main /un/dev_public/postgis/liblwgeom/cunit/cu_tester.c:177:13
    #23 0x7f5ed6c3c222 in __libc_start_main (/usr/lib/libc.so.6+0x24222)
    #24 0x55b755d7f0bd in _start (/un/dev_public/postgis/liblwgeom/cunit/.libs/lt-cu_tester+0x250bd)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/char_traits.h:310:25 in std::char_traits<char>::compare(char const*, char const*, unsigned long)
```

I've only built and tested this against 3.7. Let me know if you need the extra PRs