### PR TITLE
Add missing parts of doxygen generated documentation

### DIFF
--- a/include/geos/algorithm/ConvexHull.h
+++ b/include/geos/algorithm/ConvexHull.h
@@ -45,7 +45,7 @@ class GeometryFactory;
 namespace geos {
 namespace algorithm { // geos::algorithm
 
-/**
+/** \brief
  * Computes the convex hull of a Geometry.
  *
  * The convex hull is the smallest convex Geometry that contains all the

--- a/include/geos/algorithm/Distance.h
+++ b/include/geos/algorithm/Distance.h
@@ -26,7 +26,7 @@
 namespace geos {
 namespace algorithm { // geos::algorithm
 
-/**
+/** \brief
  * Functions to compute distance between basic geometric structures.
  *
  * @author Martin Davis

--- a/include/geos/algorithm/Intersection.h
+++ b/include/geos/algorithm/Intersection.h
@@ -22,7 +22,7 @@
 namespace geos {
 namespace algorithm { // geos::algorithm
 
-/**
+/** \brief
 * Computes the intersection point of two lines.
 * If the lines are parallel or collinear this case is detected
 * and <code>null</code> is returned.

--- a/include/geos/algorithm/Length.h
+++ b/include/geos/algorithm/Length.h
@@ -26,7 +26,7 @@
 namespace geos {
 namespace algorithm { // geos::algorithm
 
-/**
+/** \brief
 * Functions for computing length.
 *
 * @author Martin Davis

--- a/include/geos/geomgraph/Depth.h
+++ b/include/geos/geomgraph/Depth.h
@@ -37,6 +37,8 @@ class Label;
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
+/// \brief A Depth object records the topological depth of the sides of an Edge
+/// for up to two Geometries.
 class GEOS_DLL Depth {
 public:
     static int depthAtLocation(geom::Location location);

--- a/include/geos/geomgraph/EdgeIntersection.h
+++ b/include/geos/geomgraph/EdgeIntersection.h
@@ -34,7 +34,7 @@
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
-/**
+/** \brief
  * Represents a point on an edge which intersects with another edge.
  *
  * The intersection may either be a single point, or a line segment

--- a/include/geos/geomgraph/EdgeIntersectionList.h
+++ b/include/geos/geomgraph/EdgeIntersectionList.h
@@ -51,8 +51,9 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 
-/**
+/** \brief
  * A list of edge intersections along an Edge.
+ *
  * Implements splitting an edge with intersections
  * into multiple resultant edges.
  */

--- a/include/geos/geomgraph/EdgeList.h
+++ b/include/geos/geomgraph/EdgeList.h
@@ -49,7 +49,7 @@ class Edge;
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
-/**
+/** \brief
  * A EdgeList is a list of Edges.
  *
  * It supports locating edges

--- a/include/geos/geomgraph/Label.h
+++ b/include/geos/geomgraph/Label.h
@@ -35,6 +35,7 @@ namespace geomgraph { // geos.geomgraph
 /** \brief
  * A <code>Label</code> indicates the topological relationship of a component
  * of a topology graph to a given <code>Geometry</code>.
+ *
  * This class supports labels for relationships to two <code>Geometry</code>s,
  * which is sufficient for algorithms for binary operations.
  *

--- a/include/geos/geomgraph/Node.h
+++ b/include/geos/geomgraph/Node.h
@@ -58,7 +58,7 @@ class NodeFactory;
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
-/** The node component of a geometry graph */
+/** \brief The node component of a geometry graph. */
 class GEOS_DLL Node: public GraphComponent {
     using GraphComponent::setLabel;
 

--- a/include/geos/geomgraph/Quadrant.h
+++ b/include/geos/geomgraph/Quadrant.h
@@ -36,8 +36,10 @@ class Coordinate;
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
-/**
- * Utility functions for working with quadrants, which are numbered as follows:
+/** \brief
+ * Utility functions for working with quadrants.
+ *
+ * The quadrants are numbered as follows:
  * <pre>
  * 1 | 0
  * --+--

--- a/include/geos/geomgraph/index/EdgeSetIntersector.h
+++ b/include/geos/geomgraph/index/EdgeSetIntersector.h
@@ -33,12 +33,14 @@ namespace geos {
 namespace geomgraph { // geos::geomgraph
 namespace index { // geos::geomgraph::index
 
-/*
- * This is derived from a Java interface.
+/** \brief
+ * An EdgeSetIntersector computes all the intersections between the edges in the set.
+ *
+ * \note This is derived from a Java interface.
  */
 class GEOS_DLL EdgeSetIntersector {
 public:
-    /**
+    /** \brief
      * Computes all self-intersections between edges in a set of edges,
      * allowing client to choose whether self-intersections are computed.
      *
@@ -49,7 +51,7 @@ public:
     virtual void computeIntersections(std::vector<Edge*>* edges,
                                       SegmentIntersector* si, bool testAllSegments) = 0;
 
-    /**
+    /** \brief
      * Computes all mutual intersections between two sets of edges
      */
     virtual void computeIntersections(std::vector<Edge*>* edges0,

--- a/include/geos/geomgraph/index/MonotoneChainEdge.h
+++ b/include/geos/geomgraph/index/MonotoneChainEdge.h
@@ -41,6 +41,8 @@ namespace geos {
 namespace geomgraph { // geos::geomgraph
 namespace index { // geos::geomgraph::index
 
+/// \brief MonotoneChains are a way of partitioning the segments of an edge to
+/// allow for fast searching of intersections.
 class GEOS_DLL MonotoneChainEdge {
 public:
     //MonotoneChainEdge();

--- a/include/geos/geomgraph/index/MonotoneChainIndexer.h
+++ b/include/geos/geomgraph/index/MonotoneChainIndexer.h
@@ -30,7 +30,28 @@ namespace geos {
 namespace geomgraph { // geos::geomgraph
 namespace index { // geos::geomgraph::index
 
-
+/// \brief MonotoneChains are a way of partitioning the segments of an edge to
+/// allow for fast searching of intersections.
+///
+/// Specifically, a sequence of contiguous line segments is a monotone chain
+/// iff all the vectors defined by the oriented segments lies in the same
+/// quadrant.
+///
+/// Monotone Chains have the following useful properties:
+///
+/// - the segments within a monotone chain will never intersect each other
+///
+/// - the envelope of any contiguous subset of the segments in a monotone chain
+///   is simply the envelope of the endpoints of the subset.
+///
+/// Property 1 means that there is no need to test pairs of segments from
+/// within the same monotone chain for intersection. Property 2 allows binary
+/// search to be used to find the intersection points of two monotone chains.
+/// For many types of real-world data, these properties eliminate a large
+/// number of segment comparisons, producing substantial speed gains.
+///
+/// \note Due to the efficient intersection test, there is no need to limit the
+/// size of chains to obtain fast performance.
 class GEOS_DLL MonotoneChainIndexer {
 
 public:

--- a/include/geos/geomgraph/index/SegmentIntersector.h
+++ b/include/geos/geomgraph/index/SegmentIntersector.h
@@ -42,7 +42,8 @@ namespace geos {
 namespace geomgraph { // geos::geomgraph
 namespace index { // geos::geomgraph::index
 
-
+/// \brief Computes the intersection of line segments, and adds the
+/// intersection to the edges containing the segments.
 class GEOS_DLL SegmentIntersector {
 
 private:

--- a/include/geos/geomgraph/index/SimpleEdgeSetIntersector.h
+++ b/include/geos/geomgraph/index/SimpleEdgeSetIntersector.h
@@ -35,6 +35,11 @@ namespace geos {
 namespace geomgraph { // geos::geomgraph
 namespace index { // geos::geomgraph::index
 
+/// \brief Finds all intersections in one or two sets of edges, using the
+/// straightforward method of comparing all segments.
+///
+/// \note This algorithm is too slow for production use, but is useful for
+/// testing purposes.
 class GEOS_DLL SimpleEdgeSetIntersector: public EdgeSetIntersector {
 
 public:

--- a/include/geos/geomgraphindex.h
+++ b/include/geos/geomgraphindex.h
@@ -18,6 +18,9 @@
 
 namespace geos {
 namespace geomgraph {
+
+/// \brief Contains classes that implement indexes for performing noding on
+/// geometry graph edges.
 namespace index {
 }
 }

--- a/include/geos/geosAlgorithm.h
+++ b/include/geos/geosAlgorithm.h
@@ -87,6 +87,10 @@ namespace algorithm { // geos::algorithm
  */
 namespace locate {
 } // namespace geos::algorithm::locate
+
+/// \brief Classes to compute distance metrics between geometries.
+namespace distance { // namespace geos::algorithm::distance
+} // namespace geos::algorithm::distance
 } // namespace geos::algorithm
 } // namespace geos
 

--- a/include/geos/io/ByteOrderDataInStream.h
+++ b/include/geos/io/ByteOrderDataInStream.h
@@ -31,10 +31,10 @@
 namespace geos {
 namespace io {
 
-/*
+/**
  * \class ByteOrderDataInStream io.h geos.h
  *
- * Allows reading an stream of primitive datatypes from an underlying
+ * \brief Allows reading an stream of primitive datatypes from an underlying
  * istream, with the representation being in either common byte ordering.
  *
  */

--- a/include/geos/io/ByteOrderValues.h
+++ b/include/geos/io/ByteOrderValues.h
@@ -26,11 +26,11 @@
 namespace geos {
 namespace io {
 
-/*
+/**
  * \class ByteOrderValues io.h geos.h
  *
- * Methods to read and write primitive datatypes from/to byte
- * sequences, allowing the byte order to be specified
+ * \brief Methods to read and write primitive datatypes from/to byte
+ * sequences, allowing the byte order to be specified.
  *
  * Similar to the standard Java <code>ByteBuffer</code> class.
  */

--- a/include/geos/linearref/LengthLocationMap.h
+++ b/include/geos/linearref/LengthLocationMap.h
@@ -28,9 +28,10 @@
 namespace geos {
 namespace linearref { // geos::linearref
 
-/**
- * Computes the LinearLocation for a given length
- * along a linear [Geometry](@ref geom::Geometry).
+/** \brief
+ * Computes the LinearLocation for a given length along a linear
+ * [Geometry](@ref geom::Geometry).
+ *
  * Negative lengths are measured in reverse from end of the linear geometry.
  * Out-of-range values are clamped.
  */

--- a/include/geos/noding/NodingValidator.h
+++ b/include/geos/noding/NodingValidator.h
@@ -38,7 +38,7 @@ class SegmentString;
 namespace geos {
 namespace noding { // geos.noding
 
-/**
+/** \brief
  * Validates that a collection of {@link SegmentString}s is correctly noded.
  * Throws a TopologyException if a noding error is found.
  *

--- a/include/geos/noding/SegmentPointComparator.h
+++ b/include/geos/noding/SegmentPointComparator.h
@@ -26,9 +26,10 @@
 namespace geos {
 namespace noding { // geos.noding
 
-/**
+/** \brief
  * Implements a robust method of comparing the relative position of two
  * points along the same segment.
+ *
  * The coordinates are assumed to lie "near" the segment.
  * This means that this algorithm will only return correct results
  * if the input coordinates
@@ -40,7 +41,7 @@ class GEOS_DLL SegmentPointComparator {
 
 public:
 
-    /**
+    /** \brief
      * Compares two Coordinates for their relative position along a
      * segment lying in the specified Octant.
      *

--- a/include/geos/opPolygonize.h
+++ b/include/geos/opPolygonize.h
@@ -18,6 +18,8 @@
 
 namespace geos {
 namespace operation { // geos.operation
+
+/// An API for polygonizing sets of lines.
 namespace polygonize { // geos.operation.polygonize
 
 } // namespace geos.operation.polygonize

--- a/include/geos/opPredicate.h
+++ b/include/geos/opPredicate.h
@@ -17,6 +17,8 @@
 
 namespace geos {
 namespace operation {
+
+/// Classes which implement topological predicates optimized for particular kinds of geometries.
 namespace predicate {
 
 } // namespace predicate

--- a/include/geos/operation/polygonize/HoleAssigner.h
+++ b/include/geos/operation/polygonize/HoleAssigner.h
@@ -28,8 +28,9 @@ namespace geos {
 namespace operation {
 namespace polygonize {
 
-/**
+/** \brief
  * Assigns hole rings to shell rings during polygonization.
+ *
  * Uses spatial indexing to improve performance of shell lookup.
  *
  * @author mdavis

--- a/include/geos/operation/polygonize/PolygonizeEdge.h
+++ b/include/geos/operation/polygonize/PolygonizeEdge.h
@@ -36,7 +36,7 @@ namespace geos {
 namespace operation { // geos::operation
 namespace polygonize { // geos::operation::polygonize
 
-/* \brief
+/** \brief
  * An edge of a polygonization graph.
  *
  * @version 1.4

--- a/include/geos/operation/sharedpaths/SharedPathsOp.h
+++ b/include/geos/operation/sharedpaths/SharedPathsOp.h
@@ -42,6 +42,8 @@ class GeometryFactory;
 
 namespace geos {
 namespace operation { // geos.operation
+
+/// Find shared paths among two linear Geometry objects.
 namespace sharedpaths { // geos.operation.sharedpaths
 
 /** \brief
@@ -53,7 +55,7 @@ namespace sharedpaths { // geos.operation.sharedpaths
  * Paths reported as shared are given in the direction they
  * appear in the first geometry.
  *
- * Developed by Sandro Santilli (strk@kbt.io)
+ * \remark Developed by Sandro Santilli (strk@kbt.io)
  * for Faunalia (http://www.faunalia.it)
  * with funding from Regione Toscana - Settore SISTEMA INFORMATIVO
  * TERRITORIALE ED AMBIENTALE - for the project: "Sviluppo strumenti

--- a/include/geos/operation/union/OverlapUnion.h
+++ b/include/geos/operation/union/OverlapUnion.h
@@ -39,13 +39,14 @@ namespace geos {
 namespace operation { // geos::operation
 namespace geounion {  // geos::operation::geounion
 
-/**
- * Unions MultiPolygons efficiently by
- * using full topological union only for polygons which may overlap
- * by virtue of intersecting the common area of the inputs.
- * Other polygons are simply combined with the union result,
- * which is much more performant.
- * <p>
+/** \brief
+ * Unions MultiPolygons efficiently by using full topological union only
+ * for polygons which may overlap by virtue of intersecting the common
+ * area of the inputs.
+ *
+ * Other polygons are simply combined with the union result, which is much
+ * more performant.
+ *
  * This situation is likely to occur during cascaded polygon union,
  * since the partitioning of polygons is done heuristically
  * and thus may group disjoint polygons which can lie far apart.

--- a/include/geos/operation/valid/RepeatedPointRemover.h
+++ b/include/geos/operation/valid/RepeatedPointRemover.h
@@ -20,6 +20,8 @@
 namespace geos {
 namespace operation {
 namespace valid {
+
+    /// Removes repeated, consecutive equal, coordinates from a CoordinateSequence.
     class GEOS_DLL RepeatedPointRemover {
 
     /// \brief

--- a/include/geos/precision/MinimumClearance.h
+++ b/include/geos/precision/MinimumClearance.h
@@ -25,6 +25,8 @@
 
 namespace geos {
 namespace precision {
+
+/// Computes the Minimum Clearance of a Geometry.
 class GEOS_DLL MinimumClearance {
 private:
     const geom::Geometry* inputGeom;

--- a/include/geos/triangulate/DelaunayTriangulationBuilder.h
+++ b/include/geos/triangulate/DelaunayTriangulationBuilder.h
@@ -43,7 +43,7 @@ namespace geos {
 namespace triangulate { //geos.triangulate
 
 
-/**
+/** \brief
  * A utility class which creates Delaunay Triangulations
  * from collections of points and extract the resulting
  * triangulation edges or triangles as geometries.

--- a/include/geos/triangulate/IncrementalDelaunayTriangulator.h
+++ b/include/geos/triangulate/IncrementalDelaunayTriangulator.h
@@ -32,7 +32,7 @@ class QuadEdge;
 class QuadEdgeSubdivision;
 }
 
-/**
+/** \brief
  * Computes a Delauanay Triangulation of a set of {@link quadedge::Vertex}es,
  * using an incrementatal insertion algorithm.
  *

--- a/include/geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h
+++ b/include/geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h
@@ -29,7 +29,7 @@ namespace quadedge { //geos.triangulate.quadedge
 //fwd declarations
 class QuadEdgeSubdivision;
 
-/**
+/** \brief
 * Locates {@link QuadEdge}s in a {@link QuadEdgeSubdivision},
 * optimizing the search by starting in the
 * locality of the last edge found.

--- a/include/geos/triangulate/quadedge/QuadEdgeLocator.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeLocator.h
@@ -26,10 +26,11 @@ namespace quadedge { //geos.triangulate.quadedge
 class Vertex;
 class QuadEdge;
 
-/**
+/** \brief
  * An interface for classes which locate an edge in a {@link QuadEdgeSubdivision}
- * which either contains a given {@link Vertex} V
- * or is an edge of a triangle which contains V.
+ * which either contains a given {@link Vertex} V or is an edge of a triangle
+ * which contains V.
+ *
  * Implementors may utilized different strategies for
  * optimizing locating containing edges/triangles.
  *

--- a/include/geos/triangulate/quadedge/TrianglePredicate.h
+++ b/include/geos/triangulate/quadedge/TrianglePredicate.h
@@ -24,9 +24,10 @@ namespace geom { // geos.geom
 
 class Coordinate;
 
-/**
+/** \brief
  * Algorithms for computing values and predicates
  * associated with triangles.
+ *
  * For some algorithms extended-precision
  * implementations are provided, which are more robust
  * (i.e. they produce correct answers in more cases).

--- a/include/geos/triangulate/quadedge/TriangleVisitor.h
+++ b/include/geos/triangulate/quadedge/TriangleVisitor.h
@@ -25,7 +25,7 @@ namespace geos {
 namespace triangulate { //geos.triangulate
 namespace quadedge { //geos.triangulate.quadedge
 
-/**
+/** \brief
  * An interface for algorithms which process the triangles in a {@link QuadEdgeSubdivision}.
  *
  * @author JTS: Martin Davis

--- a/include/geos/util.h
+++ b/include/geos/util.h
@@ -82,6 +82,10 @@ make_unique(Args &&...) = delete;
 
 #endif
 }
+
+/// Utility classes for GEOS.
+namespace util { // geos.util
+} // geos.util
 }
 
 #endif // GEOS_UTIL_H

--- a/include/geos/util/GeometricShapeFactory.h
+++ b/include/geos/util/GeometricShapeFactory.h
@@ -48,7 +48,7 @@ namespace geos {
 namespace util { // geos::util
 
 
-/**
+/** \brief
  * Computes various kinds of common geometric shapes.
  *
  * Allows various ways of specifying the location and extent of the shapes,

--- a/include/geos/util/Interrupt.h
+++ b/include/geos/util/Interrupt.h
@@ -22,7 +22,7 @@ namespace util { // geos::util
 
 #define GEOS_CHECK_FOR_INTERRUPTS() geos::util::Interrupt::process()
 
-/** Used to manage interruption requests and callbacks */
+/** \brief Used to manage interruption requests and callbacks. */
 class GEOS_DLL Interrupt {
 
 public:


### PR DESCRIPTION
A lot of the nicely documented code never get generated at all or poorly by doxygen. The reason is primarily missing descriptions of namespaces, as well as some classes, but also by missing brief tags.

This PR addresses this issue in two commits. Unfortunately,  I could't come up with a better approach for adding namespace description than adding package/namespace header files (in the same pattern as for other similar cases, e.g. `geos/geosAlgorithm.h`).