### PR TITLE
Fix #947: Fix getCoordinate() of non-empty collection with empty first item.

### DIFF
--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -273,8 +273,13 @@ GeometryCollection::getCoordinate() const
 {
 	// should use unique_ptr here or return NULL or throw an exception !
 	// 	--strk;
-	if (isEmpty()) return new Coordinate();
-    	return (*geometries)[0]->getCoordinate();
+    for (size_t i = 0; i < geometries->size(); ++i)
+    {
+        if (!(*geometries)[i]->isEmpty()) {
+            return (*geometries)[i]->getCoordinate();
+        }
+    }
+    return new Coordinate();
 }
 
 /**

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -67,6 +67,7 @@ geos_unit_SOURCES = \
 	geom/Geometry/equalsTest.cpp \
 	geom/Geometry/isRectangleTest.cpp \
 	geom/Geometry/normalize.cpp \
+	geom/GeometryCollectionTest.cpp \
 	geom/GeometryFactoryTest.cpp \
 	geom/IntersectionMatrixTest.cpp \
 	geom/LinearRingTest.cpp \

--- a/tests/unit/geom/GeometryCollectionTest.cpp
+++ b/tests/unit/geom/GeometryCollectionTest.cpp
@@ -1,0 +1,56 @@
+//
+// Test Suite for geos::geom::GeometryCollection class.
+
+#include <tut/tut.hpp>
+#include <utility.h>
+
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used by tests
+struct test_geometry_collection_data {
+    typedef geos::geom::GeometryFactory GeometryFactory;
+
+    geos::geom::PrecisionModel pm_;
+    GeometryFactory::Ptr factory_;
+
+    test_geometry_collection_data()
+        : pm_(1000), factory_(GeometryFactory::create(&pm_, 0))
+    {
+    }
+};
+
+typedef test_group<test_geometry_collection_data> group;
+typedef group::object object;
+
+group test_geometry_collection_group("geos::geom::GeometryCollection");
+
+//
+// Test Cases
+//
+
+// Test of user's constructor to build empty Point
+template<>
+template<>
+void object::test<1>()
+{
+    GeometryPtr empty_point = factory_->createPoint();
+    ensure( empty_point != nullptr );
+
+    geos::geom::Coordinate coord(1, 2);
+    GeometryPtr point = factory_->createPoint(coord);
+    ensure( point != nullptr );
+
+    std::vector<GeometryPtr> geoms{empty_point, point};
+    GeometryColPtr col = factory_->createGeometryCollection(geoms);
+    ensure( col != nullptr );
+
+    ensure( col->getCoordinate() != nullptr );
+    ensure_equals( col->getCoordinate()->x, 1 );
+    ensure_equals( col->getCoordinate()->y, 2 );
+}
+
+} // namespace tut


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/947