### PR TITLE
Move CoordinateSequence::add variants to CoordinateArraySequence

### DIFF
--- a/doc/example.cpp
+++ b/doc/example.cpp
@@ -233,7 +233,7 @@ LineString*
 create_ushaped_linestring(double xoffset, double yoffset, double side)
 {
     // We will use a coordinate list to build the linestring
-    CoordinateSequence* cl = new CoordinateArraySequence();
+    CoordinateArraySequence* cl = new CoordinateArraySequence();
 
     cl->add(Coordinate(xoffset, yoffset));
     cl->add(Coordinate(xoffset, yoffset + side));
@@ -260,7 +260,7 @@ LinearRing*
 create_square_linearring(double xoffset, double yoffset, double side)
 {
     // We will use a coordinate list to build the linearring
-    CoordinateSequence* cl = new CoordinateArraySequence();
+    CoordinateArraySequence* cl = new CoordinateArraySequence();
 
     cl->add(Coordinate(xoffset, yoffset));
     cl->add(Coordinate(xoffset, yoffset + side));

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -84,9 +84,16 @@ public:
         vect->clear();
     }
 
-    void add(const Coordinate& c) override;
+    /// Add a Coordinate to the list
+    void add(const Coordinate& c);
 
-    void add(const Coordinate& c, bool allowRepeated) override;
+    /**
+     * \brief Add a coordinate
+     * @param c the coordinate to add
+     * @param allowRepeated if set to false, repeated coordinates
+     *                      are collapsed
+     */
+    void add(const Coordinate& c, bool allowRepeated);
 
     /** \brief
      * Inserts the specified coordinate at the specified position in
@@ -99,7 +106,9 @@ public:
      *
      * NOTE: this is a CoordinateList interface in JTS
      */
-    void add(std::size_t i, const Coordinate& coord, bool allowRepeated) override;
+    void add(std::size_t i, const Coordinate& coord, bool allowRepeated);
+
+    void add(const CoordinateSequence* cl, bool allowRepeated, bool direction);
 
     void setAt(const Coordinate& c, std::size_t pos) override;
 

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -126,51 +126,8 @@ public:
     ///
     virtual void toVector(std::vector<Coordinate>& coords) const = 0;
 
-    /**
-     * \brief Add an array of coordinates
-     * @param vc the coordinates
-     * @param allowRepeated if set to false, repeated coordinates
-     *                      are collapsed
-     */
-    void add(const std::vector<Coordinate>* vc, bool allowRepeated);
-
-    /** \brief
-     *  Add an array of coordinates
-     *
-     *  @param cl the coordinates
-     *  @param allowRepeated
-     *         if set to false, repeated coordinates are collapsed
-     *  @param direction if false, the array is added in reverse order
-     */
-    void add(const CoordinateSequence* cl, bool allowRepeated,
-             bool direction);
-
-    /**
-     * \brief Add a coordinate
-     * @param c the coordinate to add
-     * @param allowRepeated if set to false, repeated coordinates
-     *                      are collapsed
-     */
-    virtual void add(const Coordinate& c, bool allowRepeated);
-
-    /** \brief
-     * Inserts the specified coordinate at the specified position in
-     * this list.
-     *
-     * @param i the position at which to insert
-     * @param coord the coordinate to insert
-     * @param allowRepeated if set to false, repeated coordinates are
-     *                      collapsed
-     *
-     * NOTE: this is a CoordinateList interface in JTS
-     */
-    virtual void add(std::size_t i, const Coordinate& coord, bool allowRepeated) = 0;
-
     /// Returns <code>true</code> it list contains no coordinates.
     virtual bool isEmpty() const = 0;
-
-    /// Add a Coordinate to the list
-    virtual void add(const Coordinate& c) = 0;
 
     /// Copy Coordinate c to position pos
     virtual void setAt(const Coordinate& c, std::size_t pos) = 0;

--- a/include/geos/geomgraph/EdgeRing.h
+++ b/include/geos/geomgraph/EdgeRing.h
@@ -44,7 +44,7 @@ class GeometryFactory;
 class LinearRing;
 class Polygon;
 class Coordinate;
-class CoordinateSequence;
+class CoordinateArraySequence;
 }
 namespace geomgraph {
 class DirectedEdge;
@@ -181,7 +181,7 @@ private:
     /// the DirectedEdges making up this EdgeRing
     std::vector<DirectedEdge*> edges;
 
-    geom::CoordinateSequence* pts;
+    geom::CoordinateArraySequence* pts;
 
     // label stores the locations of each geometry on the
     // face surrounded by this ring

--- a/include/geos/linearref/LinearGeometryBuilder.h
+++ b/include/geos/linearref/LinearGeometryBuilder.h
@@ -48,7 +48,7 @@ private:
 
     bool ignoreInvalidLines;
     bool fixInvalidLines;
-    geom::CoordinateSequence* coordList;
+    geom::CoordinateArraySequence* coordList;
 
     geom::Coordinate lastPt;
 

--- a/include/geos/noding/SegmentIntersectionDetector.h
+++ b/include/geos/noding/SegmentIntersectionDetector.h
@@ -20,7 +20,7 @@
 #include <geos/noding/SegmentIntersector.h>
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/geom/Coordinate.h>
-#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/noding/SegmentString.h>
 
 namespace geos {
@@ -51,7 +51,7 @@ private:
     bool _hasNonProperIntersection;
 
     const geom::Coordinate* intPt;
-    geom::CoordinateSequence* intSegments;
+    geom::CoordinateArraySequence* intSegments;
 
 protected:
 public:

--- a/include/geos/operation/linemerge/EdgeString.h
+++ b/include/geos/operation/linemerge/EdgeString.h
@@ -33,6 +33,7 @@
 namespace geos {
 namespace geom {
 class GeometryFactory;
+class CoordinateArraySequence;
 class CoordinateSequence;
 class LineString;
 }
@@ -56,7 +57,7 @@ class GEOS_DLL EdgeString {
 private:
     const geom::GeometryFactory* factory;
     std::vector<LineMergeDirectedEdge*> directedEdges;
-    geom::CoordinateSequence* coordinates;
+    geom::CoordinateArraySequence* coordinates;
     geom::CoordinateSequence* getCoordinates();
 public:
     /*

--- a/include/geos/operation/polygonize/EdgeRing.h
+++ b/include/geos/operation/polygonize/EdgeRing.h
@@ -72,7 +72,7 @@ private:
 
     // cache the following data for efficiency
     std::unique_ptr<geom::LinearRing> ring;
-    std::unique_ptr<geom::CoordinateSequence> ringPts;
+    std::unique_ptr<geom::CoordinateArraySequence> ringPts;
     std::unique_ptr<algorithm::locate::PointOnGeometryLocator> ringLocator;
 
     std::unique_ptr<std::vector<geom::Geometry*>> holes;
@@ -94,7 +94,7 @@ private:
 
     static void addEdge(const geom::CoordinateSequence* coords,
                         bool isForward,
-                        geom::CoordinateSequence* coordList);
+                        geom::CoordinateArraySequence* coordList);
 
     algorithm::locate::PointOnGeometryLocator* getLocator() {
         if (ringLocator == nullptr) {

--- a/include/geos/operation/valid/RepeatedPointRemover.h
+++ b/include/geos/operation/valid/RepeatedPointRemover.h
@@ -15,7 +15,7 @@
 #ifndef GEOS_OP_VALID_REPEATEDPOINTREMOVER_H
 #define GEOS_OP_VALID_REPEATEDPOINTREMOVER_H
 
-#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 
 namespace geos {
 namespace operation {
@@ -32,7 +32,7 @@ namespace valid {
     /// \param seq
     /// \return
     public:
-        static std::unique_ptr<geom::CoordinateSequence> removeRepeatedPoints(const geom::CoordinateSequence* seq);
+        static std::unique_ptr<geom::CoordinateArraySequence> removeRepeatedPoints(const geom::CoordinateSequence* seq);
     };
 }
 }

--- a/src/algorithm/MinimumBoundingCircle.cpp
+++ b/src/algorithm/MinimumBoundingCircle.cpp
@@ -71,11 +71,11 @@ MinimumBoundingCircle::getFarthestPoints()
         return input->getFactory()->createPoint(centre);
     }
 
-    size_t dims = input->getDimension();
+    size_t dims = input->getCoordinateDimension();
     size_t len = 2;
     auto cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
-    cs->add(extremalPts[0], true);
-    cs->add(extremalPts[extremalPts.size() - 1], true);
+    cs->setAt(extremalPts[0], 0);
+    cs->setAt(extremalPts[extremalPts.size() - 1], 1);
     return input->getFactory()->createLineString(cs.release());
 }
 
@@ -90,13 +90,13 @@ MinimumBoundingCircle::getDiameter()
     case 1:
         return input->getFactory()->createPoint(centre);
     }
-    size_t dims = input->getDimension();
+    size_t dims = input->getCoordinateDimension();
     size_t len = 2;
     auto cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
     // TODO: handle case of 3 extremal points, by computing a line from one of
     // them through the centre point with len = 2*radius
-    cs->add(extremalPts[0], true);
-    cs->add(extremalPts[1], true);
+    cs->setAt(extremalPts[0], 0);
+    cs->setAt(extremalPts[1], 1);
     return input->getFactory()->createLineString(cs.release());
 }
 

--- a/src/algorithm/MinimumDiameter.cpp
+++ b/src/algorithm/MinimumDiameter.cpp
@@ -137,9 +137,9 @@ MinimumDiameter::getSupportingSegment()
 {
     computeMinimumDiameter();
     const GeometryFactory* fact = inputGeom->getFactory();
-    auto cl = fact->getCoordinateSequenceFactory()->create();
-    cl->add(minBaseSeg->p0);
-    cl->add(minBaseSeg->p1);
+    auto cl = fact->getCoordinateSequenceFactory()->create(2);
+    cl->setAt(minBaseSeg->p0, 0);
+    cl->setAt(minBaseSeg->p1, 1);
     return fact->createLineString(cl.release());
 }
 
@@ -160,9 +160,9 @@ MinimumDiameter::getDiameter()
     Coordinate basePt;
     minBaseSeg->project(*minWidthPt, basePt);
 
-    auto cl = inputGeom->getFactory()->getCoordinateSequenceFactory()->create();
-    cl->add(basePt);
-    cl->add(*minWidthPt);
+    auto cl = inputGeom->getFactory()->getCoordinateSequenceFactory()->create(2);
+    cl->setAt(basePt, 0);
+    cl->setAt(*minWidthPt, 1);
     return inputGeom->getFactory()->createLineString(cl.release());
 }
 

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -32,7 +32,7 @@ namespace geom { // geos::geom
 
 CoordinateArraySequence::CoordinateArraySequence():
     vect(new vector<Coordinate>()),
-    dimension(3)
+    dimension(0)
 {
 }
 
@@ -129,6 +129,24 @@ CoordinateArraySequence::add(const Coordinate& c, bool allowRepeated)
         }
     }
     vect->push_back(c);
+}
+
+void
+CoordinateArraySequence::add(const CoordinateSequence* cl, bool allowRepeated, bool direction)
+{
+    // FIXME:  don't rely on negative values for 'j' (the reverse case)
+
+    const auto npts = cl->size();
+    if(direction) {
+        for(size_t i = 0; i < npts; ++i) {
+            add(cl->getAt(i), allowRepeated);
+        }
+    }
+    else {
+        for(auto j = npts; j > 0; --j) {
+            add(cl->getAt(j - 1), allowRepeated);
+        }
+    }
 }
 
 /*public*/

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -179,53 +179,6 @@ CoordinateSequence::equals(const CoordinateSequence* cl1,
     return true;
 }
 
-/*public*/
-void
-CoordinateSequence::add(const vector<Coordinate>* vc, bool allowRepeated)
-{
-    assert(vc);
-    for(size_t i = 0; i < vc->size(); ++i) {
-        add((*vc)[i], allowRepeated);
-    }
-}
-
-/*public*/
-void
-CoordinateSequence::add(const Coordinate& c, bool allowRepeated)
-{
-    if(!allowRepeated) {
-        std::size_t npts = getSize();
-        if(npts >= 1) {
-            const Coordinate& last = getAt(npts - 1);
-            if(last.equals2D(c)) {
-                return;
-            }
-        }
-    }
-    add(c);
-}
-
-/*public*/
-void
-CoordinateSequence::add(const CoordinateSequence* cl,
-                        bool allowRepeated, bool direction)
-{
-    // FIXME:  don't rely on negative values for 'j' (the reverse case)
-
-    const auto npts = cl->size();
-    if(direction) {
-        for(size_t i = 0; i < npts; ++i) {
-            add(cl->getAt(i), allowRepeated);
-        }
-    }
-    else {
-        for(auto j = npts; j > 0; --j) {
-            add(cl->getAt(j - 1), allowRepeated);
-        }
-    }
-}
-
-
 void
 CoordinateSequence::expandEnvelope(Envelope& env) const
 {

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -277,22 +277,27 @@ GeometryFactory::toGeometry(const Envelope* envelope) const
         return createPoint(coord);
     }
     auto cl = CoordinateArraySequenceFactory::instance()->
-                             create((size_t) 0, 2);
+                             create((size_t) 5, 2);
+
     coord.x = envelope->getMinX();
     coord.y = envelope->getMinY();
-    cl->add(coord);
+    cl->setAt(coord, 0);
+
     coord.x = envelope->getMaxX();
     coord.y = envelope->getMinY();
-    cl->add(coord);
+    cl->setAt(coord, 1);
+
     coord.x = envelope->getMaxX();
     coord.y = envelope->getMaxY();
-    cl->add(coord);
+    cl->setAt(coord, 2);
+
     coord.x = envelope->getMinX();
     coord.y = envelope->getMaxY();
-    cl->add(coord);
+    cl->setAt(coord, 3);
+
     coord.x = envelope->getMinX();
     coord.y = envelope->getMinY();
-    cl->add(coord);
+    cl->setAt(coord, 4);
 
     Polygon* p = createPolygon(createLinearRing(cl.release()), nullptr);
     return p;

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -313,9 +313,9 @@ LineSegment::pointAlongOffset(double segmentLengthFraction,
 std::unique_ptr<LineString>
 LineSegment::toGeometry(const GeometryFactory& gf) const
 {
-    CoordinateSequence* cl = new CoordinateArraySequence();
-    cl->add(p0);
-    cl->add(p1);
+    CoordinateSequence* cl = new CoordinateArraySequence(2);
+    cl->setAt(p0, 0);
+    cl->setAt(p1, 1);
     return std::unique_ptr<LineString>(
                gf.createLineString(cl) // ownership transferred
            );

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -20,7 +20,7 @@
 
 #include <geos/algorithm/Area.h>
 #include <geos/algorithm/Orientation.h>
-#include <geos/util/IllegalArgumentException.h>
+#include <geos/util.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/Polygon.h>
 #include <geos/geom/LinearRing.h>
@@ -29,7 +29,7 @@
 #include <geos/geom/Dimension.h>
 #include <geos/geom/Envelope.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
-#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/CoordinateSequenceFilter.h>
 #include <geos/geom/GeometryFilter.h>
 #include <geos/geom/GeometryComponentFilter.h>
@@ -332,13 +332,12 @@ Polygon::normalize(LinearRing* ring, bool clockwise)
         return;
     }
 
-    auto seqFactory = ring->getFactory()->getCoordinateSequenceFactory();
-
-    std::unique_ptr<std::vector<Coordinate>> coords(new std::vector<Coordinate>());
+    auto coords = detail::make_unique<std::vector<Coordinate>>();
     ring->getCoordinatesRO()->toVector(*coords);
     coords->erase(coords->end() - 1); // remove last point (repeated)
 
-    std::unique_ptr<CoordinateSequence> uniqueCoordinates = seqFactory->create(coords.release());
+    auto uniqueCoordinates = detail::make_unique<CoordinateArraySequence>(coords.release());
+
     const Coordinate* minCoordinate = uniqueCoordinates->minCoordinate();
 
     CoordinateSequence::scroll(uniqueCoordinates.get(), minCoordinate);

--- a/src/geomgraph/EdgeRing.cpp
+++ b/src/geomgraph/EdgeRing.cpp
@@ -30,6 +30,7 @@
 #include <geos/geomgraph/Label.h>
 #include <geos/geomgraph/Position.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/LinearRing.h>
@@ -55,7 +56,7 @@ EdgeRing::EdgeRing(DirectedEdge* newStart,
     holes(),
     maxNodeDegree(-1),
     edges(),
-    pts(newGeometryFactory->getCoordinateSequenceFactory()->create().release()),
+    pts(new CoordinateArraySequence()),
     label(Location::UNDEF), // new Label(Location::UNDEF)),
     ring(nullptr),
     isHoleVar(false),

--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -32,8 +32,10 @@
 #include <geos/geom/MultiPolygon.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/PrecisionModel.h>
 #include <geos/inline.h>
+#include <geos/util.h>
 
 #include <sstream>
 #include <string>
@@ -81,7 +83,7 @@ WKTReader::getCoordinates(StringTokenizer* tokenizer)
     Coordinate coord;
     getPreciseCoordinate(tokenizer, coord, dim);
 
-    auto coordinates = geometryFactory->getCoordinateSequenceFactory()->create((size_t)0, dim);
+    auto coordinates = detail::make_unique<CoordinateArraySequence>(0, dim);
     coordinates->add(coord);
 
     nextToken = getNextCloserOrComma(tokenizer);
@@ -91,7 +93,7 @@ WKTReader::getCoordinates(StringTokenizer* tokenizer)
         nextToken = getNextCloserOrComma(tokenizer);
     }
 
-    return coordinates;
+    return std::move(coordinates);
 }
 
 
@@ -295,9 +297,7 @@ WKTReader::readMultiPointText(StringTokenizer* tokenizer)
         size_t dim;
 
         // Try to parse deprecated form "MULTIPOINT(0 0, 1 1)"
-        const CoordinateSequenceFactory* csf = \
-                                               geometryFactory->getCoordinateSequenceFactory();
-        auto coords = csf->create();
+        auto coords = detail::make_unique<CoordinateArraySequence>();
 
         do {
             Coordinate coord;

--- a/src/operation/buffer/BufferInputLineSimplifier.cpp
+++ b/src/operation/buffer/BufferInputLineSimplifier.cpp
@@ -21,6 +21,7 @@
 #include <geos/geom/CoordinateArraySequence.h> // for constructing the return
 #include <geos/algorithm/Distance.h> // for use
 #include <geos/algorithm/Orientation.h> // for use
+#include <geos/util.h>
 
 #include <memory>
 #include <cmath>
@@ -127,8 +128,7 @@ BufferInputLineSimplifier::findNextNonDeletedIndex(size_t index) const
 std::unique_ptr<geom::CoordinateSequence>
 BufferInputLineSimplifier::collapseLine() const
 {
-    std::unique_ptr<geom::CoordinateSequence> coordList(
-        new CoordinateArraySequence());
+    auto coordList = detail::make_unique<CoordinateArraySequence>();
 
     for(size_t i = 0, n = inputLine.size(); i < n; ++i) {
         if(isDeleted[i] != DELETE) {
@@ -136,7 +136,7 @@ BufferInputLineSimplifier::collapseLine() const
         }
     }
 
-    return coordList;
+    return std::move(coordList);
 }
 
 /* private */

--- a/src/operation/linemerge/EdgeString.cpp
+++ b/src/operation/linemerge/EdgeString.cpp
@@ -24,6 +24,7 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/LineString.h>
 
 #include <vector>
@@ -66,7 +67,7 @@ EdgeString::getCoordinates()
     if(coordinates == nullptr) {
         int forwardDirectedEdges = 0;
         int reverseDirectedEdges = 0;
-        coordinates = factory->getCoordinateSequenceFactory()->create().release();
+        coordinates = new CoordinateArraySequence();
         for(std::size_t i = 0, e = directedEdges.size(); i < e; ++i) {
             LineMergeDirectedEdge* directedEdge = directedEdges[i];
             if(directedEdge->getEdgeDirection()) {

--- a/src/operation/polygonize/EdgeRing.cpp
+++ b/src/operation/polygonize/EdgeRing.cpp
@@ -20,6 +20,7 @@
 #include <geos/operation/polygonize/EdgeRing.h>
 #include <geos/operation/polygonize/PolygonizeEdge.h>
 #include <geos/planargraph/DirectedEdge.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/LinearRing.h>
 #include <geos/geom/Coordinate.h>
@@ -221,7 +222,7 @@ const CoordinateSequence*
 EdgeRing::getCoordinates()
 {
     if(ringPts == nullptr) {
-        ringPts = factory->getCoordinateSequenceFactory()->create();
+        ringPts = detail::make_unique<CoordinateArraySequence>(0, 0);
         for(const auto& de : deList) {
             auto edge = dynamic_cast<PolygonizeEdge*>(de->getEdge());
             addEdge(edge->getLine()->getCoordinatesRO(),
@@ -274,7 +275,7 @@ EdgeRing::getRingOwnership()
 /*private*/
 void
 EdgeRing::addEdge(const CoordinateSequence* coords, bool isForward,
-                  CoordinateSequence* coordList)
+                  CoordinateArraySequence* coordList)
 {
     const std::size_t npts = coords->getSize();
     if(isForward) {

--- a/src/operation/valid/RepeatedPointRemover.cpp
+++ b/src/operation/valid/RepeatedPointRemover.cpp
@@ -22,14 +22,12 @@ namespace geos {
 namespace operation {
 namespace valid {
 
-std::unique_ptr<geom::CoordinateSequence>
+std::unique_ptr<geom::CoordinateArraySequence>
 RepeatedPointRemover::removeRepeatedPoints(const geom::CoordinateSequence* seq) {
     using geom::Coordinate;
 
-    auto seqFactory = geom::CoordinateArraySequenceFactory::instance();
-
     if (seq->isEmpty()) {
-        return std::unique_ptr<geom::CoordinateSequence>(seqFactory->create());
+        return detail::make_unique<geom::CoordinateArraySequence>(0, seq->getDimension());
     }
 
     auto pts = detail::make_unique<std::vector<Coordinate>>();
@@ -47,7 +45,7 @@ RepeatedPointRemover::removeRepeatedPoints(const geom::CoordinateSequence* seq) 
         prevPt = nextPt;
     }
 
-    return std::unique_ptr<geom::CoordinateSequence>(seqFactory->create(pts.release(), seq->getDimension()));
+    return detail::make_unique<geom::CoordinateArraySequence>(pts.release(), seq->getDimension());
 }
 
 }

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -470,10 +470,10 @@ QuadEdgeSubdivision::getEdges(const geom::GeometryFactory& geomFact)
     int i = 0;
     for(QuadEdgeSubdivision::QuadEdgeList::iterator it = p_quadEdges->begin(); it != p_quadEdges->end(); ++it) {
         QuadEdge* qe = *it;
-        auto coordSeq = coordSeqFact->create((std::vector<geom::Coordinate>*)nullptr);;
+        auto coordSeq = coordSeqFact->create(2);
 
-        coordSeq->add(qe->orig().getCoordinate());
-        coordSeq->add(qe->dest().getCoordinate());
+        coordSeq->setAt(qe->orig().getCoordinate(), 0);
+        coordSeq->setAt(qe->dest().getCoordinate(), 1);
 
         edges[i++] = static_cast<Geometry*>(geomFact.createLineString(coordSeq.release()));
     }

--- a/tests/bigtest/GeometryTestFactory.cpp
+++ b/tests/bigtest/GeometryTestFactory.cpp
@@ -34,7 +34,7 @@ CoordinateSequence*
 GeometryTestFactory::createBox(double minx, double miny, int nSide, double segLen)
 {
     int i;
-    CoordinateSequence* pts = new CoordinateArraySequence();
+    CoordinateArraySequence* pts = new CoordinateArraySequence();
     double maxx = minx + nSide * segLen;
     double maxy = miny + nSide * segLen;
 
@@ -72,7 +72,7 @@ GeometryTestFactory::createBox(double minx, double miny, int nSide, double segLe
 CoordinateSequence*
 GeometryTestFactory::createCircle(double basex, double basey, double size, int nPts)
 {
-    CoordinateSequence* pts = new CoordinateArraySequence(nPts + 1);
+    CoordinateArraySequence* pts = new CoordinateArraySequence(nPts + 1);
     double len = size / 2.0;
 
     for(int i = 0; i < nPts; i++) {
@@ -116,7 +116,7 @@ GeometryTestFactory::createSineStar(double basex, double basey, double size, dou
     }
 
     //int nPts2=nArmPt*nArms;
-    CoordinateSequence* pts = new CoordinateArraySequence();
+    CoordinateArraySequence* pts = new CoordinateArraySequence();
 
     double starAng = 0.0;
 
@@ -128,15 +128,13 @@ GeometryTestFactory::createSineStar(double basex, double basey, double size, dou
             double y = len * sin(starAng + iArmPt * angInc / nArmPt) + basey;
 
             // FIXME - mloskot: Number of problems here:
-            // - new'd Coordinate definitely leaks
             // - add() method makes a copy
-            // - why temporarily used Coordinate is allocated on the heap?!?
-            pts->add(*(new Coordinate(x, y)));
+            pts->add(Coordinate(x, y));
         }
         starAng += angInc;
     }
     // FIXME - mloskot: The same problems as above
-    pts->add(*(new Coordinate(pts->getAt(0))));
+    pts->add(pts->getAt(0));
     return pts;
 }
 

--- a/tests/unit/algorithm/RobustLineIntersectorTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectorTest.cpp
@@ -248,7 +248,7 @@ void object::test<13>
     using geos::geom::LineString;
 
     GeometryFactory::Ptr factory = GeometryFactory::create();
-    CoordinateSequence* cs = new CoordinateArraySequence();
+    CoordinateArraySequence* cs = new CoordinateArraySequence();
     cs->add(p1);
     cs->add(p2);
 

--- a/tests/unit/geom/PointTest.cpp
+++ b/tests/unit/geom/PointTest.cpp
@@ -94,8 +94,9 @@ void object::test<2>
     ensure(!point->isEmpty());
 
     // currently the empty CoordinateArraySequence constructor
-    // produces a dimension 3 sequence.
-    ensure(point->getCoordinateDimension() == 3);
+    // produces a dimension 0 sequence. The dimension is then
+    // autodetected when the first point is inserted.
+    ensure(point->getCoordinateDimension() == 2);
 }
 
 // Test of user's constructor throwing IllegalArgumentException

--- a/tests/unit/noding/BasicSegmentStringTest.cpp
+++ b/tests/unit/noding/BasicSegmentStringTest.cpp
@@ -6,8 +6,9 @@
 #include <geos/noding/BasicSegmentString.h>
 #include <geos/noding/Octant.h>
 #include <geos/geom/Coordinate.h>
-#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/CoordinateArraySequenceFactory.h>
+#include <geos/util.h>
 // std
 #include <memory>
 
@@ -62,7 +63,7 @@ template<>
 void object::test<1>
 ()
 {
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
 
     ensure(nullptr != cs.get());
 
@@ -107,7 +108,7 @@ template<>
 void object::test<2>
 ()
 {
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
 
     ensure(nullptr != cs.get());
 
@@ -144,7 +145,7 @@ template<>
 void object::test<3>
 ()
 {
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
 
     ensure(nullptr != cs.get());
 

--- a/tests/unit/noding/NodedSegmentStringTest.cpp
+++ b/tests/unit/noding/NodedSegmentStringTest.cpp
@@ -6,8 +6,9 @@
 #include <geos/noding/NodedSegmentString.h>
 #include <geos/noding/Octant.h>
 #include <geos/geom/Coordinate.h>
-#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/CoordinateArraySequenceFactory.h>
+#include <geos/util.h>
 // std
 #include <memory>
 
@@ -62,7 +63,7 @@ template<>
 void object::test<1>
 ()
 {
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
 
     ensure(nullptr != cs.get());
 
@@ -98,7 +99,7 @@ template<>
 void object::test<2>
 ()
 {
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
 
     ensure(nullptr != cs.get());
 
@@ -134,7 +135,7 @@ template<>
 void object::test<3>
 ()
 {
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
 
     ensure(nullptr != cs.get());
 
@@ -207,7 +208,7 @@ void object::test<5>
     geos::geom::Coordinate p1(10, 0);
 
 
-    CoordinateSequenceAutoPtr cs(csFactory->create((size_t)0, 2));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, 2);
     cs->add(p0);
     cs->add(p1);
 

--- a/tests/unit/noding/SegmentNodeTest.cpp
+++ b/tests/unit/noding/SegmentNodeTest.cpp
@@ -6,8 +6,9 @@
 #include <geos/noding/SegmentNode.h>
 #include <geos/noding/NodedSegmentString.h>
 #include <geos/geom/Coordinate.h>
-#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/CoordinateArraySequenceFactory.h>
+#include <geos/util.h>
 // std
 #include <memory>
 
@@ -53,7 +54,7 @@ void object::test<1>
 
     // Create coordinates sequence
     const size_t coords_size = 2;
-    CoordSeqPtr cs(factory_->create((size_t)0, coords_size));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, coords_size);
 
     ensure(nullptr != cs.get());
 
@@ -102,7 +103,7 @@ void object::test<2>
 
     // Create coordinates sequence
     const size_t coords_size = 2;
-    CoordSeqPtr cs(factory_->create((size_t)0, coords_size));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, coords_size);
 
     ensure(nullptr != cs.get());
 
@@ -145,7 +146,7 @@ void object::test<3>
 
     // Create coordinates sequence
     const size_t coords_size = 2;
-    CoordSeqPtr cs(factory_->create((size_t)0, coords_size));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, coords_size);
 
     ensure(nullptr != cs.get());
 
@@ -188,7 +189,7 @@ void object::test<4>
 
     // Create coordinates sequence
     const size_t coords_size = 2;
-    CoordSeqPtr cs(factory_->create((size_t)0, coords_size));
+    auto cs = geos::detail::make_unique<geos::geom::CoordinateArraySequence>(0, coords_size);
 
     ensure(nullptr != cs.get());
 

--- a/tests/unit/operation/valid/IsValidTest.cpp
+++ b/tests/unit/operation/valid/IsValidTest.cpp
@@ -56,7 +56,7 @@ template<>
 void object::test<1>
 ()
 {
-    CoordinateSequence* cs = new CoordinateArraySequence();
+    CoordinateArraySequence* cs = new CoordinateArraySequence();
     cs->add(Coordinate(0.0, 0.0));
     cs->add(Coordinate(1.0, geos::DoubleNotANumber));
     GeomPtr line(factory_->createLineString(cs));


### PR DESCRIPTION
Making this change removes the assumption that any CoordinateSequence is
resizable, which opens the door to a CoordinateSequence that is blocked
by a raw block of memory (such as a PostGIS POINTARRAY).

The default CoordinateArraySequence constructor now creates a
CoordinateSequence of unknown dimension (dimension determined when the
first Coordinate is assigned) rather than of dimension 3. This is for
consistency with the behavior of the CoordinateArraySequenceFactory.