### PR TITLE
Remove copy-paste error handling in C API

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -156,11 +156,13 @@ stages:
   - job: 'Windows'
     strategy:
       matrix:
-        VS 2019 C++20 Strict:
-          TOOLSET: msvc-14.2
-          CXXSTD: 20
-          CXXFLAGS: -permissive-
-          VM_IMAGE: 'windows-2019'
+        #Disabled until MSVC 16.4 is released
+        #(see https://developercommunity.visualstudio.com/content/problem/726778/this-snippet-compiles-totally-fine-on-godbolt-msvc.html?childToView=744771#comment-744771)
+        #VS 2019 C++20 Strict:
+        #  TOOLSET: msvc-14.2
+        #  CXXSTD: 20
+        #  CXXFLAGS: -permissive-
+        #  VM_IMAGE: 'windows-2019'
         VS 2017 C++17:
           TOOLSET: msvc-14.1
           CXXSTD: 17


### PR DESCRIPTION
This PR defines some templates that execute a chunk of code (expressed as a lambda), capture any exceptions, and pass them to the context's error handler.

This allows over 3,000 lines of copy-paste to be removed from `geos_ts_c.cpp`, improving readability/maintainability, and ensures a consistent return value for any error occurring within a function.

There is a very small increase in library file size; on my system, `libgeos_c.a` goes from 390K to 402K. Inspecting the libraries with `nm -C` shows that two of the lambdas (`GEOSWKBWriter_writeHEX_R` and `GEOSWKBWriter_write_r`) are not inlined.