### PR TITLE
Implement CoordinateSequence::toString()

### DIFF
--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -103,8 +103,6 @@ public:
 
     void setAt(const Coordinate& c, std::size_t pos) override;
 
-    std::string toString() const override;
-
     void setPoints(const std::vector<Coordinate>& v) override;
 
     double getOrdinate(std::size_t index,

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -176,7 +176,7 @@ public:
     virtual void setAt(const Coordinate& c, std::size_t pos) = 0;
 
     /// Get a string representation of CoordinateSequence
-    virtual	std::string toString() const = 0;
+    std::string toString() const;
 
     /// Substitute Coordinate list with a copy of the given vector
     virtual void setPoints(const std::vector<Coordinate>& v) = 0;

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -182,25 +182,6 @@ CoordinateArraySequence::setAt(const Coordinate& c, size_t pos)
     (*vect)[pos] = c;
 }
 
-string
-CoordinateArraySequence::toString() const
-{
-    string result("(");
-    if(getSize() > 0) {
-        //char buffer[100];
-        for(size_t i = 0, n = vect->size(); i < n; i++) {
-            Coordinate& c = (*vect)[i];
-            if(i) {
-                result.append(", ");
-            }
-            result.append(c.toString());
-        }
-    }
-    result.append(")");
-
-    return result;
-}
-
 CoordinateArraySequence::~CoordinateArraySequence()
 {
     delete vect;

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cassert>
 #include <iterator>
+#include <sstream>
 
 using namespace std;
 
@@ -249,6 +250,14 @@ operator<< (std::ostream& os, const CoordinateSequence& cs)
     os << ")";
 
     return os;
+}
+
+std::string
+CoordinateSequence::toString() const
+{
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
 }
 
 bool


### PR DESCRIPTION
Instead of being a pure virtual function that all implementations must
provide, CoordinateSequence::toString() now uses the existing ostream
operator to provide a consistent string representation for any
CoordinateSequence.