### PR TITLE
Reduce travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,33 +51,9 @@ matrix:
       addons:
         apt:
           sources: *sources
-          packages: ['g++-7-multilib','gcc-7-multilib','g++-multilib','gcc-multilib','ccache','git2cl']
-      env:
-        - E="TOOL=autotools && CXX=g++-7 && ARCH=-m32 && CC=gcc-7"
-
-    - os: linux
-      cache:
-        apt: true
-        directories:
-          - $HOME/.ccache
-      addons:
-        apt:
-          sources: *sources
           packages: ['g++-4.8','cmake','ccache']
       env:
         - E="TOOL=cmake && CXX=g++-4.8 && ARCH=-m64 && CC=gcc-4.8"
-
-    - os: linux
-      cache:
-        apt: true
-        directories:
-          - $HOME/.ccache
-      addons:
-        apt:
-          sources: *sources
-          packages: ['g++-4.8','ccache','git2cl']
-      env:
-        - E="TOOL=autotools && CXX=g++-4.8 && ARCH=-m64 && CC=gcc-4.8"
 
     - os: linux
       cache:
@@ -102,30 +78,6 @@ matrix:
           packages: ['clang-3.9','cmake','ccache']
       env:
         - E="TOOL=cmake && CXX=clang++-3.9 && ARCH=-m64 && CC=clang-3.9"
-
-    - os: linux
-      cache:
-        apt: true
-        directories:
-          - $HOME/.ccache
-      addons:
-        apt:
-          sources: *sources
-          packages: ['clang-3.9','ccache','git2cl']
-      env:
-        - E="TOOL=autotools && CXX=clang++-3.9 && ARCH=-m64 && CC=clang-3.9"
-
-    - os: linux
-      cache:
-        apt: true
-        directories:
-          - $HOME/.ccache
-      addons:
-        apt:
-          sources: *sources
-          packages: ['clang','ccache','git2cl']
-      env:
-        - E="TOOL=autotools && CXX=clang++ && ARCH=-m64 && CC=clang"
 
     - os: linux
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 # by the Free Software Foundation.
 # See the COPYING file for more information.
 #
-dist: trusty
+dist: xenial
 sudo: false
 
 language: cpp


### PR DESCRIPTION
There is no need to test each compiler/architecture combination using
both build systems. This commit uses CMake as the primary build system
for Travis (since it is significantly faster) and includes one autotools
build for a single compiler/architecture to verify that the autotools
system can continue to be used.