### PR TITLE
Add DefaultCoordinateSequenceFactory

### DIFF
--- a/include/geos/geom/DefaultCoordinateSequenceFactory.h
+++ b/include/geos/geom/DefaultCoordinateSequenceFactory.h
@@ -1,0 +1,66 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#ifndef GEOS_GEOM_DEFAULTCOORDINATESEQUENCEFACTORY_H
+#define GEOS_GEOM_DEFAULTCOORDINATESEQUENCEFACTORY_H
+
+#include <geos/geom/CoordinateSequenceFactory.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <geos/geom/FixedSizeCoordinateSequence.h>
+
+namespace geos {
+namespace geom {
+
+class GEOS_DLL DefaultCoordinateSequenceFactory : public CoordinateSequenceFactory {
+public:
+
+    std::unique_ptr<CoordinateSequence> create() const final {
+        return detail::make_unique<CoordinateArraySequence>();
+    }
+
+    std::unique_ptr<CoordinateSequence> create(std::vector<Coordinate> *coords, std::size_t dims = 0) const final {
+        return detail::make_unique<CoordinateArraySequence>(coords, dims);
+    }
+
+    std::unique_ptr <CoordinateSequence> create(std::vector <Coordinate> &&coords, std::size_t dims = 0) const final {
+        return detail::make_unique<CoordinateArraySequence>(std::move(coords), dims);
+    }
+
+    std::unique_ptr <CoordinateSequence> create(std::size_t size, std::size_t dims = 0) const final {
+        switch(size) {
+            case 5: return detail::make_unique<FixedSizeCoordinateSequence<5>>(dims);
+            case 4: return detail::make_unique<FixedSizeCoordinateSequence<4>>(dims);
+            case 3: return detail::make_unique<FixedSizeCoordinateSequence<3>>(dims);
+            case 2: return detail::make_unique<FixedSizeCoordinateSequence<2>>(dims);
+            case 1: return detail::make_unique<FixedSizeCoordinateSequence<1>>(dims);
+            default:
+                return detail::make_unique<CoordinateArraySequence>(size, dims);
+        }
+    }
+
+    std::unique_ptr <CoordinateSequence> create(const CoordinateSequence &coordSeq) const final {
+        auto cs = create(coordSeq.size(), coordSeq.getDimension());
+        for (size_t i = 0; i < cs->size(); i++) {
+            cs->setAt(coordSeq[i], i);
+        }
+        return cs;
+    }
+
+    static const CoordinateSequenceFactory *instance();
+};
+
+}
+}
+
+#endif //GEOS_DEFAULTCOORDINATESEQUENCEFACTORY_H

--- a/include/geos/geom/Makefile.am
+++ b/include/geos/geom/Makefile.am
@@ -21,6 +21,7 @@ geos_HEADERS = \
     CoordinateSequenceFactory.h \
     CoordinateSequenceFilter.h \
     CoordinateSequence.h \
+    DefaultCoordinateSequenceFactory.h \
     Dimension.h \
     Envelope.h \
     Envelope.inl \

--- a/src/geom/DefaultCoordinateSequenceFactory.cpp
+++ b/src/geom/DefaultCoordinateSequenceFactory.cpp
@@ -1,0 +1,30 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/geom/DefaultCoordinateSequenceFactory.h>
+
+namespace geos {
+namespace geom { // geos::geom
+
+static DefaultCoordinateSequenceFactory defaultCoordinateSequenceFactory;
+
+const CoordinateSequenceFactory*
+DefaultCoordinateSequenceFactory::instance()
+{
+    return &defaultCoordinateSequenceFactory;
+}
+
+} // namespace geos::geom
+} // namespace geos
+

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -19,8 +19,8 @@
  **********************************************************************/
 
 #include <geos/geom/Coordinate.h>
-#include <geos/geom/CoordinateArraySequenceFactory.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/DefaultCoordinateSequenceFactory.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Point.h>
 #include <geos/geom/LineString.h>
@@ -83,7 +83,7 @@ public:
 GeometryFactory::GeometryFactory()
     :
     SRID(0),
-    coordinateListFactory(CoordinateArraySequenceFactory::instance())
+    coordinateListFactory(DefaultCoordinateSequenceFactory::instance())
     , _refCount(0), _autoDestroy(false)
 {
 #if GEOS_DEBUG
@@ -115,7 +115,7 @@ GeometryFactory::GeometryFactory(const PrecisionModel* pm, int newSRID,
     }
 
     if(! nCoordinateSequenceFactory) {
-        coordinateListFactory = CoordinateArraySequenceFactory::instance();
+        coordinateListFactory = DefaultCoordinateSequenceFactory::instance();
     }
     else {
         coordinateListFactory = nCoordinateSequenceFactory;
@@ -144,7 +144,7 @@ GeometryFactory::GeometryFactory(
               nCoordinateSequenceFactory << "])" << std::endl;
 #endif
     if(! nCoordinateSequenceFactory) {
-        coordinateListFactory = CoordinateArraySequenceFactory::instance();
+        coordinateListFactory = DefaultCoordinateSequenceFactory::instance();
     }
     else {
         coordinateListFactory = nCoordinateSequenceFactory;
@@ -165,7 +165,7 @@ GeometryFactory::create(
 GeometryFactory::GeometryFactory(const PrecisionModel* pm)
     :
     SRID(0),
-    coordinateListFactory(CoordinateArraySequenceFactory::instance())
+    coordinateListFactory(DefaultCoordinateSequenceFactory::instance())
     , _refCount(0), _autoDestroy(false)
 {
 #if GEOS_DEBUG
@@ -189,7 +189,7 @@ GeometryFactory::create(const PrecisionModel* pm)
 GeometryFactory::GeometryFactory(const PrecisionModel* pm, int newSRID)
     :
     SRID(newSRID),
-    coordinateListFactory(CoordinateArraySequenceFactory::instance())
+    coordinateListFactory(DefaultCoordinateSequenceFactory::instance())
     , _refCount(0), _autoDestroy(false)
 {
 #if GEOS_DEBUG
@@ -262,8 +262,8 @@ GeometryFactory::toGeometry(const Envelope* envelope) const
         coord.y = envelope->getMinY();
         return createPoint(coord);
     }
-    auto cl = CoordinateArraySequenceFactory::instance()->
-                             create((size_t) 5, 2);
+
+    auto cl = coordinateListFactory->create(5, 2);
 
     coord.x = envelope->getMinX();
     coord.y = envelope->getMinY();

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -23,8 +23,8 @@
 #include <geos/geom/LineString.h> // for toGeometry
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/GeometryFactory.h>
-#include <geos/geom/CoordinateArraySequence.h> // should we really be using this?
 #include <geos/algorithm/Orientation.h>
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/algorithm/Intersection.h>
@@ -298,12 +298,11 @@ LineSegment::pointAlongOffset(double segmentLengthFraction,
 std::unique_ptr<LineString>
 LineSegment::toGeometry(const GeometryFactory& gf) const
 {
-    CoordinateSequence* cl = new CoordinateArraySequence(2);
+    auto cl = gf.getCoordinateSequenceFactory()->create(2, 0);
+
     cl->setAt(p0, 0);
     cl->setAt(p1, 1);
-    return std::unique_ptr<LineString>(
-               gf.createLineString(cl) // ownership transferred
-           );
+    return gf.createLineString(std::move(cl));
 }
 
 } // namespace geos::geom

--- a/src/geom/Makefile.am
+++ b/src/geom/Makefile.am
@@ -16,6 +16,7 @@ libgeom_la_SOURCES = \
     CoordinateSequenceFactory.cpp  \
     CoordinateArraySequence.cpp \
     CoordinateArraySequenceFactory.cpp \
+    DefaultCoordinateSequenceFactory.cpp \
     Dimension.cpp \
     Envelope.cpp \
     Geometry.cpp \


### PR DESCRIPTION
The previous default, `CoordinateArraySequenceFactory`, always creates a
heap-allocating `CoordinateArraySequence`, even for small sizes. This
commit defines a `DefaultCoordinateSequenceFactory` that delegates to
`FixedSizeCoordinateSequence` for length <= 5. This is big enough to cover
some common cases like conversion of line segments, triangles, and
boxes into geometries.