### PR TITLE
Remove virtual inheritance in Geometry subclasses

### DIFF
--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -52,7 +52,7 @@ namespace geom { // geos::geom
  * represented by GeometryCollection subclasses MultiPoint,
  * MultiLineString, MultiPolygon.
  */
-class GEOS_DLL GeometryCollection : public virtual Geometry {
+class GEOS_DLL GeometryCollection : public Geometry {
 
 public:
     friend class GeometryFactory;

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -65,7 +65,7 @@ namespace geom { // geos::geom
  *  If these conditions are not met, the constructors throw
  *  an {@link util::IllegalArgumentException}.
  */
-class GEOS_DLL LineString: public virtual Geometry {
+class GEOS_DLL LineString: public Geometry {
 
 public:
 

--- a/include/geos/geom/MultiLineString.inl
+++ b/include/geos/geom/MultiLineString.inl
@@ -31,7 +31,6 @@ namespace geom { // geos::geom
 INLINE
 MultiLineString::MultiLineString(const MultiLineString& mp)
     :
-    Geometry(mp),
     GeometryCollection(mp)
 {
 }

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -119,7 +119,7 @@ protected:
      */
     MultiPoint(std::vector<Geometry*>* newPoints, const GeometryFactory* newFactory);
 
-    MultiPoint(const MultiPoint& mp): Geometry(mp), GeometryCollection(mp) {}
+    MultiPoint(const MultiPoint& mp): GeometryCollection(mp) {}
 
     const Coordinate* getCoordinateN(size_t n) const;
 

--- a/include/geos/geom/MultiPolygon.inl
+++ b/include/geos/geom/MultiPolygon.inl
@@ -28,7 +28,6 @@ namespace geom { // geos::geom
 INLINE
 MultiPolygon::MultiPolygon(const MultiPolygon& mp)
     :
-    Geometry(mp),
     GeometryCollection(mp)
 {
 }

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -62,7 +62,7 @@ namespace geom { // geos::geom
  *   (i.e does not have an NaN X or Y ordinate)
  *
  */
-class GEOS_DLL Point : public virtual Geometry {
+class GEOS_DLL Point : public Geometry {
 
 public:
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -61,7 +61,7 @@ namespace geom { // geos::geom
  *  Specification for SQL</A> .
  *
  */
-class GEOS_DLL Polygon: public virtual Geometry {
+class GEOS_DLL Polygon: public Geometry {
 
 public:
 

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -34,13 +34,12 @@ namespace geos {
 namespace geom { // geos::geom
 
 /*public*/
-LinearRing::LinearRing(const LinearRing& lr): Geometry(lr), LineString(lr) {}
+LinearRing::LinearRing(const LinearRing& lr): LineString(lr) {}
 
 /*public*/
 LinearRing::LinearRing(CoordinateSequence* newCoords,
                        const GeometryFactory* newFactory)
     :
-    Geometry(newFactory),
     LineString(newCoords, newFactory)
 {
     validateConstruction();
@@ -50,7 +49,6 @@ LinearRing::LinearRing(CoordinateSequence* newCoords,
 LinearRing::LinearRing(CoordinateSequence::Ptr newCoords,
                        const GeometryFactory* newFactory)
     :
-    Geometry(newFactory),
     LineString(std::move(newCoords), newFactory)
 {
     validateConstruction();

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -43,7 +43,6 @@ namespace geom { // geos::geom
 MultiLineString::MultiLineString(vector<Geometry*>* newLines,
                                  const GeometryFactory* factory)
     :
-    Geometry(factory),
     GeometryCollection(newLines, factory)
 {
 }

--- a/src/geom/MultiPoint.cpp
+++ b/src/geom/MultiPoint.cpp
@@ -34,7 +34,6 @@ namespace geom { // geos::geom
 /*protected*/
 MultiPoint::MultiPoint(vector<Geometry*>* newPoints, const GeometryFactory* factory)
     :
-    Geometry(factory),
     GeometryCollection(newPoints, factory)
 {
 }

--- a/src/geom/MultiPolygon.cpp
+++ b/src/geom/MultiPolygon.cpp
@@ -41,8 +41,7 @@ namespace geom { // geos::geom
 
 /*protected*/
 MultiPolygon::MultiPolygon(vector<Geometry*>* newPolys, const GeometryFactory* factory)
-    : Geometry(factory),
-      GeometryCollection(newPolys, factory)
+      : GeometryCollection(newPolys, factory)
 {}
 
 MultiPolygon::~MultiPolygon() {}


### PR DESCRIPTION
Virtual inheritance is not required, increases the size of all Geometry
subclasses by 8 bytes, and introduces a step of indirection when
accessing Geometry members.