### PR TITLE
Add Azure Pipelines configuration for CI builds using CMake

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,292 @@
+# Azure Pipelines for GEOS
+# All builds are based on the CMake configuration.
+#
+# Author: Mateusz Loskot <mateusz at loskot dot net>
+
+# trigger:
+#   branches:
+#     include:
+#     - master
+#     - bugfix/*
+#     - feature/*
+#     - fix/*
+#     - pr/*
+
+pr:
+  branches:
+    include:
+    - master
+
+variables:
+  - name: BUILD_TYPE
+    value: Release
+
+stages:
+
+- stage: Test
+  jobs:
+
+  - job: 'Linux'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    strategy:
+      matrix:
+        GCC 8:
+          CXXSTD: 11, 14, 17, 20
+          CXX: g++-8
+          PACKAGES: g++-8
+        GCC 7:
+          CXXSTD: 11, 14, 17
+          CXX: g++-7
+          PACKAGES: g++-7
+        GCC 6:
+          CXXSTD: 11, 14
+          CXX: g++-6
+          PACKAGES: g++-6
+        GCC 5:
+          CXXSTD: 11
+          CXX: g++-5
+          PACKAGES: g++-5
+        GCC 4.9:
+          CXXSTD: 11
+          CXX: g++-4.9
+          PACKAGES: g++-4.9
+        GCC 4.8:
+          CXXSTD: 11
+          CXX: g++-4.8
+          PACKAGES: g++-4.8
+        Clang 8:
+          CXXSTD: 11, 14, 17, 20
+          CXX: clang++-8
+          PACKAGES: clang-8
+          LLVM_REPO: llvm-toolchain-xenial-8
+        Clang 7:
+          CXXSTD: 14, 17, 20
+          CXX: clang++-7
+          PACKAGES: clang-7
+          LLVM_REPO: llvm-toolchain-xenial-7
+        Clang 6:
+          CXXSTD: 14, 17, 20
+          CXX: clang++-6.0
+          PACKAGES: clang-6.0
+          LLVM_REPO: llvm-toolchain-xenial-6.0
+        Clang 5:
+          CXXSTD: 11, 14, 17
+          PACKAGES: clang-5.0
+          CXX: clang++-5.0
+          LLVM_REPO: llvm-toolchain-xenial-5.0
+        Clang 4:
+          CXXSTD: 11, 14
+          CXX: clang++-4.0
+          PACKAGES: clang-4.0
+          LLVM_REPO: llvm-toolchain-xenial-4.0
+        Clang 3.9:
+          CXXSTD: 11, 14
+          CXX: clang++-3.9
+          PACKAGES: clang-3.9
+        Clang 3.8:
+          CXX: clang++-3.8
+          CXXSTD: 11, 14
+          PACKAGES: clang-3.8
+        Clang 3.7:
+          CXXSTD: 11
+          CXX: clang++-3.7
+          PACKAGES: clang-3.7
+        Clang 3.6:
+          CXXSTD: 11
+          CXX: clang++-3.6
+          PACKAGES: clang-3.6
+        Clang 3.5:
+          CXXSTD: 11
+          CXX: clang++-3.5
+          PACKAGES: clang-3.5
+    steps:
+    - script: |
+        set -e
+        uname -a
+        sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+        if test -n "${LLVM_REPO}" ; then
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo -E apt-add-repository "deb http://apt.llvm.org/xenial/ ${LLVM_REPO} main"
+        fi
+        sudo -E apt-get update
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends install cmake ${PACKAGES}
+      displayName: 'Install'
+    - script: |
+        set -e
+        mkdir build.cxx11
+        cd build.cxx11
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++11'
+      condition: contains(variables['CXXSTD'], '11')
+    - script: |
+        set -e
+        mkdir build.cxx14
+        cd build.cxx14
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++14'
+      condition: contains(variables['CXXSTD'], '14')
+    - script: |
+        set -e
+        mkdir build.cxx17
+        cd build.cxx17
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++17'
+      condition: contains(variables['CXXSTD'], '17')
+    - script: |
+        set -e
+        mkdir build.cxx20
+        cd build.cxx20
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++20'
+      condition: contains(variables['CXXSTD'], '20')
+
+  - job: 'Windows'
+    strategy:
+      matrix:
+        VS 2019 C++20 Strict:
+          TOOLSET: msvc-14.2
+          CXXSTD: 20
+          CXXFLAGS: -permissive-
+          VM_IMAGE: 'windows-2019'
+        VS 2017 C++20 Strict:
+          TOOLSET: msvc-14.1
+          CXXSTD: 20
+          CXXFLAGS: -permissive-
+          VM_IMAGE: 'vs2017-win2016'
+        VS 2017 C++17:
+          TOOLSET: msvc-14.1
+          CXXSTD: 17
+          VM_IMAGE: 'vs2017-win2016'
+        VS 2017 C++14:
+          TOOLSET: msvc-14.1
+          CXXSTD: 14 # default
+          VM_IMAGE: 'vs2017-win2016'
+        VS 2015 C++14:
+          TOOLSET: msvc-14.0
+          CXXSTD: 14 # default
+          VM_IMAGE: 'vs2015-win2012r2'
+    pool:
+      vmImage: $(VM_IMAGE)
+    steps:
+    - powershell: |
+        Write-Host "Installing CMake 3.14.4"
+        Invoke-WebRequest https://cmake.org/files/v3.14/cmake-3.14.4-win64-x64.zip -OutFile C:\cmake-3.14.4-win64-x64.zip
+        Expand-Archive C:\cmake-3.14.4-win64-x64.zip -DestinationPath C:\
+        Rename-Item -Path C:\cmake-3.14.4-win64-x64 -NewName C:\cmake
+        Write-Host "##vso[task.prependpath]C:\cmake\bin"
+      displayName: 'Install'
+    - script: |
+        mkdir build.cxx%CXXSTD%
+        cd build.cxx%CXXSTD%
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=%CXXSTD% -DBUILD_SHARED_LIBS=OFF ..
+      displayName: 'CMake'
+    - script: |
+        cd build.cxx%CXXSTD%
+        cmake --build . --config %BUILD_TYPE%
+      displayName: 'Build'
+    - script: |
+        cd build.cxx%CXXSTD%
+        ctest -V --output-on-failure -C %BUILD_TYPE%
+      displayName: 'Test'
+
+  - job: 'macOS'
+    pool:
+      vmImage: 'macOS-10.13'
+    strategy:
+      matrix:
+        Xcode 10.1:
+          TOOLSET: clang
+          CXXSTD: 14, 17, 20
+          XCODE_APP: /Applications/Xcode_10.1.app
+        Xcode 10.0:
+          CXXSTD: 14, 17, 20
+          XCODE_APP: /Applications/Xcode_10.app
+        Xcode 9.4.1:
+          CXXSTD: 11, 14, 17
+          XCODE_APP: /Applications/Xcode_9.4.1.app
+        Xcode 9.4:
+          CXXSTD: 11, 14, 17
+          XCODE_APP: /Applications/Xcode_9.4.app
+        Xcode 9.3.1:
+          CXXSTD: 11, 14, 17
+          XCODE_APP: /Applications/Xcode_9.3.1.app
+        Xcode 9.3:
+          CXXSTD: 11, 14
+          XCODE_APP: /Applications/Xcode_9.3.app
+        Xcode 9.2:
+          CXXSTD: 11, 14
+          XCODE_APP: /Applications/Xcode_9.2.app
+        Xcode 9.1:
+          CXXSTD: 11
+          XCODE_APP: /Applications/Xcode_9.1.app
+        Xcode 9.0.1:
+          CXXSTD: 11
+          XCODE_APP: /Applications/Xcode_9.0.1.app
+        Xcode 9.0:
+          CXXSTD: 11
+          XCODE_APP: /Applications/Xcode_9.app
+        Xcode 8.3.3:
+          CXXSTD: 11
+          XCODE_APP: /Applications/Xcode_8.3.3.app
+    steps:
+    - script: |
+        set -e
+        uname -a
+        sudo xcode-select -switch ${XCODE_APP}
+        which clang++
+        clang++ --version
+      displayName: Install
+    - script: |
+        set -e
+        mkdir build.cxx11
+        cd build.cxx11
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++11'
+      condition: contains(variables['CXXSTD'], '11')
+    - script: |
+        set -e
+        mkdir build.cxx14
+        cd build.cxx14
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++14'
+      condition: contains(variables['CXXSTD'], '14')
+    - script: |
+        set -e
+        mkdir build.cxx17
+        cd build.cxx17
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++17'
+      condition: contains(variables['CXXSTD'], '17')
+    - script: |
+        set -e
+        mkdir build.cxx20
+        cd build.cxx20
+        cmake --version
+        cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake --build . --config $BUILD_TYPE
+        ctest -V --output-on-failure -C $BUILD_TYPE
+      displayName: 'Build C++20'
+      condition: contains(variables['CXXSTD'], '20')


### PR DESCRIPTION
This AzP provides comprehensive setup for CI builds:
- on Linux, MacOS, Windows
- compiling with
    - clang 3.5 - 8
    - GCC 4.9 - 8
    - Visual Studio 2017, 2015, 2019
    - Xcode 8.3.3 to 10.1
- targeting C++ standard versions: 11, 14, 17, 20 (2a)
- configuring with CMake 3.12.4 (Linux), 3.14.3 (MacOS), 3.14.4 (Windows)
- with CMAKE_BUILD_TYPE=Release

This configuration allows any contributor to set up CI pipelines with AzP at `https://dev.azure.com/<owner>/geos` and build directly from GitHub upstream (libgeos/geos) or own fork in order to test own topic branches as well the master.

-----

/cc @dbaston 

Sample build matrix available at https://dev.azure.com/mloskot/geos/_build/