### PR TITLE
Return Point::coordinates to the heap

### DIFF
--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -177,8 +177,7 @@ private:
     /**
      *  The <code>Coordinate</code> wrapped by this <code>Point</code>.
      */
-    FixedSizeCoordinateSequence<1> coordinates;
-    bool empty;
+    std::unique_ptr<CoordinateSequence> coordinates;
 };
 
 } // namespace geos::geom

--- a/tests/unit/geom/PointTest.cpp
+++ b/tests/unit/geom/PointTest.cpp
@@ -549,5 +549,15 @@ void object::test<43>
     ensure(!point_->isDimensionStrict(geos::geom::Dimension::A));
 }
 
+// empty point has size-0 coordinate sequence
+template<>
+template<>
+void object::test<44>
+()
+{
+    ensure_equals(empty_point_->getCoordinates()->getSize(), 0u);
+    ensure_equals(empty_point_->getCoordinatesRO()->getSize(), 0u);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
This re-allows the type of the CoordinateSequence to be polymorphic,
which is necessary for empty points to have an empty CoordinateSequence.

Fixes #1001