### PR TITLE
Remove CoordinateSequence::toVector()

### DIFF
--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -52,9 +52,6 @@ public:
     //int size() const;
     size_t getSize() const override;
 
-    // @deprecated
-    const std::vector<Coordinate>* toVector() const override;
-
     // See dox in CoordinateSequence.h
     void toVector(std::vector<Coordinate>&) const override;
 

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -120,30 +120,8 @@ public:
         return getSize();
     }
 
-    /** \brief
-     * Returns a read-only vector with the Coordinates in this collection.
-     *
-     * Whether or not the Coordinates returned are the actual underlying
-     * Coordinates or merely copies depends on the implementation.
-     * Note that if this implementation does not store its data as an
-     * array of Coordinates, this method will incur a performance penalty
-     * because the array needs to be built from scratch.
-     *
-     * This method is a port of the toCoordinateArray() method of JTS.
-     * It is not much used as memory management requires us to
-     * know whether we should or not delete the returned object
-     * in a consistent way. Our options are: use shared_ptr<Coordinate>
-     * or always keep ownership of an eventual newly created vector.
-     * We opted for the second, so the returned object is a const, to
-     * also ensure that returning an internal pointer doesn't make
-     * the object mutable.
-     *
-     * @deprecated use toVector(std::vector<Coordinate>&) instead
-     */
-    virtual	const std::vector<Coordinate>* toVector() const = 0;
-
-    /// Pushes all Coordinates of this sequence onto the provided vector.
-    //
+    /// Pushes all Coordinates of this sequence into the provided vector.
+    ///
     /// This method is a port of the toCoordinateArray() method of JTS.
     ///
     virtual	void toVector(std::vector<Coordinate>& coords) const = 0;
@@ -206,7 +184,7 @@ public:
     /// Delete Coordinate at position pos (list will shrink).
     virtual	void deleteAt(std::size_t pos) = 0;
 
-    /// Get a string rapresentation of CoordinateSequence
+    /// Get a string representation of CoordinateSequence
     virtual	std::string toString() const = 0;
 
     /// Substitute Coordinate list with a copy of the given vector

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -85,12 +85,6 @@ CoordinateArraySequence::setPoints(const vector<Coordinate>& v)
     vect->assign(v.begin(), v.end());
 }
 
-const vector<Coordinate>*
-CoordinateArraySequence::toVector() const
-{
-    return vect; //new vector<Coordinate>(vect->begin(),vect->end());
-}
-
 std::size_t
 CoordinateArraySequence::getDimension() const
 {

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -111,9 +111,7 @@ LinearRing::getGeometryType() const
 void
 LinearRing::setPoints(const CoordinateSequence* cl)
 {
-    const vector<Coordinate>* v = cl->toVector();
-    points->setPoints(*(v));
-    //delete v;
+    points = cl->clone();
 }
 
 GeometryTypeId

--- a/src/operation/overlay/snap/GeometrySnapper.cpp
+++ b/src/operation/overlay/snap/GeometrySnapper.cpp
@@ -59,8 +59,9 @@ private:
         using std::unique_ptr;
 
         assert(srcPts);
-        assert(srcPts->toVector());
-        LineStringSnapper snapper(*(srcPts->toVector()), snapTol);
+        std::vector<Coordinate> coords;
+        srcPts->toVector(coords);
+        LineStringSnapper snapper(coords, snapTol);
         unique_ptr<Coordinate::Vect> newPts = snapper.snapTo(snapPts);
 
         const CoordinateSequenceFactory* cfact = factory->getCoordinateSequenceFactory();

--- a/src/operation/overlay/validate/OverlayResultValidator.cpp
+++ b/src/operation/overlay/validate/OverlayResultValidator.cpp
@@ -146,8 +146,11 @@ OverlayResultValidator::addVertices(const Geometry& g)
     // TODO: optimize this by not copying coordinates
     //       and pre-allocating memory
     unique_ptr<CoordinateSequence> cs(g.getCoordinates());
-    const vector<Coordinate>* coords = cs->toVector();
-    testCoords.insert(testCoords.end(), coords->begin(), coords->end());
+
+    testCoords.reserve(testCoords.size() + cs->size());
+    for (size_t i = 0; i < cs->size(); i++) {
+        testCoords.push_back(cs->getAt(i));
+    }
 }
 
 /*private*/

--- a/src/simplify/DouglasPeuckerSimplifier.cpp
+++ b/src/simplify/DouglasPeuckerSimplifier.cpp
@@ -105,12 +105,11 @@ DPTransformer::transformCoordinates(
 {
     ::geos::ignore_unused_variable_warning(parent);
 
-    const Coordinate::Vect* inputPts = coords->toVector();
-    assert(inputPts);
+    Coordinate::Vect inputPts;
+    coords->toVector(inputPts);
 
     std::unique_ptr<Coordinate::Vect> newPts =
-        DouglasPeuckerLineSimplifier::simplify(*inputPts,
-                distanceTolerance);
+        DouglasPeuckerLineSimplifier::simplify(inputPts, distanceTolerance);
 
     return CoordinateSequence::Ptr(
                factory->getCoordinateSequenceFactory()->create(


### PR DESCRIPTION
Deprecated a decade ago, but still used a couple of times within GEOS.
Supports the goal of a smaller CoordinateSequence interface.