### PR TITLE
Remove LineSegment virtual destructor

### DIFF
--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -74,8 +74,6 @@ public:
 
     LineSegment(double x0, double y0, double x1, double y1);
 
-    virtual ~LineSegment();
-
     void setCoordinates(const Coordinate& c0, const Coordinate& c1);
 
     // obsoleted, use operator[] instead

--- a/include/geos/geom/LineSegment.inl
+++ b/include/geos/geom/LineSegment.inl
@@ -60,11 +60,6 @@ LineSegment::LineSegment()
 {
 }
 
-INLINE
-LineSegment::~LineSegment()
-{
-}
-
 INLINE double
 LineSegment::distancePerpendicular(const Coordinate& p) const
 {


### PR DESCRIPTION
LineSegment controls no resources, so we're not really concerned if its
destructor is called from a hypothetical derived class. Removing the
destructor removes the vtable and decreases the class size.