### PR TITLE
Disable dist and distcheck targets for multi-configuration generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,41 +279,47 @@ add_custom_target(uninstall
 #-----------------------------------------------------------------------------
 # "make dist" workalike
 #-----------------------------------------------------------------------------
+get_property(_is_multi_config_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _is_multi_config_generator)
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GEOS Computational Geometry Library")
+  set(CPACK_PACKAGE_VENDOR "OSGeo")
+  set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+  set(CPACK_SOURCE_GENERATOR "TBZ2")
+  set(CPACK_PACKAGE_VERSION_MAJOR ${GEOS_VERSION_MAJOR})
+  set(CPACK_PACKAGE_VERSION_MINOR ${GEOS_VERSION_MINOR})
+  set(CPACK_PACKAGE_VERSION_PATCH ${GEOS_VERSION_PATCH})
+  set(CPACK_SOURCE_PACKAGE_FILE_NAME "geos-${GEOS_VERSION_FULL}")
 
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GEOS Computational Geometry Library")
-set(CPACK_PACKAGE_VENDOR "OSGeo")
-set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
-set(CPACK_SOURCE_GENERATOR "TBZ2")
-set(CPACK_PACKAGE_VERSION_MAJOR ${GEOS_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${GEOS_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${GEOS_VERSION_PATCH})
-set(CPACK_SOURCE_PACKAGE_FILE_NAME "geos-${GEOS_VERSION_FULL}")
+  set(CPACK_SOURCE_IGNORE_FILES
+    "/\\\\.git"
+    "/autogen\\\\.sh"
+    "/tools/ci"
+    "/HOWTO_RELEASE"
+    "/autom4te\\\\.cache"
+    "\\\\.yml\$"
+    "\\\\.deps"
+    "/debian/"
+    "/php/"
+    "/.*build-.*/"
+    ${PROJECT_BINARY_DIR}
+    )
 
-set(CPACK_SOURCE_IGNORE_FILES
-  "/\\\\.git"
-  "/autogen\\\\.sh"
-  "/tools/ci"
-  "/HOWTO_RELEASE"
-  "/autom4te\\\\.cache"
-  "\\\\.yml\$"
-  "\\\\.deps"
-  "/debian/"
-  "/php/"
-  "/.*build-.*/"
-  ${PROJECT_BINARY_DIR}
-  )
+  # message(STATUS "GEOS: CPACK_SOURCE_PACKAGE_FILE_NAME: ${CPACK_SOURCE_PACKAGE_FILE_NAME}")
+  # message(STATUS "GEOS: CPACK_SOURCE_IGNORE_FILES: ${CPACK_SOURCE_IGNORE_FILES}")
+  # message(STATUS "GEOS: CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
+  include(CPack)
+  add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 
-# message(STATUS "GEOS: CPACK_SOURCE_PACKAGE_FILE_NAME: ${CPACK_SOURCE_PACKAGE_FILE_NAME}")
-# message(STATUS "GEOS: CPACK_SOURCE_IGNORE_FILES: ${CPACK_SOURCE_IGNORE_FILES}")
-# message(STATUS "GEOS: CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
-include(CPack)
-add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
+  message(STATUS "GEOS: Configured 'dist' target")
+endif()
 
 #-----------------------------------------------------------------------------
 # "make distcheck" workalike
 #-----------------------------------------------------------------------------
+if(NOT _is_multi_config_generator)
+  find_package(MakeDistCheck)
+  AddMakeDistCheck()
+  message(STATUS "GEOS: Configured 'distcheck' target")
+endif()
 
-find_package(MakeDistCheck)
-AddMakeDistCheck()
-
-
+unset(_is_multi_config_generator)


### PR DESCRIPTION
Those targets are useless for the IDEs.
Those targets have also potential to be troublesome for the IDEs.

-----

```
5>  Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Framework
5>  Copyright (C) Microsoft Corporation. All rights reserved.
5>
5>  MSBUILD : error MSB1009: Project file does not exist.
5>  Switch: package_source
5>Done building target "CustomBuild" in project "dist.vcxproj" -- FAILED.
```

Yup, I remain stubborn all that Autotoolization is simply "habits worst enemy of human" cruft.
The `include(CPack)` already defines dedicated target, so `cmake --build <build dir> --target package_source` or even `make package_source`. 