### PR TITLE
Fix incorrect error return values in CAPI

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -419,7 +419,7 @@ GEOSFree_r (GEOSContextHandle_t extHandle, void* buffer)
 
 //-----------------------------------------------------------
 // relate()-related functions
-//  return 0 = false, 1 = true, 2 = error occured
+//  return 0 = false, 1 = true, 2 = error occurred
 //-----------------------------------------------------------
 
 char
@@ -1016,14 +1016,14 @@ GEOSisValidDetail_r(GEOSContextHandle_t extHandle, const Geometry *g,
 {
     if ( 0 == extHandle )
     {
-        return 0;
+        return 2;
     }
 
     GEOSContextHandleInternal_t *handle = 0;
     handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
     if ( 0 == handle->initialized )
     {
-        return 0;
+        return 2;
     }
 
     try
@@ -1378,7 +1378,7 @@ GEOSLength_r(GEOSContextHandle_t extHandle, const Geometry *g, double *length)
 
     if ( 0 == extHandle )
     {
-        return 2;
+        return 0;
     }
 
     GEOSContextHandleInternal_t *handle = 0;


### PR DESCRIPTION
In some cases, the CAPI function `GEOSLength_r` returns `2` on error, when it is documented to return `0`. The `2` is likely to be interpreted as "success" by a caller.

In some cases, the CAPI function `GEOSIsValidDetail_r` returns `0` on error, when it is documented to return `2`. The `0` would be falsely interpreted as "geometry invalid."

Trac ticket https://trac.osgeo.org/geos/ticket/941#ticket