### PR TITLE
Delaunay performance enhancements

### DIFF
--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -56,6 +56,10 @@ public:
     /// Construct an empty sequence
     CoordinateArraySequence();
 
+    /// Construct sequence moving from given Coordinate vector
+    CoordinateArraySequence(std::vector<Coordinate> && coords,
+                            std::size_t dimension = 0);
+
     /// Construct sequence taking ownership of given Coordinate vector
     CoordinateArraySequence(std::vector<Coordinate>* coords,
                             std::size_t dimension = 0);

--- a/include/geos/triangulate/quadedge/QuadEdge.h
+++ b/include/geos/triangulate/quadedge/QuadEdge.h
@@ -102,6 +102,7 @@ private:
     QuadEdge* next;			  // A reference to a connected edge
     void*   data;
     bool isAlive;
+    bool visited;
 
     /**
      * Quadedges must be made using {@link makeEdge},
@@ -165,11 +166,21 @@ public:
      * @return `true` if this edge has not been deleted.
      */
     inline bool
-    isLive()
+    isLive() const
     {
         return isAlive;
     }
 
+    inline bool
+    isVisited() const
+    {
+        return visited;
+    }
+
+    inline void
+    setVisited(bool v) {
+        visited = v;
+    }
 
     /** \brief
      * Sets the connected edge

--- a/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
@@ -99,6 +99,7 @@ private:
     Vertex frameVertex[3];
     geom::Envelope frameEnv;
     std::unique_ptr<QuadEdgeLocator> locator;
+    bool visit_state_clean;
 
 public:
     /** \brief
@@ -348,7 +349,6 @@ public:
 
 private:
     typedef std::stack<QuadEdge*> QuadEdgeStack;
-    typedef std::unordered_set<QuadEdge*> QuadEdgeSet;
     typedef std::vector<geom::CoordinateSequence*> TriList;
 
     /** \brief
@@ -357,6 +357,11 @@ private:
      * Only one visitor is allowed to be active at a time, so this is safe.
      */
     QuadEdge* triEdges[3];
+
+    /** \brief
+     * Resets the `visited` flag of each `QuadEdge` prior to iteration, if necessary.
+     */
+    void prepareVisit();
 
     /** \brief
      * Stores the edges for a visited triangle. Also pushes sym (neighbour) edges
@@ -369,8 +374,7 @@ private:
      * @return `null` if the triangle should not be visited (for instance, if it is
      *         outer)
      */
-    QuadEdge** fetchTriangleToVisit(QuadEdge* edge, QuadEdgeStack& edgeStack, bool includeFrame,
-                                    QuadEdgeSet& visitedEdges);
+    QuadEdge** fetchTriangleToVisit(QuadEdge* edge, QuadEdgeStack& edgeStack, bool includeFrame);
 
     /** \brief
      * Gets the coordinates for each triangle in the subdivision as an array.

--- a/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
@@ -458,7 +458,7 @@ public:
      * @param geomFact a geometry factory
      * @return a List of LineString
      */
-    std::unique_ptr< std::vector<geom::Geometry*> > getVoronoiCellEdges(const geom::GeometryFactory& geomFact);
+    std::vector<std::unique_ptr<geom::Geometry>> getVoronoiCellEdges(const geom::GeometryFactory& geomFact);
 
     /** \brief
      * Gets a collection of [QuadEdges](@ref QuadEdge) whose origin vertices are a unique set

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -40,6 +40,12 @@ CoordinateArraySequence::CoordinateArraySequence(size_t n,
 {
 }
 
+CoordinateArraySequence::CoordinateArraySequence(std::vector<Coordinate> && coords, size_t dimension_in):
+        vect(std::move(coords)),
+        dimension(dimension_in)
+{
+}
+
 CoordinateArraySequence::CoordinateArraySequence(
     std::vector<Coordinate>* coords, size_t dimension_in)
     : dimension(dimension_in)

--- a/src/triangulate/VoronoiDiagramBuilder.cpp
+++ b/src/triangulate/VoronoiDiagramBuilder.cpp
@@ -143,27 +143,23 @@ VoronoiDiagramBuilder::clipGeometryCollection(std::vector<std::unique_ptr<Geomet
     auto gfact = geoms[0]->getFactory();
 
     std::unique_ptr<geom::Geometry> clipPoly(gfact->toGeometry(&clipEnv));
-    auto clipped = make_unique<std::vector<Geometry*>>();
+    std::vector<std::unique_ptr<Geometry>> clipped;
 
     for(auto& g : geoms) {
-        std::unique_ptr<Geometry> result;
-
         // don't clip unless necessary
         if(clipEnv.contains(g->getEnvelopeInternal())) {
-            result = std::move(g);
+            clipped.push_back(std::move(g));
             // TODO: check if userData is correctly cloned here?
-        }
-        else if(clipEnv.intersects(g->getEnvelopeInternal())) {
-            result = clipPoly->intersection(g.get());
+        } else if(clipEnv.intersects(g->getEnvelopeInternal())) {
+            auto result = clipPoly->intersection(g.get());
             result->setUserData(g->getUserData()); // TODO: needed ?
-        }
-
-        if(result.get() && !result->isEmpty()) {
-            clipped->push_back(result.release());
+            if (!result->isEmpty()) {
+                clipped.push_back(std::move(result));
+            }
         }
     }
 
-    return std::unique_ptr<GeometryCollection>(gfact->createGeometryCollection(clipped.release()));
+    return gfact->createGeometryCollection(std::move(clipped));
 }
 
 } //namespace geos.triangulate

--- a/src/triangulate/quadedge/QuadEdge.cpp
+++ b/src/triangulate/quadedge/QuadEdge.cpp
@@ -89,7 +89,7 @@ QuadEdge::swap(QuadEdge& e)
     e.setDest(b.dest());
 }
 
-QuadEdge::QuadEdge() : _rot(nullptr), vertex(), next(nullptr), data(nullptr), isAlive(true)
+QuadEdge::QuadEdge() : _rot(nullptr), vertex(), next(nullptr), data(nullptr), isAlive(true), visited(false)
 { }
 
 QuadEdge::~QuadEdge()


### PR DESCRIPTION
Net benefit is approximately 20% for Delaunay, 2-3% for Voronoi.

- Avoid copying all triangles after construction
- Avoid inFrame checks if result will be ignored
- Avoid heap-allocating std::vector
- Avoid conversions from unique_ptr to raw pointers