### PR TITLE
[CMake] Add target for doc/example.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,11 @@ endif()
 add_subdirectory(benchmarks)
 
 #-----------------------------------------------------------------------------
+# Documentation/Examples
+#-----------------------------------------------------------------------------
+add_subdirectory(doc)
+
+#-----------------------------------------------------------------------------
 # Install and export targets - support 'make install' or equivalent
 #-----------------------------------------------------------------------------
 include(CMakePackageConfigHelpers)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,17 @@
+################################################################################
+# Part of CMake configuration for GEOS
+#
+# Copyright (C) 2018 Mateusz Loskot <mateusz@loskot.net>
+#
+# This is free software; you can redistribute and/or modify it under
+# the terms of the GNU Lesser General Public Licence as published
+# by the Free Software Foundation.
+# See the COPYING file for more information.
+################################################################################
+
+add_executable(example example.cpp)
+
+target_link_libraries(example PRIVATE geos)
+target_include_directories(test_geos_unit
+        PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)


### PR DESCRIPTION
Important to make sure example still compiles after C++ API changes.
Resolves #901.