### PR TITLE
Add make_unique to geos_util.h

### DIFF
--- a/include/geos/util.h
+++ b/include/geos/util.h
@@ -31,6 +31,8 @@
 #include <geos/util/GeometricShapeFactory.h>
 //#include <geos/util/math.h>
 
+#include <memory>
+
 //
 // Private macros definition
 //
@@ -38,8 +40,48 @@
 namespace geos {
 template<class T>
 void
-ignore_unused_variable_warning(T const&) {}
+ignore_unused_variable_warning(T const &) {}
+
+namespace detail {
+#if __cplusplus >= 201402L
+using std::make_unique;
+#else
+// Backport of std::make_unique to C++11
+// Source: https://stackoverflow.com/a/19472607
+template<class T>
+struct _Unique_if {
+    typedef std::unique_ptr<T> _Single_object;
+};
+
+template<class T>
+struct _Unique_if<T[]> {
+    typedef std::unique_ptr<T[]> _Unknown_bound;
+};
+
+template<class T, size_t N>
+struct _Unique_if<T[N]> {
+    typedef void _Known_bound;
+};
+
+template<class T, class... Args>
+typename _Unique_if<T>::_Single_object
+make_unique(Args &&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+template<class T>
+typename _Unique_if<T>::_Unknown_bound
+make_unique(size_t n) {
+    typedef typename std::remove_extent<T>::type U;
+    return std::unique_ptr<T>(new U[n]());
+}
+
+template<class T, class... Args>
+typename _Unique_if<T>::_Known_bound
+make_unique(Args &&...) = delete;
+
+#endif
+}
+}
 
 #endif // GEOS_UTIL_H

--- a/src/algorithm/locate/IndexedPointInAreaLocator.cpp
+++ b/src/algorithm/locate/IndexedPointInAreaLocator.cpp
@@ -31,8 +31,6 @@
 #include <algorithm>
 #include <typeinfo>
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace algorithm {
 namespace locate {
@@ -74,7 +72,7 @@ IndexedPointInAreaLocator::IntervalIndexedGeometry::addLine(const geom::Coordina
 void
 IndexedPointInAreaLocator::buildIndex(const geom::Geometry& g)
 {
-    index = make_unique<IntervalIndexedGeometry>(g);
+    index = detail::make_unique<IntervalIndexedGeometry>(g);
 }
 
 

--- a/src/algorithm/locate/IndexedPointInAreaLocator.cpp
+++ b/src/algorithm/locate/IndexedPointInAreaLocator.cpp
@@ -24,12 +24,14 @@
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/util/LinearComponentExtracter.h>
 #include <geos/index/intervalrtree/SortedPackedIntervalRTree.h>
-#include <geos/util/IllegalArgumentException.h>
+#include <geos/util.h>
 #include <geos/algorithm/RayCrossingCounter.h>
 #include <geos/index/ItemVisitor.h>
 
 #include <algorithm>
 #include <typeinfo>
+
+using geos::detail::make_unique;
 
 namespace geos {
 namespace algorithm {
@@ -72,7 +74,7 @@ IndexedPointInAreaLocator::IntervalIndexedGeometry::addLine(const geom::Coordina
 void
 IndexedPointInAreaLocator::buildIndex(const geom::Geometry& g)
 {
-    index = std::unique_ptr<IntervalIndexedGeometry>(new IntervalIndexedGeometry(g));
+    index = make_unique<IntervalIndexedGeometry>(g);
 }
 
 

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -27,8 +27,6 @@
 
 using namespace std;
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace geom { // geos::geom
 
@@ -78,7 +76,7 @@ CoordinateArraySequence::CoordinateArraySequence(
 std::unique_ptr<CoordinateSequence>
 CoordinateArraySequence::clone() const
 {
-    return make_unique<CoordinateArraySequence>(*this);
+    return detail::make_unique<CoordinateArraySequence>(*this);
 }
 
 void

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -17,7 +17,7 @@
 #include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateFilter.h>
-#include <geos/util/IllegalArgumentException.h>
+#include <geos/util.h>
 
 #include <sstream>
 #include <cassert>
@@ -26,6 +26,8 @@
 #include <cmath>
 
 using namespace std;
+
+using geos::detail::make_unique;
 
 namespace geos {
 namespace geom { // geos::geom
@@ -76,7 +78,7 @@ CoordinateArraySequence::CoordinateArraySequence(
 std::unique_ptr<CoordinateSequence>
 CoordinateArraySequence::clone() const
 {
-    return std::unique_ptr<CoordinateSequence>(new CoordinateArraySequence(*this));
+    return make_unique<CoordinateArraySequence>(*this);
 }
 
 void

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -34,8 +34,7 @@
 #include <geos/geom/Envelope.h>
 #include <geos/geom/util/CoordinateOperation.h>
 #include <geos/geom/util/GeometryEditor.h>
-#include <geos/util/GEOSException.h>
-#include <geos/util/IllegalArgumentException.h>
+#include <geos/util.h>
 
 #include <cassert>
 #include <vector>
@@ -637,6 +636,7 @@ std::unique_ptr<LineString>
 GeometryFactory::createLineString(const LineString& ls) const
 {
     return std::unique_ptr<LineString>(new LineString(ls));
+    //return make_unique<LineString>(ls); // TODO why doesn't this work?
 }
 
 /*public*/

--- a/src/geomgraph/PlanarGraph.cpp
+++ b/src/geomgraph/PlanarGraph.cpp
@@ -48,8 +48,6 @@ using namespace std;
 using namespace geos::algorithm;
 using namespace geos::geom;
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
@@ -217,8 +215,8 @@ PlanarGraph::addEdges(const vector<Edge*>& edgesToAdd)
         // PlanarGraph destructor will delete all DirectedEdges
         // in edgeEndList, which is where these are added
         // by the ::add(EdgeEnd) call
-        auto de1 = make_unique<DirectedEdge>(e, true);
-        auto de2 = make_unique<DirectedEdge>(e, false);
+        auto de1 = detail::make_unique<DirectedEdge>(e, true);
+        auto de2 = detail::make_unique<DirectedEdge>(e, false);
         de1->setSym(de2.get());
         de2->setSym(de1.get());
 

--- a/src/geomgraph/PlanarGraph.cpp
+++ b/src/geomgraph/PlanarGraph.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <string>
 #include <cassert>
+#include <geos/util.h>
 
 
 #ifndef GEOS_DEBUG
@@ -46,6 +47,8 @@
 using namespace std;
 using namespace geos::algorithm;
 using namespace geos::geom;
+
+using geos::detail::make_unique;
 
 namespace geos {
 namespace geomgraph { // geos.geomgraph
@@ -214,8 +217,8 @@ PlanarGraph::addEdges(const vector<Edge*>& edgesToAdd)
         // PlanarGraph destructor will delete all DirectedEdges
         // in edgeEndList, which is where these are added
         // by the ::add(EdgeEnd) call
-        std::unique_ptr<DirectedEdge> de1(new DirectedEdge(e, true));
-        std::unique_ptr<DirectedEdge> de2(new DirectedEdge(e, false));
+        auto de1 = make_unique<DirectedEdge>(e, true);
+        auto de2 = make_unique<DirectedEdge>(e, false);
         de1->setSym(de2.get());
         de2->setSym(de1.get());
 

--- a/src/operation/overlay/snap/GeometrySnapper.cpp
+++ b/src/operation/overlay/snap/GeometrySnapper.cpp
@@ -37,6 +37,8 @@
 //using namespace std;
 using namespace geos::geom;
 
+using geos::detail::make_unique;
+
 namespace geos {
 namespace operation { // geos.operation
 namespace overlay { // geos.operation.overlay
@@ -94,7 +96,7 @@ public:
 std::unique_ptr<Coordinate::ConstVect>
 GeometrySnapper::extractTargetCoordinates(const Geometry& g)
 {
-    std::unique_ptr<Coordinate::ConstVect> snapPts(new Coordinate::ConstVect());
+    auto snapPts = make_unique<Coordinate::ConstVect>();
     util::UniqueCoordinateArrayFilter filter(*snapPts);
     g.apply_ro(&filter);
     // integrity check

--- a/src/operation/overlay/snap/GeometrySnapper.cpp
+++ b/src/operation/overlay/snap/GeometrySnapper.cpp
@@ -37,8 +37,6 @@
 //using namespace std;
 using namespace geos::geom;
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace operation { // geos.operation
 namespace overlay { // geos.operation.overlay
@@ -96,7 +94,7 @@ public:
 std::unique_ptr<Coordinate::ConstVect>
 GeometrySnapper::extractTargetCoordinates(const Geometry& g)
 {
-    auto snapPts = make_unique<Coordinate::ConstVect>();
+    auto snapPts = detail::make_unique<Coordinate::ConstVect>();
     util::UniqueCoordinateArrayFilter filter(*snapPts);
     g.apply_ro(&filter);
     // integrity check

--- a/src/operation/valid/RepeatedPointRemover.cpp
+++ b/src/operation/valid/RepeatedPointRemover.cpp
@@ -16,6 +16,9 @@
 
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateArraySequenceFactory.h>
+#include <geos/util.h>
+
+using geos::detail::make_unique;
 
 namespace geos {
 namespace operation {
@@ -31,7 +34,7 @@ RepeatedPointRemover::removeRepeatedPoints(const geom::CoordinateSequence* seq) 
         return std::unique_ptr<geom::CoordinateSequence>(seqFactory->create());
     }
 
-    std::unique_ptr<std::vector<Coordinate>> pts(new std::vector<Coordinate>);
+    auto pts = make_unique<std::vector<Coordinate>>();
     auto sz = seq->getSize();
     pts->reserve(sz); // assume not many points are repeated
 

--- a/src/operation/valid/RepeatedPointRemover.cpp
+++ b/src/operation/valid/RepeatedPointRemover.cpp
@@ -18,8 +18,6 @@
 #include <geos/geom/CoordinateArraySequenceFactory.h>
 #include <geos/util.h>
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace operation {
 namespace valid {
@@ -34,7 +32,7 @@ RepeatedPointRemover::removeRepeatedPoints(const geom::CoordinateSequence* seq) 
         return std::unique_ptr<geom::CoordinateSequence>(seqFactory->create());
     }
 
-    auto pts = make_unique<std::vector<Coordinate>>();
+    auto pts = detail::make_unique<std::vector<Coordinate>>();
     auto sz = seq->getSize();
     pts->reserve(sz); // assume not many points are repeated
 

--- a/src/triangulate/DelaunayTriangulationBuilder.cpp
+++ b/src/triangulate/DelaunayTriangulationBuilder.cpp
@@ -31,8 +31,6 @@
 #include <geos/operation/valid/RepeatedPointTester.h>
 #include <geos/util.h>
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace triangulate { //geos.triangulate
 
@@ -51,7 +49,7 @@ DelaunayTriangulationBuilder::unique(const CoordinateSequence* seq) {
     auto seqFactory = CoordinateArraySequenceFactory::instance();
     auto dim = seq->getDimension();
 
-    auto coords = make_unique<std::vector<Coordinate>>();
+    auto coords = detail::make_unique<std::vector<Coordinate>>();
     seq->toVector(*(coords.get()));
     std::sort(coords->begin(), coords->end(), geos::geom::CoordinateLessThen());
 

--- a/src/triangulate/DelaunayTriangulationBuilder.cpp
+++ b/src/triangulate/DelaunayTriangulationBuilder.cpp
@@ -29,6 +29,9 @@
 #include <geos/triangulate/quadedge/QuadEdgeSubdivision.h>
 #include <geos/operation/valid/RepeatedPointRemover.h>
 #include <geos/operation/valid/RepeatedPointTester.h>
+#include <geos/util.h>
+
+using geos::detail::make_unique;
 
 namespace geos {
 namespace triangulate { //geos.triangulate
@@ -48,7 +51,7 @@ DelaunayTriangulationBuilder::unique(const CoordinateSequence* seq) {
     auto seqFactory = CoordinateArraySequenceFactory::instance();
     auto dim = seq->getDimension();
 
-    std::unique_ptr<std::vector<Coordinate>> coords(new std::vector<Coordinate>());
+    auto coords = make_unique<std::vector<Coordinate>>();
     seq->toVector(*(coords.get()));
     std::sort(coords->begin(), coords->end(), geos::geom::CoordinateLessThen());
 

--- a/src/triangulate/VoronoiDiagramBuilder.cpp
+++ b/src/triangulate/VoronoiDiagramBuilder.cpp
@@ -31,6 +31,9 @@
 #include <geos/triangulate/DelaunayTriangulationBuilder.h>
 #include <geos/triangulate/quadedge/QuadEdgeSubdivision.h>
 #include <geos/operation/valid/RepeatedPointRemover.h>
+#include <geos/util.h>
+
+using geos::detail::make_unique;
 
 namespace geos {
 namespace triangulate { //geos.triangulate
@@ -140,7 +143,7 @@ VoronoiDiagramBuilder::clipGeometryCollection(std::vector<std::unique_ptr<Geomet
     auto gfact = geoms[0]->getFactory();
 
     std::unique_ptr<geom::Geometry> clipPoly(gfact->toGeometry(&clipEnv));
-    std::unique_ptr< std::vector<Geometry*> >clipped(new std::vector<Geometry*>);
+    auto clipped = make_unique<std::vector<Geometry*>>();
 
     for(auto& g : geoms) {
         std::unique_ptr<Geometry> result;

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -44,8 +44,6 @@
 using namespace geos::geom;
 using namespace std;
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace triangulate { //geos.triangulate
 namespace quadedge { //geos.triangulate.quadedge
@@ -557,7 +555,7 @@ QuadEdgeSubdivision::getVoronoiCellPolygons(const geom::GeometryFactory& geomFac
 std::unique_ptr< std::vector<geom::Geometry*> >
 QuadEdgeSubdivision::getVoronoiCellEdges(const geom::GeometryFactory& geomFact)
 {
-    auto cells = make_unique<std::vector<geom::Geometry*>>();
+    auto cells = detail::make_unique<std::vector<geom::Geometry*>>();
     TriangleCircumcentreVisitor tricircumVisitor;
 
     visitTriangles((TriangleVisitor*) &tricircumVisitor, true);
@@ -641,7 +639,7 @@ QuadEdgeSubdivision::getVoronoiCellEdge(const QuadEdge* qe, const geom::Geometry
 std::unique_ptr<QuadEdgeSubdivision::QuadEdgeList>
 QuadEdgeSubdivision::getVertexUniqueEdges(bool includeFrame)
 {
-    auto edges = make_unique<QuadEdgeList>();
+    auto edges = detail::make_unique<QuadEdgeList>();
     std::set<Vertex> visitedVertices; // TODO unordered_set of Vertex* ?
 
     for(QuadEdge* qe : quadEdges) {

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -32,8 +32,7 @@
 #include <geos/geom/CoordinateList.h>
 #include <geos/geom/GeometryCollection.h>
 #include <geos/geom/GeometryFactory.h>
-#include <geos/util/IllegalArgumentException.h>
-#include <geos/util/GEOSException.h>
+#include <geos/util.h>
 #include <geos/triangulate/quadedge/QuadEdge.h>
 #include <geos/triangulate/quadedge/QuadEdgeLocator.h>
 #include <geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h>
@@ -44,6 +43,9 @@
 
 using namespace geos::geom;
 using namespace std;
+
+using geos::detail::make_unique;
+
 namespace geos {
 namespace triangulate { //geos.triangulate
 namespace quadedge { //geos.triangulate.quadedge
@@ -555,7 +557,7 @@ QuadEdgeSubdivision::getVoronoiCellPolygons(const geom::GeometryFactory& geomFac
 std::unique_ptr< std::vector<geom::Geometry*> >
 QuadEdgeSubdivision::getVoronoiCellEdges(const geom::GeometryFactory& geomFact)
 {
-    std::unique_ptr< std::vector<geom::Geometry*> > cells(new std::vector<geom::Geometry*>);
+    auto cells = make_unique<std::vector<geom::Geometry*>>();
     TriangleCircumcentreVisitor tricircumVisitor;
 
     visitTriangles((TriangleVisitor*) &tricircumVisitor, true);
@@ -639,7 +641,7 @@ QuadEdgeSubdivision::getVoronoiCellEdge(const QuadEdge* qe, const geom::Geometry
 std::unique_ptr<QuadEdgeSubdivision::QuadEdgeList>
 QuadEdgeSubdivision::getVertexUniqueEdges(bool includeFrame)
 {
-    std::unique_ptr<QuadEdgeSubdivision::QuadEdgeList> edges(new QuadEdgeList());
+    auto edges = make_unique<QuadEdgeList>();
     std::set<Vertex> visitedVertices; // TODO unordered_set of Vertex* ?
 
     for(QuadEdge* qe : quadEdges) {

--- a/src/triangulate/quadedge/Vertex.cpp
+++ b/src/triangulate/quadedge/Vertex.cpp
@@ -23,8 +23,6 @@
 #include <geos/algorithm/NotRepresentableException.h>
 #include <geos/util.h>
 
-using geos::detail::make_unique;
-
 namespace geos {
 namespace triangulate { //geos.triangulate
 namespace quadedge { //geos.triangulate.quadedge
@@ -108,7 +106,7 @@ Vertex::bisector(const Vertex& a, const Vertex& b)
     HCoordinate l1 = HCoordinate(a.getX() + dx / 2.0, a.getY() + dy / 2.0, 1.0);
     HCoordinate l2 = HCoordinate(a.getX() - dy + dx / 2.0, a.getY() + dx + dy / 2.0, 1.0);
 
-    return make_unique<HCoordinate>(l1, l2);
+    return detail::make_unique<HCoordinate>(l1, l2);
 }
 
 double
@@ -135,19 +133,19 @@ Vertex::midPoint(const Vertex& a)
     double xm = (p.x + a.getX()) / 2.0;
     double ym = (p.y + a.getY()) / 2.0;
     double zm = (p.z + a.getZ()) / 2.0;
-    return make_unique<Vertex>(xm, ym, zm);
+    return detail::make_unique<Vertex>(xm, ym, zm);
 }
 
 std::unique_ptr<Vertex>
 Vertex::circleCenter(const Vertex& b, const Vertex& c) const
 {
-    auto a = make_unique<Vertex>(getX(), getY());
+    auto a = detail::make_unique<Vertex>(getX(), getY());
     // compute the perpendicular bisector of cord ab
     std::unique_ptr<HCoordinate> cab = bisector(*a, b);
     // compute the perpendicular bisector of cord bc
     std::unique_ptr<HCoordinate> cbc = bisector(b, c);
     // compute the intersection of the bisectors (circle radii)
-    std::unique_ptr<HCoordinate> hcc = make_unique<HCoordinate>(*cab, *cbc);
+    std::unique_ptr<HCoordinate> hcc = detail::make_unique<HCoordinate>(*cab, *cbc);
     std::unique_ptr<Vertex> cc;
 
     try {

--- a/src/triangulate/quadedge/Vertex.cpp
+++ b/src/triangulate/quadedge/Vertex.cpp
@@ -21,7 +21,9 @@
 #include <geos/triangulate/quadedge/TrianglePredicate.h>
 #include <geos/triangulate/quadedge/QuadEdge.h>
 #include <geos/algorithm/NotRepresentableException.h>
+#include <geos/util.h>
 
+using geos::detail::make_unique;
 
 namespace geos {
 namespace triangulate { //geos.triangulate
@@ -106,7 +108,7 @@ Vertex::bisector(const Vertex& a, const Vertex& b)
     HCoordinate l1 = HCoordinate(a.getX() + dx / 2.0, a.getY() + dy / 2.0, 1.0);
     HCoordinate l2 = HCoordinate(a.getX() - dy + dx / 2.0, a.getY() + dx + dy / 2.0, 1.0);
 
-    return std::unique_ptr<HCoordinate>(new HCoordinate(l1, l2));
+    return make_unique<HCoordinate>(l1, l2);
 }
 
 double
@@ -133,19 +135,19 @@ Vertex::midPoint(const Vertex& a)
     double xm = (p.x + a.getX()) / 2.0;
     double ym = (p.y + a.getY()) / 2.0;
     double zm = (p.z + a.getZ()) / 2.0;
-    return std::unique_ptr<Vertex>(new Vertex(xm, ym, zm));
+    return make_unique<Vertex>(xm, ym, zm);
 }
 
 std::unique_ptr<Vertex>
 Vertex::circleCenter(const Vertex& b, const Vertex& c) const
 {
-    std::unique_ptr<Vertex> a(new Vertex(getX(), getY()));
+    auto a = make_unique<Vertex>(getX(), getY());
     // compute the perpendicular bisector of cord ab
     std::unique_ptr<HCoordinate> cab = bisector(*a, b);
     // compute the perpendicular bisector of cord bc
     std::unique_ptr<HCoordinate> cbc = bisector(b, c);
     // compute the intersection of the bisectors (circle radii)
-    std::unique_ptr<HCoordinate> hcc(new HCoordinate(*cab, *cbc));
+    std::unique_ptr<HCoordinate> hcc = make_unique<HCoordinate>(*cab, *cbc);
     std::unique_ptr<Vertex> cc;
 
     try {


### PR DESCRIPTION
This PR "backports" the `std::make_unique` function from C++14 to the `geos_util.h` header and applies it to a portion of the locations where it makes sense. `make_unique`, which I copied from QGIS (in turn copied from Stack Overflow) lets us replace this syntax:

`auto a = std::unique_ptr<std::vector<const Geometry*>>(new std::vector<const Geometry*>(5));`

with this syntax:

`auto a = make_unique<std::vector<const Geometry*>>(5);`

So there is a bit of a win in avoiding writing long type names two times. It also avoids the potential for a memory leak if one of the arguments to the `std::unique_ptr` construction throws; see https://stackoverflow.com/a/19472607 or Effective Modern C++

If people are OK with adding `make_unique` to our own header, I can make the rest of the conversions. I think there are only a couple dozen at this point. But if we're going to add `make_unique`, it makes sense to do it before embarking on a whole bunch of `unique_ptr` refactoring.

If the project ultimately moves to C++14 or later, we can just remove our version.

Past discussion: https://lists.osgeo.org/pipermail/geos-devel/2018-December/008768.html