### PR TITLE
Resolve segfault in BinTree

### DIFF
--- a/include/geos/algorithm/MCPointInRing.h
+++ b/include/geos/algorithm/MCPointInRing.h
@@ -22,6 +22,7 @@
 #include <geos/geom/Coordinate.h> // for composition
 #include <geos/index/bintree/Interval.h> // for composition
 
+#include <memory>
 #include <vector>
 
 // Forward declarations
@@ -37,9 +38,6 @@ namespace geos {
 		namespace bintree {
 			class Bintree;
 			class Interval;
-		}
-		namespace chain {
-			class MonotoneChain;
 		}
 	}
 }
@@ -69,8 +67,9 @@ public:
 private:
 	const geom::LinearRing *ring;
 	index::bintree::Interval interval;
-	geom::CoordinateSequence *pts;
-	index::bintree::Bintree *tree;
+	std::unique_ptr<geom::CoordinateSequence> pts;
+	std::unique_ptr<index::bintree::Bintree> tree;
+	std::unique_ptr<std::vector<std::unique_ptr<index::chain::MonotoneChain>>> chains;
 	int crossings;  // number of segment/ray crossings
 	void buildIndex();
 	void testMonotoneChain(geom::Envelope *rayEnv,

--- a/include/geos/index/chain/MonotoneChainBuilder.h
+++ b/include/geos/index/chain/MonotoneChainBuilder.h
@@ -20,6 +20,7 @@
 #define GEOS_IDX_CHAIN_MONOTONECHAINBUILDER_H
 
 #include <geos/export.h>
+#include <memory>
 #include <vector>
 #include <cstddef>
 
@@ -56,7 +57,7 @@ public:
 	 * MonotoneChain objects for the given CoordinateSequence.
 	 * Remember to deep-delete the result.
 	 */
-	static std::vector<MonotoneChain*>* getChains(
+	static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> getChains(
 			const geom::CoordinateSequence *pts,
 			void* context);
 
@@ -67,9 +68,9 @@ public:
 	 */
 	static void getChains(const geom::CoordinateSequence *pts,
 			void* context,
-			std::vector<MonotoneChain*>& mcList);
+			std::vector<std::unique_ptr<MonotoneChain>> & mcList);
 
-	static std::vector<MonotoneChain*>* getChains(const geom::CoordinateSequence *pts)
+	static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> getChains(const geom::CoordinateSequence *pts)
 	{
 		return getChains(pts, nullptr);
 	}

--- a/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
+++ b/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
@@ -59,15 +59,6 @@ public:
 
 	~MCIndexSegmentSetMutualIntersector() override;
 
-	/* Returns a reference to a vector of MonotoneChain objects owned
-	 * by this class and destroyed on next call to ::process.
-	 * Copy them if you need them alive for longer.
-	 */
-	std::vector<index::chain::MonotoneChain *>& getMonotoneChains()
-	{
-		return monoChains;
-	}
-
 	index::SpatialIndex* getIndex()
 	{
 		return index;
@@ -98,7 +89,7 @@ public:
 
 private:
 
-	typedef std::vector<index::chain::MonotoneChain *> MonoChains;
+	typedef std::vector<std::unique_ptr<index::chain::MonotoneChain>> MonoChains;
 	MonoChains monoChains;
 
 	/*

--- a/src/index/bintree/NodeBase.cpp
+++ b/src/index/bintree/NodeBase.cpp
@@ -16,13 +16,10 @@
 #include <geos/index/bintree/NodeBase.h>
 #include <geos/index/bintree/Interval.h>
 #include <geos/index/bintree/Node.h>
-#include <geos/index/chain/MonotoneChain.h> // FIXME: split
 
 #include <vector>
 
 using namespace std;
-
-using namespace geos::index::chain;
 
 namespace geos {
 namespace index { // geos.index
@@ -49,9 +46,6 @@ NodeBase::NodeBase()
 }
 
 NodeBase::~NodeBase() {
-	for(int i=0;i<(int)items->size();i++) {
-		delete (MonotoneChain*)(*items)[i];
-	}
 	delete items;
 	delete subnode[0];
 	delete subnode[1];

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -42,10 +42,11 @@ namespace index { // geos.index
 namespace chain { // geos.index.chain
 
 /* static public */
-vector<MonotoneChain*>*
+std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>>
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context)
 {
-	vector<MonotoneChain*>* mcList = new vector<MonotoneChain*>();
+   	// TODO clean this up with std::make_unique (C++14)
+	std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> mcList{new vector<std::unique_ptr<MonotoneChain>>()};
 	getChains(pts, context, *mcList);
 	return mcList;
 }
@@ -53,7 +54,7 @@ MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context)
 /* static public */
 void
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
-                                vector<MonotoneChain*>& mcList)
+                                vector<std::unique_ptr<MonotoneChain>>& mcList)
 {
 	vector<std::size_t> startIndex;
 	getChainStartIndices(*pts, startIndex);
@@ -63,8 +64,7 @@ MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
 		std::size_t n = nindexes - 1;
 		for(std::size_t i = 0; i < n; i++)
 		{
-			MonotoneChain* mc = new MonotoneChain(*pts, startIndex[i], startIndex[i+1], context);
-			mcList.push_back(mc);
+			mcList.emplace_back(new MonotoneChain(*pts, startIndex[i], startIndex[i+1], context));
 		}
 	}
 }

--- a/src/noding/MCIndexNoder.cpp
+++ b/src/noding/MCIndexNoder.cpp
@@ -105,24 +105,21 @@ MCIndexNoder::intersectChains()
 void
 MCIndexNoder::add(SegmentString* segStr)
 {
-	vector<MonotoneChain*> segChains;
+	vector<std::unique_ptr<MonotoneChain>> segChains;
 
 	// segChains will contain nelwy allocated MonotoneChain objects
 	MonotoneChainBuilder::getChains(segStr->getCoordinates(),
 			segStr, segChains);
 
-	for(vector<MonotoneChain*>::iterator
-			it=segChains.begin(), iEnd=segChains.end();
-			it!=iEnd; ++it)
+	for(auto& mc : segChains)
 	{
-		MonotoneChain* mc = *it;
 		assert(mc);
 
 		mc->setId(idCounter++);
-		index.insert(&(mc->getEnvelope()), mc);
+		index.insert(&(mc->getEnvelope()), mc.get());
 
 		// MonotoneChain objects deletion delegated to destructor
-		monoChains.push_back(mc);
+		monoChains.push_back(mc.release());
 	}
 }
 


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/912#comment:1

This PR takes things a bit farther than needed to strictly fix the bug, by using std::unique_ptr to clearly define the ownership of objects returned by MonotoneChainBuilder.