### PR TITLE
Remove use of std::mem_fun

### DIFF
--- a/src/noding/MCIndexNoder.cpp
+++ b/src/noding/MCIndexNoder.cpp
@@ -48,8 +48,9 @@ MCIndexNoder::computeNodes(SegmentString::NonConstVect* inputSegStrings)
     nodedSegStrings = inputSegStrings;
     assert(nodedSegStrings);
 
-    for_each(nodedSegStrings->begin(), nodedSegStrings->end(),
-             bind1st(mem_fun(&MCIndexNoder::add), this));
+    for (const auto& s : *nodedSegStrings) {
+        add(s);
+    }
 
     intersectChains();
 //cerr<<"MCIndexNoder: # chain overlaps = "<<nOverlaps<<endl;

--- a/src/noding/snapround/MCIndexSnapRounder.cpp
+++ b/src/noding/snapround/MCIndexSnapRounder.cpp
@@ -26,8 +26,6 @@
 
 #include <geos/inline.h>
 
-#include <functional> // std::mem_fun, std::bind1st
-#include <algorithm> // std::for_each
 #include <vector>
 
 

--- a/src/operation/overlay/OverlayOp.cpp
+++ b/src/operation/overlay/OverlayOp.cpp
@@ -47,7 +47,6 @@
 
 #include <cassert>
 #include <cmath>
-#include <functional>
 #include <vector>
 #include <sstream>
 #include <memory> // for unique_ptr
@@ -207,10 +206,6 @@ OverlayOp::insertUniqueEdges(vector<Edge*>* edges, const Envelope* env)
 #endif
         insertUniqueEdge(e);
     }
-    /*
-    	for_each(edges->begin(), edges->end(),
-    			bind1st(mem_fun(&OverlayOp::insertUniqueEdge), this));
-    */
 }
 
 /*private*/

--- a/src/operation/overlay/validate/OffsetPointGenerator.cpp
+++ b/src/operation/overlay/validate/OffsetPointGenerator.cpp
@@ -62,8 +62,10 @@ OffsetPointGenerator::getPoints()
 
     vector<const LineString*> lines;
     geos::geom::util::LinearComponentExtracter::getLines(g, lines);
-    for_each(lines.begin(), lines.end(),
-             bind1st(mem_fun(&OffsetPointGenerator::extractPoints), this));
+
+    for (const auto& line : lines) {
+        extractPoints(line);
+    }
 
     // NOTE: Apparently, this is 'source' method giving up the object resource.
     return std::move(offsetPts);


### PR DESCRIPTION
It is deprecated in C+11 and removed in C++17.