### PR TITLE
Add FixedSizeCoordinateSequence for Points

### DIFF
--- a/benchmarks/ClassSizes.cpp
+++ b/benchmarks/ClassSizes.cpp
@@ -19,6 +19,8 @@
 
 #include <geos/geom/GeometryFactory.h>
 #include <geos/io/WKTReader.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <geos/geom/FixedSizeCoordinateSequence.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/Point.h>
 #include <geos/geom/LinearRing.h>
@@ -58,6 +60,9 @@ main()
     check(geom::MultiPoint);
     check(geom::MultiLineString);
     check(geom::MultiPolygon);
+    check(geom::CoordinateArraySequence);
+    check(geom::FixedSizeCoordinateSequence<1>);
+    check(geom::FixedSizeCoordinateSequence<2>);
     check(int64);
 }
 

--- a/benchmarks/capi/GEOSPreparedContainsPerfTest.cpp
+++ b/benchmarks/capi/GEOSPreparedContainsPerfTest.cpp
@@ -57,10 +57,7 @@ public:
         size_t hits = 0;
         auto prep = GEOSPrepare(g);
         for (const auto& c : coords) {
-            auto seq = GEOSCoordSeq_create(1, 2);
-            GEOSCoordSeq_setX(seq, 0, c.x);
-            GEOSCoordSeq_setY(seq, 0, c.y);
-            auto pt = GEOSGeom_createPoint(seq);
+            auto pt = GEOSGeom_createPointFromXY(c.x, c.y);
 
             if (GEOSPreparedContains(prep, pt)) {
                 hits++;

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -912,6 +912,12 @@ extern "C" {
     }
 
     Geometry*
+    GEOSGeom_createPointFromXY(double x, double y)
+    {
+        return GEOSGeom_createPointFromXY_r(handle, x, y);
+    }
+
+    Geometry*
     GEOSGeom_createLinearRing(CoordinateSequence* cs)
     {
         return GEOSGeom_createLinearRing_r(handle, cs);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -480,6 +480,10 @@ extern GEOSGeometry GEOS_DLL *GEOSOffsetCurve_r(GEOSContextHandle_t handle,
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createPoint_r(
                                        GEOSContextHandle_t handle,
                                        GEOSCoordSequence* s);
+extern GEOSGeometry GEOS_DLL *GEOSGeom_createPointFromXY_r(
+                                       GEOSContextHandle_t handle,
+                                       double x,
+                                       double y);
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createEmptyPoint_r(
                                        GEOSContextHandle_t handle);
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createLinearRing_r(
@@ -1525,6 +1529,7 @@ extern GEOSGeometry GEOS_DLL *GEOSOffsetCurve(const GEOSGeometry* g,
  ***********************************************************************/
 
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createPoint(GEOSCoordSequence* s);
+extern GEOSGeometry GEOS_DLL *GEOSGeom_createPointFromXY(double x, double y);
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createEmptyPoint();
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createLinearRing(GEOSCoordSequence* s);
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createLineString(GEOSCoordSequence* s);

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -114,9 +114,6 @@ public:
 
     void setPoints(const std::vector<Coordinate>& v) override;
 
-    double getOrdinate(std::size_t index,
-                       size_t ordinateIndex) const override;
-
     void setOrdinate(std::size_t index, std::size_t ordinateIndex,
                      double value) override;
 

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -219,7 +219,7 @@ public:
      * @param ordinateIndex the ordinate index in the coordinate
      *                      (in range [0, dimension-1])
      */
-    virtual double getOrdinate(std::size_t index, std::size_t ordinateIndex) const = 0;
+    virtual double getOrdinate(std::size_t index, std::size_t ordinateIndex) const;
 
     /**
      * Returns ordinate X (0) of the specified coordinate.

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -116,6 +116,7 @@ namespace geom {
         void apply_rw(const CoordinateFilter* filter) override {
             std::for_each(m_data.begin(), m_data.end(),
                     [&filter](Coordinate &c) { filter->filter_rw(&c); });
+            dimension = 0; // re-check (see http://trac.osgeo.org/geos/ticket/435)
         }
 
     private:

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -1,0 +1,129 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#ifndef GEOS_GEOM_FIXEDSIZECOORDINATESEQUENCE_H
+#define GEOS_GEOM_FIXEDSIZECOORDINATESEQUENCE_H
+
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateFilter.h>
+#include <geos/geom/CoordinateSequence.h>
+#include <geos/util.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+namespace geos {
+namespace geom {
+
+    template<size_t N>
+    class FixedSizeCoordinateSequence : public CoordinateSequence {
+    public:
+        explicit FixedSizeCoordinateSequence(size_t dimension_in = 0) : dimension(dimension_in) {}
+
+        std::unique_ptr<CoordinateSequence> clone() const override {
+            auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>();
+            seq->m_data = m_data;
+            return std::unique_ptr<CoordinateSequence>(seq.release());
+        }
+
+        const Coordinate& getAt(size_t i) const override {
+            return m_data[i];
+        }
+
+        void getAt(size_t i, Coordinate& c) const override {
+            c = m_data[i];
+        }
+
+        size_t getSize() const override {
+            return N;
+        }
+
+        bool isEmpty() const override {
+            return N == 0;
+        }
+
+        void setAt(const Coordinate & c, size_t pos) override {
+            m_data[pos] = c;
+        }
+
+        void setOrdinate(size_t index, size_t ordinateIndex, double value)
+        {
+            switch(ordinateIndex) {
+                case CoordinateSequence::X:
+                    m_data[index].x = value;
+                    break;
+                case CoordinateSequence::Y:
+                    m_data[index].y = value;
+                    break;
+                case CoordinateSequence::Z:
+                    m_data[index].z = value;
+                    break;
+                default: {
+                    std::stringstream ss;
+                    ss << "Unknown ordinate index " << index;
+                    throw geos::util::IllegalArgumentException(ss.str());
+                    break;
+                }
+            }
+        }
+
+        size_t getDimension() const override {
+            if(dimension != 0) {
+                return dimension;
+            }
+
+            if(isEmpty()) {
+                return 3;
+            }
+
+            if(std::isnan(m_data[0].z)) {
+                dimension = 2;
+            }
+            else {
+                dimension = 3;
+            }
+
+            return dimension;
+        }
+
+        void toVector(std::vector<Coordinate> & out) const {
+            out.insert(out.end(), m_data.begin(), m_data.end());
+        }
+
+        void setPoints(const std::vector<Coordinate> & v) override {
+            std::copy(v.begin(), v.end(), m_data.begin());
+        }
+
+        void apply_ro(CoordinateFilter* filter) const override {
+            std::for_each(m_data.begin(), m_data.end(),
+                    [&filter](const Coordinate & c) { filter->filter_ro(&c); });
+        }
+
+        void apply_rw(const CoordinateFilter* filter) override {
+            std::for_each(m_data.begin(), m_data.end(),
+                    [&filter](Coordinate &c) { filter->filter_rw(&c); });
+        }
+
+    private:
+        std::array<Coordinate, N> m_data;
+        mutable std::size_t dimension;
+    };
+
+}
+}
+
+#endif

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -34,29 +34,29 @@ namespace geom {
     public:
         explicit FixedSizeCoordinateSequence(size_t dimension_in = 0) : dimension(dimension_in) {}
 
-        std::unique_ptr<CoordinateSequence> clone() const override {
+        std::unique_ptr<CoordinateSequence> clone() const final {
             auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>();
             seq->m_data = m_data;
             return std::unique_ptr<CoordinateSequence>(seq.release());
         }
 
-        const Coordinate& getAt(size_t i) const override {
+        const Coordinate& getAt(size_t i) const final {
             return m_data[i];
         }
 
-        void getAt(size_t i, Coordinate& c) const override {
+        void getAt(size_t i, Coordinate& c) const final {
             c = m_data[i];
         }
 
-        size_t getSize() const override {
+        size_t getSize() const final {
             return N;
         }
 
-        bool isEmpty() const override {
+        bool isEmpty() const final {
             return N == 0;
         }
 
-        void setAt(const Coordinate & c, size_t pos) override {
+        void setAt(const Coordinate & c, size_t pos) final {
             m_data[pos] = c;
         }
 
@@ -81,7 +81,7 @@ namespace geom {
             }
         }
 
-        size_t getDimension() const override {
+        size_t getDimension() const final {
             if(dimension != 0) {
                 return dimension;
             }
@@ -104,16 +104,16 @@ namespace geom {
             out.insert(out.end(), m_data.begin(), m_data.end());
         }
 
-        void setPoints(const std::vector<Coordinate> & v) override {
+        void setPoints(const std::vector<Coordinate> & v) final {
             std::copy(v.begin(), v.end(), m_data.begin());
         }
 
-        void apply_ro(CoordinateFilter* filter) const override {
+        void apply_ro(CoordinateFilter* filter) const final {
             std::for_each(m_data.begin(), m_data.end(),
                     [&filter](const Coordinate & c) { filter->filter_ro(&c); });
         }
 
-        void apply_rw(const CoordinateFilter* filter) override {
+        void apply_rw(const CoordinateFilter* filter) final {
             std::for_each(m_data.begin(), m_data.end(),
                     [&filter](Coordinate &c) { filter->filter_rw(&c); });
             dimension = 0; // re-check (see http://trac.osgeo.org/geos/ticket/435)

--- a/include/geos/geom/Makefile.am
+++ b/include/geos/geom/Makefile.am
@@ -24,6 +24,7 @@ geos_HEADERS = \
     Dimension.h \
     Envelope.h \
     Envelope.inl \
+    FixedSizeCoordinateSequence.h \
     GeometryCollection.h \
     GeometryCollection.inl \
     GeometryComponentFilter.h \

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -24,6 +24,7 @@
 #include <geos/export.h>
 #include <geos/geom/Geometry.h> // for inheritance
 #include <geos/geom/CoordinateSequence.h> // for proper use of unique_ptr<>
+#include <geos/geom/FixedSizeCoordinateSequence.h>
 #include <geos/geom/Envelope.h> // for proper use of unique_ptr<>
 #include <geos/geom/Dimension.h> // for Dimension::DimensionType
 
@@ -157,6 +158,8 @@ protected:
      */
     Point(CoordinateSequence* newCoords, const GeometryFactory* newFactory);
 
+    Point(const Coordinate& c, const GeometryFactory* newFactory);
+
     Point(const Point& p);
 
     Envelope::Ptr computeEnvelopeInternal() const override;
@@ -174,7 +177,8 @@ private:
     /**
      *  The <code>Coordinate</code> wrapped by this <code>Point</code>.
      */
-    std::unique_ptr<CoordinateSequence> coordinates;
+    FixedSizeCoordinateSequence<1> coordinates;
+    bool empty;
 };
 
 } // namespace geos::geom

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -208,21 +208,6 @@ CoordinateArraySequence::expandEnvelope(Envelope& env) const
     }
 }
 
-double
-CoordinateArraySequence::getOrdinate(size_t index, size_t ordinateIndex) const
-{
-    switch(ordinateIndex) {
-    case CoordinateSequence::X:
-        return vect[index].x;
-    case CoordinateSequence::Y:
-        return vect[index].y;
-    case CoordinateSequence::Z:
-        return vect[index].z;
-    default:
-        return DoubleNotANumber;
-    }
-}
-
 void
 CoordinateArraySequence::setOrdinate(size_t index, size_t ordinateIndex,
                                      double value)

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -19,6 +19,7 @@
 #include <geos/geom/CoordinateArraySequenceFactory.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/Envelope.h>
+#include <geos/util/IllegalArgumentException.h>
 
 #include <cstdio>
 #include <algorithm>
@@ -35,6 +36,21 @@ namespace geom { // geos::geom
 #if PROFILE
 static Profiler* profiler = Profiler::instance();
 #endif
+
+double
+CoordinateSequence::getOrdinate(size_t index, size_t ordinateIndex) const
+{
+    switch(ordinateIndex) {
+        case CoordinateSequence::X:
+            return getAt(index).x;
+        case CoordinateSequence::Y:
+            return getAt(index).y;
+        case CoordinateSequence::Z:
+            return getAt(index).z;
+        default:
+            return DoubleNotANumber;
+    }
+}
 
 bool
 CoordinateSequence::hasRepeatedPoints() const

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -325,11 +325,7 @@ GeometryFactory::createPoint(const Coordinate& coordinate) const
         return createPoint();
     }
     else {
-        std::size_t dim = std::isnan(coordinate.z) ? 2 : 3;
-        auto cl = coordinateListFactory->create(new vector<Coordinate>(1, coordinate), dim);
-
-        Point* ret = createPoint(cl.release());
-        return ret;
+        return new Point(coordinate, this);
     }
 }
 

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -46,41 +46,56 @@ namespace geom { // geos::geom
 Point::Point(CoordinateSequence* newCoords, const GeometryFactory* factory)
     :
     Geometry(factory),
-    coordinates(newCoords)
+    empty(false)
 {
-    if(coordinates.get() == nullptr) {
-        coordinates = factory->getCoordinateSequenceFactory()->create();
+    std::unique_ptr<CoordinateSequence> coords(newCoords);
+
+    if(coords == nullptr) {
+        empty = true;
         return;
     }
-    if(coordinates->getSize() != 1) {
+
+    if (coords->getSize() == 1) {
+        coordinates.setAt(coords->getAt(0), 0);
+    } else if (coords->getSize() > 1) {
         throw util::IllegalArgumentException("Point coordinate list must contain a single element");
+    } else {
+        empty = true;
     }
+}
+
+Point::Point(const Coordinate & c, const GeometryFactory* factory) :
+    Geometry(factory),
+    empty(false)
+{
+    coordinates.setAt(c, 0);
 }
 
 /*protected*/
 Point::Point(const Point& p)
     :
     Geometry(p),
-    coordinates(p.coordinates->clone())
+    coordinates(p.coordinates),
+    empty(p.empty)
 {
 }
 
 std::unique_ptr<CoordinateSequence>
 Point::getCoordinates() const
 {
-    return coordinates->clone();
+    return coordinates.clone();
 }
 
 size_t
 Point::getNumPoints() const
 {
-    return isEmpty() ? 0 : 1;
+    return empty ? 0 : 1;
 }
 
 bool
 Point::isEmpty() const
 {
-    return coordinates->isEmpty();
+    return empty;
 }
 
 bool
@@ -98,7 +113,7 @@ Point::getDimension() const
 int
 Point::getCoordinateDimension() const
 {
-    return (int) coordinates->getDimension();
+    return (int) coordinates.getDimension();
 }
 
 int
@@ -137,7 +152,7 @@ Point::getZ() const
 const Coordinate*
 Point::getCoordinate() const
 {
-    return coordinates->getSize() != 0 ? &(coordinates->getAt(0)) : nullptr;
+    return empty ? nullptr : &coordinates[0];
 }
 
 string
@@ -176,12 +191,7 @@ Point::apply_ro(CoordinateFilter* filter) const
 void
 Point::apply_rw(const CoordinateFilter* filter)
 {
-    if(isEmpty()) {
-        return;
-    }
-    Coordinate newcoord = coordinates->getAt(0);
-    filter->filter_rw(&newcoord);
-    coordinates->setAt(newcoord, 0);
+    coordinates.apply_rw(filter);
 }
 
 void
@@ -214,7 +224,7 @@ Point::apply_rw(CoordinateSequenceFilter& filter)
     if(isEmpty()) {
         return;
     }
-    filter.filter_rw(*coordinates, 0);
+    filter.filter_rw(coordinates, 0);
     if(filter.isGeometryChanged()) {
         geometryChanged();
     }
@@ -226,7 +236,7 @@ Point::apply_ro(CoordinateSequenceFilter& filter) const
     if(isEmpty()) {
         return;
     }
-    filter.filter_ro(*coordinates, 0);
+    filter.filter_ro(coordinates, 0);
     //if (filter.isGeometryChanged()) geometryChanged();
 }
 
@@ -279,7 +289,7 @@ Point::getGeometryTypeId() const
 const CoordinateSequence*
 Point::getCoordinatesRO() const
 {
-    return coordinates.get();
+    return &coordinates;
 }
 
 } // namespace geos::geom

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -63,6 +63,7 @@ geos_unit_SOURCES = \
 	geom/CoordinateTest.cpp \
 	geom/DimensionTest.cpp \
 	geom/EnvelopeTest.cpp \
+	geom/FixedSizeCoordinateSequenceTest.cpp \
 	geom/GeometryCollectionTest.cpp \
 	geom/Geometry/clone.cpp \
 	geom/Geometry/coversTest.cpp \

--- a/tests/unit/geom/FixedSizeCoordinateSequenceTest.cpp
+++ b/tests/unit/geom/FixedSizeCoordinateSequenceTest.cpp
@@ -1,0 +1,53 @@
+#include <tut/tut.hpp>
+// geos
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/FixedSizeCoordinateSequence.h>
+// std
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used by tests
+struct test_fixedsizecoordinatesequence_data {
+};
+
+typedef test_group<test_fixedsizecoordinatesequence_data> group;
+typedef group::object object;
+
+group test_fixedsizecoordinatesequence_group("geos::geom::FixedSizeCoordinateSequence");
+
+//
+// Test Cases
+//
+
+template<>
+template<>
+void object::test<1>() {
+    geos::geom::FixedSizeCoordinateSequence<0> seq;
+
+    ensure(seq.isEmpty());
+}
+
+template<>
+template<>
+void object::test<2>() {
+    geos::geom::FixedSizeCoordinateSequence<3> seq;
+
+    ensure_equals(seq.getSize(), 3ul);
+}
+
+template<>
+template<>
+void object::test<3>() {
+    geos::geom::FixedSizeCoordinateSequence<3> seq;
+
+    seq.setAt({1, 2}, 0);
+    seq.setAt({3, 4}, 1);
+    seq.setAt({5, 6}, 2);
+
+    ensure(seq.getAt(0) == geos::geom::Coordinate{1, 2});
+}
+
+}

--- a/tests/unit/geom/FixedSizeCoordinateSequenceTest.cpp
+++ b/tests/unit/geom/FixedSizeCoordinateSequenceTest.cpp
@@ -16,38 +16,112 @@ struct test_fixedsizecoordinatesequence_data {
 typedef test_group<test_fixedsizecoordinatesequence_data> group;
 typedef group::object object;
 
+using geos::geom::FixedSizeCoordinateSequence;
+
 group test_fixedsizecoordinatesequence_group("geos::geom::FixedSizeCoordinateSequence");
 
 //
 // Test Cases
 //
 
+// Empty sequence is empty
 template<>
 template<>
 void object::test<1>() {
-    geos::geom::FixedSizeCoordinateSequence<0> seq;
+    FixedSizeCoordinateSequence<0> seq;
 
     ensure(seq.isEmpty());
+
 }
 
+// test getSize
 template<>
 template<>
 void object::test<2>() {
-    geos::geom::FixedSizeCoordinateSequence<3> seq;
+    FixedSizeCoordinateSequence<3> seq;
 
     ensure_equals(seq.getSize(), 3ul);
 }
 
+//  test setAt, getAt
 template<>
 template<>
 void object::test<3>() {
-    geos::geom::FixedSizeCoordinateSequence<3> seq;
+    FixedSizeCoordinateSequence<3> seq;
 
     seq.setAt({1, 2}, 0);
     seq.setAt({3, 4}, 1);
     seq.setAt({5, 6}, 2);
 
     ensure(seq.getAt(0) == geos::geom::Coordinate{1, 2});
+
+    geos::geom::Coordinate c;
+    seq.getAt(2, c);
+    ensure(c == geos::geom::Coordinate{5, 6});
+}
+
+// test setOrdinate
+template<>
+template<>
+void object::test<4>() {
+    FixedSizeCoordinateSequence<2> seq;
+
+    seq.setOrdinate(0, geos::geom::CoordinateSequence::X, 2.2);
+    seq.setOrdinate(0, geos::geom::CoordinateSequence::Y, 3.3);
+    seq.setOrdinate(0, geos::geom::CoordinateSequence::Z, 4.4);
+
+    try {
+        seq.setOrdinate(0, 17, 5.5);
+        fail();
+    } catch (geos::util::IllegalArgumentException & e) {}
+
+    ensure(seq[0].equals3D(geos::geom::Coordinate{2.2, 3.3, 4.4}));
+}
+
+// test getDimension
+template<>
+template<>
+void object::test<5>() {
+    // empty sequence is always XYZ
+    FixedSizeCoordinateSequence<0> seq0;
+    ensure_equals(seq0.getDimension(), 3ul);
+
+    // sequence dimension is set by first coordinate
+    FixedSizeCoordinateSequence<1> seq1_2d;
+    seq1_2d.setAt({1, 2}, 0);
+    ensure_equals(seq1_2d.getDimension(), 2ul);
+
+    FixedSizeCoordinateSequence<1> seq1_3d;
+    seq1_3d.setAt({1, 2, 3}, 0);
+    ensure_equals(seq1_3d.getDimension(), 3ul);
+
+    // sequence dimension doesn't change even if coordinate dimension does
+    seq1_2d.setAt({1, 2, 3}, 0);
+    ensure_equals(seq1_2d.getDimension(), 2ul);
+
+    // sequence dimension doesn't change even if coordinate dimension does
+    seq1_3d.setAt({1, 2}, 0);
+    ensure_equals(seq1_3d.getDimension(), 3ul);
+
+    // unless it's changed by apply_rw. weird!
+
+    struct ZSetter : public geos::geom::CoordinateFilter {
+        ZSetter(double val) : m_val(val) {}
+
+        void filter_rw(geos::geom::Coordinate* c) const override {
+            c->z = m_val;
+        }
+
+        double m_val;
+    };
+
+    ZSetter setNaN(geos::DoubleNotANumber);
+    seq1_3d.apply_rw(&setNaN);
+    ensure_equals(seq1_3d.getDimension(), 2ul);
+
+    ZSetter setZero(0);
+    seq1_3d.apply_rw(&setZero);
+    ensure_equals(seq1_3d.getDimension(), 3ul);
 }
 
 }


### PR DESCRIPTION
The latest release of GEOS (3.7) uses four heap allocations to construct a Point geometry through the C API. Excessive heap allocations have been [identified](https://github.com/PDAL/PDAL/issues/1735) as a weakness of GEOS by @hobu and others.

One of the four allocations was trivially avoided and was removed in aff7bcf25a4879d95243c5a60240a4ee0b4a06a6. This PR removes two of the remaining three.

The three heap allocations are as follows:

1) A `GeometryFactory` allocates all returned Geometries on the heap. This is unavoidable if we need to return the Geometry to a C API caller via an opaque pointer, and is not impacted by this PR. Workarounds are possible, such as providing XY variants of C API functions that avoid the need for the caller to manage a point, e.g. `GEOSPreparedContainsXY(GEOSPreparedGeometry* pg, double x, double y);`

2) A Point heap-allocates a `CoordinateArraySequence` and assigns the value of its first element to the provided x,y. Why is this heap-allocated? GEOS currently allows for multiple `CoordinateSequence` implementations and gives the `GeometryFactory` (through its member `CoordinateSequenceFactory`) control over which implementation is selected at runtime. However, prior to this PR, GEOS:

    - only has a single `CoordinateSequence` implementation, making polymorphism unnecessary.
    - regularly constructs a `CoordinateArraySequence` directly anyway, instead of going to the implementation provided by the `GeometryFactory`.

3) The `CoordinateArraySequence` has a member `std::vector`, which heap-allocates space to store a single `Coordinate`.

This PR eliminates #2 and #3 by:

1) Defining a new `FixedSizeCoordinateSequence` implementation that is backed by `std::array` instead of `std::vector` (removes heap allocation #3). This seems like a no-brainer, since it improves performance, reduces memory usage, and fits into the existing design of GEOS.
2) Uses `FixedSizeCoordianteSequence` for all `Point` geometries and introduces a C API method `GEOSGeom_createPointFromXY` that creates a Point from two doubles (removes heap allocation #2). This may be more controversial, since it goes against the design of allowing a `GeometryFactory` to control how `CoordinateSequence` objects are constructed. However, this design is already widely ignored. Allowing points to have a polymorphic `CoordinateSequence` could be reintroduced in the future if there is a reason to have GEOS construct geometries using some other library's memory. (In that case we would need to construct coordinate sequences through `GeometryFactory::getCoordinateSequenceFactory`.) But we don't have that ability now, so why pay the price?

To measure performance, I ran the `GEOSPreparedContainsPerfTest` under callgrind to perform 100,000 point-in-polygon calls against the boundary of Australia.

In master,

10.4% of the test time is taken constructing and destroying points

With this PR,

3.8% of the test time is taken constructing and destroying points.

As far as storage, a `FixedSizeCoordinateSequence<1>` is 40 bytes. A `CoordinateArraySequence` is 40 bytes plus the size of the underlying array, or a minimum of 64 bytes for a `Point`.