### PR TITLE
Performance improvement

### DIFF
--- a/src/algorithm/locate/SimplePointInAreaLocator.cpp
+++ b/src/algorithm/locate/SimplePointInAreaLocator.cpp
@@ -53,6 +53,7 @@ SimplePointInAreaLocator::containsPoint(const Coordinate& p,const Geometry *geom
 		return containsPointInPolygon(p, poly);
 	}
 
+	if (!geom->getEnvelopeInternal()->contains(p)) return false;
 	if (const GeometryCollection *col = dynamic_cast<const GeometryCollection*>(geom))
 	{
 		for (GeometryCollection::const_iterator
@@ -71,6 +72,7 @@ SimplePointInAreaLocator::containsPoint(const Coordinate& p,const Geometry *geom
 bool
 SimplePointInAreaLocator::containsPointInPolygon(const Coordinate& p, const Polygon *poly)
 {
+	if (!poly->getEnvelopeInternal()->contains(p)) return false;
 	if (poly->isEmpty()) return false;
 	const LineString *shell=poly->getExteriorRing();
 	const CoordinateSequence *cl;
@@ -83,9 +85,12 @@ SimplePointInAreaLocator::containsPointInPolygon(const Coordinate& p, const Poly
 	for(size_t i=0, n=poly->getNumInteriorRing(); i<n; i++)
 	{
 		const LineString *hole = poly->getInteriorRingN(i);
-		cl = hole->getCoordinatesRO();
-		if (CGAlgorithms::isPointInRing(p,cl)) {
-			return false;
+		if (hole->getEnvelopeInternal()->contains(p))
+		{
+			cl = hole->getCoordinatesRO();
+			if (CGAlgorithms::isPointInRing(p, cl)) {
+				return false;
+			}
 		}
 	}
 	return true;

--- a/src/operation/polygonize/EdgeRing.cpp
+++ b/src/operation/polygonize/EdgeRing.cpp
@@ -103,8 +103,7 @@ EdgeRing::ptNotInList(const CoordinateSequence *testPts,
     for (std::size_t i = 0; i < npts; ++i)
     {
         const Coordinate& testPt = testPts->getAt(i);
-        // TODO: shouldn't this be ! isInList ?
-        if (isInList(testPt, pts))
+        if (!isInList(testPt, pts))
             return testPt;
     }
     return Coordinate::getNull();
@@ -119,9 +118,9 @@ EdgeRing::isInList(const Coordinate& pt,
     for (std::size_t i = 0; i < npts; ++i)
     {
         if (pt == pts->getAt(i))
-            return false;
+            return true;
     }
-    return true;
+    return false;
 }
 
 /*public*/


### PR DESCRIPTION
First check envelope before calling CGAlgorithms::isPointInRing

Performance of st_intersection went from 15.8 to 11.5 seconds for these polygons:
[Polygons.zip](https://github.com/libgeos/geos/files/2646124/Polygons.zip)

It can be improved even more, but not familiar enough with the code to do that right now.
When calculating the st_intersection, there were still 8526 calls to isPointInRing for a polygon with 5 points, and 4262 calls to isPointInRing for a polygon with 130327 points so perhaps a IndexedPointInAreaLocator or a SIRtreePointInRing can be added to the OverlayOp::computeLabelling() so that it can be used in EdgeEndStar::getLocation

