### PR TITLE
Use unique_ptr for functions returning CoordinateSequence

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -3672,7 +3672,7 @@ extern "C" {
 
         try {
             const GeometryFactory* gf = handle->geomFactory;
-            return gf->getCoordinateSequenceFactory()->create(size, dims);
+            return gf->getCoordinateSequenceFactory()->create(size, dims).release();
         }
         catch(const std::exception& e) {
             handle->ERROR_MESSAGE("%s", e.what());
@@ -3747,7 +3747,7 @@ extern "C" {
         }
 
         try {
-            return cs->clone();
+            return cs->clone().release();
         }
         catch(const std::exception& e) {
             handle->ERROR_MESSAGE("%s", e.what());

--- a/include/geos/algorithm/ConvexHull.h
+++ b/include/geos/algorithm/ConvexHull.h
@@ -22,10 +22,12 @@
 #define GEOS_ALGORITHM_CONVEXHULL_H
 
 #include <geos/export.h>
+#include <memory>
 #include <vector>
 
 // FIXME: avoid using Cordinate:: typedefs to avoid full include
 #include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateSequence.h>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -37,7 +39,6 @@ namespace geos {
 namespace geom {
 class Geometry;
 class GeometryFactory;
-class CoordinateSequence;
 }
 }
 
@@ -66,7 +67,7 @@ private:
     /// This is needed to construct the geometries.
     /// Here coordinate copies happen
     /// The returned object is newly allocated !NO EXCEPTION SAFE!
-    geom::CoordinateSequence* toCoordinateSequence(geom::Coordinate::ConstVect& cv);
+    std::unique_ptr<geom::CoordinateSequence> toCoordinateSequence(geom::Coordinate::ConstVect& cv);
 
     void computeOctPts(const geom::Coordinate::ConstVect& src,
                        geom::Coordinate::ConstVect& tgt);

--- a/include/geos/algorithm/MinimumDiameter.h
+++ b/include/geos/algorithm/MinimumDiameter.h
@@ -20,6 +20,7 @@
 #ifndef GEOS_ALGORITHM_MINIMUMDIAMETER_H
 #define GEOS_ALGORITHM_MINIMUMDIAMETER_H
 
+#include <memory>
 #include <geos/export.h>
 
 // Forward declarations
@@ -67,7 +68,7 @@ private:
     const geom::Geometry* inputGeom;
     bool isConvex;
 
-    geom::CoordinateSequence* convexHullPts;
+    std::unique_ptr<geom::CoordinateSequence> convexHullPts;
 
     geom::LineSegment* minBaseSeg;
     geom::Coordinate* minWidthPt;

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -41,7 +41,7 @@ public:
 
     CoordinateArraySequence(const CoordinateSequence& cl);
 
-    CoordinateSequence* clone() const override;
+    std::unique_ptr<CoordinateSequence> clone() const override;
 
     //const Coordinate& getCoordinate(int pos) const;
     const Coordinate& getAt(std::size_t pos) const override;

--- a/include/geos/geom/CoordinateArraySequenceFactory.h
+++ b/include/geos/geom/CoordinateArraySequenceFactory.h
@@ -43,14 +43,14 @@ namespace geom { // geos::geom
 class GEOS_DLL CoordinateArraySequenceFactory: public CoordinateSequenceFactory {
 
 public:
-    CoordinateSequence* create() const override;
+    std::unique_ptr<CoordinateSequence> create() const override;
 
-    CoordinateSequence* create(std::vector<Coordinate>* coords, std::size_t dims = 0) const override;
+    std::unique_ptr<CoordinateSequence> create(std::vector<Coordinate>* coords, std::size_t dims = 0) const override;
 
     /** @see CoordinateSequenceFactory::create(std::size_t, int) */
-    CoordinateSequence* create(std::size_t size, std::size_t dimension = 0) const override;
+    std::unique_ptr<CoordinateSequence> create(std::size_t size, std::size_t dimension = 0) const override;
 
-    CoordinateSequence* create(const CoordinateSequence& coordSeq) const override;
+    std::unique_ptr<CoordinateSequence> create(const CoordinateSequence& coordSeq) const override;
 
     /** \brief
      * Returns the singleton instance of CoordinateArraySequenceFactory

--- a/include/geos/geom/CoordinateArraySequenceFactory.inl
+++ b/include/geos/geom/CoordinateArraySequenceFactory.inl
@@ -22,32 +22,36 @@
 namespace geos {
 namespace geom { // geos::geom
 
-INLINE CoordinateSequence*
+INLINE std::unique_ptr<CoordinateSequence>
 CoordinateArraySequenceFactory::create() const
 {
-    return new CoordinateArraySequence(
-               reinterpret_cast<std::vector<Coordinate>*>(0), 0);
+    return std::unique_ptr<CoordinateSequence>(
+            new CoordinateArraySequence(
+                    reinterpret_cast<std::vector<Coordinate>*>(0), 0));
 }
 
-INLINE CoordinateSequence*
+INLINE std::unique_ptr<CoordinateSequence>
 CoordinateArraySequenceFactory::create(std::vector<Coordinate>* coords,
                                        size_t dimension) const
 {
-    return new CoordinateArraySequence(coords, dimension);
+    return std::unique_ptr<CoordinateSequence>(
+            new CoordinateArraySequence(coords, dimension));
 }
 
-INLINE CoordinateSequence*
+INLINE std::unique_ptr<CoordinateSequence>
 CoordinateArraySequenceFactory::create(std::size_t size, std::size_t dimension)
 const
 {
-    return new CoordinateArraySequence(size, dimension);
+    return std::unique_ptr<CoordinateSequence>(
+            new CoordinateArraySequence(size, dimension));
 }
 
-INLINE CoordinateSequence*
+INLINE std::unique_ptr<CoordinateSequence>
 CoordinateArraySequenceFactory::create(const CoordinateSequence& seq)
 const
 {
-    return new CoordinateArraySequence(seq);
+    return std::unique_ptr<CoordinateSequence>(
+            new CoordinateArraySequence(seq));
 }
 
 

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -73,7 +73,7 @@ public:
     /** \brief
      * Returns a deep copy of this collection.
      */
-    virtual CoordinateSequence* clone() const = 0;
+    virtual std::unique_ptr<CoordinateSequence> clone() const = 0;
 
     /** \brief
      * Returns a read-only reference to Coordinate at position i.

--- a/include/geos/geom/CoordinateSequenceFactory.h
+++ b/include/geos/geom/CoordinateSequenceFactory.h
@@ -21,6 +21,7 @@
 
 
 #include <geos/export.h>
+#include <memory>
 #include <vector>
 
 //#include <geos/geom/Coordinate.h>
@@ -51,7 +52,7 @@ public:
      * Returns an empty CoordinateSequence, the dimensions will be autodetected
      * when it is populated.
      */
-    virtual CoordinateSequence* create() const = 0;
+    virtual std::unique_ptr<CoordinateSequence> create() const = 0;
 
     /** \brief
      * Returns a CoordinateSequence based on the given array.
@@ -68,7 +69,7 @@ public:
      * @param coordinates the coordinates
      * @param dimension 0, 2 or 3 with 0 indicating unknown at this time.
      */
-    virtual CoordinateSequence* create(
+    virtual std::unique_ptr<CoordinateSequence> create(
         std::vector<Coordinate>* coordinates,
         std::size_t dimension = 0) const = 0;
 
@@ -82,8 +83,8 @@ public:
      * @param dimension the dimension of the coordinates in the sequence
      * 	(0=unknown, 2, or 3 - ignored if not user specifiable)
      */
-    virtual CoordinateSequence* create(std::size_t size,
-                                       std::size_t dimension = 0) const = 0;
+    virtual std::unique_ptr<CoordinateSequence> create(std::size_t size,
+                                                       std::size_t dimension = 0) const = 0;
 
     /** \brief
      * Creates a CoordinateSequence which is a copy of the given one.
@@ -92,7 +93,7 @@ public:
      *
      * @param coordSeq the coordinate sequence to copy
      */
-    virtual CoordinateSequence* create(const CoordinateSequence& coordSeq) const = 0;
+    virtual std::unique_ptr<CoordinateSequence> create(const CoordinateSequence& coordSeq) const = 0;
 
     virtual ~CoordinateSequenceFactory();
 };

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -298,7 +298,7 @@ public:
      * Returns this Geometry vertices.
      * Caller takes ownership of the returned object.
      */
-    virtual CoordinateSequence* getCoordinates() const = 0; //Abstract
+    virtual std::unique_ptr<CoordinateSequence> getCoordinates() const = 0; //Abstract
 
     /// Returns the count of this Geometrys vertices.
     virtual std::size_t getNumPoints() const = 0; //Abstract

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -94,7 +94,7 @@ public:
      * @return the collected coordinates
      *
      */
-    CoordinateSequence* getCoordinates() const override;
+    std::unique_ptr<CoordinateSequence> getCoordinates() const override;
 
     bool isEmpty() const override;
 

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -86,7 +86,7 @@ public:
      */
     Geometry* clone() const override;
 
-    CoordinateSequence* getCoordinates() const override;
+    std::unique_ptr<CoordinateSequence> getCoordinates() const override;
 
     /// Returns a read-only pointer to internal CoordinateSequence
     const CoordinateSequence* getCoordinatesRO() const;

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -106,7 +106,7 @@ public:
 
     GeometryTypeId getGeometryTypeId() const override;
 
-    void setPoints(CoordinateSequence* cl);
+    void setPoints(const CoordinateSequence* cl);
 
     Geometry* reverse() const override;
 

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -86,7 +86,7 @@ public:
         return new Point(*this);
     }
 
-    CoordinateSequence* getCoordinates(void) const override;
+    std::unique_ptr<CoordinateSequence> getCoordinates(void) const override;
 
     const CoordinateSequence* getCoordinatesRO() const;
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -85,7 +85,7 @@ public:
         return new Polygon(*this);
     }
 
-    CoordinateSequence* getCoordinates() const override;
+    std::unique_ptr<CoordinateSequence> getCoordinates() const override;
 
     size_t getNumPoints() const override;
 

--- a/include/geos/geomgraph/EdgeRing.h
+++ b/include/geos/geomgraph/EdgeRing.h
@@ -27,9 +27,10 @@
 
 #include <geos/inline.h>
 
-#include <vector>
 #include <cassert> // for testInvariant
 #include <iosfwd> // for operator<<
+#include <memory>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -153,7 +153,7 @@ private:
     geom::GeometryCollection* readGeometryCollection();
     // throws IOException, ParseException
 
-    geom::CoordinateSequence* readCoordinateSequence(int); // throws IOException
+    std::unique_ptr<geom::CoordinateSequence> readCoordinateSequence(int); // throws IOException
 
     void readCoordinate(); // throws IOException
 

--- a/include/geos/io/WKTReader.h
+++ b/include/geos/io/WKTReader.h
@@ -86,7 +86,7 @@ public:
 //	Geometry* read(Reader& reader);	//Not implemented yet
 
 protected:
-    geom::CoordinateSequence* getCoordinates(io::StringTokenizer* tokenizer);
+    std::unique_ptr<geom::CoordinateSequence> getCoordinates(io::StringTokenizer* tokenizer);
     double getNextNumber(io::StringTokenizer* tokenizer);
     std::string getNextEmptyOrOpener(io::StringTokenizer* tokenizer);
     std::string getNextCloserOrComma(io::StringTokenizer* tokenizer);

--- a/include/geos/noding/SegmentStringUtil.h
+++ b/include/geos/noding/SegmentStringUtil.h
@@ -60,9 +60,9 @@ public:
             // we take ownership of the coordinates here
             // TODO: check if this can be optimized by getting
             //       the internal CS.
-            geom::CoordinateSequence* pts = line->getCoordinates();
+            auto pts = line->getCoordinates();
 
-            segStr.push_back(new NodedSegmentString(pts, g));
+            segStr.push_back(new NodedSegmentString(pts.release(), g));
         }
     }
 

--- a/src/algorithm/ConvexHull.cpp
+++ b/src/algorithm/ConvexHull.cpp
@@ -99,7 +99,7 @@ public:
 } // unnamed namespace
 
 /* private */
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 ConvexHull::toCoordinateSequence(Coordinate::ConstVect& cv)
 {
     const CoordinateSequenceFactory* csf =
@@ -243,8 +243,8 @@ ConvexHull::getConvexHull()
 
     if(nInputPts == 2) { // Return a LineString
         // Copy all Coordinates from the ConstVect
-        CoordinateSequence* cs = toCoordinateSequence(inputPts);
-        return geomFactory->createLineString(cs);
+        auto cs = toCoordinateSequence(inputPts);
+        return geomFactory->createLineString(cs.release());
     }
 
     // use heuristic to reduce points, if large
@@ -352,12 +352,12 @@ ConvexHull::lineOrPolygon(const Coordinate::ConstVect& input)
 
     if(cleaned.size() == 3) { // shouldn't this be 2 ??
         cleaned.resize(2);
-        CoordinateSequence* cl1 = toCoordinateSequence(cleaned);
-        LineString* ret = geomFactory->createLineString(cl1);
+        auto cl1 = toCoordinateSequence(cleaned);
+        LineString* ret = geomFactory->createLineString(cl1.release());
         return ret;
     }
-    CoordinateSequence* cl2 = toCoordinateSequence(cleaned);
-    LinearRing* linearRing = geomFactory->createLinearRing(cl2);
+    auto cl2 = toCoordinateSequence(cleaned);
+    LinearRing* linearRing = geomFactory->createLinearRing(cl2.release());
     return geomFactory->createPolygon(linearRing, nullptr);
 }
 

--- a/src/algorithm/MinimumBoundingCircle.cpp
+++ b/src/algorithm/MinimumBoundingCircle.cpp
@@ -73,10 +73,10 @@ MinimumBoundingCircle::getFarthestPoints()
 
     size_t dims = input->getDimension();
     size_t len = 2;
-    CoordinateSequence* cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
+    auto cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
     cs->add(extremalPts[0], true);
     cs->add(extremalPts[extremalPts.size() - 1], true);
-    return input->getFactory()->createLineString(cs);
+    return input->getFactory()->createLineString(cs.release());
 }
 
 /*public*/
@@ -92,12 +92,12 @@ MinimumBoundingCircle::getDiameter()
     }
     size_t dims = input->getDimension();
     size_t len = 2;
-    CoordinateSequence* cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
+    auto cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
     // TODO: handle case of 3 extremal points, by computing a line from one of
     // them through the centre point with len = 2*radius
     cs->add(extremalPts[0], true);
     cs->add(extremalPts[1], true);
-    return input->getFactory()->createLineString(cs);
+    return input->getFactory()->createLineString(cs.release());
 }
 
 /*public*/

--- a/src/algorithm/MinimumDiameter.cpp
+++ b/src/algorithm/MinimumDiameter.cpp
@@ -101,7 +101,6 @@ MinimumDiameter::~MinimumDiameter()
 {
     delete minBaseSeg;
     delete minWidthPt;
-    delete convexHullPts;
 }
 
 /**
@@ -138,10 +137,10 @@ MinimumDiameter::getSupportingSegment()
 {
     computeMinimumDiameter();
     const GeometryFactory* fact = inputGeom->getFactory();
-    CoordinateSequence* cl = fact->getCoordinateSequenceFactory()->create();
+    auto cl = fact->getCoordinateSequenceFactory()->create();
     cl->add(minBaseSeg->p0);
     cl->add(minBaseSeg->p1);
-    return fact->createLineString(cl);
+    return fact->createLineString(cl.release());
 }
 
 /**
@@ -161,10 +160,10 @@ MinimumDiameter::getDiameter()
     Coordinate basePt;
     minBaseSeg->project(*minWidthPt, basePt);
 
-    CoordinateSequence* cl = inputGeom->getFactory()->getCoordinateSequenceFactory()->create();
+    auto cl = inputGeom->getFactory()->getCoordinateSequenceFactory()->create();
     cl->add(basePt);
     cl->add(*minWidthPt);
-    return inputGeom->getFactory()->createLineString(cl);
+    return inputGeom->getFactory()->createLineString(cl.release());
 }
 
 /* private */
@@ -191,7 +190,6 @@ void
 MinimumDiameter::computeWidthConvex(const Geometry* geom)
 {
     //System.out.println("Input = " + geom);
-    delete convexHullPts;
     if(typeid(*geom) == typeid(Polygon)) {
         const Polygon* p = dynamic_cast<const Polygon*>(geom);
         convexHullPts = p->getExteriorRing()->getCoordinates();
@@ -225,7 +223,7 @@ MinimumDiameter::computeWidthConvex(const Geometry* geom)
         minBaseSeg->p1 = convexHullPts->getAt(1);
         break;
     default:
-        computeConvexRingMinDiameter(convexHullPts);
+        computeConvexRingMinDiameter(convexHullPts.get());
     }
 }
 
@@ -355,14 +353,14 @@ MinimumDiameter::getMinimumRectangle()
     const CoordinateSequenceFactory* csf =
         inputGeom->getFactory()->getCoordinateSequenceFactory();
 
-    geom::CoordinateSequence* seq = csf->create(5, 2);
+    auto seq = csf->create(5, 2);
     seq->setAt(p0, 0);
     seq->setAt(p1, 1);
     seq->setAt(p2, 2);
     seq->setAt(p3, 3);
     seq->setAt(p0, 4); // close
 
-    LinearRing* shell = inputGeom->getFactory()->createLinearRing(seq);
+    LinearRing* shell = inputGeom->getFactory()->createLinearRing(seq.release());
     return inputGeom->getFactory()->createPolygon(shell, nullptr);
 }
 

--- a/src/algorithm/distance/DiscreteFrechetDistance.cpp
+++ b/src/algorithm/distance/DiscreteFrechetDistance.cpp
@@ -120,8 +120,8 @@ DiscreteFrechetDistance::compute(
     const geom::Geometry& discreteGeom,
     const geom::Geometry& geom)
 {
-    const CoordinateSequence* lp = discreteGeom.getCoordinates();
-    const CoordinateSequence* lq = geom.getCoordinates();
+    auto lp = discreteGeom.getCoordinates();
+    auto lq = geom.getCoordinates();
     size_t pSize, qSize;
     if(densifyFrac > 0) {
         size_t numSubSegs =  std::size_t(util::round(1.0 / densifyFrac));
@@ -139,8 +139,6 @@ DiscreteFrechetDistance::compute(
         }
     }
     ptDist = getFrecheDistance(ca, pSize - 1, qSize - 1, *lp, *lq);
-    delete lp;
-    delete lq;
 }
 
 } // namespace geos.algorithm.distance

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -73,10 +73,10 @@ CoordinateArraySequence::CoordinateArraySequence(
     }
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 CoordinateArraySequence::clone() const
 {
-    return new CoordinateArraySequence(*this);
+    return std::unique_ptr<CoordinateSequence>(new CoordinateArraySequence(*this));
 }
 
 void

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -60,7 +60,7 @@ CoordinateSequence::atLeastNCoordinatesOrNothing(size_t n,
     }
     else {
         // FIXME: return NULL rather then empty coordinate array
-        return CoordinateArraySequenceFactory::instance()->create();
+        return CoordinateArraySequenceFactory::instance()->create().release();
     }
 }
 

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -90,20 +90,19 @@ GeometryCollection::setSRID(int newSRID)
  * Returns a newly the collected coordinates
  *
  */
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 GeometryCollection::getCoordinates() const
 {
     vector<Coordinate>* coordinates = new vector<Coordinate>(getNumPoints());
 
     int k = -1;
     for(size_t i = 0; i < geometries->size(); ++i) {
-        CoordinateSequence* childCoordinates = (*geometries)[i]->getCoordinates();
+        auto childCoordinates = (*geometries)[i]->getCoordinates();
         size_t npts = childCoordinates->getSize();
         for(size_t j = 0; j < npts; ++j) {
             k++;
             (*coordinates)[k] = childCoordinates->getAt(j);
         }
-        delete childCoordinates;
     }
     return CoordinateArraySequenceFactory::instance()->create(coordinates);
 }

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -72,7 +72,7 @@ public:
     edit(const CoordinateSequence* coordSeq,
          const Geometry*) override
     {
-        return _gsf->create(*coordSeq);
+        return _gsf->create(*coordSeq).release();
     }
 };
 
@@ -277,7 +277,7 @@ GeometryFactory::toGeometry(const Envelope* envelope) const
         coord.y = envelope->getMinY();
         return createPoint(coord);
     }
-    CoordinateSequence* cl = CoordinateArraySequenceFactory::instance()->
+    auto cl = CoordinateArraySequenceFactory::instance()->
                              create((size_t) 0, 2);
     coord.x = envelope->getMinX();
     coord.y = envelope->getMinY();
@@ -295,7 +295,7 @@ GeometryFactory::toGeometry(const Envelope* envelope) const
     coord.y = envelope->getMinY();
     cl->add(coord);
 
-    Polygon* p = createPolygon(createLinearRing(cl), nullptr);
+    Polygon* p = createPolygon(createLinearRing(cl.release()), nullptr);
     return p;
 }
 
@@ -322,9 +322,9 @@ GeometryFactory::createPoint(const Coordinate& coordinate) const
     }
     else {
         std::size_t dim = std::isnan(coordinate.z) ? 2 : 3;
-        CoordinateSequence* cl = coordinateListFactory->create(new vector<Coordinate>(1, coordinate), dim);
+        auto cl = coordinateListFactory->create(new vector<Coordinate>(1, coordinate), dim);
         //cl->setAt(coordinate, 0);
-        Point* ret = createPoint(cl);
+        Point* ret = createPoint(cl.release());
         return ret;
     }
 }
@@ -340,16 +340,8 @@ GeometryFactory::createPoint(CoordinateSequence* newCoords) const
 Point*
 GeometryFactory::createPoint(const CoordinateSequence& fromCoords) const
 {
-    CoordinateSequence* newCoords = fromCoords.clone();
-    Point* g = nullptr;
-    try {
-        g = new Point(newCoords, this);
-    }
-    catch(...) {
-        delete newCoords;
-        throw;
-    }
-    return g;
+    auto newCoords = fromCoords.clone();
+    return new Point(newCoords.release(), this);
 
 }
 
@@ -499,10 +491,10 @@ GeometryFactory::createLinearRing(CoordinateSequence::Ptr newCoords) const
 LinearRing*
 GeometryFactory::createLinearRing(const CoordinateSequence& fromCoords) const
 {
-    CoordinateSequence* newCoords = fromCoords.clone();
+    auto newCoords = fromCoords.clone();
     LinearRing* g = nullptr;
     // construction failure will delete newCoords
-    g = new LinearRing(newCoords, this);
+    g = new LinearRing(newCoords.release(), this);
     return g;
 }
 
@@ -668,10 +660,10 @@ LineString*
 GeometryFactory::createLineString(const CoordinateSequence& fromCoords)
 const
 {
-    CoordinateSequence* newCoords = fromCoords.clone();
+    auto newCoords = fromCoords.clone();
     LineString* g = nullptr;
     // construction failure will delete newCoords
-    g = new LineString(newCoords, this);
+    g = new LineString(newCoords.release(), this);
     return g;
 }
 

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -62,10 +62,10 @@ LineString::reverse() const
     }
 
     assert(points.get());
-    CoordinateSequence* seq = points->clone();
-    CoordinateSequence::reverse(seq);
+    auto seq = points->clone();
+    CoordinateSequence::reverse(seq.get());
     assert(getFactory());
-    return getFactory()->createLineString(seq);
+    return getFactory()->createLineString(seq.release());
 }
 
 
@@ -74,7 +74,7 @@ void
 LineString::validateConstruction()
 {
     if(points.get() == nullptr) {
-        points.reset(getFactory()->getCoordinateSequenceFactory()->create());
+        points = getFactory()->getCoordinateSequenceFactory()->create();
         return;
     }
 
@@ -109,7 +109,7 @@ LineString::~LineString()
     //delete points;
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 LineString::getCoordinates() const
 {
     assert(points.get());

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -109,7 +109,7 @@ LinearRing::getGeometryType() const
 }
 
 void
-LinearRing::setPoints(CoordinateSequence* cl)
+LinearRing::setPoints(const CoordinateSequence* cl)
 {
     const vector<Coordinate>* v = cl->toVector();
     points->setPoints(*(v));
@@ -130,10 +130,10 @@ LinearRing::reverse() const
     }
 
     assert(points.get());
-    CoordinateSequence* seq = points->clone();
-    CoordinateSequence::reverse(seq);
+    auto seq = points->clone();
+    CoordinateSequence::reverse(seq.get());
     assert(getFactory());
-    return getFactory()->createLinearRing(seq);
+    return getFactory()->createLinearRing(seq.release());
 }
 
 } // namespace geos::geom

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -49,7 +49,7 @@ Point::Point(CoordinateSequence* newCoords, const GeometryFactory* factory)
     coordinates(newCoords)
 {
     if(coordinates.get() == nullptr) {
-        coordinates.reset(factory->getCoordinateSequenceFactory()->create());
+        coordinates = factory->getCoordinateSequenceFactory()->create();
         return;
     }
     if(coordinates->getSize() != 1) {
@@ -65,7 +65,7 @@ Point::Point(const Point& p)
 {
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 Point::getCoordinates() const
 {
     return coordinates->clone();

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -98,7 +98,7 @@ Polygon::Polygon(LinearRing* newShell, vector<Geometry*>* newHoles,
     }
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 Polygon::getCoordinates() const
 {
     if(isEmpty()) {
@@ -331,16 +331,15 @@ Polygon::normalize(LinearRing* ring, bool clockwise)
     if(ring->isEmpty()) {
         return;
     }
-    CoordinateSequence* uniqueCoordinates = ring->getCoordinates();
+    auto uniqueCoordinates = ring->getCoordinates();
     uniqueCoordinates->deleteAt(uniqueCoordinates->getSize() - 1);
-    const Coordinate* minCoordinate = CoordinateSequence::minCoordinate(uniqueCoordinates);
-    CoordinateSequence::scroll(uniqueCoordinates, minCoordinate);
+    const Coordinate* minCoordinate = CoordinateSequence::minCoordinate(uniqueCoordinates.get());
+    CoordinateSequence::scroll(uniqueCoordinates.get(), minCoordinate);
     uniqueCoordinates->add(uniqueCoordinates->getAt(0));
-    if(algorithm::Orientation::isCCW(uniqueCoordinates) == clockwise) {
-        CoordinateSequence::reverse(uniqueCoordinates);
+    if(algorithm::Orientation::isCCW(uniqueCoordinates.get()) == clockwise) {
+        CoordinateSequence::reverse(uniqueCoordinates.get());
     }
-    ring->setPoints(uniqueCoordinates);
-    delete(uniqueCoordinates);
+    ring->setPoints(uniqueCoordinates.get());
 }
 
 const Coordinate*

--- a/src/geom/util/CoordinateOperation.cpp
+++ b/src/geom/util/CoordinateOperation.cpp
@@ -44,9 +44,8 @@ CoordinateOperation::edit(const Geometry* geometry,
         return factory->createLineString(newCoords);
     }
     if(typeid(*geometry) == typeid(Point)) {
-        CoordinateSequence* coords = geometry->getCoordinates();
-        CoordinateSequence* newCoords = edit(coords, geometry);
-        delete coords;
+        auto coords = geometry->getCoordinates();
+        CoordinateSequence* newCoords = edit(coords.get(), geometry);
         return factory->createPoint(newCoords);
     }
 

--- a/src/geomgraph/EdgeNodingValidator.cpp
+++ b/src/geomgraph/EdgeNodingValidator.cpp
@@ -37,9 +37,9 @@ EdgeNodingValidator::toSegmentStrings(vector<Edge*>& edges)
     // convert Edges to SegmentStrings
     for(size_t i = 0, n = edges.size(); i < n; ++i) {
         Edge* e = edges[i];
-        CoordinateSequence* cs = e->getCoordinates()->clone();
-        newCoordSeq.push_back(cs);
-        segStr.push_back(new BasicSegmentString(cs, e));
+        auto cs = e->getCoordinates()->clone();
+        segStr.push_back(new BasicSegmentString(cs.get(), e));
+        newCoordSeq.push_back(cs.release());
     }
     return segStr;
 }

--- a/src/geomgraph/EdgeRing.cpp
+++ b/src/geomgraph/EdgeRing.cpp
@@ -55,7 +55,7 @@ EdgeRing::EdgeRing(DirectedEdge* newStart,
     holes(),
     maxNodeDegree(-1),
     edges(),
-    pts(newGeometryFactory->getCoordinateSequenceFactory()->create()),
+    pts(newGeometryFactory->getCoordinateSequenceFactory()->create().release()),
     label(Location::UNDEF), // new Label(Location::UNDEF)),
     ring(nullptr),
     isHoleVar(false),
@@ -77,16 +77,7 @@ EdgeRing::~EdgeRing()
 {
     testInvariant();
 
-    /*
-     * If we constructed a ring, we did by transferring
-     * ownership of the CoordinateSequence, so it will be
-     * destroyed by `ring' dtor and we must not destroy
-     * it twice.
-     */
-    if(ring == nullptr) {
-        delete pts;
-    }
-    else {
+    if(ring != nullptr) {
         delete ring;
     }
 
@@ -200,7 +191,6 @@ EdgeRing::computeRing()
     isHoleVar = Orientation::isCCW(pts);
 
     testInvariant();
-
 }
 
 /*public*/

--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -290,8 +290,8 @@ WKBReader::readLineString()
 #if DEBUG_WKB_READER
     cout << "WKB npoints: " << size << endl;
 #endif
-    CoordinateSequence* pts = readCoordinateSequence(size);
-    return factory.createLineString(pts);
+    auto pts = readCoordinateSequence(size);
+    return factory.createLineString(pts.release());
 }
 
 LinearRing*
@@ -301,8 +301,8 @@ WKBReader::readLinearRing()
 #if DEBUG_WKB_READER
     cout << "WKB npoints: " << size << endl;
 #endif
-    CoordinateSequence* pts = readCoordinateSequence(size);
-    return factory.createLinearRing(pts);
+    auto pts = readCoordinateSequence(size);
+    return factory.createLinearRing(pts.release());
 }
 
 Polygon*
@@ -441,10 +441,10 @@ WKBReader::readGeometryCollection()
     return factory.createGeometryCollection(geoms);
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 WKBReader::readCoordinateSequence(int size)
 {
-    CoordinateSequence* seq = factory.getCoordinateSequenceFactory()->create(size, inputDimension);
+    auto seq = factory.getCoordinateSequenceFactory()->create(size, inputDimension);
     auto targetDim = seq->getDimension();
     if(targetDim > inputDimension) {
         targetDim = inputDimension;

--- a/src/linearref/ExtractLineByLocation.cpp
+++ b/src/linearref/ExtractLineByLocation.cpp
@@ -84,7 +84,7 @@ ExtractLineByLocation::reverse(const Geometry* linear)
 LineString*
 ExtractLineByLocation::computeLine(const LinearLocation& start, const LinearLocation& end)
 {
-    CoordinateSequence* coordinates = line->getCoordinates();
+    auto coordinates = line->getCoordinates();
     CoordinateArraySequence newCoordinateArray;
 
     const size_t indexStep = 1;

--- a/src/noding/GeometryNoder.cpp
+++ b/src/noding/GeometryNoder.cpp
@@ -58,9 +58,9 @@ public:
     {
         const geom::LineString* ls = dynamic_cast<const geom::LineString*>(g);
         if(ls) {
-            geom::CoordinateSequence* coord = ls->getCoordinates();
+            auto coord = ls->getCoordinates();
             // coord ownership transferred to SegmentString
-            SegmentString* ss = new NodedSegmentString(coord, nullptr);
+            SegmentString* ss = new NodedSegmentString(coord.release(), nullptr);
             _to.push_back(ss);
         }
     }
@@ -106,7 +106,7 @@ GeometryNoder::toGeometry(SegmentString::NonConstVect& nodedEdges)
         // Check if an equivalent edge is known
         OrientedCoordinateArray oca1(*coords);
         if(ocas.insert(oca1).second) {
-            geom::Geometry* tmp = geomFact->createLineString(coords->clone());
+            geom::Geometry* tmp = geomFact->createLineString(coords->clone().release());
             lines->push_back(tmp);
         }
     }

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -88,7 +88,7 @@ convertSegStrings(const GeometryFactory* fact, Iterator it, Iterator et)
     std::vector<Geometry*> lines;
     while(it != et) {
         const SegmentString* ss = *it;
-        LineString* line = fact->createLineString(ss->getCoordinates()->clone());
+        LineString* line = fact->createLineString(ss->getCoordinates()->clone().release());
         lines.push_back(line);
         ++it;
     }
@@ -213,7 +213,7 @@ BufferBuilder::bufferLineSingleSided(const Geometry* g, double distance,
         SegmentString* ss = (*nodedEdges)[i];
 
         Geometry* tmp = geomFact->createLineString(
-                            ss->getCoordinates()->clone()
+                            ss->getCoordinates()->clone().release()
                         );
         delete ss;
 

--- a/src/operation/buffer/OffsetCurveBuilder.cpp
+++ b/src/operation/buffer/OffsetCurveBuilder.cpp
@@ -178,7 +178,7 @@ OffsetCurveBuilder::getRingCurve(const CoordinateSequence* inputPts,
 
     // optimize creating ring for zero distance
     if(distance == 0.0) {
-        lineList.push_back(inputPts->clone());
+        lineList.push_back(inputPts->clone().release());
         return;
     }
 

--- a/src/operation/intersection/Rectangle.cpp
+++ b/src/operation/intersection/Rectangle.cpp
@@ -50,13 +50,13 @@ geom::LinearRing*
 Rectangle::toLinearRing(const geom::GeometryFactory& f) const
 {
     const geom::CoordinateSequenceFactory* csf = f.getCoordinateSequenceFactory();
-    geom::CoordinateSequence* seq = csf->create(5, 2);
+    auto seq = csf->create(5, 2);
     seq->setAt(geom::Coordinate(xMin, yMin), 0);
     seq->setAt(geom::Coordinate(xMin, yMax), 1);
     seq->setAt(geom::Coordinate(xMax, yMax), 2);
     seq->setAt(geom::Coordinate(xMax, yMin), 3);
     seq->setAt(seq->getAt(0), 4); // close
-    return f.createLinearRing(seq);
+    return f.createLinearRing(seq.release());
 }
 
 } // namespace geos::operation::intersection

--- a/src/operation/intersection/RectangleIntersection.cpp
+++ b/src/operation/intersection/RectangleIntersection.cpp
@@ -231,8 +231,8 @@ RectangleIntersection::clip_linestring_parts(const geom::LineString* gi,
                     std::vector<Coordinate>* coords = new std::vector<Coordinate>(2);
                     (*coords)[0] = Coordinate(x0, y0);
                     (*coords)[1] = Coordinate(x, y);
-                    CoordinateSequence* seq = _csf->create(coords);
-                    geom::LineString* line = _gf->createLineString(seq);
+                    auto seq = _csf->create(coords);
+                    geom::LineString* line = _gf->createLineString(seq.release());
                     parts.add(line);
                 }
 
@@ -302,8 +302,8 @@ RectangleIntersection::clip_linestring_parts(const geom::LineString* gi,
                             coords->push_back(Coordinate(x, y));
                         }
 
-                        CoordinateSequence* seq = _csf->create(coords);
-                        geom::LineString* line = _gf->createLineString(seq);
+                        auto seq = _csf->create(coords);
+                        geom::LineString* line = _gf->createLineString(seq.release());
                         parts.add(line);
                     }
                     // And continue main loop on the outside
@@ -323,8 +323,8 @@ RectangleIntersection::clip_linestring_parts(const geom::LineString* gi,
                             //line->addSubLineString(&g, start_index, i-1);
                             coords->insert(coords->end(), cs.begin() + start_index, cs.begin() + i);
 
-                            CoordinateSequence* seq = _csf->create(coords);
-                            geom::LineString* line = _gf->createLineString(seq);
+                            auto seq = _csf->create(coords);
+                            geom::LineString* line = _gf->createLineString(seq.release());
                             parts.add(line);
                         }
                         start_index = i;
@@ -356,8 +356,8 @@ RectangleIntersection::clip_linestring_parts(const geom::LineString* gi,
                 //line->addSubLineString(&g, start_index, i-1);
                 coords->insert(coords->end(), cs.begin() + start_index, cs.begin() + i);
 
-                CoordinateSequence* seq = _csf->create(coords);
-                geom::LineString* line = _gf->createLineString(seq);
+                auto seq = _csf->create(coords);
+                geom::LineString* line = _gf->createLineString(seq.release());
                 parts.add(line);
             }
 

--- a/src/operation/intersection/RectangleIntersectionBuilder.cpp
+++ b/src/operation/intersection/RectangleIntersectionBuilder.cpp
@@ -451,8 +451,8 @@ RectangleIntersectionBuilder::reconnectPolygons(const Rectangle& rect)
             if(best_distance < 0 || own_distance < best_distance) {
                 close_ring(rect, ring);
                 normalize_ring(*ring);
-                geom::CoordinateSequence* shell_cs = _csf.create(ring);
-                geom::LinearRing* shell = _gf.createLinearRing(shell_cs);
+                auto shell_cs = _csf.create(ring);
+                geom::LinearRing* shell = _gf.createLinearRing(shell_cs.release());
                 exterior.push_back(make_pair(shell, new LinearRingVect()));
                 ring = nullptr;
             }

--- a/src/operation/linemerge/EdgeString.cpp
+++ b/src/operation/linemerge/EdgeString.cpp
@@ -66,7 +66,7 @@ EdgeString::getCoordinates()
     if(coordinates == nullptr) {
         int forwardDirectedEdges = 0;
         int reverseDirectedEdges = 0;
-        coordinates = factory->getCoordinateSequenceFactory()->create();
+        coordinates = factory->getCoordinateSequenceFactory()->create().release();
         for(std::size_t i = 0, e = directedEdges.size(); i < e; ++i) {
             LineMergeDirectedEdge* directedEdge = directedEdges[i];
             if(directedEdge->getEdgeDirection()) {

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -241,9 +241,9 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
 LineString*
 LineSequencer::reverse(const LineString* line)
 {
-    CoordinateSequence* cs = line->getCoordinates();
-    CoordinateSequence::reverse(cs);
-    return line->getFactory()->createLineString(cs);
+    auto cs = line->getCoordinates();
+    CoordinateSequence::reverse(cs.get());
+    return line->getFactory()->createLineString(cs.release());
 }
 
 /*private static*/

--- a/src/operation/overlay/LineBuilder.cpp
+++ b/src/operation/overlay/LineBuilder.cpp
@@ -192,11 +192,11 @@ LineBuilder::buildLines(OverlayOp::OpCode /* opCode */)
 {
     for(size_t i = 0, s = lineEdgesList.size(); i < s; ++i) {
         Edge* e = lineEdgesList[i];
-        CoordinateSequence* cs = e->getCoordinates()->clone();
+        auto cs = e->getCoordinates()->clone();
 #if COMPUTE_Z
-        propagateZ(cs);
+        propagateZ(cs.get());
 #endif
-        LineString* line = geometryFactory->createLineString(cs);
+        LineString* line = geometryFactory->createLineString(cs.release());
         resultLineList->push_back(line);
         e->setInResult(true);
     }

--- a/src/operation/polygonize/EdgeRing.cpp
+++ b/src/operation/polygonize/EdgeRing.cpp
@@ -221,7 +221,7 @@ const CoordinateSequence*
 EdgeRing::getCoordinates()
 {
     if(ringPts == nullptr) {
-        ringPts.reset(factory->getCoordinateSequenceFactory()->create());
+        ringPts = factory->getCoordinateSequenceFactory()->create();
         for(const auto& de : deList) {
             auto edge = dynamic_cast<PolygonizeEdge*>(de->getEdge());
             addEdge(edge->getLine()->getCoordinatesRO(),

--- a/src/operation/valid/RepeatedPointTester.cpp
+++ b/src/operation/valid/RepeatedPointTester.cpp
@@ -97,12 +97,12 @@ RepeatedPointTester::hasRepeatedPoint(const CoordinateSequence* coord)
 bool
 RepeatedPointTester::hasRepeatedPoint(const Polygon* p)
 {
-    if(hasRepeatedPoint(p->getExteriorRing()->getCoordinates())) {
+    if(hasRepeatedPoint(p->getExteriorRing()->getCoordinatesRO())) {
         return true;
     }
 
     for(size_t i = 0, n = p->getNumInteriorRing(); i < n; ++i) {
-        if(hasRepeatedPoint(p->getInteriorRingN(i)->getCoordinates())) {
+        if(hasRepeatedPoint(p->getInteriorRingN(i)->getCoordinatesRO())) {
             return true;
         }
     }

--- a/src/operation/valid/SimpleNestedRingTester.cpp
+++ b/src/operation/valid/SimpleNestedRingTester.cpp
@@ -37,10 +37,10 @@ SimpleNestedRingTester::isNonNested()
 {
     for(size_t i = 0, ni = rings.size(); i < ni; i++) {
         LinearRing* innerRing = rings[i];
-        CoordinateSequence* innerRingPts = innerRing->getCoordinates();
+        const CoordinateSequence* innerRingPts = innerRing->getCoordinatesRO();
         for(size_t j = 0, nj = rings.size(); j < nj; j++) {
             LinearRing* searchRing = rings[j];
-            CoordinateSequence* searchRingPts = searchRing->getCoordinates();
+            const CoordinateSequence* searchRingPts = searchRing->getCoordinatesRO();
             if(innerRing == searchRing) {
                 continue;
             }

--- a/src/operation/valid/SweeplineNestedRingTester.cpp
+++ b/src/operation/valid/SweeplineNestedRingTester.cpp
@@ -78,8 +78,8 @@ SweeplineNestedRingTester::buildIndex()
 bool
 SweeplineNestedRingTester::isInside(LinearRing* innerRing, LinearRing* searchRing)
 {
-    CoordinateSequence* innerRingPts = innerRing->getCoordinates();
-    CoordinateSequence* searchRingPts = searchRing->getCoordinates();
+    const CoordinateSequence* innerRingPts = innerRing->getCoordinatesRO();
+    const CoordinateSequence* searchRingPts = searchRing->getCoordinatesRO();
 
     if(!innerRing->getEnvelopeInternal()->intersects(searchRing->getEnvelopeInternal())) {
         return false;

--- a/src/precision/MinimumClearance.cpp
+++ b/src/precision/MinimumClearance.cpp
@@ -51,7 +51,7 @@ MinimumClearance::getLine()
         return std::unique_ptr<LineString>(inputGeom->getFactory()->createLineString());
     }
 
-    return std::unique_ptr<LineString>(inputGeom->getFactory()->createLineString(minClearancePts->clone()));
+    return std::unique_ptr<LineString>(inputGeom->getFactory()->createLineString(minClearancePts->clone().release()));
 }
 
 void

--- a/src/precision/PrecisionReducerCoordinateOperation.cpp
+++ b/src/precision/PrecisionReducerCoordinateOperation.cpp
@@ -55,7 +55,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // reducedCoords take ownership of 'vc'
     CoordinateSequence* reducedCoords =
-        geom->getFactory()->getCoordinateSequenceFactory()->create(vc);
+        geom->getFactory()->getCoordinateSequenceFactory()->create(vc).release();
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.

--- a/src/precision/SimpleGeometryPrecisionReducer.cpp
+++ b/src/precision/SimpleGeometryPrecisionReducer.cpp
@@ -86,7 +86,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // reducedCoords take ownership of 'vc'
     CoordinateSequence* reducedCoords =
-        geom->getFactory()->getCoordinateSequenceFactory()->create(vc);
+        geom->getFactory()->getCoordinateSequenceFactory()->create(vc).release();
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -401,13 +401,13 @@ public:
     void
     visit(QuadEdge* triEdges[3]) override
     {
-        geom::CoordinateSequence* coordSeq = coordSeqFact.create(4, 0);
+        auto coordSeq = coordSeqFact.create(4, 0);
         for(int i = 0; i < 3; i++) {
             Vertex v = triEdges[i]->orig();
             coordSeq->setAt(v.getCoordinate(), i);
         }
         coordSeq->setAt(triEdges[0]->orig().getCoordinate(), 3);
-        triCoords->push_back(coordSeq);
+        triCoords->push_back(coordSeq.release());
     }
 };
 
@@ -470,14 +470,12 @@ QuadEdgeSubdivision::getEdges(const geom::GeometryFactory& geomFact)
     int i = 0;
     for(QuadEdgeSubdivision::QuadEdgeList::iterator it = p_quadEdges->begin(); it != p_quadEdges->end(); ++it) {
         QuadEdge* qe = *it;
-        CoordinateSequence* coordSeq = coordSeqFact->create((std::vector<geom::Coordinate>*)nullptr);;
+        auto coordSeq = coordSeqFact->create((std::vector<geom::Coordinate>*)nullptr);;
 
         coordSeq->add(qe->orig().getCoordinate());
         coordSeq->add(qe->dest().getCoordinate());
 
-        edges[i++] = static_cast<Geometry*>(geomFact.createLineString(*coordSeq));
-
-        delete coordSeq;
+        edges[i++] = static_cast<Geometry*>(geomFact.createLineString(coordSeq.release()));
     }
 
     geom::MultiLineString* result = geomFact.createMultiLineString(edges);

--- a/src/util/GeometricShapeFactory.cpp
+++ b/src/util/GeometricShapeFactory.cpp
@@ -20,6 +20,7 @@
 #include <geos/constants.h>
 #include <geos/util/GeometricShapeFactory.h>
 #include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/PrecisionModel.h>
@@ -117,8 +118,8 @@ GeometricShapeFactory::createRectangle()
         (*vc)[ipt++] = coord(x, y);
     }
     (*vc)[ipt++] = (*vc)[0];
-    CoordinateSequence* cs = geomFact->getCoordinateSequenceFactory()->create(vc);
-    LinearRing* ring = geomFact->createLinearRing(cs);
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(vc);
+    LinearRing* ring = geomFact->createLinearRing(cs.release());
     Polygon* poly = geomFact->createPolygon(ring, nullptr);
     return poly;
 }
@@ -143,8 +144,8 @@ GeometricShapeFactory::createCircle()
         (*pts)[iPt++] = coord(x, y);
     }
     (*pts)[iPt++] = (*pts)[0];
-    CoordinateSequence* cs = geomFact->getCoordinateSequenceFactory()->create(pts);
-    LinearRing* ring = geomFact->createLinearRing(cs);
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(pts);
+    LinearRing* ring = geomFact->createLinearRing(cs.release());
     Polygon* poly = geomFact->createPolygon(ring, nullptr);
     return poly;
 }
@@ -174,8 +175,8 @@ GeometricShapeFactory::createArc(double startAng, double angExtent)
         double y = yRadius * sin(ang) + centreY;
         (*pts)[iPt++] = coord(x, y);
     }
-    CoordinateSequence* cs = geomFact->getCoordinateSequenceFactory()->create(pts);
-    LineString* line = geomFact->createLineString(cs);
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(pts);
+    LineString* line = geomFact->createLineString(cs.release());
     return line;
 }
 
@@ -207,8 +208,8 @@ GeometricShapeFactory::createArcPolygon(double startAng, double angExtent)
     }
     (*pts)[iPt++] = coord(centreX, centreY);
 
-    CoordinateSequence* cs = geomFact->getCoordinateSequenceFactory()->create(pts);
-    LinearRing* ring = geomFact->createLinearRing(cs);
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(pts);
+    LinearRing* ring = geomFact->createLinearRing(cs.release());
     Polygon* geom = geomFact->createPolygon(ring, nullptr);
     return geom;
 }

--- a/tests/unit/algorithm/CGAlgorithms/isCCWTest.cpp
+++ b/tests/unit/algorithm/CGAlgorithms/isCCWTest.cpp
@@ -28,7 +28,7 @@ namespace tut {
 struct test_isccw_data {
     typedef std::unique_ptr<geos::geom::Geometry> GeometryPtr;
 
-    geos::geom::CoordinateSequence* cs_;
+    std::unique_ptr<geos::geom::CoordinateSequence> cs_;
     geos::io::WKTReader reader_;
     geos::io::WKBReader breader_;
 
@@ -40,8 +40,6 @@ struct test_isccw_data {
 
     ~test_isccw_data()
     {
-        delete cs_;
-        cs_ = nullptr;
     }
 };
 
@@ -64,7 +62,7 @@ void object::test<1>
     GeometryPtr geom(reader_.read(wkt));
 
     cs_ = geom->getCoordinates();
-    bool isCCW = Orientation::isCCW(cs_);
+    bool isCCW = Orientation::isCCW(cs_.get());
 
     ensure_equals(false, isCCW);
 }
@@ -79,7 +77,7 @@ void object::test<2>
     GeometryPtr geom(reader_.read(wkt));
 
     cs_ = geom->getCoordinates();
-    bool isCCW = Orientation::isCCW(cs_);
+    bool isCCW = Orientation::isCCW(cs_.get());
 
     ensure_equals(true, isCCW);
 }
@@ -94,7 +92,7 @@ void object::test<3>
     GeometryPtr geom(reader_.read(wkt));
 
     cs_ = geom->getCoordinates();
-    bool isCCW = Orientation::isCCW(cs_);
+    bool isCCW = Orientation::isCCW(cs_.get());
 
     ensure_equals(true, isCCW);
 }
@@ -111,7 +109,7 @@ void object::test<4>
     wkt("0102000000040000000000000000000000841D588465963540F56BFB214F0341408F26B714B2971B40F66BFB214F0341408C26B714B2971B400000000000000000841D588465963540");
     GeometryPtr geom(breader_.readHEX(wkt));
     cs_ = geom->getCoordinates();
-    bool isCCW = Orientation::isCCW(cs_);
+    bool isCCW = Orientation::isCCW(cs_.get());
     ensure_equals(isCCW, true);
 }
 
@@ -127,7 +125,7 @@ void object::test<5>
     wkt("0102000000040000000000000000000000841D588465963540F56BFB214F0341408F26B714B2971B40F66BFB214F0341408E26B714B2971B400000000000000000841D588465963540");
     GeometryPtr geom(breader_.readHEX(wkt));
     cs_ = geom->getCoordinates();
-    bool isCCW = Orientation::isCCW(cs_);
+    bool isCCW = Orientation::isCCW(cs_.get());
     ensure_equals(isCCW, true);
 }
 

--- a/tests/unit/algorithm/CGAlgorithms/isPointInRingTest.cpp
+++ b/tests/unit/algorithm/CGAlgorithms/isPointInRingTest.cpp
@@ -24,7 +24,7 @@ namespace tut {
 struct test_ispointinring_data {
     typedef std::unique_ptr<geos::geom::Geometry> GeomPtr;
 
-    geos::geom::CoordinateSequence* cs_;
+    std::unique_ptr<geos::geom::CoordinateSequence> cs_;
     geos::io::WKTReader reader_;
 
     test_ispointinring_data()
@@ -35,8 +35,6 @@ struct test_ispointinring_data {
 
     ~test_ispointinring_data()
     {
-        delete cs_;
-        cs_ = nullptr;
     }
 };
 
@@ -61,7 +59,7 @@ void object::test<1>
     geos::geom::Coordinate pt(10, 10);
 
     cs_ = geom->getCoordinates();
-    bool isInRing = PointLocation::isInRing(pt, cs_);
+    bool isInRing = PointLocation::isInRing(pt, cs_.get());
 
     ensure_equals(true, isInRing);
 }
@@ -80,7 +78,7 @@ void object::test<2>
     geos::geom::Coordinate pt(0, 0);
 
     cs_ = geom->getCoordinates();
-    bool isInRing = PointLocation::isInRing(pt, cs_);
+    bool isInRing = PointLocation::isInRing(pt, cs_.get());
 
     ensure_equals(true, isInRing);
 }

--- a/tests/unit/algorithm/CGAlgorithms/signedAreaTest.cpp
+++ b/tests/unit/algorithm/CGAlgorithms/signedAreaTest.cpp
@@ -27,7 +27,7 @@ namespace tut {
 struct test_signedarea_data {
     typedef std::unique_ptr<geos::geom::Geometry> GeometryPtr;
 
-    geos::geom::CoordinateSequence* cs_;
+    std::unique_ptr<geos::geom::CoordinateSequence> cs_;
     geos::io::WKTReader reader_;
     geos::io::WKBReader breader_;
 
@@ -39,8 +39,6 @@ struct test_signedarea_data {
 
     ~test_signedarea_data()
     {
-        delete cs_;
-        cs_ = nullptr;
     }
 };
 
@@ -63,7 +61,7 @@ void object::test<1>
     GeometryPtr geom(reader_.read(wkt));
 
     cs_ = geom->getCoordinates();
-    double area = Area::ofRingSigned(cs_);
+    double area = Area::ofRingSigned(cs_.get());
 
     ensure_equals(area, 8400);
 }
@@ -78,7 +76,7 @@ void object::test<2>
     GeometryPtr geom(reader_.read(wkt));
 
     cs_ = geom->getCoordinates();
-    double area = Area::ofRingSigned(cs_);
+    double area = Area::ofRingSigned(cs_.get());
 
     ensure_equals(area, -2400);
 }
@@ -93,7 +91,7 @@ void object::test<3>
     GeometryPtr geom(reader_.read(wkt));
 
     cs_ = geom->getCoordinates();
-    double area = Area::ofRingSigned(cs_);
+    double area = Area::ofRingSigned(cs_.get());
 
     ensure_equals(area, -2400);
 }

--- a/tests/unit/geom/CoordinateArraySequenceFactoryTest.cpp
+++ b/tests/unit/geom/CoordinateArraySequenceFactoryTest.cpp
@@ -78,14 +78,11 @@ void object::test<2>
         ensure(nullptr != col);
 
         const size_t size0 = 0;
-        CoordinateSequencePtr sequence = factory->create(col);
+        auto sequence = factory->create(col);
 
         ensure(nullptr != sequence);
         ensure(sequence->isEmpty());
         ensure_equals(sequence->size(), size0);
-
-        // FREE MEMORY
-        delete sequence;
     }
     catch(std::exception& e) {
         fail(e.what());
@@ -112,15 +109,12 @@ void object::test<3>
         col->push_back(Coordinate(5, 10, 15));
 
         const size_t size2 = 2;
-        CoordinateSequencePtr sequence = factory->create(col);
+        auto sequence = factory->create(col);
 
         ensure(nullptr != sequence);
         ensure(!sequence->isEmpty());
         ensure_equals(sequence->size(), size2);
         ensure(sequence->getAt(0) != sequence->getAt(1));
-
-        // FREE MEMORY
-        delete sequence;
     }
     catch(std::exception& e) {
         fail(e.what());
@@ -141,7 +135,7 @@ void object::test<4>
         ensure(nullptr != factory);
 
         const size_t size1000 = 1000;
-        CoordinateSequencePtr sequence = factory->create(size1000, 3);
+        auto sequence = factory->create(size1000, 3);
 
         ensure(nullptr != sequence);
         ensure(!sequence->isEmpty());
@@ -149,9 +143,6 @@ void object::test<4>
         ensure(sequence->hasRepeatedPoints());
         ensure_equals(sequence->getAt(0), sequence->getAt(size1000 - 1));
         ensure_equals(sequence->getAt(0), sequence->getAt(size1000 / 2));
-
-        // FREE MEMORY
-        delete sequence;
     }
     catch(std::exception& e) {
         fail(e.what());
@@ -172,14 +163,11 @@ void object::test<5>
         ensure(nullptr != factory);
 
         const size_t size0 = 0;
-        CoordinateSequencePtr sequence = factory->create();
+        auto sequence = factory->create();
 
         ensure(nullptr != sequence);
         ensure(sequence->isEmpty());
         ensure_equals(sequence->size(), size0);
-
-        // FREE MEMORY
-        delete sequence;
     }
     catch(std::exception& e) {
         fail(e.what());

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -399,13 +399,10 @@ void object::test<26>
     ensure(poly_ != nullptr);
 
     // Caller takes ownership of 'coords'
-    CoordSeqPtr coords = poly_->getCoordinates();
+    auto coords = poly_->getCoordinates();
     ensure(coords != nullptr);
     ensure(!coords->isEmpty());
     ensure_equals(coords->getSize(), poly_->getNumPoints());
-
-    // FREE MEMORY
-    delete coords;
 }
 
 // Test of clone() and equals() for non-empty Polygon
@@ -497,7 +494,7 @@ void object::test<32>
     ensure(poly_ != nullptr);
     // "POLYGON((0 10, 5 5, 10 5, 15 10, 10 15, 5 15, 0 10))"
 
-    CoordSeqPtr coords = poly_->getCoordinates();
+    auto coords = poly_->getCoordinates();
     ensure(coords != nullptr);
     ensure_equals(coords->getSize(), poly_size_);
 
@@ -509,9 +506,6 @@ void object::test<32>
     const int middlePos = 3;
     ensure_equals(coords->getAt(middlePos).x, 15);
     ensure_equals(coords->getAt(middlePos).y, 10);
-
-    // FREE MEMORY
-    delete coords;
 }
 
 // Test of getGeometryType() for non-empty Polygon

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -58,12 +58,11 @@ void object::test<1>
 ()
 {
     GeomPtr geom(wktreader.read("POINT(-117 33)"));
-    geos::geom::CoordinateSequence* coords = geom->getCoordinates();
+    auto coords = geom->getCoordinates();
 
     ensure(coords->getDimension() == 2);
     ensure(coords->getX(0) == -117);
     ensure(coords->getY(0) == 33);
-    delete coords;
 }
 
 // 2 - Read a point, confirm 3D.
@@ -73,11 +72,10 @@ void object::test<2>
 ()
 {
     GeomPtr geom(wktreader.read("POINT(-117 33 10)"));
-    geos::geom::CoordinateSequence* coords = geom->getCoordinates();
+    auto coords = geom->getCoordinates();
 
     ensure(coords->getDimension() == 3);
     ensure(coords->getOrdinate(0, geos::geom::CoordinateSequence::Z) == 10.0);
-    delete coords;
 }
 
 // 3 - Linestring dimension preserved.
@@ -87,11 +85,9 @@ void object::test<3>
 ()
 {
     GeomPtr geom(wktreader.read("LINESTRING(-117 33, -116 34)"));
-    geos::geom::CoordinateSequence* coords = geom->getCoordinates();
+    auto coords = geom->getCoordinates();
 
     ensure(coords->getDimension() == 2);
-
-    delete coords;
 }
 
 // 4 - Ensure we can read ZM geometries, just discarding the M.
@@ -101,14 +97,12 @@ void object::test<4>
 ()
 {
     GeomPtr geom(wktreader.read("LINESTRING ZM (-117 33 2 3, -116 34 4 5)"));
-    geos::geom::CoordinateSequence* coords = geom->getCoordinates();
+    auto coords = geom->getCoordinates();
 
     ensure(coords->getDimension() == 3);
 
     ensure_equals(wktwriter.write(geom.get()),
                   std::string("LINESTRING Z (-117 33 2, -116 34 4)"));
-
-    delete coords;
 }
 
 // 5 - Check support for mixed case keywords (and old style 3D)
@@ -161,11 +155,10 @@ void object::test<7>
         const std::string str = " POINT (0 0) ";
         geom.reset(wktReader.read(str)); //HERE IT FAILS
 
-        geos::geom::CoordinateSequence* coords = geom->getCoordinates();
+        auto coords = geom->getCoordinates();
         ensure_equals(coords->getDimension(), 2U);
         ensure_distance(coords->getX(0), 0.0, 1e-12);
         ensure_distance(coords->getY(0), 0.0, 1e-12);
-        delete coords;
     }
     catch(const geos::util::IllegalArgumentException& ex) {
         ensure("Did get expected exception");

--- a/tests/unit/util/UniqueCoordinateArrayFilterTest.cpp
+++ b/tests/unit/util/UniqueCoordinateArrayFilterTest.cpp
@@ -60,7 +60,7 @@ void object::test<1>
 
     ensure_equals(geo->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT);
     std::unique_ptr<geos::geom::CoordinateSequence> cs;
-    cs.reset(geo->getCoordinates());
+    cs = geo->getCoordinates();
     ensure_equals(cs->getSize(), size5);
 
     // Create collection buffer for filtered coordinates
@@ -76,7 +76,7 @@ void object::test<1>
     const Coordinate::ConstVect::size_type size3 = 3;
     geo->apply_ro(&filter);
 
-    cs.reset(geo->getCoordinates());
+    cs = geo->getCoordinates();
     ensure_equals(cs->getSize(), size5);
     ensure_equals(coords.size(), size3);
     ensure_equals(coords.at(0)->x, 10);


### PR DESCRIPTION
This incrementally chips away at the long-term goal of using managed
pointers throughout GEOS, while also working to solidify the
CoordinateSequence interface before building additional implementations.