### PR TITLE
Remove manual memory management from GeometryCollection, Polygon

### DIFF
--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -893,6 +893,8 @@ protected:
 
     int compare(std::vector<Geometry*> a, std::vector<Geometry*> b) const;
 
+    int compare(const std::vector<std::unique_ptr<Geometry>> & a, const std::vector<std::unique_ptr<Geometry>> & b) const;
+
     bool equal(const Coordinate& a, const Coordinate& b,
                double tolerance) const;
     int SRID;

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -57,9 +57,9 @@ class GEOS_DLL GeometryCollection : public virtual Geometry {
 public:
     friend class GeometryFactory;
 
-    typedef std::vector<Geometry*>::const_iterator const_iterator;
+    typedef std::vector<std::unique_ptr<Geometry>>::const_iterator const_iterator;
 
-    typedef std::vector<Geometry*>::iterator iterator;
+    typedef std::vector<std::unique_ptr<Geometry>>::iterator iterator;
 
     const_iterator begin() const;
 
@@ -107,7 +107,7 @@ public:
      */
     Dimension::DimensionType getDimension() const override;
 
-    virtual bool isDimensionStrict(Dimension::DimensionType d) const;
+    bool isDimensionStrict(Dimension::DimensionType d) const override;
 
     /// Returns coordinate dimension.
     int getCoordinateDimension() const override;
@@ -207,7 +207,7 @@ protected:
         return SORTINDEX_GEOMETRYCOLLECTION;
     };
 
-    std::vector<Geometry*>* geometries;
+    std::vector<std::unique_ptr<Geometry>> geometries;
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 

--- a/include/geos/geom/GeometryCollection.inl
+++ b/include/geos/geom/GeometryCollection.inl
@@ -29,13 +29,13 @@ namespace geom { // geos::geom
 INLINE GeometryCollection::const_iterator
 GeometryCollection::begin() const
 {
-    return geometries->begin();
+    return geometries.begin();
 }
 
 INLINE GeometryCollection::const_iterator
 GeometryCollection::end() const
 {
-    return geometries->end();
+    return geometries.end();
 }
 
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -171,9 +171,9 @@ protected:
     Polygon(LinearRing* newShell, std::vector<LinearRing*>* newHoles,
             const GeometryFactory* newFactory);
 
-    LinearRing* shell;
+    std::unique_ptr<LinearRing> shell;
 
-    std::vector<LinearRing*>* holes;
+    std::vector<std::unique_ptr<LinearRing>> holes;
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 

--- a/src/algorithm/PointLocator.cpp
+++ b/src/algorithm/PointLocator.cpp
@@ -94,13 +94,9 @@ PointLocator::computeLocation(const Coordinate& p, const Geometry* geom)
         }
     }
     else if(const GeometryCollection* col = dynamic_cast<const GeometryCollection*>(geom)) {
-        for(GeometryCollection::const_iterator
-                it = col->begin(), endIt = col->end();
-                it != endIt;
-                ++it) {
-            const Geometry* g2 = *it;
-            assert(g2 != geom); // is this check really needed ?
-            computeLocation(p, g2);
+        for(const auto & g2 : *col) {
+            assert(g2.get() != geom); // is this check really needed ?
+            computeLocation(p, g2.get());
         }
     }
 

--- a/src/algorithm/locate/SimplePointInAreaLocator.cpp
+++ b/src/algorithm/locate/SimplePointInAreaLocator.cpp
@@ -70,9 +70,9 @@ SimplePointInAreaLocator::locateInGeometry(const Coordinate& p, const Geometry* 
         return Location::EXTERIOR;
     }
     if(const GeometryCollection* col = dynamic_cast<const GeometryCollection*>(geom)) {
-        for(auto g2 : *col) {
-            assert(g2 != geom);
-            Location loc = locateInGeometry(p, g2);
+        for(auto& g2 : *col) {
+            assert(g2.get() != geom);
+            Location loc = locateInGeometry(p, g2.get());
             if(loc != Location::EXTERIOR) {
                 return loc;
             }

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -778,6 +778,31 @@ Geometry::compare(vector<Geometry*> a, vector<Geometry*> b) const
     return 0;
 }
 
+int
+Geometry::compare(const std::vector<std::unique_ptr<Geometry>> & a,
+        const std::vector<std::unique_ptr<Geometry>> & b) const
+{
+    size_t i = 0;
+    size_t j = 0;
+    while(i < a.size() && j < b.size()) {
+        Geometry* aGeom = a[i].get();
+        Geometry* bGeom = b[j].get();
+        int comparison = aGeom->compareTo(bGeom);
+        if(comparison != 0) {
+            return comparison;
+        }
+        i++;
+        j++;
+    }
+    if(i < a.size()) {
+        return 1;
+    }
+    if(j < b.size()) {
+        return -1;
+    }
+    return 0;
+}
+
 /**
  *  Returns the minimum distance between this Geometry
  *  and the other Geometry

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -27,6 +27,7 @@
 #include <geos/geom/GeometryFilter.h>
 #include <geos/geom/GeometryComponentFilter.h>
 #include <geos/geom/Envelope.h>
+#include <geos/util.h>
 
 #ifndef GEOS_INLINE
 # include <geos/geom/GeometryCollection.inl>
@@ -36,51 +37,45 @@
 #include <vector>
 #include <memory>
 
-using namespace std;
-
 namespace geos {
 namespace geom { // geos::geom
 
 /*protected*/
 GeometryCollection::GeometryCollection(const GeometryCollection& gc)
     :
-    Geometry(gc)
+    Geometry(gc),
+    geometries(gc.geometries.size())
 {
-    size_t ngeoms = gc.geometries->size();
-
-    geometries = new vector<Geometry*>(ngeoms);
-    for(size_t i = 0; i < ngeoms; ++i) {
-        (*geometries)[i] = (*gc.geometries)[i]->clone().release();
+    for(size_t i = 0; i < geometries.size(); ++i) {
+        geometries[i] = gc.geometries[i]->clone();
     }
 }
 
 /*protected*/
-GeometryCollection::GeometryCollection(vector<Geometry*>* newGeoms, const GeometryFactory* factory):
+GeometryCollection::GeometryCollection(std::vector<Geometry*>* newGeoms, const GeometryFactory* factory):
     Geometry(factory)
 {
     if(newGeoms == nullptr) {
-        geometries = new vector<Geometry*>();
         return;
     }
     if(hasNullElements(newGeoms)) {
         throw  util::IllegalArgumentException("geometries must not contain null elements\n");
-        return;
     }
-    geometries = newGeoms;
+    for (const auto& geom : *newGeoms) {
+        geometries.emplace_back(geom);
+    }
+    delete newGeoms;
 
     // Set SRID for inner geoms
-    size_t ngeoms = geometries->size();
-    for(size_t i = 0; i < ngeoms; ++i) {
-        (*geometries)[i]->setSRID(getSRID());
-    }
+    setSRID(getSRID());
 }
 
 void
 GeometryCollection::setSRID(int newSRID)
 {
     Geometry::setSRID(newSRID);
-    for(size_t i = 0; i < geometries->size(); i++) {
-        (*geometries)[i]->setSRID(newSRID);
+    for(auto& g : geometries) {
+        g->setSRID(newSRID);
     }
 }
 
@@ -93,25 +88,25 @@ GeometryCollection::setSRID(int newSRID)
 std::unique_ptr<CoordinateSequence>
 GeometryCollection::getCoordinates() const
 {
-    vector<Coordinate>* coordinates = new vector<Coordinate>(getNumPoints());
+    auto coordinates = detail::make_unique<std::vector<Coordinate>>(getNumPoints());
 
-    int k = -1;
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        auto childCoordinates = (*geometries)[i]->getCoordinates();
+    size_t k = 0;
+    for(const auto& g : geometries) {
+        auto childCoordinates = g->getCoordinates(); // TODO avoid this copy
         size_t npts = childCoordinates->getSize();
         for(size_t j = 0; j < npts; ++j) {
-            k++;
             (*coordinates)[k] = childCoordinates->getAt(j);
+            k++;
         }
     }
-    return CoordinateArraySequenceFactory::instance()->create(coordinates);
+    return CoordinateArraySequenceFactory::instance()->create(coordinates.release());
 }
 
 bool
 GeometryCollection::isEmpty() const
 {
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        if(!(*geometries)[i]->isEmpty()) {
+    for(const auto& g : geometries) {
+        if(!g->isEmpty()) {
             return false;
         }
     }
@@ -122,16 +117,16 @@ Dimension::DimensionType
 GeometryCollection::getDimension() const
 {
     Dimension::DimensionType dimension = Dimension::False;
-    for(size_t i = 0, n = geometries->size(); i < n; ++i) {
-        dimension = max(dimension, (*geometries)[i]->getDimension());
+    for(const auto& g : geometries) {
+        dimension = std::max(dimension, g->getDimension());
     }
     return dimension;
 }
 
 bool
 GeometryCollection::isDimensionStrict(Dimension::DimensionType d) const {
-    return std::all_of(geometries->begin(), geometries->end(),
-            [&d](const Geometry* g) {
+    return std::all_of(geometries.begin(), geometries.end(),
+            [&d](const std::unique_ptr<Geometry> & g) {
                 return g->getDimension() == d;
             });
 }
@@ -140,8 +135,8 @@ int
 GeometryCollection::getBoundaryDimension() const
 {
     int dimension = Dimension::False;
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        dimension = max(dimension, (*geometries)[i]->getBoundaryDimension());
+    for(const auto& g : geometries) {
+        dimension = std::max(dimension, g->getBoundaryDimension());
     }
     return dimension;
 }
@@ -151,8 +146,8 @@ GeometryCollection::getCoordinateDimension() const
 {
     int dimension = 2;
 
-    for(size_t i = 0, n = geometries->size(); i < n; ++i) {
-        dimension = max(dimension, (*geometries)[i]->getCoordinateDimension());
+    for(const auto& g : geometries) {
+        dimension = std::max(dimension, g->getCoordinateDimension());
     }
     return dimension;
 }
@@ -160,26 +155,26 @@ GeometryCollection::getCoordinateDimension() const
 size_t
 GeometryCollection::getNumGeometries() const
 {
-    return geometries->size();
+    return geometries.size();
 }
 
 const Geometry*
 GeometryCollection::getGeometryN(size_t n) const
 {
-    return (*geometries)[n];
+    return geometries[n].get();
 }
 
 size_t
 GeometryCollection::getNumPoints() const
 {
     size_t numPoints = 0;
-    for(size_t i = 0, n = geometries->size(); i < n; ++i) {
-        numPoints += (*geometries)[i]->getNumPoints();
+    for(const auto& g : geometries) {
+        numPoints += g->getNumPoints();
     }
     return numPoints;
 }
 
-string
+std::string
 GeometryCollection::getGeometryType() const
 {
     return "GeometryCollection";
@@ -203,11 +198,11 @@ GeometryCollection::equalsExact(const Geometry* other, double tolerance) const
         return false;
     }
 
-    if(geometries->size() != otherCollection->geometries->size()) {
+    if(geometries.size() != otherCollection->geometries.size()) {
         return false;
     }
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        if(!((*geometries)[i]->equalsExact((*(otherCollection->geometries))[i], tolerance))) {
+    for(size_t i = 0; i < geometries.size(); ++i) {
+        if(!(geometries[i]->equalsExact(otherCollection->geometries[i].get(), tolerance))) {
             return false;
         }
     }
@@ -217,16 +212,16 @@ GeometryCollection::equalsExact(const Geometry* other, double tolerance) const
 void
 GeometryCollection::apply_rw(const CoordinateFilter* filter)
 {
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        (*geometries)[i]->apply_rw(filter);
+    for(auto& g : geometries) {
+        g->apply_rw(filter);
     }
 }
 
 void
 GeometryCollection::apply_ro(CoordinateFilter* filter) const
 {
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        (*geometries)[i]->apply_ro(filter);
+    for(const auto& g : geometries) {
+        g->apply_ro(filter);
     }
 }
 
@@ -234,8 +229,8 @@ void
 GeometryCollection::apply_ro(GeometryFilter* filter) const
 {
     filter->filter_ro(this);
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        (*geometries)[i]->apply_ro(filter);
+    for(const auto& g : geometries) {
+        g->apply_ro(filter);
     }
 }
 
@@ -243,26 +238,28 @@ void
 GeometryCollection::apply_rw(GeometryFilter* filter)
 {
     filter->filter_rw(this);
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        (*geometries)[i]->apply_rw(filter);
+    for(auto& g : geometries) {
+        g->apply_rw(filter);
     }
 }
 
 void
 GeometryCollection::normalize()
 {
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        (*geometries)[i]->normalize();
+    for(auto& g : geometries) {
+        g->normalize();
     }
-    sort(geometries->begin(), geometries->end(), GeometryGreaterThen());
+    std::sort(geometries.begin(), geometries.end(), [](const std::unique_ptr<Geometry> & a, const std::unique_ptr<Geometry> & b) {
+        return a->compareTo(b.get()) > 0;
+    });
 }
 
 Envelope::Ptr
 GeometryCollection::computeEnvelopeInternal() const
 {
     Envelope::Ptr p_envelope(new Envelope());
-    for(size_t i = 0; i < geometries->size(); i++) {
-        const Envelope* env = (*geometries)[i]->getEnvelopeInternal();
+    for(const auto& g : geometries) {
+        const Envelope* env = g->getEnvelopeInternal();
         p_envelope->expandToInclude(env);
     }
     return p_envelope;
@@ -272,15 +269,15 @@ int
 GeometryCollection::compareToSameClass(const Geometry* g) const
 {
     const GeometryCollection* gc = dynamic_cast<const GeometryCollection*>(g);
-    return compare(*geometries, *(gc->geometries));
+    return compare(geometries, gc->geometries);
 }
 
 const Coordinate*
 GeometryCollection::getCoordinate() const
 {
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        if(!(*geometries)[i]->isEmpty()) {
-            return (*geometries)[i]->getCoordinate();
+    for(const auto& g : geometries) {
+        if(!g->isEmpty()) {
+            return g->getCoordinate();
         }
     }
     return nullptr;
@@ -293,8 +290,8 @@ double
 GeometryCollection::getArea() const
 {
     double area = 0.0;
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        area += (*geometries)[i]->getArea();
+    for(const auto& g : geometries) {
+        area += g->getArea();
     }
     return area;
 }
@@ -306,8 +303,8 @@ double
 GeometryCollection::getLength() const
 {
     double sum = 0.0;
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        sum += (*geometries)[i]->getLength();
+    for(const auto& g : geometries) {
+        sum += g->getLength();
     }
     return sum;
 }
@@ -316,8 +313,11 @@ void
 GeometryCollection::apply_rw(GeometryComponentFilter* filter)
 {
     filter->filter_rw(this);
-    for(size_t i = 0; i < geometries->size() && !filter->isDone(); ++i) {
-        (*geometries)[i]->apply_rw(filter);
+    for(auto& g : geometries) {
+        if (filter->isDone()) {
+            return;
+        }
+        g->apply_rw(filter);
     }
 }
 
@@ -325,20 +325,19 @@ void
 GeometryCollection::apply_ro(GeometryComponentFilter* filter) const
 {
     filter->filter_ro(this);
-    for(size_t i = 0; i < geometries->size() && !filter->isDone(); ++i) {
-        (*geometries)[i]->apply_ro(filter);
+    for(const auto& g : geometries) {
+        if (filter->isDone()) {
+            return;
+        }
+        g->apply_ro(filter);
     }
 }
 
 void
 GeometryCollection::apply_rw(CoordinateSequenceFilter& filter)
 {
-    size_t ngeoms = geometries->size();
-    if(ngeoms == 0) {
-        return;
-    }
-    for(size_t i = 0; i < ngeoms; ++i) {
-        (*geometries)[i]->apply_rw(filter);
+    for(auto& g : geometries) {
+        g->apply_rw(filter);
         if(filter.isDone()) {
             break;
         }
@@ -351,12 +350,8 @@ GeometryCollection::apply_rw(CoordinateSequenceFilter& filter)
 void
 GeometryCollection::apply_ro(CoordinateSequenceFilter& filter) const
 {
-    size_t ngeoms = geometries->size();
-    if(ngeoms == 0) {
-        return;
-    }
-    for(size_t i = 0; i < ngeoms; ++i) {
-        (*geometries)[i]->apply_ro(filter);
+    for(const auto& g : geometries) {
+        g->apply_ro(filter);
         if(filter.isDone()) {
             break;
         }
@@ -366,13 +361,7 @@ GeometryCollection::apply_ro(CoordinateSequenceFilter& filter) const
     //if (filter.isGeometryChanged()) geometryChanged();
 }
 
-GeometryCollection::~GeometryCollection()
-{
-    for(size_t i = 0; i < geometries->size(); ++i) {
-        delete(*geometries)[i];
-    }
-    delete geometries;
-}
+GeometryCollection::~GeometryCollection() = default;
 
 GeometryTypeId
 GeometryCollection::getGeometryTypeId() const
@@ -387,12 +376,12 @@ GeometryCollection::reverse() const
         return clone();
     }
 
-    auto* reversed = new std::vector<Geometry*> {geometries->size()};
+    auto* reversed = new std::vector<Geometry*> {geometries.size()};
 
-    std::transform(geometries->begin(),
-                   geometries->end(),
+    std::transform(geometries.begin(),
+                   geometries.end(),
                    reversed->begin(),
-    [](const Geometry * g) {
+    [](const std::unique_ptr<Geometry> & g) {
         return g->reverse().release();
     });
 

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -77,8 +77,8 @@ MultiLineString::isClosed() const
     if(isEmpty()) {
         return false;
     }
-    for(size_t i = 0, n = geometries->size(); i < n; ++i) {
-        LineString* ls = dynamic_cast<LineString*>((*geometries)[i]);
+    for(const auto& g : geometries) {
+        LineString* ls = dynamic_cast<LineString*>(g.get());
         if(! ls->isClosed()) {
             return false;
         }
@@ -119,10 +119,10 @@ MultiLineString::reverse() const
         return clone();
     }
 
-    size_t nLines = geometries->size();
+    size_t nLines = geometries.size();
     Geometry::NonConstVect* revLines = new Geometry::NonConstVect(nLines);
     for(size_t i = 0; i < nLines; ++i) {
-        LineString* iLS = dynamic_cast<LineString*>((*geometries)[i]);
+        LineString* iLS = dynamic_cast<LineString*>(geometries[i].get());
         assert(iLS);
         (*revLines)[nLines - 1 - i] = iLS->reverse().release();
     }

--- a/src/geom/MultiPoint.cpp
+++ b/src/geom/MultiPoint.cpp
@@ -78,7 +78,7 @@ MultiPoint::equalsExact(const Geometry* other, double tolerance) const
 const Coordinate*
 MultiPoint::getCoordinateN(size_t n) const
 {
-    return ((*geometries)[n])->getCoordinate();
+    return geometries[n]->getCoordinate();
 }
 GeometryTypeId
 MultiPoint::getGeometryTypeId() const

--- a/src/geom/MultiPolygon.cpp
+++ b/src/geom/MultiPolygon.cpp
@@ -72,8 +72,8 @@ MultiPolygon::getBoundary() const
         return std::unique_ptr<Geometry>(getFactory()->createMultiLineString());
     }
     vector<Geometry*>* allRings = new vector<Geometry*>();
-    for(size_t i = 0; i < geometries->size(); i++) {
-        Polygon* pg = dynamic_cast<Polygon*>((*geometries)[i]);
+    for(size_t i = 0; i < geometries.size(); i++) {
+        Polygon* pg = dynamic_cast<Polygon*>(geometries[i].get());
         assert(pg);
         auto g = pg->getBoundary();
         if(LineString* ls = dynamic_cast<LineString*>(g.get())) {
@@ -115,12 +115,12 @@ MultiPolygon::reverse() const
         return clone();
     }
 
-    auto* reversed = new std::vector<Geometry*> {geometries->size()};
+    auto* reversed = new std::vector<Geometry*> {geometries.size()};
 
-    std::transform(geometries->begin(),
-                   geometries->end(),
+    std::transform(geometries.begin(),
+                   geometries.end(),
                    reversed->begin(),
-    [](const Geometry * g) {
+    [](const std::unique_ptr<Geometry> & g) {
         return g->reverse().release();
     });
 

--- a/src/operation/IsSimpleOp.cpp
+++ b/src/operation/IsSimpleOp.cpp
@@ -263,10 +263,8 @@ IsSimpleOp::computeSimple(const geom::Geometry* g)
 bool
 IsSimpleOp::isSimpleGeometryCollection(const geom::GeometryCollection* col)
 {
-    GeometryCollection::const_iterator it;
-    for(it = col->begin(); it < col->end(); ++it) {
-        const geom::Geometry* g = *it;
-        if(!computeSimple(g)) {
+    for(const auto& g : *col) {
+        if(!computeSimple(g.get())) {
             return false;
         }
     }

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -118,10 +118,8 @@ CascadedPolygonUnion::Union(const geom::MultiPolygon* multipoly)
 {
     std::vector<geom::Polygon*> polys;
 
-    typedef geom::MultiPolygon::const_iterator iterator;
-    iterator end = multipoly->end();
-    for(iterator i = multipoly->begin(); i != end; ++i) {
-        polys.push_back(dynamic_cast<geom::Polygon*>(*i));
+    for(const auto& g : *multipoly) {
+        polys.push_back(dynamic_cast<geom::Polygon*>(g.get()));
     }
 
     CascadedPolygonUnion op(&polys);

--- a/src/operation/valid/MakeValid.cpp
+++ b/src/operation/valid/MakeValid.cpp
@@ -96,8 +96,8 @@ static std::unique_ptr<geom::Geometry> MakeValidMultiLine(const geom::MultiLineS
     std::vector<std::unique_ptr<geom::Geometry>> points;
     std::vector<std::unique_ptr<geom::Geometry>> lines;
 
-    for(const auto subgeom: *mls) {
-        auto line = dynamic_cast<const geom::LineString*>(subgeom);
+    for(const auto& subgeom: *mls) {
+        auto line = dynamic_cast<const geom::LineString*>(subgeom.get());
         assert(line);
         auto validSubGeom = MakeValidLine(line);
         if( !validSubGeom || validSubGeom->isEmpty() ) {
@@ -111,7 +111,7 @@ static std::unique_ptr<geom::Geometry> MakeValidMultiLine(const geom::MultiLineS
             lines.emplace_back(std::move(validSubGeom));
         } else if( validLineType == GEOS_MULTILINESTRING ) {
             auto mlsValid = dynamic_cast<const geom::MultiLineString*>(validSubGeom.get());
-            for(const auto subgeomMlsValid: *mlsValid) {
+            for(const auto& subgeomMlsValid: *mlsValid) {
                 lines.emplace_back(subgeomMlsValid->clone());
             }
         } else {
@@ -290,9 +290,9 @@ static std::unique_ptr<geom::Geometry> MakeValidCollection(const geom::GeometryC
 {
     auto validGeoms = new std::vector<geom::Geometry*>();
     try {
-        for( auto geom: *coll )
+        for(const auto& geom: *coll )
         {
-            validGeoms->push_back(MakeValid().build(geom).release());
+            validGeoms->push_back(MakeValid().build(geom.get()).release());
         }
         return std::unique_ptr<geom::Geometry>(
             GeometryFactory::create()->createGeometryCollection(validGeoms));


### PR DESCRIPTION
This PR updates `GeometryCollection` and `Polygon` to manage their
components using a std::vector of std::unique_ptr. It also avoids
heap-allocating the std::vectors themselves.

An improvement I can think of is to have `GeometryColleciton::begin`
iterate over the raw pointers themselves instead of the `unique_ptr`.
This avoids `GeometryCollection` users needing to care about the
storage method within `GeometryCollection`. I'm not sure how to
implement that, though.