### PR TITLE
Augment GeometryFactory with a methods taking and returning unique_ptr

### DIFF
--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -845,8 +845,8 @@ protected:
 
     /// Returns true if the array contains any non-empty Geometrys.
     template<typename T>
-    static bool hasNonEmptyElements(const std::vector<T*>* geometries) {
-        return std::any_of(geometries->begin(), geometries->end(), [](const Geometry* g) { return !g->isEmpty(); });
+    static bool hasNonEmptyElements(const std::vector<T>* geometries) {
+        return std::any_of(geometries->begin(), geometries->end(), [](const T& g) { return !g->isEmpty(); });
     }
 
     /// Returns true if the CoordinateSequence contains any null elements.
@@ -854,8 +854,8 @@ protected:
 
     /// Returns true if the vector contains any null elements.
     template<typename T>
-    static bool hasNullElements(const std::vector<T*>* geometries) {
-        return std::any_of(geometries->begin(), geometries->end(), [](const Geometry* g) { return g == nullptr; });
+    static bool hasNullElements(const std::vector<T>* geometries) {
+        return std::any_of(geometries->begin(), geometries->end(), [](const T& g) { return g == nullptr; });
     }
 
 //	static void reversePointOrder(CoordinateSequence* coordinates);
@@ -903,6 +903,15 @@ protected:
      */
     Geometry(const GeometryFactory* factory);
 
+    template<typename T>
+    static std::vector<std::unique_ptr<Geometry>> toGeometryArray(std::vector<std::unique_ptr<T>> && v) {
+        static_assert(std::is_base_of<Geometry, T>::value, "");
+        std::vector<std::unique_ptr<Geometry>> gv(v.size());
+        for (size_t i = 0; i < v.size(); i++) {
+            gv[i] = std::move(v[i]);
+        }
+        return gv;
+    }
 
 protected:
 

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -201,6 +201,13 @@ protected:
      */
     GeometryCollection(std::vector<Geometry*>* newGeoms, const GeometryFactory* newFactory);
 
+    GeometryCollection(std::vector<std::unique_ptr<Geometry>> && newGeoms, const GeometryFactory& newFactory);
+
+    /// Convenience constructor to build a GeometryCollection from vector of Geometry subclass pointers
+    template<typename T>
+    GeometryCollection(std::vector<std::unique_ptr<T>> && newGeoms, const GeometryFactory& newFactory) :
+        GeometryCollection(toGeometryArray(std::move(newGeoms)), newFactory) {}
+
     int
     getSortIndex() const override
     {

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -45,7 +45,6 @@ class LinearRing;
 class MultiLineString;
 class MultiPoint;
 class MultiPolygon;
-class Point;
 class Polygon;
 class PrecisionModel;
 }
@@ -184,6 +183,9 @@ public:
     GeometryCollection* createGeometryCollection(
         std::vector<Geometry*>* newGeoms) const;
 
+    std::unique_ptr<GeometryCollection> createGeometryCollection(
+            std::vector<std::unique_ptr<Geometry>> && newGeoms) const;
+
     /// Constructs a GeometryCollection with a deep-copy of args
     GeometryCollection* createGeometryCollection(
         const std::vector<Geometry*>& newGeoms) const;
@@ -199,6 +201,12 @@ public:
     MultiLineString* createMultiLineString(
         const std::vector<Geometry*>& fromLines) const;
 
+    std::unique_ptr<MultiLineString> createMultiLineString(
+            std::vector<std::unique_ptr<LineString>> && fromLines) const;
+
+    std::unique_ptr<MultiLineString> createMultiLineString(
+            std::vector<std::unique_ptr<Geometry>> && fromLines) const;
+
     /// Construct an EMPTY MultiPolygon
     MultiPolygon* createMultiPolygon() const;
 
@@ -209,14 +217,20 @@ public:
     MultiPolygon* createMultiPolygon(
         const std::vector<Geometry*>& fromPolys) const;
 
+    std::unique_ptr<MultiPolygon> createMultiPolygon(
+        std::vector<std::unique_ptr<Polygon>> && fromPolys) const;
+
+    std::unique_ptr<MultiPolygon> createMultiPolygon(
+            std::vector<std::unique_ptr<Geometry>> && fromPolys) const;
+
     /// Construct an EMPTY LinearRing
     LinearRing* createLinearRing() const;
 
     /// Construct a LinearRing taking ownership of given arguments
     LinearRing* createLinearRing(CoordinateSequence* newCoords) const;
 
-    std::unique_ptr<Geometry> createLinearRing(
-        std::unique_ptr<CoordinateSequence> newCoords) const;
+    std::unique_ptr<LinearRing> createLinearRing(
+        std::unique_ptr<CoordinateSequence> && newCoords) const;
 
     /// Construct a LinearRing with a deep-copy of given arguments
     LinearRing* createLinearRing(
@@ -227,6 +241,10 @@ public:
 
     /// Construct a MultiPoint taking ownership of given arguments
     MultiPoint* createMultiPoint(std::vector<Geometry*>* newPoints) const;
+
+    std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Point>> && newPoints) const;
+
+    std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints) const;
 
     /// Construct a MultiPoint with a deep-copy of given arguments
     MultiPoint* createMultiPoint(
@@ -251,6 +269,11 @@ public:
     Polygon* createPolygon(LinearRing* shell,
                            std::vector<LinearRing*>* holes) const;
 
+    std::unique_ptr<Polygon> createPolygon(std::unique_ptr<LinearRing> && shell) const;
+
+    std::unique_ptr<Polygon> createPolygon(std::unique_ptr<LinearRing> && shell,
+                                           std::vector<std::unique_ptr<LinearRing>> && holes) const;
+
     /// Construct a Polygon with a deep-copy of given arguments
     Polygon* createPolygon(const LinearRing& shell,
                            const std::vector<LinearRing*>& holes) const;
@@ -264,8 +287,8 @@ public:
     /// Construct a LineString taking ownership of given argument
     LineString* createLineString(CoordinateSequence* coordinates) const;
 
-    std::unique_ptr<Geometry> createLineString(
-        std::unique_ptr<CoordinateSequence> coordinates) const;
+    std::unique_ptr<LineString> createLineString(
+        std::unique_ptr<CoordinateSequence> && coordinates) const;
 
     /// Construct a LineString with a deep-copy of given argument
     LineString* createLineString(

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -193,8 +193,8 @@ protected:
     LineString(CoordinateSequence* pts, const GeometryFactory* newFactory);
 
     /// Hopefully cleaner version of the above
-    LineString(CoordinateSequence::Ptr pts,
-               const GeometryFactory* newFactory);
+    LineString(CoordinateSequence::Ptr && pts,
+               const GeometryFactory& newFactory);
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -79,8 +79,8 @@ public:
                const GeometryFactory* newFactory);
 
     /// Hopefully cleaner version of the above
-    LinearRing(CoordinateSequence::Ptr points,
-               const GeometryFactory* newFactory);
+    LinearRing(CoordinateSequence::Ptr && points,
+            const GeometryFactory& newFactory);
 
     std::unique_ptr<Geometry>
     clone() const override

--- a/include/geos/geom/MultiLineString.h
+++ b/include/geos/geom/MultiLineString.h
@@ -24,6 +24,7 @@
 #include <geos/export.h>
 #include <geos/geom/GeometryCollection.h> // for inheritance
 #include <geos/geom/Dimension.h>
+#include <geos/geom/LineString.h>
 
 #include <string>
 #include <vector>
@@ -114,6 +115,12 @@ protected:
      */
     MultiLineString(std::vector<Geometry*>* newLines,
                     const GeometryFactory* newFactory);
+
+    MultiLineString(std::vector<std::unique_ptr<LineString>> && newLines,
+            const GeometryFactory& newFactory);
+
+    MultiLineString(std::vector<std::unique_ptr<Geometry>> && newLines,
+                    const GeometryFactory& newFactory);
 
     MultiLineString(const MultiLineString& mp);
 

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -119,6 +119,10 @@ protected:
      */
     MultiPoint(std::vector<Geometry*>* newPoints, const GeometryFactory* newFactory);
 
+    MultiPoint(std::vector<std::unique_ptr<Point>> && newPoints, const GeometryFactory& newFactory);
+
+    MultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints, const GeometryFactory& newFactory);
+
     MultiPoint(const MultiPoint& mp): GeometryCollection(mp) {}
 
     const Coordinate* getCoordinateN(size_t n) const;

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 #include <geos/geom/GeometryCollection.h> // for inheritance
+#include <geos/geom/Polygon.h> // for inheritance
 #include <geos/geom/Dimension.h> // for Dimension::DimensionType
 
 #include <geos/inline.h>
@@ -114,6 +115,12 @@ protected:
      *	of the constructed MultiPolygon.
      */
     MultiPolygon(std::vector<Geometry*>* newPolys, const GeometryFactory* newFactory);
+
+    MultiPolygon(std::vector<std::unique_ptr<Polygon>> && newPolys,
+            const GeometryFactory& newFactory);
+
+    MultiPolygon(std::vector<std::unique_ptr<Geometry>> && newPolys,
+                 const GeometryFactory& newFactory);
 
     MultiPolygon(const MultiPolygon& mp);
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -171,6 +171,13 @@ protected:
     Polygon(LinearRing* newShell, std::vector<LinearRing*>* newHoles,
             const GeometryFactory* newFactory);
 
+    Polygon(std::unique_ptr<LinearRing> && newShell,
+            const GeometryFactory& newFactory);
+
+    Polygon(std::unique_ptr<LinearRing> && newShell,
+            std::vector<std::unique_ptr<LinearRing>> && newHoles,
+            const GeometryFactory& newFactory);
+
     std::unique_ptr<LinearRing> shell;
 
     std::vector<std::unique_ptr<LinearRing>> holes;

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -70,6 +70,17 @@ GeometryCollection::GeometryCollection(std::vector<Geometry*>* newGeoms, const G
     setSRID(getSRID());
 }
 
+GeometryCollection::GeometryCollection(std::vector<std::unique_ptr<Geometry>> && newGeoms, const GeometryFactory& factory) :
+    Geometry(&factory),
+    geometries(std::move(newGeoms)) {
+
+    if (hasNullElements(&geometries)) {
+        throw util::IllegalArgumentException("geometries must not contain null elements\n");
+    }
+
+    setSRID(getSRID());
+}
+
 void
 GeometryCollection::setSRID(int newSRID)
 {

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -327,7 +327,7 @@ GeometryFactory::createPoint(const Coordinate& coordinate) const
     else {
         std::size_t dim = std::isnan(coordinate.z) ? 2 : 3;
         auto cl = coordinateListFactory->create(new vector<Coordinate>(1, coordinate), dim);
-        //cl->setAt(coordinate, 0);
+
         Point* ret = createPoint(cl.release());
         return ret;
     }
@@ -366,29 +366,34 @@ const
 
 /*public*/
 MultiLineString*
-GeometryFactory::createMultiLineString(const vector<Geometry*>& fromLines)
+GeometryFactory::createMultiLineString(const std::vector<Geometry*>& fromLines)
 const
 {
-    vector<Geometry*>* newGeoms = new vector<Geometry*>(fromLines.size());
+    std::vector<std::unique_ptr<Geometry>> newGeoms(fromLines.size());
+
     for(size_t i = 0; i < fromLines.size(); i++) {
-        const LineString* line = dynamic_cast<const LineString*>(fromLines[i]);
-        if(! line) {
+        auto line = dynamic_cast<const LineString*>(fromLines[i]);
+
+        if(!line) {
             throw geos::util::IllegalArgumentException("createMultiLineString called with a vector containing non-LineStrings");
         }
-        (*newGeoms)[i] = new LineString(*line);
+
+        newGeoms[i].reset(new LineString(*line));
     }
-    MultiLineString* g = nullptr;
-    try {
-        g = new MultiLineString(newGeoms, this);
-    }
-    catch(...) {
-        for(size_t i = 0; i < newGeoms->size(); i++) {
-            delete(*newGeoms)[i];
-        }
-        delete newGeoms;
-        throw;
-    }
-    return g;
+
+    return new MultiLineString(std::move(newGeoms), *this);
+}
+
+std::unique_ptr<MultiLineString>
+GeometryFactory::createMultiLineString(std::vector<std::unique_ptr<LineString>> && fromLines) const {
+    // Can't use make_unique because constructor is protected
+    return std::unique_ptr<MultiLineString>(new MultiLineString(std::move(fromLines), *this));
+}
+
+std::unique_ptr<MultiLineString>
+GeometryFactory::createMultiLineString(std::vector<std::unique_ptr<Geometry>> && fromLines) const {
+    // Can't use make_unique because constructor is protected
+    return std::unique_ptr<MultiLineString>(new MultiLineString(std::move(fromLines), *this));
 }
 
 /*public*/
@@ -412,26 +417,23 @@ GeometryFactory::createGeometryCollection(vector<Geometry*>* newGeoms) const
     return new GeometryCollection(newGeoms, this);
 }
 
+std::unique_ptr<GeometryCollection>
+GeometryFactory::createGeometryCollection(std::vector<std::unique_ptr<geos::geom::Geometry>> && newGeoms) const {
+    // Can't use make_unique because constructor is protected
+    return std::unique_ptr<GeometryCollection>(new GeometryCollection(std::move(newGeoms), *this));
+}
+
 /*public*/
 GeometryCollection*
-GeometryFactory::createGeometryCollection(const vector<Geometry*>& fromGeoms) const
+GeometryFactory::createGeometryCollection(const std::vector<Geometry*>& fromGeoms) const
 {
-    vector<Geometry*>* newGeoms = new vector<Geometry*>(fromGeoms.size());
+    std::vector<std::unique_ptr<Geometry>> newGeoms(fromGeoms.size());
+
     for(size_t i = 0; i < fromGeoms.size(); i++) {
-        (*newGeoms)[i] = fromGeoms[i]->clone().release();
+        newGeoms[i] = fromGeoms[i]->clone();
     }
-    GeometryCollection* g = nullptr;
-    try {
-        g = new GeometryCollection(newGeoms, this);
-    }
-    catch(...) {
-        for(size_t i = 0; i < newGeoms->size(); i++) {
-            delete(*newGeoms)[i];
-        }
-        delete newGeoms;
-        throw;
-    }
-    return g;
+
+    return new GeometryCollection(std::move(newGeoms), *this);
 }
 
 /*public*/
@@ -448,26 +450,31 @@ GeometryFactory::createMultiPolygon(vector<Geometry*>* newPolys) const
     return new MultiPolygon(newPolys, this);
 }
 
+std::unique_ptr<MultiPolygon>
+GeometryFactory::createMultiPolygon(std::vector<std::unique_ptr<Polygon>> && newPolys) const
+{
+    // Can't use make_unique because constructor is protected
+    return std::unique_ptr<MultiPolygon>(new MultiPolygon(std::move(newPolys), *this));
+}
+
+std::unique_ptr<MultiPolygon>
+GeometryFactory::createMultiPolygon(std::vector<std::unique_ptr<Geometry>> && newPolys) const
+{
+    // Can't use make_unique because constructor is protected
+    return std::unique_ptr<MultiPolygon>(new MultiPolygon(std::move(newPolys), *this));
+}
+
 /*public*/
 MultiPolygon*
-GeometryFactory::createMultiPolygon(const vector<Geometry*>& fromPolys) const
+GeometryFactory::createMultiPolygon(const std::vector<Geometry*>& fromPolys) const
 {
-    vector<Geometry*>* newGeoms = new vector<Geometry*>(fromPolys.size());
+    std::vector<std::unique_ptr<Geometry>> newGeoms(fromPolys.size());
+
     for(size_t i = 0; i < fromPolys.size(); i++) {
-        (*newGeoms)[i] = fromPolys[i]->clone().release();
+        newGeoms[i] = fromPolys[i]->clone();
     }
-    MultiPolygon* g = nullptr;
-    try {
-        g = new MultiPolygon(newGeoms, this);
-    }
-    catch(...) {
-        for(size_t i = 0; i < newGeoms->size(); i++) {
-            delete(*newGeoms)[i];
-        }
-        delete newGeoms;
-        throw;
-    }
-    return g;
+
+    return new MultiPolygon(std::move(newGeoms), *this);
 }
 
 /*public*/
@@ -484,11 +491,11 @@ GeometryFactory::createLinearRing(CoordinateSequence* newCoords) const
     return new LinearRing(newCoords, this);
 }
 
-/*public*/
-Geometry::Ptr
-GeometryFactory::createLinearRing(CoordinateSequence::Ptr newCoords) const
+std::unique_ptr<LinearRing>
+GeometryFactory::createLinearRing(CoordinateSequence::Ptr && newCoords) const
 {
-    return Geometry::Ptr(new LinearRing(std::move(newCoords), this));
+    // Can't use make_unique with protected constructor
+    return std::unique_ptr<LinearRing>(new LinearRing(std::move(newCoords), *this));
 }
 
 /*public*/
@@ -509,27 +516,28 @@ GeometryFactory::createMultiPoint(vector<Geometry*>* newPoints) const
     return new MultiPoint(newPoints, this);
 }
 
+std::unique_ptr<MultiPoint>
+GeometryFactory::createMultiPoint(std::vector<std::unique_ptr<Point>> && newPoints) const
+{
+    return std::unique_ptr<MultiPoint>(new MultiPoint(std::move(newPoints), *this));
+}
+
+std::unique_ptr<MultiPoint>
+GeometryFactory::createMultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints) const
+{
+    return std::unique_ptr<MultiPoint>(new MultiPoint(std::move(newPoints), *this));
+}
+
 /*public*/
 MultiPoint*
 GeometryFactory::createMultiPoint(const vector<Geometry*>& fromPoints) const
 {
-    vector<Geometry*>* newGeoms = new vector<Geometry*>(fromPoints.size());
+    std::vector<std::unique_ptr<Geometry>> newGeoms(fromPoints.size());
     for(size_t i = 0; i < fromPoints.size(); i++) {
-        (*newGeoms)[i] = fromPoints[i]->clone().release();
+        newGeoms[i] = fromPoints[i]->clone();
     }
 
-    MultiPoint* g = nullptr;
-    try {
-        g = new MultiPoint(newGeoms, this);
-    }
-    catch(...) {
-        for(size_t i = 0; i < newGeoms->size(); i++) {
-            delete(*newGeoms)[i];
-        }
-        delete newGeoms;
-        throw;
-    }
-    return g;
+    return new MultiPoint(std::move(newGeoms), *this);
 }
 
 /*public*/
@@ -544,24 +552,13 @@ MultiPoint*
 GeometryFactory::createMultiPoint(const CoordinateSequence& fromCoords) const
 {
     size_t npts = fromCoords.getSize();
-    vector<Geometry*>* pts = new vector<Geometry*>;
-    pts->reserve(npts);
+    vector<std::unique_ptr<Geometry>> pts(npts);
+
     for(size_t i = 0; i < npts; ++i) {
-        Point* pt = createPoint(fromCoords.getAt(i));
-        pts->push_back(pt);
+        pts[i].reset(createPoint(fromCoords.getAt(i)));
     }
-    MultiPoint* mp = nullptr;
-    try {
-        mp = createMultiPoint(pts);
-    }
-    catch(...) {
-        for(size_t i = 0; i < npts; ++i) {
-            delete(*pts)[i];
-        }
-        delete pts;
-        throw;
-    }
-    return mp;
+
+    return new MultiPoint(std::move(pts), *this);
 }
 
 /*public*/
@@ -569,24 +566,13 @@ MultiPoint*
 GeometryFactory::createMultiPoint(const std::vector<Coordinate>& fromCoords) const
 {
     size_t npts = fromCoords.size();
-    vector<Geometry*>* pts = new vector<Geometry*>;
-    pts->reserve(npts);
+    std::vector<std::unique_ptr<Geometry>> pts(npts);
+
     for(size_t i = 0; i < npts; ++i) {
-        Point* pt = createPoint(fromCoords[i]);
-        pts->push_back(pt);
+        pts[i].reset(createPoint(fromCoords[i]));
     }
-    MultiPoint* mp = nullptr;
-    try {
-        mp = createMultiPoint(pts);
-    }
-    catch(...) {
-        for(size_t i = 0; i < npts; ++i) {
-            delete(*pts)[i];
-        }
-        delete pts;
-        throw;
-    }
-    return mp;
+
+    return new MultiPoint(std::move(pts), *this);
 }
 
 /*public*/
@@ -604,29 +590,36 @@ const
     return new Polygon(shell, holes, this);
 }
 
-/*public*/
-Polygon*
-GeometryFactory::createPolygon(const LinearRing& shell, const vector<LinearRing*>& holes)
+std::unique_ptr<Polygon>
+GeometryFactory::createPolygon(std::unique_ptr<LinearRing> && shell)
 const
 {
-    LinearRing* newRing = new LinearRing(shell);
-    vector<LinearRing*>* newHoles = new vector<LinearRing*>(holes.size());
+    // Can't use make_unique with protected constructor
+    return std::unique_ptr<Polygon>(new Polygon(std::move(shell), *this));
+}
+
+std::unique_ptr<Polygon>
+GeometryFactory::createPolygon(std::unique_ptr<LinearRing> && shell, std::vector<std::unique_ptr<LinearRing>> && holes)
+const
+{
+    // Can't use make_unique with protected constructor
+    return std::unique_ptr<Polygon>(new Polygon(std::move(shell), std::move(holes), *this));
+}
+
+/*public*/
+Polygon*
+GeometryFactory::createPolygon(const LinearRing& shell, const std::vector<LinearRing*>& holes)
+const
+{
+    std::unique_ptr<LinearRing> newRing(new LinearRing(shell));
+
+    std::vector<std::unique_ptr<LinearRing>> newHoles(holes.size());
+
     for(size_t i = 0; i < holes.size(); i++) {
-        (*newHoles)[i] = new LinearRing(*(holes[i]));
+        newHoles[i].reset(new LinearRing(*holes[i]));
     }
-    Polygon* g = nullptr;
-    try {
-        g = new Polygon(newRing, newHoles, this);
-    }
-    catch(...) {
-        delete newRing;
-        for(size_t i = 0; i < holes.size(); i++) {
-            delete(*newHoles)[i];
-        }
-        delete newHoles;
-        throw;
-    }
-    return g;
+
+    return new Polygon(std::move(newRing), std::move(newHoles), *this);
 }
 
 /*public*/
@@ -640,8 +633,8 @@ GeometryFactory::createLineString() const
 std::unique_ptr<LineString>
 GeometryFactory::createLineString(const LineString& ls) const
 {
+    // Can't use make_unique with protected constructor
     return std::unique_ptr<LineString>(new LineString(ls));
-    //return make_unique<LineString>(ls); // TODO why doesn't this work?
 }
 
 /*public*/
@@ -653,11 +646,12 @@ const
 }
 
 /*public*/
-Geometry::Ptr
-GeometryFactory::createLineString(CoordinateSequence::Ptr newCoords)
+std::unique_ptr<LineString>
+GeometryFactory::createLineString(CoordinateSequence::Ptr && newCoords)
 const
 {
-    return Geometry::Ptr(new LineString(std::move(newCoords), this));
+    // Can't use make_unique with protected constructor
+    return std::unique_ptr<LineString>(new LineString(std::move(newCoords), *this));
 }
 
 /*public*/

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -94,10 +94,10 @@ LineString::LineString(CoordinateSequence* newCoords,
 }
 
 /*public*/
-LineString::LineString(CoordinateSequence::Ptr newCoords,
-                       const GeometryFactory* factory)
+LineString::LineString(CoordinateSequence::Ptr && newCoords,
+                       const GeometryFactory& factory)
     :
-    Geometry(factory),
+    Geometry(&factory),
     points(std::move(newCoords))
 {
     validateConstruction();

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -46,10 +46,9 @@ LinearRing::LinearRing(CoordinateSequence* newCoords,
 }
 
 /*public*/
-LinearRing::LinearRing(CoordinateSequence::Ptr newCoords,
-                       const GeometryFactory* newFactory)
-    :
-    LineString(std::move(newCoords), newFactory)
+LinearRing::LinearRing(CoordinateSequence::Ptr && newCoords,
+                       const GeometryFactory& newFactory)
+        : LineString(std::move(newCoords), newFactory)
 {
     validateConstruction();
 }

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -47,6 +47,16 @@ MultiLineString::MultiLineString(vector<Geometry*>* newLines,
 {
 }
 
+MultiLineString::MultiLineString(std::vector<std::unique_ptr<LineString>> && newLines,
+        const GeometryFactory& factory)
+        : GeometryCollection(std::move(newLines), factory)
+{}
+
+MultiLineString::MultiLineString(std::vector<std::unique_ptr<Geometry>> && newLines,
+                                 const GeometryFactory& factory)
+        : GeometryCollection(std::move(newLines), factory)
+{}
+
 MultiLineString::~MultiLineString() {}
 
 Dimension::DimensionType

--- a/src/geom/MultiPoint.cpp
+++ b/src/geom/MultiPoint.cpp
@@ -18,26 +18,36 @@
  *
  **********************************************************************/
 
+#include <geos/geom/Point.h>
 #include <geos/geom/MultiPoint.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Dimension.h>
 
 #include <vector>
 
-using namespace std;
-
-//using namespace geos::operation;
-
 namespace geos {
 namespace geom { // geos::geom
 
 /*protected*/
-MultiPoint::MultiPoint(vector<Geometry*>* newPoints, const GeometryFactory* factory)
+MultiPoint::MultiPoint(std::vector<Geometry*>* newPoints, const GeometryFactory* factory)
     :
     GeometryCollection(newPoints, factory)
 {
 }
 
+MultiPoint::MultiPoint(std::vector<std::unique_ptr<Point>> && newPoints, const GeometryFactory& factory)
+    :
+    GeometryCollection(std::move(newPoints), factory)
+{
+
+}
+
+MultiPoint::MultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints, const GeometryFactory& factory)
+        :
+        GeometryCollection(std::move(newPoints), factory)
+{
+
+}
 
 MultiPoint::~MultiPoint() {}
 
@@ -53,7 +63,7 @@ MultiPoint::getBoundaryDimension() const
     return Dimension::False;
 }
 
-string
+std::string
 MultiPoint::getGeometryType() const
 {
     return "MultiPoint";

--- a/src/geom/MultiPolygon.cpp
+++ b/src/geom/MultiPolygon.cpp
@@ -44,6 +44,14 @@ MultiPolygon::MultiPolygon(vector<Geometry*>* newPolys, const GeometryFactory* f
       : GeometryCollection(newPolys, factory)
 {}
 
+MultiPolygon::MultiPolygon(std::vector<std::unique_ptr<Polygon>> && newPolys, const GeometryFactory& factory)
+      : GeometryCollection(std::move(newPolys), factory)
+{}
+
+MultiPolygon::MultiPolygon(std::vector<std::unique_ptr<Geometry>> && newPolys, const GeometryFactory& factory)
+        : GeometryCollection(std::move(newPolys), factory)
+{}
+
 MultiPolygon::~MultiPolygon() {}
 
 Dimension::DimensionType

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -87,6 +87,37 @@ Polygon::Polygon(LinearRing* newShell, std::vector<LinearRing*>* newHoles,
     }
 }
 
+Polygon::Polygon(std::unique_ptr<LinearRing> && newShell,
+                 const GeometryFactory& newFactory) :
+        Geometry(&newFactory),
+        shell(std::move(newShell))
+{
+    if(shell == nullptr) {
+        shell.reset(getFactory()->createLinearRing(nullptr));
+    }
+}
+
+Polygon::Polygon(std::unique_ptr<LinearRing> && newShell,
+                 std::vector<std::unique_ptr<LinearRing>> && newHoles,
+                 const GeometryFactory& newFactory) :
+                 Geometry(&newFactory),
+                 shell(std::move(newShell)),
+                 holes(std::move(newHoles))
+{
+    if(shell == nullptr) {
+        shell.reset(getFactory()->createLinearRing(nullptr));
+    }
+
+    // TODO move into validateConstruction() method
+    if(shell->isEmpty() && hasNonEmptyElements(&holes)) {
+        throw util::IllegalArgumentException("shell is empty but holes are not");
+    }
+    if (hasNullElements(&holes)) {
+        throw util::IllegalArgumentException("holes must not contain null elements");
+    }
+}
+
+
 std::unique_ptr<CoordinateSequence>
 Polygon::getCoordinates() const
 {

--- a/src/simplify/TaggedLineString.cpp
+++ b/src/simplify/TaggedLineString.cpp
@@ -20,6 +20,7 @@
 #include <geos/simplify/TaggedLineSegment.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/LineString.h>
+#include <geos/geom/LinearRing.h>
 #include <geos/geom/Geometry.h> // for unique_ptr destructor
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/CoordinateSequenceFactory.h>
@@ -224,8 +225,8 @@ TaggedLineString::asLineString() const
 unique_ptr<Geometry>
 TaggedLineString::asLinearRing() const
 {
-    return parentLine->getFactory()->createLinearRing(
-               getResultCoordinates());
+    return std::unique_ptr<Geometry>(parentLine->getFactory()->createLinearRing(
+               getResultCoordinates()));
 }
 
 /*public*/


### PR DESCRIPTION
This PR augments `GeometryFactory` with additional factory methods to create Geometries using rvalue references for their underlying components. This allows a user to avoid heap-allocating the components simply to pass them into the constructor. The new factory methods all return `unique_ptr`.

The PR also reworks `WKTReader` and `WKBReader` to demonstrate how library code can be simplified using the new factory methods.