### PR TITLE
GEOSPreparedContains performance improvements

### DIFF
--- a/benchmarks/capi/CMakeLists.txt
+++ b/benchmarks/capi/CMakeLists.txt
@@ -16,3 +16,6 @@ target_include_directories(perf_memleak_mp_prep
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
 target_link_libraries(perf_memleak_mp_prep PRIVATE geos_c)
+
+add_executable(perf_geospreparedcontains GEOSPreparedContainsPerfTest.cpp)
+target_link_libraries(perf_geospreparedcontains PRIVATE geos geos_c)

--- a/benchmarks/capi/GEOSPreparedContainsPerfTest.cpp
+++ b/benchmarks/capi/GEOSPreparedContainsPerfTest.cpp
@@ -1,0 +1,114 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston <dbaston@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/profiler.h>
+#include <geos_c.h>
+
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/Polygon.h>
+#include <geos/geom/util/SineStarFactory.h>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+#include <memory>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+class GEOSPreparedContainsPerfTest {
+
+public:
+    void test(const GEOSGeometry* g, size_t num_points) {
+        using namespace geos::geom;
+
+        double xmin, xmax, ymin, ymax;
+
+        GEOSGeom_getXMin(g, &xmin);
+        GEOSGeom_getXMax(g, &xmax);
+        GEOSGeom_getYMin(g, &ymin);
+        GEOSGeom_getYMax(g, &ymax);
+
+        std::default_random_engine e(12345);
+        std::uniform_real_distribution<> xdist(xmin, xmax);
+        std::uniform_real_distribution<> ydist(ymin, ymax);
+
+        std::vector<Coordinate> coords(num_points);
+        std::generate(coords.begin(), coords.end(), [&xdist, &ydist, &e]() {
+            return Coordinate(xdist(e), ydist(e));
+        });
+
+        geos::util::Profile sw("GEOSPreparedContains");
+        sw.start();
+
+        size_t hits = 0;
+        auto prep = GEOSPrepare(g);
+        for (const auto& c : coords) {
+            auto seq = GEOSCoordSeq_create(1, 2);
+            GEOSCoordSeq_setX(seq, 0, c.x);
+            GEOSCoordSeq_setY(seq, 0, c.y);
+            auto pt = GEOSGeom_createPoint(seq);
+
+            if (GEOSPreparedContains(prep, pt)) {
+                hits++;
+            }
+
+            GEOSGeom_destroy(pt);
+        }
+
+        GEOSPreparedGeom_destroy(prep);
+
+        sw.stop();
+
+        std::cout << sw.name << ": " << hits << " hits from " << num_points << " points in " <<  sw.getTotFormatted() << std::endl;
+
+    }
+};
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        std::cout << "perf_geospreparedcontins performs a specified number of point-in-polygon tests" << std::endl;
+        std::cout << "on randomly generated points from the bounding box of a single geometry provided" << std::endl;
+        std::cout << "in a file as WKT." << std::endl;
+        std::cout << std::endl;
+        std::cout << "Usage: perf_geospreparedcontins [wktfile] [n]" << std::endl;
+        return 0;
+    }
+
+    GEOSPreparedContainsPerfTest tester;
+
+    int n = std::atoi(argv[2]);
+    std::cout << "Performing " << n << " point-in-polygon tests." << std::endl;
+
+    std::string fname{argv[1]};
+    std::cout << "Reading shape from " << fname << std::endl;
+
+    std::ifstream f(fname);
+    std::stringstream buff;
+    buff << f.rdbuf();
+    f.close();
+
+    std::string wkt = buff.str();
+    buff.clear();
+
+    initGEOS(nullptr, nullptr);
+    GEOSGeometry* g = GEOSGeomFromWKT(wkt.c_str());
+    wkt.clear();
+
+    tester.test(g, n);
+
+    GEOSGeom_destroy(g);
+}

--- a/include/geos/algorithm/RayCrossingCounter.h
+++ b/include/geos/algorithm/RayCrossingCounter.h
@@ -92,22 +92,6 @@ public:
     static int locatePointInRing(const geom::Coordinate& p,
                                  const std::vector<const geom::Coordinate*>& ring);
 
-    /** \brief
-     * Returns the index of the direction of the point <code>q</code>
-     * relative to a vector specified by <code>p1-p2</code>.
-     *
-     * @param p1 the origin point of the vector
-     * @param p2 the final point of the vector
-     * @param q the point to compute the direction to
-     *
-     * @return 1 if q is counter-clockwise (left) from p1-p2
-     * @return -1 if q is clockwise (right) from p1-p2
-     * @return 0 if q is collinear with p1-p2
-     */
-    static int orientationIndex(const geom::Coordinate& p1,
-                                const geom::Coordinate& p2,
-                                const geom::Coordinate& q);
-
     RayCrossingCounter(const geom::Coordinate& p_point)
         :	point(p_point),
           crossingCount(0),

--- a/include/geos/geom/GeometryComponentFilter.h
+++ b/include/geos/geom/GeometryComponentFilter.h
@@ -52,6 +52,8 @@ public:
     virtual void filter_rw(Geometry* geom);
     virtual void filter_ro(const Geometry* geom);
 
+    virtual bool isDone() { return false; }
+
     virtual
     ~GeometryComponentFilter() {}
 };

--- a/include/geos/geom/prep/AbstractPreparedPolygonContains.h
+++ b/include/geos/geom/prep/AbstractPreparedPolygonContains.h
@@ -99,6 +99,16 @@ protected:
     bool eval(const geom::Geometry* geom);
 
     /**
+     * Evaluate the <tt>contains</tt> or <tt>covers</tt> relationship
+     * for the given Puntal geometry.
+     *
+     * @param geom the test geometry
+     * @param outermostLoc outermost Location of all points in geom
+     * @return true if the test geometry is contained/covered in the target
+     */
+    bool evalPointTestGeom(const geom::Geometry* geom, geom::Location::Value outermostLoc);
+
+    /**
      * Computes the full topological predicate.
      * Used when short-circuit tests are not conclusive.
      *

--- a/include/geos/geom/prep/PreparedPolygonPredicate.h
+++ b/include/geos/geom/prep/PreparedPolygonPredicate.h
@@ -22,6 +22,7 @@
 #define GEOS_GEOM_PREP_PREPAREDPOLYGONPREDICATE_H
 
 #include <geos/geom/Coordinate.h>
+#include <geos/geom/Location.h>
 
 // forward declarations
 namespace geos {
@@ -64,16 +65,13 @@ protected:
     const PreparedPolygon* const prepPoly;
 
     /** \brief
-     * Tests whether all components of the test Geometry
-     * are contained in the target geometry.
-     *
-     * Handles both linear and point components.
+     * Returns the outermost Location among a test point from each
+     * components of the test geometry.
      *
      * @param testGeom a geometry to test
-     * @return true if all components of the argument are contained
-     *              in the target geometry
+     * @return the outermost Location
      */
-    bool isAllTestComponentsInTarget(const geom::Geometry* testGeom) const;
+    geom::Location::Value getOutermostTestComponentLocation(const geom::Geometry* testGeom) const;
 
     /** \brief
      * Tests whether all components of the test Geometry

--- a/src/algorithm/RayCrossingCounter.cpp
+++ b/src/algorithm/RayCrossingCounter.cpp
@@ -75,21 +75,6 @@ RayCrossingCounter::locatePointInRing(const geom::Coordinate& point,
     return rcc.getLocation();
 }
 
-/*public static*/
-int
-RayCrossingCounter::orientationIndex(const geom::Coordinate& p1,
-                                     const geom::Coordinate& p2, const geom::Coordinate& q)
-{
-    // travelling along p1->p2, turn counter clockwise to get to q return 1,
-    // travelling along p1->p2, turn clockwise to get to q return -1,
-    // p1, p2 and q are colinear return 0.
-    double dx1 = p2.x - p1.x;
-    double dy1 = p2.y - p1.y;
-    double dx2 = q.x - p2.x;
-    double dy2 = q.y - p2.y;
-    return CGAlgorithmsDD::signOfDet2x2(dx1, dy1, dx2, dy2);
-}
-
 void
 RayCrossingCounter::countSegment(const geom::Coordinate& p1,
                                  const geom::Coordinate& p2)
@@ -138,7 +123,7 @@ RayCrossingCounter::countSegment(const geom::Coordinate& p1,
             ((p2.y > point.y) && (p1.y <= point.y))) {
         // For an upward edge, orientationIndex will be positive when p1->p2
         // crosses ray. Conversely, downward edges should have negative sign.
-        int sign = orientationIndex(p1, p2, point);
+        int sign = CGAlgorithmsDD::orientationIndex(p1, p2, point);
         if(sign == 0) {
             isPointOnSegment = true;
             return;

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -310,7 +310,7 @@ void
 GeometryCollection::apply_rw(GeometryComponentFilter* filter)
 {
     filter->filter_rw(this);
-    for(size_t i = 0; i < geometries->size(); ++i) {
+    for(size_t i = 0; i < geometries->size() && !filter->isDone(); ++i) {
         (*geometries)[i]->apply_rw(filter);
     }
 }
@@ -319,7 +319,7 @@ void
 GeometryCollection::apply_ro(GeometryComponentFilter* filter) const
 {
     filter->filter_ro(this);
-    for(size_t i = 0; i < geometries->size(); ++i) {
+    for(size_t i = 0; i < geometries->size() && !filter->isDone(); ++i) {
         (*geometries)[i]->apply_ro(filter);
     }
 }

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -394,7 +394,7 @@ Polygon::apply_ro(GeometryComponentFilter* filter) const
 {
     filter->filter_ro(this);
     shell->apply_ro(filter);
-    for(size_t i = 0, n = holes->size(); i < n; ++i) {
+    for(size_t i = 0, n = holes->size(); i < n && !filter->isDone(); ++i) {
         (*holes)[i]->apply_ro(filter);
     }
 }
@@ -404,7 +404,7 @@ Polygon::apply_rw(GeometryComponentFilter* filter)
 {
     filter->filter_rw(this);
     shell->apply_rw(filter);
-    for(size_t i = 0, n = holes->size(); i < n; ++i) {
+    for(size_t i = 0, n = holes->size(); i < n && !filter->isDone(); ++i) {
         (*holes)[i]->apply_rw(filter);
     }
 }

--- a/src/geom/prep/AbstractPreparedPolygonContains.cpp
+++ b/src/geom/prep/AbstractPreparedPolygonContains.cpp
@@ -112,9 +112,11 @@ AbstractPreparedPolygonContains::eval(const geom::Geometry* geom)
     //
     // If a point of any test components does not lie in target,
     // result is false
-    bool isAllInTargetArea = isAllTestComponentsInTarget(geom);
-    if(!isAllInTargetArea) {
-        return false;
+    if (!requireSomePointInInterior || geom->getGeometryTypeId() != GEOS_POINT) {
+        bool isAllInTargetArea = isAllTestComponentsInTarget(geom);
+        if (!isAllInTargetArea) {
+            return false;
+        }
     }
 
     // If the test geometry consists of only Points,

--- a/src/geom/prep/BasicPreparedGeometry.cpp
+++ b/src/geom/prep/BasicPreparedGeometry.cpp
@@ -40,12 +40,20 @@ BasicPreparedGeometry::setGeometry(const geom::Geometry* geom)
 bool
 BasicPreparedGeometry::envelopesIntersect(const geom::Geometry* g) const
 {
+    if (g->getGeometryTypeId() == GEOS_POINT) {
+        return baseGeom->getEnvelopeInternal()->intersects(*(g->getCoordinate()));
+    }
+
     return baseGeom->getEnvelopeInternal()->intersects(g->getEnvelopeInternal());
 }
 
 bool
 BasicPreparedGeometry::envelopeCovers(const geom::Geometry* g) const
 {
+    if (g->getGeometryTypeId() == GEOS_POINT) {
+        return baseGeom->getEnvelopeInternal()->covers(g->getCoordinate());
+    }
+
     return baseGeom->getEnvelopeInternal()->covers(g->getEnvelopeInternal());
 }
 

--- a/src/geom/prep/PreparedPolygonPredicate.cpp
+++ b/src/geom/prep/PreparedPolygonPredicate.cpp
@@ -91,6 +91,11 @@ bool
 PreparedPolygonPredicate::isAnyTestComponentInTargetInterior(
     const geom::Geometry* testGeom) const
 {
+    if (testGeom->getGeometryTypeId() == GEOS_POINT) {
+        // Avoid creating a vector to store a single point
+        return prepPoly->getPointLocator()->locate(testGeom->getCoordinate()) == geom::Location::INTERIOR;
+    }
+
     geom::Coordinate::ConstVect pts;
     geom::util::ComponentCoordinateExtracter::getCoordinates(*testGeom, pts);
 

--- a/src/geom/prep/PreparedPolygonPredicate.cpp
+++ b/src/geom/prep/PreparedPolygonPredicate.cpp
@@ -47,13 +47,16 @@ struct AnyMatchingLocationFilter : public GeometryComponentFilter {
     bool found;
 
     void filter_ro(const Geometry* g) override {
-        auto pt = g->getCoordinate();
-        if (!found) {
-            const int loc = pt_locator->locate(pt);
-            if (loc == test_loc) {
-                found = true;
-            }
+        const Coordinate* pt = g->getCoordinate();
+        const int loc = pt_locator->locate(pt);
+
+        if (loc == test_loc) {
+            found = true;
         }
+    }
+
+    bool isDone() override {
+        return found;
     }
 };
 
@@ -66,13 +69,16 @@ struct AnyNotMatchingLocationFilter : public GeometryComponentFilter {
     bool found;
 
     void filter_ro(const Geometry* g) override {
-        auto pt = g->getCoordinate();
-        if (!found) {
-            const int loc = pt_locator->locate(pt);
-            if (loc != test_loc) {
-                found = true;
-            }
+        const Coordinate* pt = g->getCoordinate();
+        const int loc = pt_locator->locate(pt);
+
+        if (loc != test_loc) {
+            found = true;
         }
+    }
+
+    bool isDone() override {
+        return found;
     }
 };
 

--- a/src/geom/prep/PreparedPolygonPredicate.cpp
+++ b/src/geom/prep/PreparedPolygonPredicate.cpp
@@ -38,8 +38,8 @@ namespace prep { // geos.geom.prep
 //
 // protected:
 //
-struct AnyMatchingLocationFilter : public GeometryComponentFilter {
-    explicit AnyMatchingLocationFilter(algorithm::locate::PointOnGeometryLocator* locator, int loc) :
+struct LocationMatchingFilter : public GeometryComponentFilter {
+    explicit LocationMatchingFilter(algorithm::locate::PointOnGeometryLocator* locator, int loc) :
         pt_locator(locator), test_loc(loc), found(false) {}
 
     algorithm::locate::PointOnGeometryLocator* pt_locator;
@@ -60,8 +60,8 @@ struct AnyMatchingLocationFilter : public GeometryComponentFilter {
     }
 };
 
-struct AnyNotMatchingLocationFilter : public GeometryComponentFilter {
-    explicit AnyNotMatchingLocationFilter(algorithm::locate::PointOnGeometryLocator* locator, int loc) :
+struct LocationNotMatchingFilter : public GeometryComponentFilter {
+    explicit LocationNotMatchingFilter(algorithm::locate::PointOnGeometryLocator* locator, int loc) :
             pt_locator(locator), test_loc(loc), found(false) {}
 
     algorithm::locate::PointOnGeometryLocator* pt_locator;
@@ -126,7 +126,7 @@ bool
 PreparedPolygonPredicate::isAllTestComponentsInTargetInterior(
     const geom::Geometry* testGeom) const
 {
-    AnyNotMatchingLocationFilter filter(prepPoly->getPointLocator(), geom::Location::INTERIOR);
+    LocationNotMatchingFilter filter(prepPoly->getPointLocator(), geom::Location::INTERIOR);
     testGeom->apply_ro(&filter);
 
     return !filter.found;
@@ -136,7 +136,7 @@ bool
 PreparedPolygonPredicate::isAnyTestComponentInTarget(
     const geom::Geometry* testGeom) const
 {
-    AnyNotMatchingLocationFilter filter(prepPoly->getPointLocator(), geom::Location::EXTERIOR);
+    LocationNotMatchingFilter filter(prepPoly->getPointLocator(), geom::Location::EXTERIOR);
     testGeom->apply_ro(&filter);
 
     return filter.found;
@@ -146,7 +146,7 @@ bool
 PreparedPolygonPredicate::isAnyTestComponentInTargetInterior(
     const geom::Geometry* testGeom) const
 {
-    AnyMatchingLocationFilter filter(prepPoly->getPointLocator(), geom::Location::INTERIOR);
+    LocationMatchingFilter filter(prepPoly->getPointLocator(), geom::Location::INTERIOR);
     testGeom->apply_ro(&filter);
 
     return filter.found;

--- a/tests/unit/geom/GeometryComponentFilterTest.cpp
+++ b/tests/unit/geom/GeometryComponentFilterTest.cpp
@@ -4,6 +4,8 @@
 #include <tut/tut.hpp>
 // geos
 #include <geos/geom/Geometry.h>
+#include <geos/geom/Polygon.h>
+#include <geos/geom/LineString.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/GeometryComponentFilter.h>
 #include <geos/io/WKTReader.h>
@@ -34,6 +36,34 @@ group test_geometrycomponentfilter_group("geos::geom::GeometryComponentFilter");
 //
 // Test Cases
 //
+
+class NumPointsInFirstNComponents : public geos::geom::GeometryComponentFilter {
+public:
+
+    NumPointsInFirstNComponents(size_t n) : components_remaining(n), num_points(0) {}
+
+    void
+    filter_ro(const geos::geom::Geometry* g) override {
+        num_points += g->getNumPoints();
+        components_remaining--;
+    }
+
+    void
+    filter_rw(geos::geom::Geometry* g) override {
+        filter_ro(g);
+    }
+
+    size_t numPoints() {
+        return num_points;
+    }
+
+    bool isDone() override {
+        return components_remaining == 0;
+    }
+private:
+    size_t components_remaining;
+    size_t num_points;
+};
 
 // Split components into two categories: Lineal and all other types
 template<>
@@ -93,5 +123,63 @@ void object::test<1>
     // TODO: is 8 right?
     ensure_equals(lineal.size() + nonlineal.size(), 8ul);
 }
+
+template<>
+template<>
+void object::test<2>()
+{
+    // Test isDone() behavior for collections
+
+    // collection of 4 geometries
+    GeometryPtr g(reader.read("GEOMETRYCOLLECTION("
+                              "POINT(0 0),"
+                              "LINESTRING(0 0,1 1,1 2),"
+                              "POLYGON((0 0,4 0,4 4,0 4,0 0)),"
+                              "MULTILINESTRING((0 0,1 1,1 2),(2 3,3 2,5 4)))"));
+
+    auto filter = NumPointsInFirstNComponents(3);
+    g->apply_ro(&filter);
+
+    // Current GeometryComponentFilter semantics have the filter visit the entire collection
+    // in addition to each of its components. So the first 3 components are the the entire collection,
+    // the Point, and the LineString
+    ensure_equals(g->getNumPoints() + g->getGeometryN(0)->getNumPoints() + g->getGeometryN(1)->getNumPoints(),
+            filter.numPoints());
+
+    // isDone() behavior should be the same in apply_rw scenario.
+    filter = NumPointsInFirstNComponents(2);
+    g->apply_rw(&filter);
+    ensure_equals(g->getNumPoints() + g->getGeometryN(0)->getNumPoints(),
+            filter.numPoints());
+}
+
+template<>
+template<>
+void object::test<3>()
+{
+    // Test isDone() behavior for polygons
+
+    // collection of 4 geometries
+    GeometryPtr g(reader.read("POLYGON((0 0, 100 0, 100 100, 0 100, 0 0),"  // 5 pt exterior ring
+                              "(1 1, 2 1, 2 2, 1 1),"                       // 4 pt interior ring
+                              "(5 5, 5 8, 8 8, 7 7, 6 6, 5 5))"));          // 6 pt interior ring
+    auto poly = dynamic_cast<geos::geom::Polygon*>(g.get());
+
+    auto filter = NumPointsInFirstNComponents(3);
+    poly->apply_ro(&filter);
+
+    // Current GeometryComponentFilter semantics have the filter visit the entire polygon
+    // in addition to each of its rings. So the first 3 components are the the entire polygon,
+    // the the exterior ring, and the first interior ring.
+    ensure_equals(poly->getNumPoints() + poly->getExteriorRing()->getNumPoints() + poly->getInteriorRingN(0)->getNumPoints(),
+                  filter.numPoints());
+
+    // isDone() behavior should be the same in apply_rw scenario.
+    filter = NumPointsInFirstNComponents(2);
+    g->apply_rw(&filter);
+    ensure_equals(poly->getNumPoints() + poly->getExteriorRing()->getNumPoints(),
+                  filter.numPoints());
+}
+
 
 } // namespace tut

--- a/tests/xmltester/tests/general/TestPreparedPolygonPredicate.xml
+++ b/tests/xmltester/tests/general/TestPreparedPolygonPredicate.xml
@@ -18,7 +18,21 @@
 </case>
 
 <case>
-  <desc>A/P - point equal to start point of polygon
+  <desc>A/P - point in polygon interior
+  </desc>
+  <a>
+    POLYGON ((10 10, 60 100, 110 10, 10 10))
+  </a>
+  <b>
+    POINT (20 20)
+  </b>
+  <test>  <op name="contains"   		arg1="A" arg2="B">   true  </op> </test>
+  <test>  <op name="covers"     		arg1="A" arg2="B">   true  </op> </test>
+  <test>  <op name="intersects" 		arg1="A" arg2="B">   true  </op> </test>
+</case>
+
+<case>
+  <desc>A/P - point outside of polygon
   </desc>
   <a>
     POLYGON ((10 10, 60 100, 110 10, 10 10))
@@ -29,6 +43,76 @@
 <test>  <op name="contains"   		arg1="A" arg2="B">   false  </op> </test>
 <test>  <op name="covers"     		arg1="A" arg2="B">   false  </op> </test>
 <test>  <op name="intersects" 		arg1="A" arg2="B">   false  </op> </test>
+</case>
+
+<case>
+  <desc>A/mP - both points equal to polygon vertices
+  </desc>
+  <a>
+    POLYGON ((10 10, 60 100, 110 10, 10 10))
+  </a>
+  <b>
+    MULTIPOINT ((10 10), (60 100))
+  </b>
+  <test>  <op name="contains"   		arg1="A" arg2="B">   false  </op> </test>
+  <test>  <op name="covers"     		arg1="A" arg2="B">   true   </op> </test>
+  <test>  <op name="intersects" 		arg1="A" arg2="B">   true   </op> </test>
+</case>
+
+<case>
+  <desc>A/mP - both points in polygon interior
+  </desc>
+  <a>
+    POLYGON ((10 10, 60 100, 110 10, 10 10))
+  </a>
+  <b>
+    MULTIPOINT ((20 20), (21 21))
+  </b>
+  <test>  <op name="contains"   		arg1="A" arg2="B">   true   </op> </test>
+  <test>  <op name="covers"     		arg1="A" arg2="B">   true   </op> </test>
+  <test>  <op name="intersects" 		arg1="A" arg2="B">   true   </op> </test>
+</case>
+
+<case>
+  <desc>A/mP - one point interior, one point equal to a polygon vertex
+  </desc>
+  <a>
+    POLYGON ((10 10, 60 100, 110 10, 10 10))
+  </a>
+  <b>
+    MULTIPOINT ((60 100), (21 21))
+  </b>
+  <test>  <op name="contains"   		arg1="A" arg2="B">   true   </op> </test>
+  <test>  <op name="covers"     		arg1="A" arg2="B">   true   </op> </test>
+  <test>  <op name="intersects" 		arg1="A" arg2="B">   true   </op> </test>
+</case>
+
+<case>
+  <desc>A/mP - one point interior, one point exterior
+  </desc>
+  <a>
+    POLYGON ((10 10, 60 100, 110 10, 10 10))
+  </a>
+  <b>
+    MULTIPOINT ((20 20), (500 500))
+  </b>
+  <test>  <op name="contains"   		arg1="A" arg2="B">   false   </op> </test>
+  <test>  <op name="covers"     		arg1="A" arg2="B">   false   </op> </test>
+  <test>  <op name="intersects" 		arg1="A" arg2="B">   true   </op> </test>
+</case>
+
+<case>
+  <desc>A/mP - one point equal to a polygon vertex, one point exterior
+  </desc>
+  <a>
+    POLYGON ((10 10, 60 100, 110 10, 10 10))
+  </a>
+  <b>
+    MULTIPOINT ((10 10), (500 500))
+  </b>
+  <test>  <op name="contains"   		arg1="A" arg2="B">   false   </op> </test>
+  <test>  <op name="covers"     		arg1="A" arg2="B">   false   </op> </test>
+  <test>  <op name="intersects" 		arg1="A" arg2="B">   true   </op> </test>
 </case>
 
 <case>


### PR DESCRIPTION
This PR improves the performance of GEOSPreparedContains by about 30% for point inputs and adds some benchmarking code to the repository.

@dr-jts some of the tweaks here may be relevant for JTS. They're probably most easily reviewed in the individual commits, rather than by the whole PR diff.