### PR TITLE
Pull removeRepeatedPoints out of CoordinateSequence

### DIFF
--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -128,8 +128,6 @@ public:
 
     void apply_ro(CoordinateFilter* filter) const override;
 
-    CoordinateSequence& removeRepeatedPoints() override;
-
 private:
     std::vector<Coordinate>* vect;
     mutable std::size_t dimension;

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -81,7 +81,6 @@ public:
      * Whether or not the Coordinate returned is the actual underlying
      * Coordinate or merely a copy depends on the implementation.
      */
-    //virtual const Coordinate& getCoordinate(int i) const=0;
     virtual const Coordinate& getAt(std::size_t i) const = 0;
 
     /// Return last Coordinate in the sequence
@@ -113,7 +112,6 @@ public:
      * Returns the number of Coordinates (actual or otherwise, as
      * this implementation may not store its data in Coordinate objects).
      */
-    //virtual int size() const=0;
     virtual std::size_t getSize() const = 0;
 
     size_t
@@ -133,9 +131,9 @@ public:
      *
      * This method is a port of the toCoordinateArray() method of JTS.
      * It is not much used as memory management requires us to
-     * know wheter we should or not delete the returned object
+     * know whether we should or not delete the returned object
      * in a consistent way. Our options are: use shared_ptr<Coordinate>
-     * or always keep ownerhips of an eventual newly created vector.
+     * or always keep ownership of an eventual newly created vector.
      * We opted for the second, so the returned object is a const, to
      * also ensure that returning an internal pointer doesn't make
      * the object mutable.
@@ -158,9 +156,6 @@ public:
      * @return true (as by general collection contract)
      */
     void add(const std::vector<Coordinate>* vc, bool allowRepeated);
-
-    /* This is here for backward compatibility.. */
-    //void add(CoordinateSequence *cl,bool allowRepeated,bool direction);
 
     /** \brief
      *  Add an array of coordinates
@@ -205,12 +200,6 @@ public:
     /// Add a Coordinate to the list
     virtual	void add(const Coordinate& c) = 0;
 
-    // Get number of coordinates
-    //virtual int getSize() const=0;
-
-    /// Get a reference to Coordinate at position pos
-    //virtual	const Coordinate& getAt(std::size_t pos) const=0;
-
     /// Copy Coordinate c to position pos
     virtual	void setAt(const Coordinate& c, std::size_t pos) = 0;
 
@@ -228,24 +217,6 @@ public:
 
     /// Returns lower-left Coordinate in list
     const Coordinate* minCoordinate() const;
-
-
-    /// \brief
-    /// Returns a new CoordinateSequence being a copy of the input
-    /// with any consecutive equal Coordinate removed.
-    ///
-    /// Equality test is 2D based
-    ///
-    /// Ownership of returned object goes to the caller.
-    ///
-    static CoordinateSequence* removeRepeatedPoints(
-        const CoordinateSequence* cl);
-
-    /// Remove consecutive equal Coordinates from the sequence
-    //
-    /// Equality test is 2D based. Returns a reference to self.
-    ///
-    virtual CoordinateSequence& removeRepeatedPoints() = 0;
 
     /** \brief
      *  Returns true if given CoordinateSequence contains

--- a/include/geos/operation/valid/Makefile.am
+++ b/include/geos/operation/valid/Makefile.am
@@ -13,6 +13,7 @@ geos_HEADERS = \
     IsValidOp.h                 \
     MakeValid.h                 \
     QuadtreeNestedRingTester.h  \
+    RepeatedPointRemover.h      \
     RepeatedPointTester.h       \
     SimpleNestedRingTester.h    \
     SweeplineNestedRingTester.h \

--- a/include/geos/operation/valid/RepeatedPointRemover.h
+++ b/include/geos/operation/valid/RepeatedPointRemover.h
@@ -1,0 +1,41 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston <dbaston@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#ifndef GEOS_OP_VALID_REPEATEDPOINTREMOVER_H
+#define GEOS_OP_VALID_REPEATEDPOINTREMOVER_H
+
+#include <geos/geom/CoordinateSequence.h>
+
+namespace geos {
+namespace operation {
+namespace valid {
+    class RepeatedPointRemover {
+
+    /// \brief
+    /// Returns a new CoordinateSequence being a copy of the input
+    /// with any consecutive equal Coordinate removed.
+    ///
+    /// Equality test is 2D based
+    ///
+    /// Ownership of returned object goes to the caller.
+    /// \param seq
+    /// \return
+    public:
+        static std::unique_ptr<geom::CoordinateSequence> removeRepeatedPoints(const geom::CoordinateSequence* seq);
+    };
+}
+}
+}
+
+#endif

--- a/include/geos/triangulate/DelaunayTriangulationBuilder.h
+++ b/include/geos/triangulate/DelaunayTriangulationBuilder.h
@@ -20,11 +20,12 @@
 #define GEOS_TRIANGULATE_DELAUNAYTRIANGULATIONBUILDER_H
 
 #include <geos/triangulate/IncrementalDelaunayTriangulator.h>
+#include <geos/geom/CoordinateSequence.h>
 
+#include <memory>
 
 namespace geos {
 namespace geom {
-class CoordinateSequence;
 class Geometry;
 class MultiLineString;
 class GeometryCollection;
@@ -58,9 +59,7 @@ public:
      * @param geom the geometry to extract from
      * @return a List of the unique Coordinates. Caller takes ownership of the returned object.
      */
-    static geom::CoordinateSequence* extractUniqueCoordinates(const geom::Geometry& geom);
-
-    static void unique(geom::CoordinateSequence& coords);
+    static std::unique_ptr<geom::CoordinateSequence> extractUniqueCoordinates(const geom::Geometry& geom);
 
     /**
      * Converts all {@link Coordinate}s in a collection to {@link Vertex}es.
@@ -69,8 +68,15 @@ public:
      */
     static IncrementalDelaunayTriangulator::VertexList* toVertices(const geom::CoordinateSequence& coords);
 
+    /**
+     * Returns a CoordinateSequence containing only the unique coordinates of its input.
+     * @param seq a coordinateSequence
+     * @return a sorted CoordinateSequence with the unique points of seq.
+     */
+    static std::unique_ptr<geom::CoordinateSequence> unique(const geom::CoordinateSequence* seq);
+
 private:
-    geom::CoordinateSequence* siteCoords;
+    std::unique_ptr<geom::CoordinateSequence> siteCoords;
     double tolerance;
     quadedge::QuadEdgeSubdivision* subdiv;
 

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -281,17 +281,5 @@ CoordinateArraySequence::apply_ro(CoordinateFilter* filter) const
     }
 }
 
-CoordinateSequence&
-CoordinateArraySequence::removeRepeatedPoints()
-{
-    // We use == operator, which is 2D only
-    vector<Coordinate>::iterator new_end = \
-                                           std::unique(vect->begin(), vect->end());
-
-    vect->erase(new_end, vect->end());
-
-    return *this;
-}
-
 } // namespace geos::geom
 } //namespace geos

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -248,25 +248,25 @@ CoordinateSequence::add(const CoordinateSequence* cl,
 
 
 /*public static*/
-CoordinateSequence*
-CoordinateSequence::removeRepeatedPoints(const CoordinateSequence* cl)
-{
-#if PROFILE
-    static Profile* prof = profiler->get("CoordinateSequence::removeRepeatedPoints()");
-    prof->start();
-#endif
-    const vector<Coordinate>* v = cl->toVector();
-
-    vector<Coordinate>* nv = new vector<Coordinate>;
-    nv->reserve(v->size());
-    unique_copy(v->begin(), v->end(), back_inserter(*nv));
-    CoordinateSequence* ret = CoordinateArraySequenceFactory::instance()->create(nv);
-
-#if PROFILE
-    prof->stop();
-#endif
-    return ret;
-}
+//CoordinateSequence*
+//CoordinateSequence::removeRepeatedPoints(const CoordinateSequence* cl)
+//{
+//#if PROFILE
+//    static Profile* prof = profiler->get("CoordinateSequence::removeRepeatedPoints()");
+//    prof->start();
+//#endif
+//    const vector<Coordinate>* v = cl->toVector();
+//
+//    vector<Coordinate>* nv = new vector<Coordinate>;
+//    nv->reserve(v->size());
+//    unique_copy(v->begin(), v->end(), back_inserter(*nv));
+//    CoordinateSequence* ret = CoordinateArraySequenceFactory::instance()->create(nv);
+//
+//#if PROFILE
+//    prof->stop();
+//#endif
+//    return ret;
+//}
 
 void
 CoordinateSequence::expandEnvelope(Envelope& env) const

--- a/src/noding/ScaledNoder.cpp
+++ b/src/noding/ScaledNoder.cpp
@@ -21,6 +21,8 @@
 #include <geos/geom/CoordinateFilter.h> // for inheritance
 #include <geos/noding/ScaledNoder.h>
 #include <geos/noding/SegmentString.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
+#include <geos/operation/valid/RepeatedPointTester.h>
 #include <geos/util/math.h>
 #include <geos/util.h>
 
@@ -169,8 +171,13 @@ ScaledNoder::scale(SegmentString::NonConstVect& segStrings) const
         // SegmentStrings here, but who's going
         // to delete them then ? And is it worth
         // the memory cost ?
-        cs->removeRepeatedPoints();
-
+        operation::valid::RepeatedPointTester rpt;
+        if (rpt.hasRepeatedPoint(cs)) {
+            auto cs2 = operation::valid::RepeatedPointRemover::removeRepeatedPoints(cs);
+            delete cs;
+            cs = cs2.release();
+            // FIXME
+        }
     }
 }
 

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -35,6 +35,7 @@
 #include <geos/operation/overlay/snap/SnapOverlayOp.h>
 #include <geos/operation/overlay/PolygonBuilder.h>
 #include <geos/operation/overlay/OverlayNodeFactory.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 #include <geos/operation/linemerge/LineMerger.h>
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/noding/IntersectionAdder.h>
@@ -556,17 +557,16 @@ BufferBuilder::computeNodedEdges(SegmentString::NonConstVect& bufferSegStrList,
         SegmentString* segStr = *i;
         const Label* oldLabel = static_cast<const Label*>(segStr->getData());
 
-        CoordinateSequence* cs = CoordinateSequence::removeRepeatedPoints(segStr->getCoordinates());
+        auto cs = operation::valid::RepeatedPointRemover::removeRepeatedPoints(segStr->getCoordinates());
         delete segStr;
         if(cs->size() < 2) {
             // don't insert collapsed edges
             // we need to take care of the memory here as cs is a new sequence
-            delete cs;
             continue;
         }
 
         // Edge takes ownership of the CoordinateSequence
-        Edge* edge = new Edge(cs, *oldLabel);
+        Edge* edge = new Edge(cs.release(), *oldLabel);
 
         // will take care of the Edge ownership
         insertUniqueEdge(edge);

--- a/src/operation/intersection/RectangleIntersectionBuilder.cpp
+++ b/src/operation/intersection/RectangleIntersectionBuilder.cpp
@@ -14,6 +14,7 @@
 
 #include <geos/operation/intersection/Rectangle.h>
 #include <geos/operation/intersection/RectangleIntersectionBuilder.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/GeometryCollection.h>
@@ -72,14 +73,13 @@ RectangleIntersectionBuilder::reconnect()
     }
 
     // Merge the two linestrings
-
-    CoordinateSequence* ncs = CoordinateSequence::removeRepeatedPoints(&cs2);
+    auto ncs = valid::RepeatedPointRemover::removeRepeatedPoints(&cs2);
     ncs->add(&cs1, false, true);
 
     delete line1;
     delete line2;
 
-    LineString* nline = _gf.createLineString(ncs);
+    LineString* nline = _gf.createLineString(ncs.release());
     lines.pop_front();
     lines.pop_back();
 

--- a/src/operation/linemerge/LineMergeGraph.cpp
+++ b/src/operation/linemerge/LineMergeGraph.cpp
@@ -21,6 +21,7 @@
 #include <geos/operation/linemerge/LineMergeGraph.h>
 #include <geos/operation/linemerge/LineMergeEdge.h>
 #include <geos/operation/linemerge/LineMergeDirectedEdge.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 #include <geos/planargraph/DirectedEdge.h>
 #include <geos/planargraph/Node.h>
 #include <geos/geom/CoordinateSequence.h>
@@ -56,9 +57,7 @@ LineMergeGraph::addEdge(const LineString* lineString)
     cerr << "Adding LineString " << lineString->toString() << endl;
 #endif
 
-    std::unique_ptr<CoordinateSequence> coordinates(
-        CoordinateSequence::removeRepeatedPoints(lineString->getCoordinatesRO())
-    );
+    auto coordinates = valid::RepeatedPointRemover::removeRepeatedPoints(lineString->getCoordinatesRO());
 
     std::size_t nCoords = coordinates->size(); // virtual call..
 

--- a/src/operation/polygonize/PolygonizeGraph.cpp
+++ b/src/operation/polygonize/PolygonizeGraph.cpp
@@ -21,6 +21,7 @@
 #include <geos/operation/polygonize/PolygonizeDirectedEdge.h>
 #include <geos/operation/polygonize/PolygonizeEdge.h>
 #include <geos/operation/polygonize/EdgeRing.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 #include <geos/planargraph/Node.h>
 #include <geos/planargraph/DirectedEdgeStar.h>
 #include <geos/planargraph/DirectedEdge.h>
@@ -127,14 +128,13 @@ PolygonizeGraph::addEdge(const LineString* line)
         return;
     }
 
-    CoordinateSequence* linePts = CoordinateSequence::removeRepeatedPoints(line->getCoordinatesRO());
+    auto linePts = valid::RepeatedPointRemover::removeRepeatedPoints(line->getCoordinatesRO());
 
     /*
      * This would catch invalid linestrings
      * (containing duplicated points only)
      */
     if(linePts->getSize() < 2) {
-        delete linePts;
         return;
     }
 
@@ -152,7 +152,7 @@ PolygonizeGraph::addEdge(const LineString* line)
     edge->setDirectedEdges(de0, de1);
     add(edge);
 
-    newCoords.push_back(linePts);
+    newCoords.push_back(linePts.release());
 }
 
 Node*

--- a/src/operation/valid/Makefile.am
+++ b/src/operation/valid/Makefile.am
@@ -16,6 +16,7 @@ libopvalid_la_SOURCES = \
     ConsistentAreaTester.cpp \
     IsValidOp.cpp \
     QuadtreeNestedRingTester.cpp \
+    RepeatedPointRemover.cpp \
     RepeatedPointTester.cpp \
     SimpleNestedRingTester.cpp \
     SweeplineNestedRingTester.cpp \

--- a/src/operation/valid/RepeatedPointRemover.cpp
+++ b/src/operation/valid/RepeatedPointRemover.cpp
@@ -1,0 +1,54 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston <dbaston@gmail.com
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/operation/valid/RepeatedPointRemover.h>
+
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateArraySequenceFactory.h>
+
+namespace geos {
+namespace operation {
+namespace valid {
+
+std::unique_ptr<geom::CoordinateSequence>
+RepeatedPointRemover::removeRepeatedPoints(const geom::CoordinateSequence* seq) {
+    using geom::Coordinate;
+
+    auto seqFactory = geom::CoordinateArraySequenceFactory::instance();
+
+    if (seq->isEmpty()) {
+        return std::unique_ptr<geom::CoordinateSequence>(seqFactory->create());
+    }
+
+    std::unique_ptr<std::vector<Coordinate>> pts(new std::vector<Coordinate>);
+    auto sz = seq->getSize();
+    pts->reserve(sz); // assume not many points are repeated
+
+    const Coordinate* prevPt = &(seq->getAt(0));
+    pts->push_back(*prevPt) ;
+
+    for (size_t i = 1; i < sz; i++) {
+        const Coordinate* nextPt = &(seq->getAt(i));
+        if (*nextPt != *prevPt) {
+            pts->push_back(*nextPt);
+        }
+        prevPt = nextPt;
+    }
+
+    return std::unique_ptr<geom::CoordinateSequence>(seqFactory->create(pts.release(), seq->getDimension()));
+}
+
+}
+}
+}

--- a/src/precision/PrecisionReducerCoordinateOperation.cpp
+++ b/src/precision/PrecisionReducerCoordinateOperation.cpp
@@ -24,6 +24,7 @@
 #include <geos/geom/Geometry.h>
 #include <geos/geom/LineString.h>
 #include <geos/geom/LinearRing.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 
 #include <vector>
 
@@ -58,8 +59,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.
-    //
-    CoordinateSequence* noRepeatedCoords = CoordinateSequence::removeRepeatedPoints(reducedCoords);
+    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords);
 
     /**
      * Check to see if the removal of repeated points
@@ -89,13 +89,12 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // return null or orginal length coordinate array
     if(noRepeatedCoords->getSize() < minLength) {
-        delete noRepeatedCoords;
         return collapsedCoords;
     }
 
     // ok to return shorter coordinate array
     delete reducedCoords;
-    return noRepeatedCoords;
+    return noRepeatedCoords.release();
 }
 
 

--- a/src/precision/SimpleGeometryPrecisionReducer.cpp
+++ b/src/precision/SimpleGeometryPrecisionReducer.cpp
@@ -27,6 +27,7 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/LineString.h>
 #include <geos/geom/LinearRing.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 
 #include <vector>
 #include <typeinfo>
@@ -89,8 +90,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.
-    //
-    CoordinateSequence* noRepeatedCoords = CoordinateSequence::removeRepeatedPoints(reducedCoords);
+    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords);
 
     /**
      * Check to see if the removal of repeated points
@@ -118,12 +118,11 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
     }
     // return null or orginal length coordinate array
     if(noRepeatedCoords->getSize() < minLength) {
-        delete noRepeatedCoords;
         return collapsedCoords;
     }
     // ok to return shorter coordinate array
     delete reducedCoords;
-    return noRepeatedCoords;
+    return noRepeatedCoords.release();
 }
 
 } // anonymous namespace

--- a/src/triangulate/VoronoiDiagramBuilder.cpp
+++ b/src/triangulate/VoronoiDiagramBuilder.cpp
@@ -30,6 +30,7 @@
 #include <geos/triangulate/IncrementalDelaunayTriangulator.h>
 #include <geos/triangulate/DelaunayTriangulationBuilder.h>
 #include <geos/triangulate/quadedge/QuadEdgeSubdivision.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 
 namespace geos {
 namespace triangulate { //geos.triangulate
@@ -49,14 +50,13 @@ VoronoiDiagramBuilder::~VoronoiDiagramBuilder()
 void
 VoronoiDiagramBuilder::setSites(const geom::Geometry& geom)
 {
-    siteCoords.reset(DelaunayTriangulationBuilder::extractUniqueCoordinates(geom));
+    siteCoords = DelaunayTriangulationBuilder::extractUniqueCoordinates(geom);
 }
 
 void
 VoronoiDiagramBuilder::setSites(const geom::CoordinateSequence& coords)
 {
-    siteCoords.reset(coords.clone());
-    DelaunayTriangulationBuilder::unique(*siteCoords);
+    siteCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(&coords);
 }
 
 void

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -120,6 +120,7 @@ geos_unit_SOURCES = \
 	operation/union/CascadedPolygonUnionTest.cpp \
 	operation/union/UnaryUnionOpTest.cpp \
 	operation/valid/IsValidTest.cpp \
+	operation/valid/RepeatedPointRemoverTest.cpp \
 	operation/valid/ValidClosedRingTest.cpp \
 	operation/valid/ValidSelfTouchingRingFormingHoleTest.cpp \
 	precision/SimpleGeometryPrecisionReducerTest.cpp \

--- a/tests/unit/geom/CoordinateArraySequenceTest.cpp
+++ b/tests/unit/geom/CoordinateArraySequenceTest.cpp
@@ -408,34 +408,6 @@ void object::test<10>
     ensure_equals(sequence.getAt(2).z, 27);
 }
 
-// Test of removeRepeatedPoints
-template<>
-template<>
-void object::test<11>
-()
-{
-    using geos::geom::Coordinate;
-
-    geos::geom::CoordinateArraySequence sequence;
-
-    // Add new 3 equal coordinates
-    Coordinate c(1, 2, 3);
-    sequence.add(c);
-    sequence.add(c);
-    sequence.add(c);
-
-    Coordinate c2(5, 10, 15);
-    sequence.add(c2);
-    sequence.add(c2);
-
-    sequence.add(c);
-
-    ensure_equals(sequence.size(), 6u);
-    sequence.removeRepeatedPoints();
-
-    ensure_equals(sequence.size(), 3u);
-}
-
 // Test of equality and inequality operators
 template<>
 template<>

--- a/tests/unit/operation/valid/RepeatedPointRemoverTest.cpp
+++ b/tests/unit/operation/valid/RepeatedPointRemoverTest.cpp
@@ -1,0 +1,62 @@
+//
+// Test Suite for geos::operation::valid::RepeatedPointRemover class.
+//
+
+// tut
+#include <tut/tut.hpp>
+// geos
+#include <geos/operation/valid/RepeatedPointRemover.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/CoordinateSequence.h>
+#include <geos/io/WKTReader.h>
+// std
+#include <memory>
+#include <string>
+
+using geos::geom::Geometry;
+using geos::geom::LineString;
+using geos::geom::CoordinateSequence;
+using geos::operation::valid::RepeatedPointRemover;
+
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used by tests
+    struct test_repeated_point_remover_test_data {
+        geos::io::WKTReader wktreader;
+
+        test_repeated_point_remover_test_data()
+                : wktreader()
+        {}
+
+        std::unique_ptr<Geometry> readWKT(const std::string & wkt) {
+            return std::unique_ptr<Geometry>(wktreader.read(wkt));
+        }
+    };
+
+    typedef test_group<test_repeated_point_remover_test_data> group;
+    typedef group::object object;
+
+    group test_repeated_point_remover_group("geos::operation::valid::RepeatedPointRemover");
+
+    template<>
+    template<>
+    void object::test<1>()
+    {
+        auto input = readWKT("LINESTRING (3 7, 8 8, 8 8, 8 8, 10 9)");
+        auto expected = readWKT("LINESTRING (3 7, 8 8, 10 9)");
+
+        std::unique_ptr<CoordinateSequence> coords(input->getCoordinates());
+        auto resultCoords = RepeatedPointRemover::removeRepeatedPoints(coords.get());
+
+        std::unique_ptr<LineString> result(input->getFactory()->createLineString(resultCoords.release()));
+
+        ensure(expected->equalsExact(result.get()));
+    }
+} // namespace tut
+
+

--- a/tests/unit/triangulate/DelaunayTest.cpp
+++ b/tests/unit/triangulate/DelaunayTest.cpp
@@ -38,7 +38,7 @@ typedef group::object object;
 
 group test_incdelaunaytri_group("geos::triangulate::Delaunay");
 
-//helper function for funning triangulation
+//helper function for running triangulation
 void
 runDelaunay(const char* sitesWkt, bool computeTriangles, const char* expectedWkt, double tolerance = 0.0)
 {

--- a/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
+++ b/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
@@ -19,6 +19,7 @@
 #include <geos/io/WKTReader.h>
 #include <geos/geom/Envelope.h>
 #include <geos/geom/Coordinate.h>
+#include <geos/operation/valid/RepeatedPointRemover.h>
 // std
 #include <stdio.h>
 #include <iostream>
@@ -87,7 +88,7 @@ void object::test<2>
     Geometry* sites;
     QuadEdgeSubdivision* subdiv;
     sites = reader.read("MULTIPOINT ((150 200), (180 270), (275 163))");
-    CoordinateSequence* siteCoords = DelaunayTriangulationBuilder::extractUniqueCoordinates(*sites);
+    auto siteCoords = DelaunayTriangulationBuilder::extractUniqueCoordinates(*sites);
     Envelope Env = DelaunayTriangulationBuilder::envelope(*siteCoords);
 
     double expandBy = std::max(Env.getWidth(), Env.getHeight());
@@ -109,7 +110,6 @@ void object::test<2>
     polys->normalize();
     expected->normalize();
     ensure(polys->equalsExact(expected, 1e-7));
-    delete siteCoords;
     delete sites;
     delete subdiv;
     delete vertices;
@@ -158,7 +158,7 @@ template<> template<> void object::test<3>
             p->getExteriorRing()->getCoordinates()
         );
         size_t from = cs->size();
-        cs->removeRepeatedPoints();
+        cs = geos::operation::valid::RepeatedPointRemover::removeRepeatedPoints(cs.get());
         ensure_equals(from, cs->size());
     }
 }


### PR DESCRIPTION
This refactoring supports the goal of a slimmed-down CoordinateSequence
interface against which it will be easier to develop alternative
implementations.