### PR TITLE
Resolve memory leaks in DistanceOp

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -1293,7 +1293,7 @@ extern "C" {
             if(g1->isEmpty() || g2->isEmpty()) {
                 return 0;
             }
-            return geos::operation::distance::DistanceOp::nearestPoints(g1, g2);
+            return geos::operation::distance::DistanceOp::nearestPoints(g1, g2).release();
         }
         catch(const std::exception& e) {
             handle->ERROR_MESSAGE("%s", e.what());

--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -26,6 +26,7 @@
 
 #include <geos/inline.h>
 
+#include <array>
 #include <iostream> // for ostream
 #include <functional> // for std::hash
 #include <memory> // for unique_ptr
@@ -319,11 +320,10 @@ public:
      * @param line the line segment to find the closest points to
      * @return a pair of Coordinates which are the closest points on
      * the line segments.
-     * The returned CoordinateSequence must be deleted by caller
      */
-    CoordinateSequence* closestPoints(const LineSegment& line);
+    std::array<Coordinate, 2> closestPoints(const LineSegment& line);
 
-    CoordinateSequence* closestPoints(const LineSegment* line);
+    std::array<Coordinate, 2> closestPoints(const LineSegment* line);
 
     /**
      * Computes an intersection point between two segments,

--- a/include/geos/geom/LineSegment.inl
+++ b/include/geos/geom/LineSegment.inl
@@ -165,7 +165,7 @@ LineSegment::orientationIndex(const Coordinate& p) const
     return algorithm::Orientation::index(p0, p1, p);
 }
 
-INLINE CoordinateSequence*
+INLINE std::array<Coordinate, 2>
 LineSegment::closestPoints(const LineSegment* line)
 {
     assert(line);

--- a/include/geos/operation/distance/ConnectedElementLocationFilter.h
+++ b/include/geos/operation/distance/ConnectedElementLocationFilter.h
@@ -22,18 +22,15 @@
 #include <geos/export.h>
 
 #include <geos/geom/GeometryFilter.h> // for inheritance
+#include <geos/operation/distance/GeometryLocation.h>
 
+#include <memory>
 #include <vector>
 
 // Forward declarations
 namespace geos {
 namespace geom {
 class Geometry;
-}
-namespace operation {
-namespace distance {
-class GeometryLocation;
-}
 }
 }
 
@@ -52,7 +49,8 @@ namespace distance { // geos::operation::distance
 class GEOS_DLL ConnectedElementLocationFilter: public geom::GeometryFilter {
 private:
 
-    std::vector<GeometryLocation*>* locations;
+    std::vector<std::unique_ptr<GeometryLocation>> locations;
+    ConnectedElementLocationFilter() = default;
 
 public:
     /**
@@ -61,12 +59,7 @@ public:
      * not a GeometryCollection, an empty list will be returned. The elements of the list
      * are {@link com.vividsolutions.jts.operation.distance.GeometryLocation}s.
      */
-    static std::vector<GeometryLocation*>* getLocations(const geom::Geometry* geom);
-
-    ConnectedElementLocationFilter(std::vector<GeometryLocation*>* newLocations)
-        :
-        locations(newLocations)
-    {}
+    static std::vector<std::unique_ptr<GeometryLocation>> getLocations(const geom::Geometry* geom);
 
     void filter_ro(const geom::Geometry* geom) override;
     void filter_rw(geom::Geometry* geom) override;

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -193,22 +193,20 @@ LineSegment::orientationIndex(const LineSegment& seg) const
     return 0;
 }
 
-CoordinateSequence*
+std::array<Coordinate, 2>
 LineSegment::closestPoints(const LineSegment& line)
 {
     // test for intersection
     Coordinate intPt;
     if(intersection(line, intPt)) {
-        CoordinateSequence* cl = new CoordinateArraySequence(new vector<Coordinate>(2, intPt));
-        return cl;
+        return { intPt, intPt };
     }
 
     /*
      * if no intersection closest pair contains at least one endpoint.
      * Test each endpoint in turn.
      */
-    CoordinateSequence* closestPt = new CoordinateArraySequence(2);
-    //vector<Coordinate> *cv = new vector<Coordinate>(2);
+    std::array<Coordinate, 2> closestPt;
 
     double minDistance = DoubleMax;
     double dist;
@@ -217,18 +215,16 @@ LineSegment::closestPoints(const LineSegment& line)
     closestPoint(line.p0, close00);
     minDistance = close00.distance(line.p0);
 
-    closestPt->setAt(close00, 0);
-    closestPt->setAt(line.p0, 1);
+    closestPt[0] = close00;
+    closestPt[1] = line.p0;
 
     Coordinate close01;
     closestPoint(line.p1, close01);
     dist = close01.distance(line.p1);
     if(dist < minDistance) {
         minDistance = dist;
-        closestPt->setAt(close01, 0);
-        closestPt->setAt(line.p1, 1);
-        //(*cv)[0] = close01;
-        //(*cv)[1] = line.p1;
+        closestPt[0] = close01;
+        closestPt[1] = line.p1;
     }
 
     Coordinate close10;
@@ -236,10 +232,8 @@ LineSegment::closestPoints(const LineSegment& line)
     dist = close10.distance(p0);
     if(dist < minDistance) {
         minDistance = dist;
-        closestPt->setAt(p0, 0);
-        closestPt->setAt(close10, 1);
-        //(*cv)[0] = p0;
-        //(*cv)[1] = close10;
+        closestPt[0] = p0;
+        closestPt[1] = close10;
     }
 
     Coordinate close11;
@@ -247,10 +241,8 @@ LineSegment::closestPoints(const LineSegment& line)
     dist = close11.distance(p1);
     if(dist < minDistance) {
         minDistance = dist;
-        closestPt->setAt(p1, 0);
-        closestPt->setAt(close11, 1);
-        //(*cv)[0] = p1;
-        //(*cv)[1] = *close11;
+        closestPt[0] = p1;
+        closestPt[1] = close11;
     }
 
     return closestPt;

--- a/src/operation/distance/ConnectedElementLocationFilter.cpp
+++ b/src/operation/distance/ConnectedElementLocationFilter.cpp
@@ -35,13 +35,12 @@ namespace operation { // geos.operation
 namespace distance { // geos.operation.distance
 
 /*public*/
-vector<GeometryLocation*>*
+vector<unique_ptr<GeometryLocation>>
 ConnectedElementLocationFilter::getLocations(const Geometry* geom)
 {
-    vector<GeometryLocation*>* loc = new vector<GeometryLocation*>();
-    ConnectedElementLocationFilter c(loc);
+    ConnectedElementLocationFilter c;
     geom->apply_ro(&c);
-    return loc;
+    return std::move(c.locations);
 }
 
 void
@@ -51,7 +50,7 @@ ConnectedElementLocationFilter::filter_ro(const Geometry* geom)
             (typeid(*geom) == typeid(LineString)) ||
             (typeid(*geom) == typeid(LinearRing)) ||
             (typeid(*geom) == typeid(Polygon))) {
-        locations->push_back(new GeometryLocation(geom, 0, *(geom->getCoordinate())));
+        locations.emplace_back(new GeometryLocation(geom, 0, *(geom->getCoordinate())));
     }
 }
 
@@ -62,7 +61,7 @@ ConnectedElementLocationFilter::filter_rw(Geometry* geom)
             (typeid(*geom) == typeid(LineString)) ||
             (typeid(*geom) == typeid(LinearRing)) ||
             (typeid(*geom) == typeid(Polygon))) {
-        locations->push_back(new GeometryLocation(geom, 0, *(geom->getCoordinate())));
+        locations.emplace_back(new GeometryLocation(geom, 0, *(geom->getCoordinate())));
     }
 }
 

--- a/src/operation/distance/FacetSequence.cpp
+++ b/src/operation/distance/FacetSequence.cpp
@@ -200,16 +200,14 @@ FacetSequence::updateNearestLocationsLineLine(size_t i, const Coordinate& p0, co
 {
     LineSegment seg0(p0, p1);
     LineSegment seg1(q0, q1);
-    std::unique_ptr<CoordinateSequence> closestPts(seg0.closestPoints(seg1));
-    Coordinate c0, c1;
-    closestPts->getAt(0, c0);
-    closestPts->getAt(1, c1);
-    GeometryLocation gl0(geom, i, c0);
-    GeometryLocation gl1(facetSeq.geom, j, c1);
+
+    auto closestPts = seg0.closestPoints(seg1);
+    GeometryLocation gl0(geom, i, closestPts[0]);
+    GeometryLocation gl1(facetSeq.geom, j, closestPts[1]);
+
     locs->clear();
     locs->push_back(gl0);
     locs->push_back(gl1);
-    return;
 }
 
 void

--- a/tests/unit/operation/distance/DistanceOpTest.cpp
+++ b/tests/unit/operation/distance/DistanceOpTest.cpp
@@ -64,7 +64,7 @@ void object::test<1>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(0, 0));
     ensure_equals(cs->getAt(1), Coordinate(10, 0));
 }
@@ -86,7 +86,7 @@ void object::test<2>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(0, 0));
     ensure_equals(cs->getAt(1), Coordinate(10, 0));
 
@@ -109,7 +109,7 @@ void object::test<3>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(3, 0));
     ensure_equals(cs->getAt(1), Coordinate(3, 10));
 
@@ -132,7 +132,7 @@ void object::test<4>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(3, 0));
     ensure_equals(cs->getAt(1), Coordinate(3, 10));
 
@@ -155,7 +155,7 @@ void object::test<5>
 
     ensure_equals(dist.distance(), 6);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(35, 60));
     ensure_equals(cs->getAt(1), Coordinate(35, 54));
 
@@ -179,7 +179,7 @@ void object::test<6>
 
     ensure_equals(dist.distance(), 6);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(35, 60));
     ensure_equals(cs->getAt(1), Coordinate(35, 54));
 
@@ -206,7 +206,7 @@ void object::test<7>
 
     ensure_equals(dist.distance(), 6);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(35, 60));
     ensure_equals(cs->getAt(1), Coordinate(35, 54));
 }
@@ -231,7 +231,7 @@ void object::test<8>
 
     ensure_equals(dist.distance(), 0);
 
-    ensure_equals(dist.closestPoints(), (void*)nullptr);
+    ensure(dist.nearestPoints() == nullptr);
 }
 
 template<>
@@ -251,7 +251,7 @@ void object::test<9>
 
     ensure_equals(dist.distance(), 0);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(10, 0));
     ensure_equals(cs->getAt(1), Coordinate(10, 0));
 
@@ -274,7 +274,7 @@ void object::test<10>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(10, 0));
     ensure_equals(cs->getAt(1), Coordinate(0, 0));
 
@@ -297,7 +297,7 @@ void object::test<11>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(3, 0));
     ensure_equals(cs->getAt(1), Coordinate(3, 10));
 
@@ -320,7 +320,7 @@ void object::test<12>
 
     ensure_equals(dist.distance(), 10);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(3, 0));
     ensure_equals(cs->getAt(1), Coordinate(3, 10));
 
@@ -343,7 +343,7 @@ void object::test<13>
 
     ensure_equals(dist.distance(), 6);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(35, 60));
     ensure_equals(cs->getAt(1), Coordinate(35, 54));
 
@@ -367,7 +367,7 @@ void object::test<14>
 
     ensure_equals(dist.distance(), 6);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(35, 60));
     ensure_equals(cs->getAt(1), Coordinate(35, 54));
 }
@@ -393,7 +393,7 @@ void object::test<15>
 
     ensure_equals(dist.distance(), 6);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(35, 60));
     ensure_equals(cs->getAt(1), Coordinate(35, 54));
 
@@ -419,8 +419,7 @@ void object::test<16>
 
     ensure_equals(dist.distance(), 0);
 
-    ensure_equals(dist.closestPoints(), (void*)nullptr);
-
+    ensure(dist.nearestPoints() == nullptr);
 }
 
 // Test for crash reported in Ticket #236:
@@ -442,7 +441,7 @@ void object::test<17>
     DistanceOp dist(g0.get(), g1.get());
     ensure_equals(dist.distance(), 0.25);
 
-    CSPtr cs(dist.closestPoints());
+    CSPtr cs(dist.nearestPoints());
     ensure_equals(cs->getAt(0), Coordinate(1, 0.25));
     ensure_equals(cs->getAt(1), Coordinate(1.25, 0.25));
 }
@@ -537,7 +536,7 @@ void object::test<20>()
     GeomPtr g1(gfact->createLineString(seq1.release()));
 
     DistanceOp dist(g0.get(), g1.get());
-    CSPtr seq(dist.closestPoints());
+    CSPtr seq(dist.nearestPoints());
 
     // input lines overlap, so generated point should intersect both geometries
     ensure(geos::geom::LineSegment(a0, a1).distance(seq->getAt(0)) < 1e-8);
@@ -546,8 +545,8 @@ void object::test<20>()
     ensure(geos::geom::LineSegment(b0, b1).distance(seq->getAt(1)) < 1e-8);
 
     // reverse argument order and check again
-    dist = DistanceOp(g1.get(), g0.get());
-    seq.reset(dist.closestPoints());
+    DistanceOp dist2(g1.get(), g0.get());
+    seq = dist2.nearestPoints();
 
     ensure(geos::geom::LineSegment(a0, a1).distance(seq->getAt(0)) < 1e-8);
     ensure(geos::geom::LineSegment(a0, a1).distance(seq->getAt(1)) < 1e-8);


### PR DESCRIPTION
This PR takes a fairly invasive approach to resolving the leaks
and removes all manual memory management from the DistanceOp class.

It also removes some deprecated methods and replaces fixed-size std::vectors
with std::array.