### PR TITLE
Add multi-ordinate coordseq setters and getters to C API

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Changes in 3.8.0
   - CAPI: GEOSMakeValid (#952, Even Rouault)
   - CAPI: GEOSPolygonize_valid (#727, Dan Baston)
   - CAPI: GEOSCoverageUnion (Dan Baston)
+  - CAPI: GEOSCoordSeq_setXY, GEOSCoordSeq_setXYZ,
+          GEOSCoordSeq_getXY, GEOSCoordSeq_getXYZ (Dan Baston)
 
 - Improvements:
   - Improve performance and robustness of GEOSPointOnSurface (Martin Davis)

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -845,6 +845,18 @@ extern "C" {
         return GEOSCoordSeq_setOrdinate(s, idx, 2, val);
     }
 
+    int
+    GEOSCoordSeq_setXY(CoordinateSequence* s, unsigned int idx, double x, double y)
+    {
+        return GEOSCoordSeq_setXY_r(handle, s, idx, x, y);
+    }
+
+    int
+    GEOSCoordSeq_setXYZ(CoordinateSequence* s, unsigned int idx, double x, double y, double z)
+    {
+        return GEOSCoordSeq_setXYZ_r(handle, s, idx, x, y, z);
+    }
+
     CoordinateSequence*
     GEOSCoordSeq_clone(const CoordinateSequence* s)
     {
@@ -873,6 +885,18 @@ extern "C" {
     GEOSCoordSeq_getZ(const CoordinateSequence* s, unsigned int idx, double* val)
     {
         return GEOSCoordSeq_getOrdinate(s, idx, 2, val);
+    }
+
+    int
+    GEOSCoordSeq_getXY(const CoordinateSequence* s, unsigned int idx, double* x, double* y)
+    {
+        return GEOSCoordSeq_getXY_r(handle, s, idx, x, y);
+    }
+
+    int
+    GEOSCoordSeq_getXYZ(const CoordinateSequence* s, unsigned int idx, double* x, double* y, double* z)
+    {
+        return GEOSCoordSeq_getXYZ_r(handle, s, idx, x, y, z);
     }
 
     int

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -302,6 +302,13 @@ extern int GEOS_DLL GEOSCoordSeq_setY_r(GEOSContextHandle_t handle,
 extern int GEOS_DLL GEOSCoordSeq_setZ_r(GEOSContextHandle_t handle,
                                         GEOSCoordSequence* s, unsigned int idx,
                                         double val);
+extern int GEOS_DLL GEOSCoordSeq_setXY_r(GEOSContextHandle_t handle,
+                                        GEOSCoordSequence* s, unsigned int idx,
+                                        double x, double y);
+extern int GEOS_DLL GEOSCoordSeq_setXYZ_r(GEOSContextHandle_t handle,
+                                        GEOSCoordSequence* s, unsigned int idx,
+                                        double x, double y, double z);
+
 extern int GEOS_DLL GEOSCoordSeq_setOrdinate_r(GEOSContextHandle_t handle,
                                                GEOSCoordSequence* s,
                                                unsigned int idx,
@@ -320,6 +327,12 @@ extern int GEOS_DLL GEOSCoordSeq_getY_r(GEOSContextHandle_t handle,
 extern int GEOS_DLL GEOSCoordSeq_getZ_r(GEOSContextHandle_t handle,
                                         const GEOSCoordSequence* s,
                                         unsigned int idx, double *val);
+extern int GEOS_DLL GEOSCoordSeq_getXY_r(GEOSContextHandle_t handle,
+                                         const GEOSCoordSequence* s,
+                                         unsigned int idx, double *x, double *y);
+extern int GEOS_DLL GEOSCoordSeq_getXYZ_r(GEOSContextHandle_t handle,
+                                          const GEOSCoordSequence* s,
+                                          unsigned int idx, double *x, double *y, double *z);
 extern int GEOS_DLL GEOSCoordSeq_getOrdinate_r(GEOSContextHandle_t handle,
                                                const GEOSCoordSequence* s,
                                                unsigned int idx,
@@ -1393,6 +1406,10 @@ extern int GEOS_DLL GEOSCoordSeq_setY(GEOSCoordSequence* s,
     unsigned int idx, double val);
 extern int GEOS_DLL GEOSCoordSeq_setZ(GEOSCoordSequence* s,
     unsigned int idx, double val);
+extern int GEOS_DLL GEOSCoordSeq_setXY(GEOSCoordSequence* s,
+    unsigned int idx, double x, double y);
+extern int GEOS_DLL GEOSCoordSeq_setXYZ(GEOSCoordSequence* s,
+    unsigned int idx, double x, double y, double z);
 extern int GEOS_DLL GEOSCoordSeq_setOrdinate(GEOSCoordSequence* s,
     unsigned int idx, unsigned int dim, double val);
 
@@ -1406,6 +1423,10 @@ extern int GEOS_DLL GEOSCoordSeq_getY(const GEOSCoordSequence* s,
     unsigned int idx, double *val);
 extern int GEOS_DLL GEOSCoordSeq_getZ(const GEOSCoordSequence* s,
     unsigned int idx, double *val);
+extern int GEOS_DLL GEOSCoordSeq_getXY(const GEOSCoordSequence* s,
+    unsigned int idx, double *x, double *y);
+extern int GEOS_DLL GEOSCoordSeq_getXYZ(const GEOSCoordSequence* s,
+    unsigned int idx, double *x, double *y, double *z);
 extern int GEOS_DLL GEOSCoordSeq_getOrdinate(const GEOSCoordSequence* s,
     unsigned int idx, unsigned int dim, double *val);
 /*

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -3761,6 +3761,62 @@ extern "C" {
         return GEOSCoordSeq_setOrdinate_r(extHandle, s, idx, 2, val);
     }
 
+    int
+    GEOSCoordSeq_setXY_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs, unsigned int idx, double x, double y)
+    {
+        assert(0 != cs);
+        if(0 == extHandle) {
+            return 0;
+        }
+
+        GEOSContextHandleInternal_t* handle = 0;
+        handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+        if(0 == handle->initialized) {
+            return 0;
+        }
+
+        try {
+            cs->setAt({x, y}, idx);
+            return 1;
+        }
+        catch(const std::exception& e) {
+            handle->ERROR_MESSAGE("%s", e.what());
+        }
+        catch(...) {
+            handle->ERROR_MESSAGE("Unknown exception thrown");
+        }
+
+        return 0;
+    }
+
+    int
+    GEOSCoordSeq_setXYZ_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs, unsigned int idx, double x, double y, double z)
+    {
+        assert(0 != cs);
+        if(0 == extHandle) {
+            return 0;
+        }
+
+        GEOSContextHandleInternal_t* handle = 0;
+        handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+        if(0 == handle->initialized) {
+            return 0;
+        }
+
+        try {
+            cs->setAt({x, y, z}, idx);
+            return 1;
+        }
+        catch(const std::exception& e) {
+            handle->ERROR_MESSAGE("%s", e.what());
+        }
+        catch(...) {
+            handle->ERROR_MESSAGE("Unknown exception thrown");
+        }
+
+        return 0;
+    }
+
     CoordinateSequence*
     GEOSCoordSeq_clone_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs)
     {
@@ -3838,6 +3894,67 @@ extern "C" {
     GEOSCoordSeq_getZ_r(GEOSContextHandle_t extHandle, const CoordinateSequence* s, unsigned int idx, double* val)
     {
         return GEOSCoordSeq_getOrdinate_r(extHandle, s, idx, 2, val);
+    }
+
+    int
+    GEOSCoordSeq_getXY_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs, unsigned int idx, double* x, double* y)
+    {
+        assert(0 != cs);
+        if(0 == extHandle) {
+            return 0;
+        }
+
+        GEOSContextHandleInternal_t* handle = 0;
+        handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+        if(0 == handle->initialized) {
+            return 0;
+        }
+
+        try {
+            auto& c = cs->getAt(idx);
+            *x = c.x;
+            *y = c.y;
+            return 1;
+        }
+        catch(const std::exception& e) {
+            handle->ERROR_MESSAGE("%s", e.what());
+        }
+        catch(...) {
+            handle->ERROR_MESSAGE("Unknown exception thrown");
+        }
+
+        return 0;
+    }
+
+    int
+    GEOSCoordSeq_getXYZ_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs, unsigned int idx, double* x, double* y, double* z)
+    {
+        assert(0 != cs);
+        if(0 == extHandle) {
+            return 0;
+        }
+
+        GEOSContextHandleInternal_t* handle = 0;
+        handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+        if(0 == handle->initialized) {
+            return 0;
+        }
+
+        try {
+            auto& c = cs->getAt(idx);
+            *x = c.x;
+            *y = c.y;
+            *z = c.z;
+            return 1;
+        }
+        catch(const std::exception& e) {
+            handle->ERROR_MESSAGE("%s", e.what());
+        }
+        catch(...) {
+            handle->ERROR_MESSAGE("Unknown exception thrown");
+        }
+
+        return 0;
     }
 
     int

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -344,5 +344,48 @@ void object::test<10>
     ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 0);
 }
 
+template<>
+template<>
+void object::test<11>
+()
+{
+    cs_ = GEOSCoordSeq_create(1, 2);
+
+    unsigned int size;
+    unsigned int dims;
+
+    ensure(0 != GEOSCoordSeq_getSize(cs_, &size));
+    ensure_equals(size, 1u);
+
+    ensure(0 != GEOSCoordSeq_getDimensions(cs_, &dims));
+    ensure_equals(dims, 2u);
+
+    double x = 10;
+    double y = 11;
+
+    GEOSCoordSeq_setXY(cs_, 0, x, y);
+
+    double xcheck, ycheck, zcheck;
+    ensure(0 != GEOSCoordSeq_getXY(cs_, 0, &xcheck, &ycheck));
+
+    ensure_equals(xcheck, x);
+    ensure_equals(ycheck, y);
+
+    ensure(0 != GEOSCoordSeq_getXYZ(cs_, 0, &xcheck, &ycheck, &zcheck));
+
+    ensure_equals(xcheck, x);
+    ensure_equals(ycheck, y);
+    ensure(std::isnan(zcheck));
+
+    double z = 12;
+    GEOSCoordSeq_setXYZ(cs_, 0, x, y, z);
+
+    ensure(0 != GEOSCoordSeq_getXYZ(cs_, 0, &xcheck, &ycheck, &zcheck));
+
+    ensure_equals(xcheck, x);
+    ensure_equals(ycheck, y);
+    ensure_equals(zcheck, z);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
From the dumb-but-useful department, this PR adds the following CAPI functions:

```
GEOSCoordSeq_setXY
GEOSCoordSeq_setXYZ
GEOSCoordSeq_getXY
GEOSCoordSeq_getXYZ
```

This allows for marginally less verbose client code, and reduces the time to create GEOS geometries by, unsurprisingly, about 50%. This is rarely a bottleneck, but still reduces total time of a PostGIS query like `SELECT ST_NPoints(ST_Collect(ST_Centroid(geom))) FROM basins_lev05;` by about 15%, so might as well.

This adds a lot of copy-paste to the already out-of-control `geos_ts.cpp`. There was some talk of simplifying that with, e.g., https://github.com/dbaston/libgeos/commit/e271b8dd467c359d090dc221c083effd0fbe2a26. Maybe worth revisiting that separately.
