### PR TITLE
Use unique_ptr in GeometryEditor

### DIFF
--- a/include/geos/geom/util/CoordinateOperation.h
+++ b/include/geos/geom/util/CoordinateOperation.h
@@ -45,8 +45,8 @@ public:
     /**
      * Return a newly created geometry, ownership to caller
      */
-    Geometry* edit(const Geometry* geometry,
-                   const GeometryFactory* factory) override;
+    std::unique_ptr<Geometry> edit(const Geometry* geometry,
+                                   const GeometryFactory* factory) override;
 
     /**
      * Edits the array of Coordinate from a Geometry.
@@ -56,11 +56,11 @@ public:
      * @return an edited coordinate array (which may be the same as
      *         the input)
      */
-    virtual CoordinateSequence* edit(const CoordinateSequence* coordinates,
-                                     const Geometry* geometry) = 0;
+    virtual std::unique_ptr<CoordinateSequence> edit(const CoordinateSequence* coordinates,
+                                                     const Geometry* geometry) = 0;
 
 
-    ~CoordinateOperation() override {}
+    ~CoordinateOperation() override = default;
 };
 
 

--- a/include/geos/geom/util/GeometryCombiner.h
+++ b/include/geos/geom/util/GeometryCombiner.h
@@ -19,6 +19,7 @@
 #ifndef GEOS_GEOM_UTIL_GEOMETRYCOMBINER_H
 #define GEOS_GEOM_UTIL_GEOMETRYCOMBINER_H
 
+#include <memory>
 #include <vector>
 
 // Forward declarations
@@ -52,7 +53,7 @@ public:
      * @param geoms the geometries to combine (ownership left to caller)
      * @return the combined geometry
      */
-    static Geometry* combine(std::vector<Geometry*> const& geoms);
+    static std::unique_ptr<Geometry> combine(std::vector<Geometry*> const& geoms);
 
     /**
      * Combines two geometries.
@@ -61,7 +62,7 @@ public:
      * @param g1 a geometry to combine (ownership left to caller)
      * @return the combined geometry
      */
-    static Geometry* combine(const Geometry* g0, const Geometry* g1);
+    static std::unique_ptr<Geometry> combine(const Geometry* g0, const Geometry* g1);
 
     /**
      * Combines three geometries.
@@ -71,7 +72,7 @@ public:
      * @param g2 a geometry to combine (ownership left to caller)
      * @return the combined geometry
      */
-    static Geometry* combine(const Geometry* g0, const Geometry* g1, const Geometry* g2);
+    static std::unique_ptr<Geometry> combine(const Geometry* g0, const Geometry* g1, const Geometry* g2);
 
 private:
     GeometryFactory const* geomFactory;
@@ -100,7 +101,7 @@ public:
      *
      * @return a Geometry which is the combination of the inputs
      */
-    Geometry* combine();
+    std::unique_ptr<Geometry> combine();
 
 private:
     void extractElements(Geometry* geom, std::vector<Geometry*>& elems);

--- a/include/geos/geom/util/GeometryEditor.h
+++ b/include/geos/geom/util/GeometryEditor.h
@@ -22,6 +22,7 @@
 #define GEOS_GEOM_UTIL_GEOMETRYEDITOR_H
 
 #include <geos/export.h>
+#include <memory>
 
 // Forward declarations
 namespace geos {
@@ -82,12 +83,12 @@ private:
      */
     const GeometryFactory* factory;
 
-    Polygon* editPolygon(const Polygon* polygon,
-                         GeometryEditorOperation* operation);
+    std::unique_ptr<Polygon> editPolygon(const Polygon* polygon,
+                                         GeometryEditorOperation* operation);
 
-    GeometryCollection* editGeometryCollection(
-        const GeometryCollection* collection,
-        GeometryEditorOperation* operation);
+    std::unique_ptr<GeometryCollection> editGeometryCollection(
+            const GeometryCollection* collection,
+            GeometryEditorOperation* operation);
 
 public:
 
@@ -117,8 +118,8 @@ public:
      * @return a new Geometry which is the result of the editing
      *
      */
-    Geometry* edit(const Geometry* geometry,
-                   GeometryEditorOperation* operation); // final
+    std::unique_ptr<Geometry> edit(const Geometry* geometry,
+                                   GeometryEditorOperation* operation); // final
 };
 
 } // namespace geos.geom.util

--- a/include/geos/geom/util/GeometryEditorOperation.h
+++ b/include/geos/geom/util/GeometryEditorOperation.h
@@ -17,6 +17,7 @@
 #define GEOS_GEOM_UTIL_GEOMETRYEDITOROPERATION_H
 
 #include <geos/export.h>
+#include <memory>
 
 // Forward declarations
 namespace geos {
@@ -50,8 +51,8 @@ public:
      *
      * @return a new Geometry which is a modification of the input Geometry
      */
-    virtual Geometry* edit(const Geometry* geometry,
-                           const GeometryFactory* factory) = 0;
+    virtual std::unique_ptr<Geometry> edit(const Geometry* geometry,
+                                           const GeometryFactory* factory) = 0;
 
     virtual
     ~GeometryEditorOperation() {}

--- a/include/geos/precision/PrecisionReducerCoordinateOperation.h
+++ b/include/geos/precision/PrecisionReducerCoordinateOperation.h
@@ -57,8 +57,8 @@ public:
     /// Ownership of returned CoordinateSequence to caller
     //
     /// virtual function
-    geom::CoordinateSequence* edit(const geom::CoordinateSequence* coordinates,
-                                   const geom::Geometry* geom) override;
+    std::unique_ptr<geom::CoordinateSequence> edit(const geom::CoordinateSequence* coordinates,
+                                                   const geom::Geometry* geom) override;
 };
 
 } // namespace geos.precision

--- a/include/geos/precision/SimpleGeometryPrecisionReducer.h
+++ b/include/geos/precision/SimpleGeometryPrecisionReducer.h
@@ -16,6 +16,7 @@
 #define GEOS_PRECISION_SIMPLEGEOMETRYPRECISIONREDUCER_H
 
 #include <geos/export.h>
+#include <memory>
 
 // Forward declarations
 namespace geos {
@@ -80,7 +81,7 @@ public:
     const geom::PrecisionModel* getPrecisionModel();
 
     bool getRemoveCollapsed();
-    geom::Geometry* reduce(const geom::Geometry* geom);
+    std::unique_ptr<geom::Geometry> reduce(const geom::Geometry* geom);
 };
 
 } // namespace geos.precision

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -67,11 +67,11 @@ public:
     gfCoordinateOperation(const CoordinateSequenceFactory* gsf)
         : _gsf(gsf)
     {}
-    CoordinateSequence*
+    std::unique_ptr<CoordinateSequence>
     edit(const CoordinateSequence* coordSeq,
          const Geometry*) override
     {
-        return _gsf->create(*coordSeq).release();
+        return _gsf->create(*coordSeq);
     }
 };
 
@@ -777,8 +777,7 @@ GeometryFactory::createGeometry(const Geometry* g) const
     //return g->clone();
     util::GeometryEditor editor(this);
     gfCoordinateOperation coordOp(coordinateListFactory);
-    Geometry* ret = editor.edit(g, &coordOp);
-    return ret;
+    return editor.edit(g, &coordOp).release();
 }
 
 /*public*/

--- a/src/geom/util/CoordinateOperation.cpp
+++ b/src/geom/util/CoordinateOperation.cpp
@@ -26,30 +26,28 @@ namespace geos {
 namespace geom { // geos.geom
 namespace util { // geos.geom.util
 
-Geometry*
+std::unique_ptr<Geometry>
 CoordinateOperation::edit(const Geometry* geometry,
                           const GeometryFactory* factory)
 {
-    const LinearRing* ring = dynamic_cast<const LinearRing*>(geometry);
-    if(ring) {
+    if(const LinearRing* ring = dynamic_cast<const LinearRing*>(geometry)) {
         const CoordinateSequence* coords = ring->getCoordinatesRO();
-        CoordinateSequence* newCoords = edit(coords, geometry);
+        auto newCoords = edit(coords, geometry);
         // LinearRing instance takes over ownership of newCoords instance
-        return factory->createLinearRing(newCoords);
+        return std::unique_ptr<Geometry>(factory->createLinearRing(newCoords.release()));
     }
-    const LineString* line = dynamic_cast<const LineString*>(geometry);
-    if(line) {
+    if(const LineString* line = dynamic_cast<const LineString*>(geometry)) {
         const CoordinateSequence* coords = line->getCoordinatesRO();
-        CoordinateSequence* newCoords = edit(coords, geometry);
-        return factory->createLineString(newCoords);
+        auto newCoords = edit(coords, geometry);
+        return std::unique_ptr<Geometry>(factory->createLineString(newCoords.release()));
     }
-    if(typeid(*geometry) == typeid(Point)) {
-        auto coords = geometry->getCoordinates();
-        CoordinateSequence* newCoords = edit(coords.get(), geometry);
-        return factory->createPoint(newCoords);
+    if(const Point* point = dynamic_cast<const Point*>(geometry)) {
+        auto coords = point->getCoordinatesRO();
+        auto newCoords = edit(coords, geometry);
+        return std::unique_ptr<Geometry>(factory->createPoint(newCoords.release()));
     }
 
-    return geometry->clone().release();
+    return geometry->clone();
 }
 
 

--- a/src/geom/util/GeometryCombiner.cpp
+++ b/src/geom/util/GeometryCombiner.cpp
@@ -25,14 +25,14 @@ namespace geos {
 namespace geom { // geos.geom
 namespace util { // geos.geom.util
 
-Geometry*
+std::unique_ptr<Geometry>
 GeometryCombiner::combine(std::vector<Geometry*> const& geoms)
 {
     GeometryCombiner combiner(geoms);
     return combiner.combine();
 }
 
-Geometry*
+std::unique_ptr<Geometry>
 GeometryCombiner::combine(const Geometry* g0, const Geometry* g1)
 {
     std::vector<Geometry*> geoms;
@@ -43,7 +43,7 @@ GeometryCombiner::combine(const Geometry* g0, const Geometry* g1)
     return combiner.combine();
 }
 
-Geometry*
+std::unique_ptr<Geometry>
 GeometryCombiner::combine(const Geometry* g0, const Geometry* g1,
                           const Geometry* g2)
 {
@@ -67,26 +67,24 @@ GeometryCombiner::extractFactory(std::vector<Geometry*> const& geoms)
     return geoms.empty() ? nullptr : geoms.front()->getFactory();
 }
 
-Geometry*
+std::unique_ptr<Geometry>
 GeometryCombiner::combine()
 {
     std::vector<Geometry*> elems;
 
-    std::vector<Geometry*>::const_iterator end = inputGeoms.end();
-    for(std::vector<Geometry*>::const_iterator i = inputGeoms.begin();
-            i != end; ++i) {
-        extractElements(*i, elems);
+    for(const auto& geom : inputGeoms) {
+        extractElements(geom, elems);
     }
 
     if(elems.empty()) {
         if(geomFactory != nullptr) {
-            return geomFactory->createGeometryCollection(nullptr);
+            return std::unique_ptr<Geometry>(geomFactory->createGeometryCollection(nullptr));
         }
         return nullptr;
     }
 
     // return the "simplest possible" geometry
-    return geomFactory->buildGeometry(elems);
+    return std::unique_ptr<Geometry>(geomFactory->buildGeometry(elems));
 }
 
 void

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -241,7 +241,7 @@ CascadedPolygonUnion::unionOptimized(geom::Geometry* g0, geom::Geometry* g1)
     geom::Envelope const* g1Env = g1->getEnvelopeInternal();
 
     if(!g0Env->intersects(g1Env)) {
-        return geom::util::GeometryCombiner::combine(g0, g1);
+        return geom::util::GeometryCombiner::combine(g0, g1).release();
     }
 
     if(g0->getNumGeometries() <= 1 && g1->getNumGeometries() <= 1) {
@@ -318,13 +318,13 @@ CascadedPolygonUnion::unionUsingEnvelopeIntersection(geom::Geometry* g0,
     std::unique_ptr<geom::Geometry> ret;
     if(polysOn.empty()) {
         disjointPolys.push_back(u.get());
-        ret.reset(geom::util::GeometryCombiner::combine(disjointPolys));
+        ret = geom::util::GeometryCombiner::combine(disjointPolys);
     }
     else {
         // TODO: could be further tweaked to only union with polysOn
         //       and combine with polysOff, but then it'll need again to
         //       recurse in the check for disjoint/intersecting
-        ret.reset(geom::util::GeometryCombiner::combine(disjointPolys));
+        ret = geom::util::GeometryCombiner::combine(disjointPolys);
         ret.reset(unionActual(ret.get(), u.get()));
     }
 

--- a/src/operation/union/CascadedUnion.cpp
+++ b/src/operation/union/CascadedUnion.cpp
@@ -152,7 +152,7 @@ CascadedUnion::unionOptimized(geom::Geometry* g0, geom::Geometry* g1)
     geom::Envelope const* g1Env = g1->getEnvelopeInternal();
 
     if(!g0Env->intersects(g1Env)) {
-        return geom::util::GeometryCombiner::combine(g0, g1);
+        return geom::util::GeometryCombiner::combine(g0, g1).release();
     }
 
     if(g0->getNumGeometries() <= 1 && g1->getNumGeometries() <= 1) {
@@ -176,7 +176,7 @@ CascadedUnion::unionUsingEnvelopeIntersection(geom::Geometry* g0,
     std::unique_ptr<geom::Geometry> u(unionActual(g0Int.get(), g1Int.get()));
     disjointPolys.push_back(u.get());
 
-    return geom::util::GeometryCombiner::combine(disjointPolys);
+    return geom::util::GeometryCombiner::combine(disjointPolys).release();
 }
 
 geom::Geometry*

--- a/src/precision/GeometryPrecisionReducer.cpp
+++ b/src/precision/GeometryPrecisionReducer.cpp
@@ -44,14 +44,7 @@ namespace precision { // geos.precision
 unique_ptr<Geometry>
 GeometryPrecisionReducer::reducePointwise(const Geometry& geom)
 {
-    unique_ptr<GeometryEditor> geomEdit;
-
-    if(newFactory) {
-        geomEdit.reset(new GeometryEditor(newFactory));
-    }
-    else {
-        geomEdit.reset(new GeometryEditor());
-    }
+    GeometryEditor geomEdit(newFactory);
 
     /**
      * For polygonal geometries, collapses are always removed, in order
@@ -64,7 +57,7 @@ GeometryPrecisionReducer::reducePointwise(const Geometry& geom)
 
     PrecisionReducerCoordinateOperation prco(targetPM, finalRemoveCollapsed);
 
-    std::unique_ptr<Geometry> g(geomEdit->edit(&geom, &prco));
+    std::unique_ptr<Geometry> g(geomEdit.edit(&geom, &prco));
 
     return g;
 }

--- a/src/precision/PrecisionReducerCoordinateOperation.cpp
+++ b/src/precision/PrecisionReducerCoordinateOperation.cpp
@@ -25,16 +25,16 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/LinearRing.h>
 #include <geos/operation/valid/RepeatedPointRemover.h>
+#include <geos/util.h>
 
 #include <vector>
 
 using namespace geos::geom;
-using namespace std;
 
 namespace geos {
 namespace precision { // geos.precision
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
         const Geometry* geom)
 {
@@ -44,7 +44,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
         return nullptr;
     }
 
-    vector<Coordinate>* vc = new vector<Coordinate>(csSize);
+    auto vc = detail::make_unique<std::vector<Coordinate>>(csSize);
 
     // copy coordinates and reduce
     for(size_t i = 0; i < csSize; ++i) {
@@ -53,12 +53,11 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
     }
 
     // reducedCoords take ownership of 'vc'
-    CoordinateSequence* reducedCoords =
-        geom->getFactory()->getCoordinateSequenceFactory()->create(vc).release();
+    auto reducedCoords = geom->getFactory()->getCoordinateSequenceFactory()->create(vc.release());
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.
-    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords);
+    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
 
     /**
      * Check to see if the removal of repeated points
@@ -79,21 +78,17 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
         minLength = 4;
     }
 
-    CoordinateSequence* collapsedCoords = reducedCoords;
     if(removeCollapsed) {
-        delete reducedCoords;
         reducedCoords = nullptr;
-        collapsedCoords = nullptr;
     }
 
-    // return null or orginal length coordinate array
+    // return null or original length coordinate array
     if(noRepeatedCoords->getSize() < minLength) {
-        return collapsedCoords;
+        return reducedCoords;
     }
 
     // ok to return shorter coordinate array
-    delete reducedCoords;
-    return noRepeatedCoords.release();
+    return noRepeatedCoords;
 }
 
 

--- a/src/precision/PrecisionReducerCoordinateOperation.cpp
+++ b/src/precision/PrecisionReducerCoordinateOperation.cpp
@@ -57,7 +57,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.
-    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
+    std::unique_ptr<CoordinateSequence> noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
 
     /**
      * Check to see if the removal of repeated points

--- a/src/precision/SimpleGeometryPrecisionReducer.cpp
+++ b/src/precision/SimpleGeometryPrecisionReducer.cpp
@@ -28,11 +28,11 @@
 #include <geos/geom/LineString.h>
 #include <geos/geom/LinearRing.h>
 #include <geos/operation/valid/RepeatedPointRemover.h>
+#include <geos/util.h>
 
 #include <vector>
 #include <typeinfo>
 
-using namespace std;
 using namespace geos::geom;
 using namespace geos::geom::util;
 
@@ -54,8 +54,8 @@ public:
         SimpleGeometryPrecisionReducer* newSgpr);
 
     /// Ownership of returned CoordinateSequence to caller
-    CoordinateSequence* edit(const CoordinateSequence* coordinates,
-                             const Geometry* geom) override;
+    std::unique_ptr<CoordinateSequence> edit(const CoordinateSequence* coordinates,
+                                             const Geometry* geom) override;
 };
 
 PrecisionReducerCoordinateOperation::PrecisionReducerCoordinateOperation(
@@ -64,7 +64,7 @@ PrecisionReducerCoordinateOperation::PrecisionReducerCoordinateOperation(
     sgpr = newSgpr;
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
         const Geometry* geom)
 {
@@ -74,7 +74,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     auto csSize = cs->size();
 
-    vector<Coordinate>* vc = new vector<Coordinate>(csSize);
+    auto vc = detail::make_unique<std::vector<Coordinate>>(csSize);
 
     // copy coordinates and reduce
     for(unsigned int i = 0; i < csSize; ++i) {
@@ -83,12 +83,11 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
     }
 
     // reducedCoords take ownership of 'vc'
-    CoordinateSequence* reducedCoords =
-        geom->getFactory()->getCoordinateSequenceFactory()->create(vc).release();
+    auto reducedCoords = geom->getFactory()->getCoordinateSequenceFactory()->create(vc.release());
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.
-    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords);
+    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
 
     /**
      * Check to see if the removal of repeated points
@@ -108,19 +107,16 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
     if(typeid(*geom) == typeid(LinearRing)) {
         minLength = 4;
     }
-    CoordinateSequence* collapsedCoords = reducedCoords;
+
     if(sgpr->getRemoveCollapsed()) {
-        delete reducedCoords;
         reducedCoords = nullptr;
-        collapsedCoords = nullptr;
     }
-    // return null or orginal length coordinate array
+    // return null or original length coordinate array
     if(noRepeatedCoords->getSize() < minLength) {
-        return collapsedCoords;
+        return reducedCoords;
     }
     // ok to return shorter coordinate array
-    delete reducedCoords;
-    return noRepeatedCoords.release();
+    return noRepeatedCoords;
 }
 
 } // anonymous namespace
@@ -164,13 +160,12 @@ SimpleGeometryPrecisionReducer::getRemoveCollapsed()
     return removeCollapsed;
 }
 
-Geometry*
+std::unique_ptr<Geometry>
 SimpleGeometryPrecisionReducer::reduce(const Geometry* geom)
 {
     GeometryEditor geomEdit;
     PrecisionReducerCoordinateOperation prco(this);
-    Geometry* g = geomEdit.edit(geom, &prco);
-    return g;
+    return geomEdit.edit(geom, &prco);
 }
 
 } // namespace geos.precision

--- a/src/precision/SimpleGeometryPrecisionReducer.cpp
+++ b/src/precision/SimpleGeometryPrecisionReducer.cpp
@@ -87,7 +87,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
 
     // remove repeated points, to simplify returned geometry as
     // much as possible.
-    auto noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
+    std::unique_ptr<CoordinateSequence> noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
 
     /**
      * Check to see if the removal of repeated points


### PR DESCRIPTION
This PR updates `GeometryEditor` and associated classes to use `std::unique_ptr`.