### PR TITLE
Avoid returning size-1 CoordinateSequence from empty point

### DIFF
--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -35,9 +35,9 @@ namespace geom {
         explicit FixedSizeCoordinateSequence(size_t dimension_in = 0) : dimension(dimension_in) {}
 
         std::unique_ptr<CoordinateSequence> clone() const final override {
-            auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>();
+            auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>(dimension);
             seq->m_data = m_data;
-            return std::unique_ptr<CoordinateSequence>(seq.release());
+            return std::move(seq); // move needed for gcc 4.8
         }
 
         const Coordinate& getAt(size_t i) const final override {

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -178,7 +178,9 @@ private:
      *  The <code>Coordinate</code> wrapped by this <code>Point</code>.
      */
     FixedSizeCoordinateSequence<1> coordinates;
-    bool empty;
+
+    bool empty2d;
+    bool empty3d;
 };
 
 } // namespace geos::geom

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -41,18 +41,20 @@ using namespace std;
 namespace geos {
 namespace geom { // geos::geom
 
-const static FixedSizeCoordinateSequence<0> emptyCoords;
+const static FixedSizeCoordinateSequence<0> emptyCoords2d(2);
+const static FixedSizeCoordinateSequence<0> emptyCoords3d(3);
 
 /*protected*/
 Point::Point(CoordinateSequence* newCoords, const GeometryFactory* factory)
     :
     Geometry(factory),
-    empty(false)
+    empty2d(false),
+    empty3d(false)
 {
     std::unique_ptr<CoordinateSequence> coords(newCoords);
 
     if(coords == nullptr) {
-        empty = true;
+        empty3d = true;
         return;
     }
 
@@ -60,14 +62,17 @@ Point::Point(CoordinateSequence* newCoords, const GeometryFactory* factory)
         coordinates.setAt(coords->getAt(0), 0);
     } else if (coords->getSize() > 1) {
         throw util::IllegalArgumentException("Point coordinate list must contain a single element");
+    } else if (coords->getDimension() == 3) {
+        empty3d = true;
     } else {
-        empty = true;
+        empty2d = true;
     }
 }
 
 Point::Point(const Coordinate & c, const GeometryFactory* factory) :
     Geometry(factory),
-    empty(false)
+    empty2d(false),
+    empty3d(false)
 {
     coordinates.setAt(c, 0);
 }
@@ -77,7 +82,8 @@ Point::Point(const Point& p)
     :
     Geometry(p),
     coordinates(p.coordinates),
-    empty(p.empty)
+    empty2d(p.empty3d),
+    empty3d(p.empty3d)
 {
 }
 
@@ -90,13 +96,13 @@ Point::getCoordinates() const
 size_t
 Point::getNumPoints() const
 {
-    return empty ? 0 : 1;
+    return isEmpty() ? 0 : 1;
 }
 
 bool
 Point::isEmpty() const
 {
-    return empty;
+    return empty2d || empty3d;
 }
 
 bool
@@ -153,7 +159,7 @@ Point::getZ() const
 const Coordinate*
 Point::getCoordinate() const
 {
-    return empty ? nullptr : &coordinates[0];
+    return isEmpty() ? nullptr : &coordinates[0];
 }
 
 string
@@ -288,8 +294,10 @@ Point::getGeometryTypeId() const
 const CoordinateSequence*
 Point::getCoordinatesRO() const
 {
-    if (isEmpty()) {
-        return &emptyCoords;
+    if (empty2d) {
+        return &emptyCoords2d;
+    } else if (empty3d) {
+        return &emptyCoords3d;
     }
     return &coordinates;
 }

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -41,6 +41,7 @@ using namespace std;
 namespace geos {
 namespace geom { // geos::geom
 
+const static FixedSizeCoordinateSequence<0> emptyCoords;
 
 /*protected*/
 Point::Point(CoordinateSequence* newCoords, const GeometryFactory* factory)
@@ -83,7 +84,7 @@ Point::Point(const Point& p)
 std::unique_ptr<CoordinateSequence>
 Point::getCoordinates() const
 {
-    return coordinates.clone();
+    return getCoordinatesRO()->clone();
 }
 
 size_t
@@ -113,7 +114,7 @@ Point::getDimension() const
 int
 Point::getCoordinateDimension() const
 {
-    return (int) coordinates.getDimension();
+    return (int) getCoordinatesRO()->getDimension();
 }
 
 int
@@ -191,6 +192,9 @@ Point::apply_ro(CoordinateFilter* filter) const
 void
 Point::apply_rw(const CoordinateFilter* filter)
 {
+    if (isEmpty()) {
+        return;
+    }
     coordinates.apply_rw(filter);
 }
 
@@ -284,6 +288,9 @@ Point::getGeometryTypeId() const
 const CoordinateSequence*
 Point::getCoordinatesRO() const
 {
+    if (isEmpty()) {
+        return &emptyCoords;
+    }
     return &coordinates;
 }
 

--- a/tests/unit/geom/FixedSizeCoordinateSequenceTest.cpp
+++ b/tests/unit/geom/FixedSizeCoordinateSequenceTest.cpp
@@ -124,4 +124,20 @@ void object::test<5>() {
     ensure_equals(seq1_3d.getDimension(), 3ul);
 }
 
+// test clone
+template<>
+template<>
+void object::test<6>
+()
+{
+    FixedSizeCoordinateSequence<1> a(2);
+    a.setAt({ 1, 2, 3 }, 0);
+
+    ensure_equals(a.getDimension(), 2);
+
+    auto b = a.clone();
+    ensure_equals(b->getDimension(), 2);
+    ensure(a.getAt(0).equals3D(b->getAt(0)));
+}
+
 }

--- a/tests/unit/geom/PointTest.cpp
+++ b/tests/unit/geom/PointTest.cpp
@@ -559,5 +559,26 @@ void object::test<44>
     ensure_equals(empty_point_->getCoordinatesRO()->getSize(), 0u);
 }
 
+// check dimensionality of empty points
+template<>
+template<>
+void object::test<45>
+()
+{
+    auto empty3d = factory_->createPoint();
+    ensure_equals(empty3d->getCoordinateDimension(), 3);
+
+    geos::geom::FixedSizeCoordinateSequence<0> seq2(2);
+    ensure_equals(seq2.getDimension(), 2u);
+    ensure_equals(factory_->createPoint(seq2)->getCoordinateDimension(), 2);
+
+    geos::geom::FixedSizeCoordinateSequence<0> seq3(3);
+    ensure_equals(seq3.getDimension(), 3u);
+    ensure_equals(factory_->createPoint(seq3)->getCoordinateDimension(), 3);
+
+
+
+}
+
 } // namespace tut
 

--- a/tests/unit/geom/PointTest.cpp
+++ b/tests/unit/geom/PointTest.cpp
@@ -549,5 +549,15 @@ void object::test<43>
     ensure(!point_->isDimensionStrict(geos::geom::Dimension::A));
 }
 
+// empty point has size-0 coordinate sequence
+template<>
+template<>
+void object::test<44>
+()
+{
+    ensure_equals(empty_point_->getCoordinates()->getSize(), 0u);
+    ensure_equals(empty_point_->getCoordinatesRO()->getSize(), 0u);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fixes https://trac.osgeo.org/geos/ticket/1001 without reintroducing a heap allocation as #243 does.