### PR TITLE
WIP: Add CMake doxygen error check #988

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -28,14 +28,28 @@ if(BUILD_DOCUMENTATION)
 
     set(srcdir ${CMAKE_CURRENT_SOURCE_DIR})
     set(VERSION ${GEOS_VERSION_FULL})
-    set(DOXYGEN_LOGFILE ${CMAKE_CURRENT_BINARY_DIR}/doxygen_log)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-                   @ONLY)
+    set(DOXYGEN_LOGFILE ${CMAKE_CURRENT_BINARY_DIR}/doxygen.log)
+    set(CHECK_ERROR_SCRIPT "check_doxygen_errors.cmake")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/${CHECK_ERROR_SCRIPT}"
+        "${CMAKE_CURRENT_BINARY_DIR}/${CHECK_ERROR_SCRIPT}"
+        COPYONLY)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+        ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        @ONLY)
     unset(srcdir)
     unset(VERSION)
-    unset(DOXYGEN_LOGFILE)
 
     add_custom_target(docs
-            COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        BYPRODUCTS ${DOXYGEN_LOGFILE} ${CMAKE_CURRENT_BINARY_DIR}/doxygen_docs)
+
+    add_test(NAME test_docs
+        COMMAND ${CMAKE_COMMAND}
+            -D DOXYGEN_LOGFILE="${DOXYGEN_LOGFILE}"
+            -P "${CMAKE_CURRENT_BINARY_DIR}/${CHECK_ERROR_SCRIPT}")
+
+    unset(DOXYGEN_LOGFILE)
+    unset(CHECK_ERROR_SCRIPT)
 endif()

--- a/doc/check_doxygen_errors.cmake
+++ b/doc/check_doxygen_errors.cmake
@@ -1,0 +1,50 @@
+################################################################################
+# Part of CMake configuration for GEOS
+#
+# Script checking the doxygen logfile for errors and warnings, which are not
+# accepted. Throws FATAL_ERROR if found.
+#
+# Copyright (C) 2019 Nicklas Larsson <n_larsson@yahoo.com>
+#
+# This is free software; you can redistribute and/or modify it under
+# the terms of the GNU Lesser General Public Licence as published
+# by the Free Software Foundation.
+# See the COPYING file for more information.
+################################################################################
+
+file(TO_NATIVE_PATH ${DOXYGEN_LOGFILE} DOXYGEN_LOGFILE)
+
+if(EXISTS "${DOXYGEN_LOGFILE}")
+  set(ERRORS "")
+  file(READ "${DOXYGEN_LOGFILE}" LOGFILE)
+
+  # convert file content to list
+  string(REGEX REPLACE "\n$" "" LOGFILE "${LOGFILE}")
+  string(REGEX REPLACE ";" "\\\\;" LOGFILE "${LOGFILE}")
+  string(REGEX REPLACE "\n" ";" LOGFILE "${LOGFILE}")
+
+  # let's not forget non-fatal warnings
+  list(LENGTH LOGFILE NUM_WARNINGS)
+  if(NUM_WARNINGS GREATER 0)
+    message(STATUS
+      "Doxygen issued ${NUM_WARNINGS} warning(s), see ${DOXYGEN_LOGFILE}")
+  endif()
+
+  foreach(LINE ${LOGFILE})
+    string(REGEX MATCH
+      ".*(not documented|ignoring unsupported tag).*" IGNORE ${LINE})
+    if("${IGNORE}" STREQUAL "")
+      list(APPEND ERRORS ${LINE})
+    endif()
+  endforeach()
+
+  if(NOT "${ERRORS}" STREQUAL "")
+    # convert list to string
+    string(REGEX REPLACE ";" "\n" ERROR_MSG "${ERRORS}")
+    message(FATAL_ERROR "${ERROR_MSG}")
+  endif()
+
+  unset(ERRORS)
+endif()
+
+message(STATUS "Doxygen documentation is OK")


### PR DESCRIPTION
This PR adds doxygen error check for CMake builds with a new target (make doxygen-checked), similar to what’s implemented for autotools.

Implemented with only CMake code it’s supposed to work on any platform, but should be tested.

This is a mirror of https://git.osgeo.org/gitea/geos/geos/pulls/95. Opened the PR here too for testing purposes.