### PR TITLE
Add deprecated macro - proposal (addressing #843)

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -150,6 +150,7 @@ typedef int (*GEOSDistanceCallback)(const void *item1, const void* item2, double
  ***********************************************************************/
 
 #include <geos/export.h>
+#include <geos/deprecated.h>
 
 /*
  * Register an interruption checking callback
@@ -169,12 +170,14 @@ extern void GEOS_DLL GEOS_interruptCancel();
  *     initialize using GEOS_init_r() and set the message handlers using
  *     GEOSContext_setNoticeHandler_r and/or GEOSContext_setErrorHandler_r
  */
+GEOS_DEPRECATED_VERSION_X_3_5("initialize using GEOS_init_r() and set the message handlers using GEOSContext_setNoticeHandler_r and/or GEOSContext_setErrorHandler_r")
 extern GEOSContextHandle_t GEOS_DLL initGEOS_r(
                                     GEOSMessageHandler notice_function,
                                     GEOSMessageHandler error_function);
 /*
  * @deprecated in 3.5.0 replaced by GEOS_finish_r.
  */
+GEOS_DEPRECATED_VERSION_X_3_5("replaced by GEOS_finish_r")
 extern void GEOS_DLL finishGEOS_r(GEOSContextHandle_t handle);
 
 extern GEOSContextHandle_t GEOS_DLL GEOS_init_r();
@@ -465,6 +468,7 @@ extern GEOSGeometry GEOS_DLL *GEOSBufferWithStyle_r(GEOSContextHandle_t handle,
 
 /* These functions return NULL on exception. Only LINESTRINGs are accepted. */
 /* @deprecated in 3.3.0: use GEOSOffsetCurve instead */
+GEOS_DEPRECATED_X("use GEOSOffsetCurve instead")
 extern GEOSGeometry GEOS_DLL *GEOSSingleSidedBuffer_r(
 	GEOSContextHandle_t handle,
 	const GEOSGeometry* g, double width, int quadsegs,
@@ -596,6 +600,7 @@ extern GEOSGeometry GEOS_DLL *GEOSUnaryUnion_r(GEOSContextHandle_t handle,
 extern GEOSGeometry GEOS_DLL *GEOSCoverageUnion_r(GEOSContextHandle_t handle,
                                                   const GEOSGeometry* g);
 /* @deprecated in 3.3.0: use GEOSUnaryUnion_r instead */
+GEOS_DEPRECATED_X("GEOSUnaryUnion_r instead")
 extern GEOSGeometry GEOS_DLL *GEOSUnionCascaded_r(GEOSContextHandle_t handle,
                                                   const GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSPointOnSurface_r(GEOSContextHandle_t handle,
@@ -1530,6 +1535,7 @@ extern GEOSGeometry GEOS_DLL *GEOSBufferWithStyle(const GEOSGeometry* g,
 
 /* These functions return NULL on exception. Only LINESTRINGs are accepted. */
 /* @deprecated in 3.3.0: use GEOSOffsetCurve instead */
+GEOS_DEPRECATED_X("use GEOSOffsetCurve instead")
 extern GEOSGeometry GEOS_DLL *GEOSSingleSidedBuffer(const GEOSGeometry* g,
     double width, int quadsegs, int joinStyle, double mitreLimit,
     int leftSide);
@@ -1644,6 +1650,7 @@ extern GEOSGeometry GEOS_DLL *GEOSUnaryUnion(const GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSCoverageUnion(const GEOSGeometry *g);
 
 /* @deprecated in 3.3.0: use GEOSUnaryUnion instead */
+GEOS_DEPRECATED_X("GEOSUnaryUnion instead")
 extern GEOSGeometry GEOS_DLL *GEOSUnionCascaded(const GEOSGeometry* g);
 
 extern GEOSGeometry GEOS_DLL *GEOSPointOnSurface(const GEOSGeometry* g);

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2025,7 +2025,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2057,7 +2057,21 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GEOS_DLL
+PREDEFINED             = GEOS_DLL \
+                         GEOS_DEPRECATED \
+                         GEOS_DEPRECATED_VARIABLE \
+                         GEOS_DEPRECATED_VERSION_2_0 \
+                         GEOS_DEPRECATED_VERSION_3_0 \
+                         GEOS_DEPRECATED_VERSION_3_1 \
+                         GEOS_DEPRECATED_VERSION_3_2 \
+                         GEOS_DEPRECATED_VERSION_3_3 \
+                         GEOS_DEPRECATED_VERSION_3_4 \
+                         GEOS_DEPRECATED_VERSION_3_5 \
+                         GEOS_DEPRECATED_VERSION_3_6 \
+                         GEOS_DEPRECATED_VERSION_3_7 \
+                         GEOS_DEPRECATED_VERSION_3_8 \
+                         GEOS_DEPRECATED_SINCE \
+                         _DOXYGEN_
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2066,7 +2080,7 @@ PREDEFINED             = GEOS_DLL
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = GEOS_DEPRECATED_SINCE
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/doc/example.cpp
+++ b/doc/example.cpp
@@ -411,9 +411,8 @@ do_all()
     vector<const Geometry*>* geoms = new vector<const Geometry*>;
     vector<const Geometry*>* newgeoms;
 
-    // Define a precision model using 0,0 as the reference origin
-    // and 2.0 as coordinates scale.
-    PrecisionModel* pm = new PrecisionModel(2.0, 0, 0);
+    // Define a precision model using 2.0 as coordinates scale.
+    PrecisionModel* pm = new PrecisionModel(2.0);
 
     // Initialize global factory with defined PrecisionModel
     // and a SRID of -1 (undefined).

--- a/include/geos/Makefile.am
+++ b/include/geos/Makefile.am
@@ -16,12 +16,13 @@ SUBDIRS = \
     triangulate \
     util
 
-EXTRA_DIST = 
+EXTRA_DIST =
 
 geosdir = $(includedir)/geos
 
 geos_HEADERS = \
     constants.h \
+    deprecated.h \
     export.h \
     geomgraph.h \
     geomgraphindex.h \

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -21,6 +21,7 @@
 #define GEOS_ALGORITHM_LINEINTERSECTOR_H
 
 #include <geos/export.h>
+#include <geos/deprecated.h>
 #include <string>
 
 #include <geos/geom/Coordinate.h>
@@ -128,12 +129,17 @@ public:
     /// Same as above but doen's compute intersection point. Faster.
     static bool hasIntersection(const geom::Coordinate& p, const geom::Coordinate& p1, const geom::Coordinate& p2);
 
-    // These are deprecated, due to ambiguous naming
+#if GEOS_DEPRECATED_SINCE(3, 2)
+    /// \deprecated These are deprecated since 3.2, due to ambiguous naming.
     enum {
+        /// Indicates that line segments do not intersect
         DONT_INTERSECT = 0,
+        /// Indicates that line segments intersect in a single point
         DO_INTERSECT = 1,
+        /// Indicates that line segments intersect in a line segment
         COLLINEAR = 2
-    };
+    } GEOS_DEPRECATED;
+#endif
 
     enum {
         /// Indicates that line segments do not intersect

--- a/include/geos/deprecated.h
+++ b/include/geos/deprecated.h
@@ -1,0 +1,484 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019   Nicklas Larsson
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ * Based on parts of QtCore (qcompilerdetection.h and qglobal.h):
+ **********************************************************************
+ *
+ * Copyright (C) 2016 The Qt Company Ltd.
+ * Copyright (C) 2016 Intel Corporation.
+ * Contact: https://www.qt.io/licensing/
+ *
+ * This file is part of the QtCore module of the Qt Toolkit.
+ *
+ * $QT_BEGIN_LICENSE:LGPL$
+ * Commercial License Usage
+ * Licensees holding valid commercial Qt licenses may use this file in
+ * accordance with the commercial license agreement provided with the
+ * Software or, alternatively, in accordance with the terms contained in
+ * a written agreement between you and The Qt Company. For licensing terms
+ * and conditions see https://www.qt.io/terms-conditions. For further
+ * information use the contact form at https://www.qt.io/contact-us.
+ *
+ * GNU Lesser General Public License Usage
+ * Alternatively, this file may be used under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software
+ * Foundation and appearing in the file LICENSE.LGPL3 included in the
+ * packaging of this file. Please review the following information to
+ * ensure the GNU Lesser General Public License version 3 requirements
+ * will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+ *
+ * GNU General Public License Usage
+ * Alternatively, this file may be used under the terms of the GNU
+ * General Public License version 2.0 or (at your option) the GNU General
+ * Public license version 3 or any later version approved by the KDE Free
+ * Qt Foundation. The licenses are as published by the Free Software
+ * Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+ * included in the packaging of this file. Please review the following
+ * information to ensure the GNU General Public License requirements will
+ * be met: https://www.gnu.org/licenses/gpl-2.0.html and
+ * https://www.gnu.org/licenses/gpl-3.0.html.
+ *
+ * $QT_END_LICENSE$
+ *
+ **********************************************************************/
+#ifndef GEOS_DEPRECATED_H
+#define GEOS_DEPRECATED_H
+
+#include <geos/version.h>
+
+/**
+ * \file deprecated.h
+ * \brief Definitions of GEOS deprecation warning macros.
+ *
+ * Deprecated declarations can be attributed with a basic deprecation macro
+ * such as `GEOS_DEPRECATED`, which issues a compilation warning. Using a
+ * versioned form e.g. `GEOS_DEPRECATED_VERSION_3_1` (in this case the
+ * deprecation version is GEOS major version 3 and the minor version is 1) a
+ * warning is issued only if `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO` is set
+ * to a version higher than the deprecation version.
+ *
+ * By default \ref GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO is set to
+ * `0x020000`, e.g. <3.0, however it may be re-defined at compilation. The
+ * version is defined as a hex in the form `0xMMmmpp`, where MM=major, mm=minor,
+ * pp=patch).
+ *
+ * Deprecation macros with version checking (e.g. `GEOS_DEPRECATED_VERSION_3_1`)
+ * only issues warnings and will not cause build failure.
+ *
+ * A *hard* deprecation can be achieved with a
+ * \ref GEOS_DEPRECATED_SINCE(major, minor) conditional clause. In this case
+ * the build will fail, if using a deprecated declaration predating
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO`.
+ *
+ * Defining \ref GEOS_NO_DEPRECATED_WARNINGS at compilation will suppress all
+ * warnings and prevent eventual build failures. Alternatively, setting
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x000000` will also prevent
+ * build failure, but not suppress warnings.
+ *
+ * ### EXAMPLE
+ *
+ * GEOS_VERSION_HEX=0x030800 (3.8.0)
+ *
+ *     GEOS_DEPRECATED_VERSION_X_3_2
+ *     void function1() {};
+ *
+ *     GEOS_DEPRECATED_VERSION_X_3_6
+ *     void function2() {};
+ *
+ *     #if GEOS_DEPRECATED_SINCE(3, 6)
+ *         GEOS_DEPRECATED size_t
+ *         function3() {};
+ *     #endif
+ *
+ *     #if GEOS_DEPRECATED_SINCE(3, 2)
+ *         GEOS_DEPRECATED size_t
+ *         function4() {};
+ *     #endif
+ *
+ *
+ * #### SCENARIO 1
+ *
+ * Default (`GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x020000`, i.e. <3.0)
+ *
+ *  - function1(): deprecation warning issued
+ *  - function2(): deprecation warning issued
+ *  - function3(): deprecation warning issued
+ *  - function4(): deprecation warning issued
+ *
+ * #### SCENARIO 2
+ *
+ *  \ref GEOS_NO_DEPRECATED_WARNINGS -- passed to compiler
+ *
+ * NO deprecation warnings issued or build error.
+ *
+ * #### SCENARIO 3
+ *
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x030200` (3.2.0) -- passed to compiler
+ *
+ *  - function1(): deprecation warning NOT issued
+ *  - function2(): deprecation warning NOT issued
+ *  - function3(): deprecation warning NOT issued
+ *  - function4(): build error if used
+ *
+ * #### SCENARIO 4
+ *
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x030400` (3.4.0) -- passed to compiler
+ *
+ *  - function1(): deprecation warning issued
+ *  - function2(): deprecation warning NOT issued
+ *  - function3(): deprecation warning issued
+ *  - function4(): build error if used
+ *
+ * #### SCENARIO 5
+ *
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x030600` (3.6.0) -- passed to compiler
+ *
+ *  - function1(): deprecation warning issued
+ *  - function2(): deprecation warning issued
+ *  - function3(): build error if used
+ *  - function4(): build error if used
+ */
+
+/**
+ * \name Internal macros
+ *
+ * \warning These are used for internally for compiler detection, do not use.
+ * \cond
+ */
+#if defined(_MSC_VER)
+#  ifdef __clang__
+#    define G_CC_CLANG
+#  endif
+#  define G_CC_MSVC (_MSC_VER)
+
+#  define G_DECL_DEPRECATED __declspec(deprecated)
+#  ifndef G_CC_CLANG
+#    define G_DECL_DEPRECATED_X(text) __declspec(deprecated(text))
+#  endif
+
+/* Intel C++ disguising as Visual C++: the `using' keyword avoids warnings */
+#  if defined(__INTEL_COMPILER)
+#    define G_DECL_VARIABLE_DEPRECATED
+#  endif
+
+/* ARM Realview Compiler Suite
+   RVCT compiler also defines __EDG__ and __GNUC__ (if --gnu flag is given),
+   so check for it before that */
+#elif defined(__ARMCC__) || defined(__CC_ARM)
+#  define G_DECL_DEPRECATED __attribute__ ((__deprecated__))
+
+#elif defined(__GNUC__)
+#  define G_CC_GNU          (__GNUC__ * 100 + __GNUC_MINOR__)
+#  if defined(__MINGW32__)
+#    define G_CC_MINGW
+#  endif
+#  if defined(__INTEL_COMPILER)
+/* Intel C++ also masquerades as GCC */
+#    define G_CC_INTEL      (__INTEL_COMPILER)
+#    ifdef __clang__
+/* Intel C++ masquerades as Clang masquerading as GCC */
+#      define G_CC_CLANG
+#    endif
+#    define G_ASSUME_IMPL(expr)  __assume(expr)
+#    define G_UNREACHABLE_IMPL() __builtin_unreachable()
+#    if __INTEL_COMPILER >= 1300 && !defined(__APPLE__)
+#      define G_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
+#    endif
+#  elif defined(__clang__)
+/* Clang also masquerades as GCC */
+#    define G_CC_CLANG
+#  else
+/* Plain GCC */
+#    if G_CC_GNU >= 405
+#      define G_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
+#    endif
+#  endif
+#  define G_DECL_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
+#if defined(G_CC_CLANG) && !defined(G_CC_INTEL) && !defined(G_CC_MSVC)
+/* General C++ features */
+#  if __has_feature(attribute_deprecated_with_message)
+#    define G_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
+#  endif
+#endif // G_CC_CLANG
+
+#if defined(__cpp_enumerator_attributes) && __cpp_enumerator_attributes >= 201411
+#if defined(G_CC_MSVC)
+// Can't mark enum values as __declspec(deprecated) with MSVC, also can't move
+// everything to [[deprecated]] because MSVC gives a compilation error when marking
+// friend methods of a class as [[deprecated("text")]], breaking qstring.h
+#  define G_DECL_ENUMERATOR_DEPRECATED [[deprecated]]
+#  define G_DECL_ENUMERATOR_DEPRECATED_X(x) [[deprecated(x)]]
+#else
+#  define G_DECL_ENUMERATOR_DEPRECATED G_DECL_DEPRECATED
+#  define G_DECL_ENUMERATOR_DEPRECATED_X(x) G_DECL_DEPRECATED_X(x)
+#endif
+#endif
+
+/*
+ * Fallback macros to certain compiler features
+ */
+#ifndef G_DECL_DEPRECATED
+#  define G_DECL_DEPRECATED
+#endif
+#ifndef G_DECL_VARIABLE_DEPRECATED
+#  define G_DECL_VARIABLE_DEPRECATED G_DECL_DEPRECATED
+#endif
+#ifndef G_DECL_DEPRECATED_X
+#  define G_DECL_DEPRECATED_X(text) G_DECL_DEPRECATED
+#endif
+/** \endcond */ /* Internal macros */
+
+/*---------------------------------------------------------------------------*/
+
+/**
+ * \name Basic deprecation macros
+ *
+ * These macros issues warnings, irrespective of deprecation version.
+ *
+ * They may be embedded in a \ref GEOS_DEPRECATED_SINCE conditional clause for
+ * version checking.
+ * \{
+ */
+#if !defined(GEOS_NO_DEPRECATED_WARNINGS)
+#  undef GEOS_DEPRECATED
+/**
+ * \def GEOS_DEPRECATED
+ * \brief Issues a simple function/member deprecation warning.
+ *
+ * Examples:
+ * ```
+ * GEOS_DEPRECATED void function();
+ *
+ * enum {x, y, z} GEOS_DEPRECATED;
+ * ```
+ */
+#  define GEOS_DEPRECATED G_DECL_DEPRECATED
+#  undef GEOS_DEPRECATED_X
+/**
+ * \def GEOS_DEPRECATED_X(text)
+ * \brief Issues a function/member deprecation warning with a message.
+ * \param text warning message
+ */
+#  define GEOS_DEPRECATED_X(text) G_DECL_DEPRECATED_X(text)
+#  undef GEOS_DEPRECATED_VARIABLE
+/**
+ * \def GEOS_DEPRECATED_VARIABLE
+ * \brief Issues a variable deprecation warning.
+ *
+ * Examples:
+ * ```
+ * enum {x, y, z, m GEOS_DEPRECATED_VARIABLE};
+ *
+ * struct {void a(int) GEOS_DEPRECATED_VARIABLE, void a_new(int), int b};
+ * ```
+ */
+#  define GEOS_DEPRECATED_VARIABLE G_DECL_VARIABLE_DEPRECATED
+#else
+#  undef GEOS_DEPRECATED
+#  define GEOS_DEPRECATED
+#  undef GEOS_DEPRECATED_X
+#  define GEOS_DEPRECATED_X(text)
+#  undef GEOS_DEPRECATED_VARIABLE
+#  define GEOS_DEPRECATED_VARIABLE
+#endif
+/**\}*/
+
+/**
+ * \name Version checking
+ *
+ * Facilitates deprecation warning version checking.
+ * \{
+ */
+/**
+ * \def GEOS_DEPRECATED_WARNINGS_SINCE
+ * \brief Enables deprecated warnings from specified version of GEOS or later.
+ *
+ * Default value is present GEOS version (`GEOS_VERSION_HEX`); or if
+ * specifically set, equal to `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO`.
+ */
+#ifndef GEOS_DEPRECATED_WARNINGS_SINCE
+# ifdef GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO
+#  define GEOS_DEPRECATED_WARNINGS_SINCE GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO
+# else
+#  define GEOS_DEPRECATED_WARNINGS_SINCE GEOS_VERSION_HEX
+# endif
+#endif
+
+#ifndef GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO
+/**
+ * \def GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO
+ * \brief This macro can be defined in the project to disable functions
+ * deprecated in a specified version of GEOS or any earlier version.
+ *
+ * The default version number is GEOS 2.x, meaning that functions deprecated
+ * before GEOS 3.0 will not be included (if embedded in a
+ * \ref GEOS_DEPRECATED_SINCE(major, minor) condition clause) and use of them
+ * will lead to build failure.
+ *
+ * For instance, when using a future release of GEOS 3, set
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x030400` to disable functions deprecated in
+ * GEOS 3.4 and earlier. In any release, set
+ * `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x000000` to enable all functions, including
+ * the ones deprecated before GEOS 3.0.
+ */
+#define GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO GEOS_VERSION_CHECK(2, 0, 0)
+#endif
+/**
+ * \def GEOS_DEPRECATED_SINCE
+ * \brief Evaluates as true if the GEOS version is greater than the deprecation
+ * point specified (with `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO`).
+ *
+ * Use it to specify from which version of GEOS a function or class has been
+ * deprecated.
+ *
+ * Example:
+ * ```
+ * #if GEOS_DEPRECATED_SINCE(3,4)
+ *     GEOS_DEPRECATED
+ *     void deprecatedFunction(); //function deprecated since GEOS 3.4
+ * #endif
+ * ```
+ * If \ref GEOS_DEPRECATED_SINCE(major, minor) in the example evaluates as
+ * false, i.e. 3.4 is less than `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO`,
+ * the `deprecatedFunction()` will be excluded from compilation. Usage of
+ * the function will consequently lead to build failure. This can be considered
+ * a hard deprecation.
+ *
+ * \param major,minor version since the function is deprecated
+ *
+ * \return true or false
+ */
+#ifdef GEOS_DEPRECATED
+#define GEOS_DEPRECATED_SINCE(major, minor) (GEOS_VERSION_CHECK(major, minor, 0) > GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO)
+#else
+#define GEOS_DEPRECATED_SINCE(major, minor) 0
+#endif
+/**\}*/
+
+/**
+ * \name Deprecation macros with version checking
+ *
+ * The macros named after patterns `GEOS_DEPRECATED_VERSION_[major]_[minor]` and
+ * `GEOS_DEPRECATED_VERSION_X_[major]_[minor]` outputs a deprecation warning if
+ * `GEOS_DEPRECATED_WARNINGS_SINCE` is equal or greater than the version
+ * specified as major, minor.
+ *
+ * This makes it possible to make a soft deprecation of a function without
+ * annoying a user who needs to stick at a specified minimum version and
+ * therefore can't use the new function.
+ *
+ * \note For GEOS version 1.x and 2.x deprecations no minor version checks are
+ * enabled.
+ * \{
+ */
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(1, 0, 0)
+# define GEOS_DEPRECATED_VERSION_X_1_0(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_1_0         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_1_0(text)
+# define GEOS_DEPRECATED_VERSION_1_0
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(2, 0, 0)
+# define GEOS_DEPRECATED_VERSION_X_2_0(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_2_0         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_2_0(text)
+# define GEOS_DEPRECATED_VERSION_2_0
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 0, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_0(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_0         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_0(text)
+# define GEOS_DEPRECATED_VERSION_3_0
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 1, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_1(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_1         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_1(text)
+# define GEOS_DEPRECATED_VERSION_3_1
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 2, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_2(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_2         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_2(text)
+# define GEOS_DEPRECATED_VERSION_3_2
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 3, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_3(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_3         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_3(text)
+# define GEOS_DEPRECATED_VERSION_3_3
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 4, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_4(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_4         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_4(text)
+# define GEOS_DEPRECATED_VERSION_3_4
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 5, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_5(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_5         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_5(text)
+# define GEOS_DEPRECATED_VERSION_3_5
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 6, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_6(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_6         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_6(text)
+# define GEOS_DEPRECATED_VERSION_3_6
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 7, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_7(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_7         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_7(text)
+# define GEOS_DEPRECATED_VERSION_3_7
+#endif
+
+#if GEOS_DEPRECATED_WARNINGS_SINCE >= GEOS_VERSION_CHECK(3, 8, 0)
+# define GEOS_DEPRECATED_VERSION_X_3_8(text) GEOS_DEPRECATED_X(text)
+# define GEOS_DEPRECATED_VERSION_3_8         GEOS_DEPRECATED
+#else
+# define GEOS_DEPRECATED_VERSION_X_3_8(text)
+# define GEOS_DEPRECATED_VERSION_3_8
+#endif
+/**\}*/
+
+/**
+ * \def GEOS_NO_DEPRECATED_WARNINGS
+ * \brief Compilation with this definition set, disables all warnings
+ * and enables all deprecated functions.
+ */
+#ifdef _DOXYGEN_
+#  define GEOS_NO_DEPRECATED_WARNINGS
+#endif
+
+#endif // GEOS_DEPRECATED_H

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -20,6 +20,7 @@
 #ifndef GEOS_GEOM_PRECISIONMODEL_H
 #define GEOS_GEOM_PRECISIONMODEL_H
 
+#include <geos/deprecated.h>
 #include <geos/export.h>
 #include <geos/inline.h>
 
@@ -112,7 +113,7 @@ public:
          * single-precision floating-point representation, which is
          * based on the IEEE-754 standard
          */
-        FLOATING_SINGLE
+         FLOATING_SINGLE
 
     } Type;
 
@@ -127,6 +128,7 @@ public:
     ///
     PrecisionModel(Type nModelType);
 
+#if GEOS_DEPRECATED_SINCE(1, 0)
     /** \brief
      * Creates a <code>PrecisionModel</code> with Fixed precision.
      *
@@ -142,7 +144,9 @@ public:
      * @deprecated offsets are no longer supported, since internal
      * representation is rounded floating point
      */
+    GEOS_DEPRECATED
     PrecisionModel(double newScale, double newOffsetX, double newOffsetY);
+#endif
 
     /**
      * \brief
@@ -217,12 +221,13 @@ public:
     /// Returns the multiplying factor used to obtain a precise coordinate.
     double getScale() const;
 
+#if GEOS_DEPRECATED_SINCE(2, 0)
     /// Returns the x-offset used to obtain a precise coordinate.
     //
     /// @return the amount by which to subtract the x-coordinate before
     ///         multiplying by the scale
     /// @deprecated Offsets are no longer used
-    ///
+    GEOS_DEPRECATED
     double getOffsetX() const;
 
     /// Returns the y-offset used to obtain a precise coordinate.
@@ -230,8 +235,9 @@ public:
     /// @return the amount by which to subtract the y-coordinate before
     ///         multiplying by the scale
     /// @deprecated Offsets are no longer used
-    ///
+    GEOS_DEPRECATED
     double getOffsetY() const;
+#endif
 
     /*
      *  Sets ´internal` to the precise representation of `external`.

--- a/include/geos/geomgraph/EdgeIntersection.h
+++ b/include/geos/geomgraph/EdgeIntersection.h
@@ -23,6 +23,7 @@
 #define GEOS_GEOMGRAPH_EDGEINTERSECTION_H
 
 #include <geos/export.h>
+#include <geos/deprecated.h>
 
 #include <geos/geom/Coordinate.h> // for composition and inlines
 
@@ -137,7 +138,7 @@ struct GEOS_DLL  EdgeIntersectionLessThen {
     {
         return ei1 < ei2;
     }
-};
+} GEOS_DEPRECATED_VERSION_3_3;
 
 /// Output operator
 inline std::ostream&

--- a/include/geos/io/WKTReader.h
+++ b/include/geos/io/WKTReader.h
@@ -21,6 +21,7 @@
 #define GEOS_IO_WKTREADER_H
 
 #include <geos/export.h>
+#include <geos/deprecated.h>
 
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/CoordinateSequence.h>
@@ -70,6 +71,7 @@ public:
     WKTReader(const geom::GeometryFactory& gf);
 
     /** @deprecated in 3.4.0 */
+    GEOS_DEPRECATED_VERSION_X_3_4("use initializer with GeometryFactory passed by reference")
     WKTReader(const geom::GeometryFactory* gf);
 
     /**

--- a/include/geos/operation/IsSimpleOp.h
+++ b/include/geos/operation/IsSimpleOp.h
@@ -22,6 +22,7 @@
 #define GEOS_OPERATION_ISSIMPLEOP_H
 
 #include <geos/export.h>
+#include <geos/deprecated.h>
 #include <geos/geom/Coordinate.h> // for dtor visibility by unique_ptr (compos)
 
 #include <map>
@@ -103,6 +104,7 @@ public:
      *
      * @deprecated use IsSimpleOp(Geometry)
      */
+    GEOS_DEPRECATED_VERSION_X_3_2("use IsSimpleOp(Geometry)")
     IsSimpleOp();
 
     /** \brief
@@ -155,6 +157,7 @@ public:
      *
      * @deprecated use isSimple()
      */
+    GEOS_DEPRECATED_VERSION_X_3_2("use isSimple()")
     bool isSimple(const geom::LineString* geom);
 
     /** \brief
@@ -165,6 +168,7 @@ public:
      *
      * @deprecated use isSimple()
      */
+    GEOS_DEPRECATED_VERSION_X_3_2("use isSimple()")
     bool isSimple(const geom::MultiLineString* geom);
 
     /** \brief
@@ -172,6 +176,7 @@ public:
      *
      * @deprecated use isSimple()
      */
+    GEOS_DEPRECATED_VERSION_X_3_2("use isSimple()")
     bool isSimple(const geom::MultiPoint* mp);
 
     bool isSimpleLinearGeometry(const geom::Geometry* geom);

--- a/include/geos/operation/buffer/BufferOp.h
+++ b/include/geos/operation/buffer/BufferOp.h
@@ -21,6 +21,7 @@
 #ifndef GEOS_OP_BUFFER_BUFFEROP_H
 #define GEOS_OP_BUFFER_BUFFEROP_H
 
+#include <geos/deprecated.h>
 #include <geos/export.h>
 #include <geos/operation/buffer/BufferParameters.h> // for enum values
 
@@ -143,7 +144,7 @@ public:
         /// Specifies a square line buffer end cap style.
         /// @deprecated use BufferParameters
         CAP_SQUARE = BufferParameters::CAP_SQUARE
-    };
+    } GEOS_DEPRECATED_VERSION_X_3_2("use BufferParameters::");
 
     /** \brief
      * Computes the buffer for a geometry for a given buffer distance

--- a/include/geos/operation/distance/DistanceOp.h
+++ b/include/geos/operation/distance/DistanceOp.h
@@ -21,6 +21,7 @@
 #define GEOS_OP_DISTANCE_DISTANCEOP_H
 
 #include <geos/export.h>
+#include <geos/deprecated.h>
 
 #include <geos/algorithm/PointLocator.h> // for composition
 #include <geos/operation/distance/GeometryLocation.h>
@@ -85,6 +86,7 @@ public:
                            const geom::Geometry& g1);
 
     /// @deprecated, use the version taking references
+    GEOS_DEPRECATED_VERSION_X_3_2("use the version taking references")
     static double distance(const geom::Geometry* g0,
                            const geom::Geometry* g1);
 
@@ -119,6 +121,7 @@ public:
         const geom::Geometry* g1);
 
     /// @deprecated use the one taking references
+    GEOS_DEPRECATED_VERSION_X_3_2("use the initializer taking references")
     DistanceOp(const geom::Geometry* g0, const geom::Geometry* g1);
 
     /**

--- a/include/geos/operation/overlay/MaximalEdgeRing.h
+++ b/include/geos/operation/overlay/MaximalEdgeRing.h
@@ -19,6 +19,7 @@
 #ifndef GEOS_OP_OVERLAY_MAXIMALEDGERING_H
 #define GEOS_OP_OVERLAY_MAXIMALEDGERING_H
 
+#include <geos/deprecated.h>
 #include <geos/export.h>
 
 #include <vector>
@@ -83,6 +84,7 @@ public:
     ///
     /// @deprecated pass the vector yourself instead
     ///
+    GEOS_DEPRECATED_VERSION_X_3_2("pass the vector yourself instead")
     std::vector<MinimalEdgeRing*>* buildMinimalRings();
 
     /// \brief

--- a/include/geos/version.h.in
+++ b/include/geos/version.h.in
@@ -26,6 +26,23 @@
 #define GEOS_VERSION_PATCH @VERSION_PATCH@
 #endif
 
+#ifndef GEOS_VERSION_HEX
+/**
+ * \brief Full version expressed in hex: 0xMMmmpp, where MM=major, mm=minor, pp=patch.
+ *
+ * Defined by (major << 16) + (minor << 8) + patch.
+ */
+/* VERSION_PATCH hard coded for testing, following doesn't work presently with autotools, for builds with GEOS_PATCH_WORD set
+# define GEOS_VERSION_HEX  GEOS_VERSION_CHECK(@VERSION_MAJOR@, @VERSION_MINOR@, @VERSION_PATCH@)
+*/
+# define GEOS_VERSION_HEX  GEOS_VERSION_CHECK(@VERSION_MAJOR@, @VERSION_MINOR@, 0)
+#endif
+
+/* can be used like #if (GEOS_VERSION_FULL >= GEOS_VERSION_CHECK(4, 4, 0)) */
+#ifndef GEOS_VERSION_CHECK
+#define GEOS_VERSION_CHECK(major, minor, patch) ((major<<16)|(minor<<8)|(patch))
+#endif
+
 #ifndef GEOS_VERSION
 #define GEOS_VERSION "@VERSION@"
 #endif

--- a/src/geom/PrecisionModel.cpp
+++ b/src/geom/PrecisionModel.cpp
@@ -107,6 +107,7 @@ PrecisionModel::PrecisionModel(Type nModelType)
 
 
 /*public (deprecated) */
+#if GEOS_DEPRECATED_SINCE(1, 0)
 PrecisionModel::PrecisionModel(double newScale, double newOffsetX, double newOffsetY)
 //throw(IllegalArgumentException *)
     :
@@ -122,6 +123,7 @@ PrecisionModel::PrecisionModel(double newScale, double newOffsetX, double newOff
     //modelType = FIXED;
     setScale(newScale);
 }
+#endif
 
 /*public*/
 PrecisionModel::PrecisionModel(double newScale)
@@ -189,6 +191,7 @@ PrecisionModel::setScale(double newScale)
 }
 
 /*public*/
+#if GEOS_DEPRECATED_SINCE(2, 0)
 double
 PrecisionModel::getOffsetX() const
 {
@@ -201,7 +204,7 @@ PrecisionModel::getOffsetY() const
 {
     return 0;
 }
-
+#endif
 
 string
 PrecisionModel::toString() const

--- a/src/geom/PrecisionModel.cpp
+++ b/src/geom/PrecisionModel.cpp
@@ -217,10 +217,7 @@ PrecisionModel::toString() const
         s << "Floating-Single";
     }
     else if(modelType == FIXED) {
-        s << "Fixed (Scale=" << getScale()
-          << " OffsetX=" << getOffsetX()
-          << " OffsetY=" << getOffsetY()
-          << ")";
+        s << "Fixed (Scale=" << getScale() << ")";
     }
     else {
         s << "UNKNOWN";

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -544,17 +544,7 @@ XMLTester::parsePrecisionModel(const tinyxml2::XMLElement* el)
         char* stopstring;
 
         double scale = std::strtod(scaleStr, &stopstring);
-        double offsetX = 0;
-        double offsetY = 2;
-
-        if(! el->QueryDoubleAttribute("offsetx", &offsetX))
-        {} // std::cerr << "No offsetx" << std::endl;
-
-        if(! el->QueryDoubleAttribute("offsety", &offsetY))
-        {} // std::cerr << "No offsety" << std::endl;
-
-        // NOTE: PrecisionModel discards offsets anyway...
-        pm.reset(new PrecisionModel(scale, offsetX, offsetY));
+        pm.reset(new PrecisionModel(scale));
     }
 }
 


### PR DESCRIPTION
This PR add a macro framework for deprecation warnings and disabeling of deprecated definitions, addressing [#843](https://trac.osgeo.org/geos/ticket/843). Consider it a proposal.

Builds and passes tests with both cmake and autotools for me locally. This introduces ~150 warnings, a majority of which is from test cases.

Note - following definitions are disabled by deprecation settings on initial commit for this PR, as they were deprecated before v3.0:
- PrecisionModel(double newScale, double newOffsetX, double newOffsetY)
- PrecisionModel::getOffsetY()
- PrecisionModel::getOffsetX()

**Description**

Deprecated declarations can be attributed with a basic deprecation macro such as `GEOS_DEPRECATED`, which issues a compilation warning. Using a versioned form e.g. `GEOS_DEPRECATED_VERSION_3_1` (in this case the deprecation version is GEOS major version 3 and the minor version is 1) a warning is issued only if `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO` is set to a version higher than the deprecation version.

By default `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO` is set to `0x020000`, e.g. <3.0, however it may be re-defined at compilation. The version is defined as a hex in the form `0xMMmmpp`, where MM=major, mm=minor, pp=patch).

Deprecation macros with version checking (e.g. `GEOS_DEPRECATED_VERSION_3_1`) only issues warnings and will not cause build failure.

A *hard* deprecation can be achieved with a `GEOS_DEPRECATED_SINCE(major, minor)` conditional clause. In this case the build will fail, if using a deprecated declaration predating `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO`.

Defining `GEOS_NO_DEPRECATED_WARNINGS` at compilation will suppress all warnings and prevent eventual build failures. Alternatively, setting `GEOS_DISABLE_DEPRECATED_BEFORE_OR_EQUAL_TO=0x000000` will also prevent build failure, but not suppress warnings.
