### PR TITLE
Reduce CMake version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 # by the Free Software Foundation.
 # See the COPYING file for more information.
 #
-dist: trusty
+dist: xenial
 sudo: false
 
 language: cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,10 @@
 # modes for specific C/C++ language standard levels.
 cmake_minimum_required(VERSION 3.8)
 
-# Require CMake 3.14+ with VS generator for complete support of VS versions.
+# Require CMake 3.13+ with VS generator for complete support of VS versions
+# and support by AppVeyor.
 if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
-  cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
This PR reduces the CMake version requirement with Visual Studio builds to 3.13, which is the version currently installed on AppVeyor.