### PR TITLE
Optimize Voronoi / Delaunay code

### DIFF
--- a/benchmarks/algorithm/CMakeLists.txt
+++ b/benchmarks/algorithm/CMakeLists.txt
@@ -12,3 +12,6 @@
 #################################################################################
 add_executable(perf_interiorpoint_area InteriorPointAreaPerfTest.cpp)
 target_link_libraries(perf_interiorpoint_area geos)
+
+add_executable(perf_voronoi VoronoiPerfTest.cpp)
+target_link_libraries(perf_voronoi geos)

--- a/benchmarks/algorithm/VoronoiPerfTest.cpp
+++ b/benchmarks/algorithm/VoronoiPerfTest.cpp
@@ -1,0 +1,91 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston <dbaston@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/triangulate/DelaunayTriangulationBuilder.h>
+#include <geos/triangulate/VoronoiDiagramBuilder.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/profiler.h>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+#include <memory>
+
+class VoronoiPerfTest {
+
+public:
+    void test(size_t num_points) {
+        using namespace geos::geom;
+
+        std::default_random_engine e(12345);
+        std::uniform_real_distribution<> dis(0, 100);
+
+        std::unique_ptr<std::vector<Coordinate>> coords(new std::vector<Coordinate>(num_points));
+        std::generate(coords->begin(), coords->end(), [&dis, &e]() {
+            return Coordinate(dis(e), dis(e));
+        });
+        CoordinateArraySequence seq(coords.release());
+        auto geom = gfact->createLineString(seq.clone());
+
+        voronoi(seq);
+        voronoi(*geom);
+
+        delaunay(seq);
+        delaunay(*geom);
+
+        std::cout << std::endl;
+    }
+private:
+    decltype(geos::geom::GeometryFactory::create()) gfact = geos::geom::GeometryFactory::create();
+
+    template<typename T>
+    void voronoi(const T & sites) {
+        geos::util::Profile sw(std::string("Voronoi from ") + typeid(T).name());
+        sw.start();
+
+        geos::triangulate::VoronoiDiagramBuilder vdb;
+        vdb.setSites(sites);
+
+        auto result = vdb.getDiagram(*gfact);
+        sw.stop();
+
+        std::cout << sw.name << ": " << result->getNumGeometries() << ": " << sw.getTotFormatted() << std::endl;
+    }
+
+    template<typename T>
+    void delaunay(const T & seq) {
+        geos::util::Profile sw(std::string("Delaunay from ") + typeid(T).name());
+        sw.start();
+
+        geos::triangulate::DelaunayTriangulationBuilder dtb;
+        dtb.setSites(seq);
+
+        auto result = dtb.getTriangles(*gfact);
+
+        sw.stop();
+        std::cout << sw.name << ": " << result->getNumGeometries() << ": " << sw.getTotFormatted() << std::endl;
+    }
+};
+
+int main() {
+    VoronoiPerfTest tester;
+
+    //tester.test(100);
+    //tester.test(1000);
+    //tester.test(10000);
+    for (auto i = 0; i < 5; i++) {
+        tester.test(100000);
+    }
+}

--- a/include/geos/triangulate/DelaunayTriangulationBuilder.h
+++ b/include/geos/triangulate/DelaunayTriangulationBuilder.h
@@ -64,9 +64,9 @@ public:
     /**
      * Converts all {@link Coordinate}s in a collection to {@link Vertex}es.
      * @param coords the coordinates to convert
-     * @return a List of Vertex objects. Call takes ownership of returned object.
+     * @return a List of Vertex objects.
      */
-    static IncrementalDelaunayTriangulator::VertexList* toVertices(const geom::CoordinateSequence& coords);
+    static IncrementalDelaunayTriangulator::VertexList toVertices(const geom::CoordinateSequence& coords);
 
     /**
      * Returns a CoordinateSequence containing only the unique coordinates of its input.
@@ -78,7 +78,7 @@ public:
 private:
     std::unique_ptr<geom::CoordinateSequence> siteCoords;
     double tolerance;
-    quadedge::QuadEdgeSubdivision* subdiv;
+    std::unique_ptr<quadedge::QuadEdgeSubdivision> subdiv;
 
 public:
     /**
@@ -87,7 +87,7 @@ public:
      */
     DelaunayTriangulationBuilder();
 
-    ~DelaunayTriangulationBuilder();
+    ~DelaunayTriangulationBuilder() = default;
 
     /**
      * Sets the sites (vertices) which will be triangulated.

--- a/include/geos/triangulate/IncrementalDelaunayTriangulator.h
+++ b/include/geos/triangulate/IncrementalDelaunayTriangulator.h
@@ -54,7 +54,7 @@ public:
      */
     IncrementalDelaunayTriangulator(quadedge::QuadEdgeSubdivision* subdiv);
 
-    typedef std::list<quadedge::Vertex> VertexList;
+    typedef std::vector<quadedge::Vertex> VertexList;
 
     /**
      * Inserts all sites in a collection. The inserted vertices <b>MUST</b> be

--- a/include/geos/triangulate/VoronoiDiagramBuilder.h
+++ b/include/geos/triangulate/VoronoiDiagramBuilder.h
@@ -125,7 +125,7 @@ private:
     void create();
 
     static std::unique_ptr<geom::GeometryCollection>
-    clipGeometryCollection(const geom::GeometryCollection& geom, const geom::Envelope& clipEnv);
+    clipGeometryCollection(std::vector<std::unique_ptr<geom::Geometry>> & geoms, const geom::Envelope& clipEnv);
 
 };
 

--- a/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <list>
 #include <stack>
-#include <set>
+#include <unordered_set>
 #include <vector>
 
 #include <geos/geom/MultiLineString.h>
@@ -353,8 +353,8 @@ public:
 
 private:
     typedef std::stack<QuadEdge*> QuadEdgeStack;
-    typedef std::set<QuadEdge*> QuadEdgeSet;
-    typedef std::list< geom::CoordinateSequence*> TriList;
+    typedef std::unordered_set<QuadEdge*> QuadEdgeSet;
+    typedef std::vector<geom::CoordinateSequence*> TriList;
 
     /**
      * The quadedges forming a single triangle.
@@ -443,7 +443,7 @@ public:
      * @param geomFact a geometry factory
      * @return a List of Polygons
      */
-    std::unique_ptr< std::vector<geom::Geometry*> > getVoronoiCellPolygons(const geom::GeometryFactory& geomFact);
+    std::vector<std::unique_ptr<geom::Geometry>> getVoronoiCellPolygons(const geom::GeometryFactory& geomFact);
 
     /**
      * Gets a List of {@link LineString}s for the Voronoi cells
@@ -486,7 +486,7 @@ public:
      * @param geomFact a factory for building the polygon
      * @return a polygon indicating the cell extent
      */
-    std::unique_ptr<geom::Geometry> getVoronoiCellPolygon(QuadEdge* qe, const geom::GeometryFactory& geomFact);
+    std::unique_ptr<geom::Geometry> getVoronoiCellPolygon(const QuadEdge* qe, const geom::GeometryFactory& geomFact);
 
     /**
      * Gets the Voronoi cell edge around a site specified
@@ -499,7 +499,7 @@ public:
      * @param geomFact a factory for building the polygon
      * @return a polygon indicating the cell extent
      */
-    std::unique_ptr<geom::Geometry> getVoronoiCellEdge(QuadEdge* qe, const geom::GeometryFactory& geomFact);
+    std::unique_ptr<geom::Geometry> getVoronoiCellEdge(const QuadEdge* qe, const geom::GeometryFactory& geomFact);
 
 };
 

--- a/src/triangulate/IncrementalDelaunayTriangulator.cpp
+++ b/src/triangulate/IncrementalDelaunayTriangulator.cpp
@@ -36,9 +36,8 @@ IncrementalDelaunayTriangulator::IncrementalDelaunayTriangulator(
 void
 IncrementalDelaunayTriangulator::insertSites(const VertexList& vertices)
 {
-    for(VertexList::const_iterator x = vertices.begin();
-            x != vertices.end(); ++x) {
-        insertSite(*x);
+    for(const auto& vertex : vertices) {
+        insertSite(vertex);
     }
 }
 

--- a/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
+++ b/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
@@ -94,10 +94,10 @@ void object::test<2>
     double expandBy = std::max(Env.getWidth(), Env.getHeight());
     Env.expandBy(expandBy);
 
-    IncrementalDelaunayTriangulator::VertexList* vertices = DelaunayTriangulationBuilder::toVertices(*siteCoords);
+    IncrementalDelaunayTriangulator::VertexList vertices = DelaunayTriangulationBuilder::toVertices(*siteCoords);
     subdiv = new quadedge::QuadEdgeSubdivision(Env, 0);
     IncrementalDelaunayTriangulator triangulator(subdiv);
-    triangulator.insertSites(*vertices);
+    triangulator.insertSites(vertices);
 
     //Test for getVoronoiDiagram::
     const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());
@@ -112,7 +112,6 @@ void object::test<2>
     ensure(polys->equalsExact(expected, 1e-7));
     delete sites;
     delete subdiv;
-    delete vertices;
     delete expected;
 //		ensure(polys->getCoordinateDimension() == expected->getCoordinateDimension());
 }
@@ -141,12 +140,10 @@ template<> template<> void object::test<3>
         new quadedge::QuadEdgeSubdivision(env, 10)
     );
 
-    std::unique_ptr<IncrementalDelaunayTriangulator::VertexList> vertices(
-        DelaunayTriangulationBuilder::toVertices(*siteCoords)
-    );
+    auto vertices(DelaunayTriangulationBuilder::toVertices(*siteCoords));
 
     IncrementalDelaunayTriangulator triangulator(subdiv.get());
-    triangulator.insertSites(*vertices);
+    triangulator.insertSites(vertices);
 
     //Test for getVoronoiDiagram::
     const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());


### PR DESCRIPTION
Improve performance of VoronoiDiagramBuilder and DelaunayTriangulationBuilder.

Overall performance improvement is about 20-30% using a benchmark of 100,000
random points. Improvements picked up a few percent at a time, via:

- Reducing manual memory allocation
- Removing some unnecessary copying
- Using unordered_set instead of set
- etc.

There may be some room for improvement in the `QuadEdgeSubdivision` structure itself; I'm not familiar enough with that to make many changes.