### PR TITLE
Change TopologyLocation.locations from vector to array(3) 

### DIFF
--- a/include/geos/geomgraph/TopologyLocation.h
+++ b/include/geos/geomgraph/TopologyLocation.h
@@ -26,6 +26,7 @@
 #include <geos/geom/Location.h>
 
 #include <vector>
+#include <array>
 #include <string>
 
 #ifdef _MSC_VER
@@ -116,7 +117,7 @@ public:
     void setLocation(geom::Location locValue);
 
     /// Warning: returns reference to owned memory
-    const std::vector<geom::Location>& getLocations() const;
+    const std::array<geom::Location, 3>& getLocations() const;
 
     void setLocations(geom::Location on, geom::Location left, geom::Location right);
 
@@ -132,7 +133,8 @@ public:
 
 private:
 
-    std::vector<geom::Location> location;
+    std::array<geom::Location, 3> location;
+    int locationSize;
 };
 
 std::ostream& operator<< (std::ostream&, const TopologyLocation&);

--- a/include/geos/geomgraph/TopologyLocation.h
+++ b/include/geos/geomgraph/TopologyLocation.h
@@ -132,7 +132,7 @@ public:
 private:
 
     std::array<geom::Location, 3> location;
-    int locationSize;
+    std::size_t locationSize;
 };
 
 std::ostream& operator<< (std::ostream&, const TopologyLocation&);

--- a/include/geos/geomgraph/TopologyLocation.h
+++ b/include/geos/geomgraph/TopologyLocation.h
@@ -67,8 +67,6 @@ public:
 
     ~TopologyLocation();
 
-    TopologyLocation(const std::vector<int>& newLocation);
-
     /** \brief
      * Constructs a TopologyLocation specifying how points on, to the
      * left of, and to the right of some GraphComponent relate to some

--- a/src/geomgraph/TopologyLocation.cpp
+++ b/src/geomgraph/TopologyLocation.cpp
@@ -32,13 +32,6 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /*public*/
-TopologyLocation::TopologyLocation(const std::vector<int>& newLocation)
-{
-    location.fill(Location::UNDEF);
-    locationSize = newLocation.size() > 3 ? 3 : newLocation.size();
-}
-
-/*public*/
 TopologyLocation::TopologyLocation()
 {
 }
@@ -61,7 +54,8 @@ TopologyLocation::TopologyLocation(Location on, Location left, Location right):
 TopologyLocation::TopologyLocation(Location on):
     locationSize(1)
 {
-    // location[Position::ON] = on;
+    location.fill(Location::UNDEF);
+    location[Position::ON] = on;
 }
 
 /*public*/
@@ -96,7 +90,7 @@ TopologyLocation::get(size_t posIndex) const
 bool
 TopologyLocation::isNull() const
 {
-    for(size_t i = 0, sz = locationSize; i < sz; ++i) {
+    for(size_t i = 0; i < locationSize; ++i) {
         if(location[i] != Location::UNDEF) {
             return false;
         }
@@ -108,7 +102,7 @@ TopologyLocation::isNull() const
 bool
 TopologyLocation::isAnyNull() const
 {
-    for(size_t i = 0, sz = locationSize; i < sz; ++i) {
+    for(size_t i = 0; i < locationSize; ++i) {
         if(location[i] == Location::UNDEF) {
             return true;
         }
@@ -158,7 +152,7 @@ TopologyLocation::setAllLocations(Location locValue)
 void
 TopologyLocation::setAllLocationsIfNull(Location locValue)
 {
-    for(size_t i = 0, sz = locationSize; i < sz; ++i) {
+    for(size_t i = 0; i < locationSize; ++i) {
         if(location[i] == Location::UNDEF) {
             location[i] = locValue;
         }
@@ -200,7 +194,7 @@ TopologyLocation::setLocations(Location on, Location left, Location right)
 bool
 TopologyLocation::allPositionsEqual(Location loc) const
 {
-    for(size_t i = 0, sz = locationSize; i < sz; ++i) {
+    for(size_t i = 0; i < locationSize; ++i) {
         if(location[i] != loc) {
             return false;
         }
@@ -220,7 +214,7 @@ TopologyLocation::merge(const TopologyLocation& gl)
         location[Position::LEFT] = Location::UNDEF;
         location[Position::RIGHT] = Location::UNDEF;
     }
-    for(size_t i = 0; i < 3; ++i) {
+    for(size_t i = 0; i < locationSize; ++i) {
         if(location[i] == Location::UNDEF && i < glsz) {
             location[i] = gl.location[i];
         }


### PR DESCRIPTION
Just running the standard tests, before this patch the test run took 23.5s and after I am getting run times of 17.5s. So... very very good. I assume much of the run-time of the tests is some long and comprehensive overlay stuff, hence this code line gets a lot of exercise.