### PR TITLE
Port of JTS PR 467

### DIFF
--- a/include/geos/index/chain/MonotoneChainBuilder.h
+++ b/include/geos/index/chain/MonotoneChainBuilder.h
@@ -55,18 +55,19 @@ public:
     /** \brief
      * Return a newly-allocated vector of newly-allocated
      * MonotoneChain objects for the given CoordinateSequence.
-     *
-     * @note Remember to deep-delete the result.
      */
     static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> getChains(
         const geom::CoordinateSequence* pts,
         void* context);
 
     /** \brief
-     * Fill the provided vector with newly-allocated MonotoneChain objects
-     * for the given CoordinateSequence.
+     * Computes a list of the {@link MonotoneChain}s
+     * for a list of coordinates,
+     * attaching a context data object to each.
      *
-     * @note Remember to delete vector elements!
+     * @param pts the list of points to compute chains for
+     * @param context a data object to attach to each chain
+     * @return a list of the monotone chains for the points
      */
     static void getChains(const geom::CoordinateSequence* pts,
                           void* context,
@@ -77,16 +78,6 @@ public:
     {
         return getChains(pts, nullptr);
     }
-
-    /** \brief
-     * Fill the given vector with start/end indexes of the monotone chains
-     * for the given CoordinateSequence.
-     *
-     * The last entry in the array points to the end point of the point
-     * array, for use as a sentinel.
-     */
-    static void getChainStartIndices(const geom::CoordinateSequence& pts,
-                                     std::vector<std::size_t>& startIndexList);
 
     /**
      * Disable copy construction and assignment. Apparently needed to make this
@@ -102,9 +93,11 @@ private:
      * Finds the index of the last point in a monotone chain
      * starting at a given point.
      *
-     * Any repeated points (0-length segments) will be included
+     * Repeated points (0-length segments) are included
      * in the monotone chain returned.
      *
+     * @param pts the points to scan
+     * @param start the index of the start of this chain
      * @return the index of the last point in the monotone chain
      *         starting at <code>start</code>.
      *

--- a/src/geomgraph/index/MonotoneChainEdge.cpp
+++ b/src/geomgraph/index/MonotoneChainEdge.cpp
@@ -57,8 +57,8 @@ MonotoneChainEdge::MonotoneChainEdge(Edge* newE):
     pts(newE->getCoordinates())
 {
     assert(e);
-    MonotoneChainIndexer mcb;
-    mcb.getChainStartIndices(pts, startIndex);
+    MonotoneChainIndexer mci;
+    mci.getChainStartIndices(pts, startIndex);
     assert(e);
 }
 

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -54,37 +54,18 @@ MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context)
 /* static public */
 void
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
-                                vector<std::unique_ptr<MonotoneChain>>& mcList)
+                                std::vector<std::unique_ptr<MonotoneChain>>& mcList)
 {
-    vector<std::size_t> startIndex;
-    getChainStartIndices(*pts, startIndex);
-    std::size_t nindexes = startIndex.size();
-    if(nindexes > 0) {
-        std::size_t n = nindexes - 1;
-        for(std::size_t i = 0; i < n; i++) {
-            mcList.emplace_back(new MonotoneChain(*pts, startIndex[i], startIndex[i + 1], context));
-        }
-    }
-}
-
-/* static public */
-void
-MonotoneChainBuilder::getChainStartIndices(const CoordinateSequence& pts,
-        vector<std::size_t>& startIndexList)
-{
-    // find the startpoint (and endpoints) of all monotone chains
-    // in this edge
-    std::size_t start = 0;
-    startIndexList.push_back(start);
-    const std::size_t n = pts.getSize() - 1;
+    std::size_t chainStart = 0;
     do {
-        std::size_t last = findChainEnd(pts, start);
-        startIndexList.push_back(last);
-        start = last;
+        std::size_t chainEnd = findChainEnd(*pts, chainStart);
+        MonotoneChain *mc = new MonotoneChain(*pts, chainStart, chainEnd, context);
+        mcList.emplace_back(mc);
+        chainStart = chainEnd;
     }
-    while(start < n);
-
+    while (chainStart < (pts->size() - 1));
 }
+
 
 /* private static */
 std::size_t


### PR DESCRIPTION
MonotoneChainBuilder can be refactored to avoid using
an array of indexes completely, by constructing
MonotoneChain objects as they determined. 
https://github.com/locationtech/jts/pull/467