### PR TITLE
Point CMAKE_*_OUTPUT_DIRECTORY to common location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,18 @@ cmake_dependent_option(GEOS_BUILD_DEVELOPER
 mark_as_advanced(GEOS_BUILD_DEVELOPER)
 
 #-----------------------------------------------------------------------------
+# Setup build directories
+#-----------------------------------------------------------------------------
+# Place executables and shared libraries in the same location for
+# convenience of direct execution from common spot and for
+# convenience in environments without RPATH support.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+message(STATUS "GEOS: Run-time output: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+message(STATUS "GEOS: Archives output: ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+
+#-----------------------------------------------------------------------------
 # Version
 #-----------------------------------------------------------------------------
 file(READ Version.txt _version_txt)


### PR DESCRIPTION
Place executables and shared libraries in the same location for
convenience of direct execution from common spot and for
convenience in environments without `RPATH` support.

In future, if number of generated executables grows significantly,
with possible name clashes, it may be more convenient to replace
the common locations with setting `PATH` per test, on Windows only:

```
set_tests_properties(<test name> PROPERTIES
  ENVIRONMENT
    "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:geos>>$<SEMICOLON>$<TARGET_FILE_DIR:geos_c>>$<SEMICOLON>$ENV{PATH}"
)
```

----

@robe2 this should fix the test issues on Windows