### PR TITLE
Fix minor stylistic flaws

### DIFF
--- a/benchmarks/algorithm/InteriorPointAreaPerfTest.cpp
+++ b/benchmarks/algorithm/InteriorPointAreaPerfTest.cpp
@@ -53,7 +53,7 @@ public:
         std::unique_ptr<geos::geom::Polygon> sinePoly =
             createSineStar(origin, SIZE, nPts);
 
-        /**
+        /*
          * Make the geometry "crinkly" by rounding off the points.
          * This defeats the  MonotoneChain optimization in the full relate
          * algorithm, and provides a more realistic test.

--- a/benchmarks/operation/predicate/RectangleIntersectsPerfTest.cpp
+++ b/benchmarks/operation/predicate/RectangleIntersectsPerfTest.cpp
@@ -52,7 +52,7 @@ public:
             createSineStar(origin, size, nPts)->getBoundary()
         );
 
-        /**
+        /*
          * Make the geometry "crinkly" by rounding off the points.
          * This defeats the  MonotoneChain optimization in the full relate
          * algorithm, and provides a more realistic test.

--- a/include/geos/algorithm/Angle.h
+++ b/include/geos/algorithm/Angle.h
@@ -53,14 +53,14 @@ public:
     static const int NONE = Orientation::COLLINEAR;
 
     /// Converts from radians to degrees.
-    //
+    ///
     /// @param radians an angle in radians
     /// @return the angle in degrees
     ///
     static double toDegrees(double radians);
 
     /// Converts from degrees to radians.
-    //
+    ///
     /// @param angleDegrees an angle in degrees
     /// @return the angle in radians
     ///
@@ -69,7 +69,7 @@ public:
     /// \brief
     /// Returns the angle of the vector from p0 to p1,
     /// relative to the positive X-axis.
-    //
+    ///
     /// The angle is normalized to be in the range [ -Pi, Pi ].
     ///
     /// @return the normalized angle (in radians) that p0-p1 makes
@@ -90,7 +90,7 @@ public:
     static double angle(const geom::Coordinate& p);
 
     /// Tests whether the angle between p0-p1-p2 is acute.
-    //
+    ///
     /// An angle is acute if it is less than 90 degrees.
     ///
     /// Note: this implementation is not precise (determistic) for
@@ -105,7 +105,7 @@ public:
                         const geom::Coordinate& p2);
 
     /// Tests whether the angle between p0-p1-p2 is obtuse.
-    //
+    ///
     /// An angle is obtuse if it is greater than 90 degrees.
     ///
     /// Note: this implementation is not precise (determistic) for
@@ -120,7 +120,7 @@ public:
                          const geom::Coordinate& p2);
 
     /// Returns the unoriented smallest angle between two vectors.
-    //
+    ///
     /// The computed angle will be in the range [0, Pi).
     ///
     /// @param tip1 the tip of one vector
@@ -133,7 +133,7 @@ public:
                                const geom::Coordinate& tip2);
 
     /// Returns the oriented smallest angle between two vectors.
-    //
+    ///
     /// The computed angle will be in the range (-Pi, Pi].
     /// A positive result corresponds to a counterclockwise rotation
     /// from v1 to v2;
@@ -149,7 +149,7 @@ public:
                                        const geom::Coordinate& tip2);
 
     /// Computes the interior angle between two segments of a ring.
-    //
+    ///
     /// The ring is assumed to be oriented in a clockwise direction.
     /// The computed angle will be in the range [0, 2Pi]
     ///
@@ -207,7 +207,7 @@ public:
 
 
     /// Computes the unoriented smallest difference between two angles.
-    //
+    ///
     /// The angles are assumed to be normalized to the range [-Pi, Pi].
     /// The result will be in the range [0, Pi].
     ///

--- a/include/geos/algorithm/Centroid.h
+++ b/include/geos/algorithm/Centroid.h
@@ -36,7 +36,7 @@ class CoordinateSequence;
 namespace geos {
 namespace algorithm { // geos::algorithm
 
-/**\brief
+/** \brief
  * Computes the centroid of a [Geometry](@ref geom::Geometry) of any dimension.
  *
  * If the geometry is nomimally of higher dimension, but contains only

--- a/include/geos/algorithm/Distance.h
+++ b/include/geos/algorithm/Distance.h
@@ -36,19 +36,19 @@ class GEOS_DLL Distance {
 public:
 
     /**
-    * Computes the distance from a line segment AB to a line segment CD
-    *
-    * Note: NON-ROBUST!
-    *
-    * @param A
-    *          a point of one line
-    * @param B
-    *          the second point of (must be different to A)
-    * @param C
-    *          one point of the line
-    * @param D
-    *          another point of the line (must be different to A)
-    */
+     * Computes the distance from a line segment AB to a line segment CD
+     *
+     * Note: NON-ROBUST!
+     *
+     * @param A
+     *          a point of one line
+     * @param B
+     *          the second point of (must be different to A)
+     * @param C
+     *          one point of the line
+     * @param D
+     *          another point of the line (must be different to A)
+     */
     // formerly distanceLineLine
     static double segmentToSegment(const geom::Coordinate& A,
                                    const geom::Coordinate& B,

--- a/include/geos/algorithm/Intersection.h
+++ b/include/geos/algorithm/Intersection.h
@@ -23,27 +23,26 @@ namespace geos {
 namespace algorithm { // geos::algorithm
 
 /** \brief
-* Computes the intersection point of two lines.
-* If the lines are parallel or collinear this case is detected
-* and <code>null</code> is returned.
-* <p>
-* In general it is not possible to accurately compute
-* the intersection point of two lines, due to
-* numerical roundoff.
-* This is particularly true when the input lines are nearly parallel.
-* This routine uses numerical conditioning on the input values
-* to ensure that the computed value should be very close to the correct value.
-*
-* @param p1 an endpoint of line 1
-* @param p2 an endpoint of line 1
-* @param q1 an endpoint of line 2
-* @param q2 an endpoint of line 2
-* @return the intersection point between the lines, if there is one,
-* or null if the lines are parallel or collinear
-*
-* @see CGAlgorithmsDD#intersection(Coordinate, Coordinate, Coordinate, Coordinate)
-*/
-
+ * Computes the intersection point of two lines.
+ * If the lines are parallel or collinear this case is detected
+ * and <code>null</code> is returned.
+ * <p>
+ * In general it is not possible to accurately compute
+ * the intersection point of two lines, due to
+ * numerical roundoff.
+ * This is particularly true when the input lines are nearly parallel.
+ * This routine uses numerical conditioning on the input values
+ * to ensure that the computed value should be very close to the correct value.
+ *
+ * @param p1 an endpoint of line 1
+ * @param p2 an endpoint of line 1
+ * @param q1 an endpoint of line 2
+ * @param q2 an endpoint of line 2
+ * @return the intersection point between the lines, if there is one,
+ * or null if the lines are parallel or collinear
+ *
+ * @see CGAlgorithmsDD#intersection(Coordinate, Coordinate, Coordinate, Coordinate)
+ */
 class GEOS_DLL Intersection {
 
 public:

--- a/include/geos/algorithm/Length.h
+++ b/include/geos/algorithm/Length.h
@@ -27,20 +27,19 @@ namespace geos {
 namespace algorithm { // geos::algorithm
 
 /** \brief
-* Functions for computing length.
-*
-* @author Martin Davis
-*
-*/
+ * Functions for computing length.
+ *
+ * @author Martin Davis
+ */
 class GEOS_DLL Length {
 public:
 
     /**
-    * Computes the length of a linestring specified by a sequence of points.
-    *
-    * @param ring the points specifying the linestring
-    * @return the length of the linestring
-    */
+     * Computes the length of a linestring specified by a sequence of points.
+     *
+     * @param ring the points specifying the linestring
+     * @return the length of the linestring
+     */
     static double ofLine(const geom::CoordinateSequence* ring);
 
 };

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -56,7 +56,7 @@ public:
 
 
     /// Computes the "edge distance" of an intersection point p in an edge.
-    //
+    ///
     /// The edge distance is a metric of the point along the edge.
     /// The metric used is a robust and easy to compute metric function.
     /// It is <b>not</b> equivalent to the usual Euclidean metric.
@@ -106,7 +106,7 @@ public:
     bool isInteriorIntersection(int inputLineIndex);
 
     /// Force computed intersection to be rounded to a given precision model.
-    //
+    ///
     /// No getter is provided, because the precision model is not required
     /// to be specified.
     /// @param newPM the PrecisionModel to use for rounding
@@ -118,14 +118,14 @@ public:
     }
 
     /// Compute the intersection of a point p and the line p1-p2.
-    //
+    ///
     /// This function computes the boolean value of the hasIntersection test.
     /// The actual value of the intersection (if there is one)
     /// is equal to the value of <code>p</code>.
     ///
     void computeIntersection(const geom::Coordinate& p, const geom::Coordinate& p1, const geom::Coordinate& p2);
 
-    /// Same as above but doen's compute intersection point. Faster.
+    /// Same as above but doesn't compute intersection point. Faster.
     static bool hasIntersection(const geom::Coordinate& p, const geom::Coordinate& p1, const geom::Coordinate& p2);
 
     // These are deprecated, due to ambiguous naming
@@ -164,7 +164,7 @@ public:
     }
 
     /// Returns the number of intersection points found.
-    //
+    ///
     /// This will be either 0, 1 or 2.
     ///
     size_t
@@ -175,7 +175,7 @@ public:
 
 
     /// Returns the intIndex'th intersection point
-    //
+    ///
     /// @param intIndex is 0 or 1
     ///
     /// @return the intIndex'th intersection point
@@ -187,7 +187,7 @@ public:
     }
 
     /// Returns false if both numbers are zero.
-    //
+    ///
     /// @return true if both numbers are positive or if both numbers are negative.
     ///
     static bool isSameSignAndNonZero(double a, double b);

--- a/include/geos/algorithm/Orientation.h
+++ b/include/geos/algorithm/Orientation.h
@@ -64,7 +64,7 @@ public:
      * by the three points
      * ( `Orientation::COUNTERCLOCKWISE`,
      * `Orientation::CLOCKWISE`, or `Orientation::STRAIGHT` )
-    */
+     */
     static int index(const geom::Coordinate& p1, const geom::Coordinate& p2,
                      const geom::Coordinate& q);
 
@@ -83,7 +83,7 @@ public:
      * @return `true` if the ring is oriented counter-clockwise.
      * @throws IllegalArgumentException
      *           if there are too few points to determine orientation (&lt; 4)
-    */
+     */
     static bool isCCW(const geom::CoordinateSequence* ring);
 
 };

--- a/include/geos/algorithm/PointLocation.h
+++ b/include/geos/algorithm/PointLocation.h
@@ -45,7 +45,7 @@ public:
      * @param line the line coordinates
      * @return true if the point is a vertex of the line or lies in the interior
      *         of a line segment in the line
-    */
+     */
     static bool isOnLine(const geom::Coordinate& p, const geom::CoordinateSequence* line);
 
     /** \brief
@@ -68,17 +68,17 @@ public:
     static bool isInRing(const geom::Coordinate& p, const geom::CoordinateSequence* ring);
 
     /** \brief
-    * Determines whether a point lies in the interior, on the boundary, or in the
-    * exterior of a ring. The ring may be oriented in either direction.
-    *
-    * This method does *not* first check the point against the envelope of
-    * the ring.
-    *
-    * @param p point to check for ring inclusion
-    * @param ring an array of coordinates representing the ring (which must have
-    *             first point identical to last point)
+     * Determines whether a point lies in the interior, on the boundary, or in the
+     * exterior of a ring. The ring may be oriented in either direction.
+     *
+     * This method does *not* first check the point against the envelope of
+     * the ring.
+     *
+     * @param p point to check for ring inclusion
+     * @param ring an array of coordinates representing the ring (which must have
+     *             first point identical to last point)
      * @return the [Location](@ref geom::Location) of p relative to the ring
-    */
+     */
     static geom::Location locateInRing(const geom::Coordinate& p, const std::vector<const geom::Coordinate*>& ring);
     static geom::Location locateInRing(const geom::Coordinate& p, const geom::CoordinateSequence& ring);
 

--- a/include/geos/geom.h
+++ b/include/geos/geom.h
@@ -91,7 +91,7 @@
 namespace geos {
 
 /// Contains the <CODE>Geometry</CODE> interface hierarchy and supporting classes.
-//
+///
 /// The Java Topology Suite (JTS) is a Java API that implements a core
 /// set of spatial data operations using an explicit precision model
 /// and robust geometric algorithms. JTS is int ended to be used in the

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -160,7 +160,7 @@ public:
             CoordinateSequence* c);
 
     /// Return position of a Coordinate, or -1 if not found
-    //
+    ///
     /// FIXME: return std::size_t, using numeric_limits<std::size_t>::max
     /// as 'not found' value.
     ///

--- a/include/geos/geom/Dimension.h
+++ b/include/geos/geom/Dimension.h
@@ -22,7 +22,7 @@ namespace geos {
 namespace geom { // geos::geom
 
 /// Constants representing the dimensions of a point, a curve and a surface.
-//
+///
 /// Also, constants representing the dimensions of the empty geometry and
 /// non-empty geometries, and a wildcard dimension meaning "any dimension".
 ///

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -153,7 +153,7 @@ public:
                                         const Geometry* exemplar) const;
 
     /// Converts an Envelope to a Geometry.
-    //
+    ///
     /// Returned Geometry can be a Point, a Polygon or an EMPTY geom.
     ///
     std::unique_ptr<Geometry> toGeometry(const Envelope* envelope) const;
@@ -415,7 +415,7 @@ public:
     void destroyGeometry(Geometry* g) const;
 
     /// Request that the instance is deleted.
-    //
+    ///
     /// It will really be deleted only after last child Geometry is
     /// deleted. Do not use the instance anymore after calling this function
     /// (unless you're a live child!).

--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -90,13 +90,13 @@ public:
     double getLength() const;
 
     /// Tests whether the segment is horizontal.
-    //
+    ///
     /// @return <code>true</code> if the segment is horizontal
     ///
     bool isHorizontal() const;
 
     /// Tests whether the segment is vertical.
-    //
+    ///
     /// @return <code>true</code> if the segment is vertical
     ///
     bool isVertical() const;

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -49,7 +49,7 @@ namespace geom { // geos::geom
 #endif
 
 /// Models a collection of {@link Polygon}s.
-//
+///
 /// As per the OGC SFS specification,
 /// the Polygons in a MultiPolygon may not overlap,
 /// and may only touch at single points.

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -120,7 +120,7 @@ public:
     PrecisionModel(void);
 
     /// Creates a PrecisionModel specifying an explicit precision model type.
-    //
+    ///
     /// If the model type is FIXED the scale factor will default to 1.
     ///
     /// @param nModelType the type of the precision model
@@ -165,7 +165,7 @@ public:
 
 
     /// The maximum precise value representable in a double.
-    //
+    ///
     /// Since IEE754 double-precision numbers allow 53 bits of mantissa,
     /// the value is equal to 2^53 - 1.
     /// This provides <i>almost</i> 16 decimal digits of precision.
@@ -190,7 +190,7 @@ public:
     void makePrecise(Coordinate* coord) const;
 
     /// Tests whether the precision model supports floating point
-    //
+    ///
     /// @return <code>true</code> if the precision model supports
     /// floating point
     ///
@@ -199,7 +199,7 @@ public:
     /// \brief
     /// Returns the maximum number of significant digits provided by
     /// this precision model.
-    //
+    ///
     /// Intended for use by routines which need to print out precise
     /// values.
     ///
@@ -209,7 +209,7 @@ public:
     int getMaximumSignificantDigits() const;
 
     /// Gets the type of this PrecisionModel
-    //
+    ///
     /// @return the type of this PrecisionModel
     ///
     Type getType() const;
@@ -218,7 +218,7 @@ public:
     double getScale() const;
 
     /// Returns the x-offset used to obtain a precise coordinate.
-    //
+    ///
     /// @return the amount by which to subtract the x-coordinate before
     ///         multiplying by the scale
     /// @deprecated Offsets are no longer used
@@ -226,7 +226,7 @@ public:
     double getOffsetX() const;
 
     /// Returns the y-offset used to obtain a precise coordinate.
-    //
+    ///
     /// @return the amount by which to subtract the y-coordinate before
     ///         multiplying by the scale
     /// @deprecated Offsets are no longer used
@@ -281,7 +281,7 @@ public:
     /// \brief
     /// Compares this PrecisionModel object with the specified object
     /// for order.
-    //
+    ///
     /// A PrecisionModel is greater than another if it provides greater
     /// precision.
     /// The comparison is based on the value returned by the

--- a/include/geos/geom/prep/PreparedPolygonContains.h
+++ b/include/geos/geom/prep/PreparedPolygonContains.h
@@ -90,12 +90,12 @@ public:
 
 protected:
     /**
-    * Computes the full topological <tt>contains</tt> predicate.
-    * Used when short-circuit tests are not conclusive.
-    *
-    * @param geom the test geometry
-    * @return true if this prepared polygon contains the test geometry
-    */
+     * Computes the full topological <tt>contains</tt> predicate.
+     * Used when short-circuit tests are not conclusive.
+     *
+     * @param geom the test geometry
+     * @return true if this prepared polygon contains the test geometry
+     */
     bool fullTopologicalPredicate(const geom::Geometry* geom) override;
 
 };

--- a/include/geos/geomgraph/DirectedEdge.h
+++ b/include/geos/geomgraph/DirectedEdge.h
@@ -85,7 +85,7 @@ public:
     int getDepthDelta() const;
 
     /// Marks both DirectedEdges attached to a given Edge.
-    //
+    ///
     /// This is used for edges corresponding to lines, which will only
     /// appear oriented in a single direction in the result.
     ///

--- a/include/geos/geomgraph/EdgeIntersection.h
+++ b/include/geos/geomgraph/EdgeIntersection.h
@@ -102,7 +102,7 @@ public:
 };
 
 /// Strict weak ordering operator for EdgeIntersection
-//
+///
 /// This is the C++ equivalent of JTS's compareTo
 inline bool
 operator< (const EdgeIntersection& ei1, const EdgeIntersection& ei2)

--- a/include/geos/geomgraph/EdgeRing.h
+++ b/include/geos/geomgraph/EdgeRing.h
@@ -71,7 +71,7 @@ public:
 
     bool isHole();
 
-    /*
+    /**
      * Return a pointer to the LinearRing owned by
      * this object. Make a copy if you need it beyond
      * this objects's lifetime.
@@ -145,7 +145,7 @@ protected:
 
     const geom::GeometryFactory* geometryFactory;
 
-    /// throw(const TopologyException &)
+    /// @throws util::TopologyException
     void computePoints(DirectedEdge* newStart);
 
     void mergeLabel(const Label& deLabel);

--- a/include/geos/noding/OrientedCoordinateArray.h
+++ b/include/geos/noding/OrientedCoordinateArray.h
@@ -88,7 +88,7 @@ private:
      *
      * @param pts the array to test
      * @return <code>true</code> if the points are oriented forwards
-     * @return <code>false</code if the points are oriented in reverse
+     * @return <code>false</code> if the points are oriented in reverse
      */
     static bool orientation(const geom::CoordinateSequence& pts);
 
@@ -100,7 +100,7 @@ private:
 };
 
 /// Strict weak ordering operator for OrientedCoordinateArray
-//
+///
 /// This is the C++ equivalent of JTS's compareTo
 inline bool
 operator< (const OrientedCoordinateArray& oca1,

--- a/include/geos/noding/SegmentNode.h
+++ b/include/geos/noding/SegmentNode.h
@@ -66,7 +66,7 @@ public:
     size_t segmentIndex;
 
     /// Construct a node on the given NodedSegmentString
-    //
+    ///
     /// @param ss the parent NodedSegmentString
     ///
     /// @param nCoord the coordinate of the intersection, will be copied

--- a/include/geos/noding/SegmentString.h
+++ b/include/geos/noding/SegmentString.h
@@ -93,7 +93,7 @@ public:
     /// \brief
     /// Return a pointer to the CoordinateSequence associated
     /// with this SegmentString.
-    //
+    ///
     /// @note The CoordinateSequence is owned by this SegmentString!
     ///
     virtual geom::CoordinateSequence* getCoordinates() const = 0;

--- a/include/geos/operation/buffer/BufferBuilder.h
+++ b/include/geos/operation/buffer/BufferBuilder.h
@@ -222,7 +222,7 @@ private:
     /// \brief
     /// Return the externally-set noding::Noder OR a newly created
     /// one using the given precisionModel.
-    //
+    ///
     /// NOTE: if an externally-set noding::Noder is available no
     /// check is performed to ensure it will use the
     /// given PrecisionModel

--- a/include/geos/operation/buffer/BufferParameters.h
+++ b/include/geos/operation/buffer/BufferParameters.h
@@ -87,7 +87,7 @@ public:
     /// \brief
     /// The default number of facets into which to divide a fillet
     /// of 90 degrees.
-    //
+    ///
     /// A value of 8 gives less than 2% max error in the buffer distance.
     /// For a max error of < 1%, use QS = 12.
     /// For a max error of < 0.1%, use QS = 18.
@@ -95,7 +95,7 @@ public:
     static const int DEFAULT_QUADRANT_SEGMENTS = 8;
 
     /// The default mitre limit
-    //
+    ///
     /// Allows fairly pointy mitres.
     ///
     static const double DEFAULT_MITRE_LIMIT; // 5.0 (in .cpp file)
@@ -104,7 +104,7 @@ public:
     BufferParameters();
 
     /// Creates a set of parameters with the given quadrantSegments value.
-    //
+    ///
     /// @param quadrantSegments the number of quadrant segments to use
     ///
     BufferParameters(int quadrantSegments);
@@ -112,7 +112,7 @@ public:
     /// \brief
     /// Creates a set of parameters with the
     /// given quadrantSegments and endCapStyle values.
-    //
+    ///
     /// @param quadrantSegments the number of quadrant segments to use
     /// @param endCapStyle the end cap style to use
     ///
@@ -121,7 +121,7 @@ public:
     /// \brief
     /// Creates a set of parameters with the
     /// given parameter values.
-    //
+    ///
     /// @param quadrantSegments the number of quadrant segments to use
     /// @param endCapStyle the end cap style to use
     /// @param joinStyle the join style to use
@@ -131,7 +131,7 @@ public:
                      JoinStyle joinStyle, double mitreLimit);
 
     /// Gets the number of quadrant segments which will be used
-    //
+    ///
     /// @return the number of quadrant segments
     ///
     int
@@ -143,7 +143,7 @@ public:
     /// \brief
     /// Sets the number of line segments used to approximate
     /// an angle fillet.
-    //
+    ///
     /// - If <tt>quadSegs</tt> >= 1, joins are round,
     ///   and <tt>quadSegs</tt> indicates the number of
     ///   segments to use to approximate a quarter-circle.
@@ -166,15 +166,13 @@ public:
     /// (in other words, the computed buffer curve is always inside
     ///  the true curve).
     ///
-    /// @param quadSegs the number of segments in a
-    ///               fillet for a quadrant
-    ////
+    /// @param quadSegs the number of segments in a fillet for a quadrant
     void setQuadrantSegments(int quadSegs);
 
     /// \brief
     /// Computes the maximum distance error due to a given level
     /// of approximation to a true arc.
-    //
+    ///
     /// @param quadSegs the number of segments used to approximate
     ///                 a quarter-circle
     /// @return the error of approximation
@@ -182,7 +180,7 @@ public:
     static double bufferDistanceError(int quadSegs);
 
     /// Gets the end cap style.
-    //
+    ///
     /// @return the end cap style
     ///
     EndCapStyle
@@ -192,7 +190,7 @@ public:
     }
 
     /// Specifies the end cap style of the generated buffer.
-    //
+    ///
     /// The styles supported are CAP_ROUND, CAP_BUTT,
     /// and CAP_SQUARE.
     ///
@@ -207,7 +205,7 @@ public:
     }
 
     /// Gets the join style.
-    //
+    ///
     /// @return the join style
     ///
     JoinStyle
@@ -219,10 +217,10 @@ public:
     /// \brief
     /// Sets the join style for outside (reflex) corners between
     /// line segments.
-    //
+    ///
     /// Allowable values are JOIN_ROUND (which is the default),
     /// JOIN_MITRE and JOIN_BEVEL.
-    //
+    ///
     /// @param style the code for the join style
     ///
     void
@@ -232,7 +230,7 @@ public:
     }
 
     /// Gets the mitre ratio limit.
-    //
+    ///
     /// @return the limit value
     ///
     double
@@ -242,7 +240,7 @@ public:
     }
 
     /// Sets the limit on the mitre ratio used for very sharp corners.
-    //
+    ///
     /// The mitre ratio is the ratio of the distance from the corner
     /// to the end of the mitred offset corner.
     /// When two line segments meet at a sharp angle,

--- a/include/geos/operation/buffer/BufferSubgraph.h
+++ b/include/geos/operation/buffer/BufferSubgraph.h
@@ -80,7 +80,7 @@ private:
     void addReachable(geomgraph::Node* startNode);
 
     /// Adds the argument node and all its out edges to the subgraph
-    //
+    ///
     /// @param node the node to add
     /// @param nodeStack the current set of nodes being traversed
     ///

--- a/include/geos/operation/buffer/OffsetSegmentGenerator.h
+++ b/include/geos/operation/buffer/OffsetSegmentGenerator.h
@@ -94,7 +94,7 @@ public:
                           const geom::Coordinate& nS2, int nSide);
 
     /// Get coordinates by taking ownership of them
-    //
+    ///
     /// After this call, the coordinates reference in
     /// this object are dropped. Calling twice will
     /// segfault...
@@ -203,7 +203,7 @@ private:
     int closingSegLengthFactor; // 1;
 
     /// Owned by this object, destroyed by dtor
-    //
+    ///
     /// This actually gets created multiple times
     /// and each of the old versions is pushed
     /// to the ptLists std::vector to ensure all
@@ -237,7 +237,7 @@ private:
     void addCollinear(bool addStartPoint);
 
     /// The mitre will be beveled if it exceeds the mitre ratio limit.
-    //
+    ///
     /// @param offset0 the first offset segment
     /// @param offset1 the second offset segment
     /// @param distance the offset distance
@@ -248,7 +248,7 @@ private:
                       double distance);
 
     /// Adds a limited mitre join connecting the two reflex offset segments.
-    //
+    ///
     /// A limited mitre is a mitre which is beveled at the distance
     /// determined by the mitre ratio limit.
     ///
@@ -265,7 +265,7 @@ private:
     /// \brief
     /// Adds a bevel join connecting the two offset segments
     /// around a reflex corner.
-    //
+    ///
     /// @param offset0 the first offset segment
     /// @param offset1 the second offset segment
     ///
@@ -289,14 +289,14 @@ private:
     static const double SIMPLIFY_FACTOR; // 100.0;
 
     /// Adds the offset points for an outside (convex) turn
-    //
+    ///
     /// @param orientation
     /// @param addStartPoint
     ///
     void addOutsideTurn(int orientation, bool addStartPoint);
 
     /// Adds the offset points for an inside (concave) turn
-    //
+    ///
     /// @param orientation
     /// @param addStartPoint
     ///

--- a/include/geos/operation/buffer/OffsetSegmentString.h
+++ b/include/geos/operation/buffer/OffsetSegmentString.h
@@ -34,7 +34,7 @@ namespace operation { // geos.operation
 namespace buffer { // geos.operation.buffer
 
 /// A dynamic list of the vertices in a constructed offset curve.
-//
+///
 /// Automatically removes close vertices
 /// which are closer than a given tolerance.
 ///
@@ -154,7 +154,7 @@ public:
     }
 
     /// Check that points are a ring
-    //
+    ///
     /// add the startpoint again if they are not
     void
     closeRing()
@@ -172,7 +172,7 @@ public:
     }
 
     /// Get coordinates by taking ownership of them
-    //
+    ///
     /// After this call, the coordinates reference in
     /// this object are dropped. Calling twice will
     /// segfault...

--- a/include/geos/operation/linemerge/EdgeString.h
+++ b/include/geos/operation/linemerge/EdgeString.h
@@ -60,7 +60,7 @@ private:
     geom::CoordinateArraySequence* coordinates;
     geom::CoordinateSequence* getCoordinates();
 public:
-    /*
+    /**
      * \brief
      * Constructs an EdgeString with the given factory used to
      * convert this EdgeString to a LineString
@@ -74,7 +74,7 @@ public:
     */
     void add(LineMergeDirectedEdge* directedEdge);
 
-    /*
+    /**
      * Converts this EdgeString into a LineString.
      */
     geom::LineString* toLineString();

--- a/include/geos/operation/overlay/OverlayOp.h
+++ b/include/geos/operation/overlay/OverlayOp.h
@@ -63,7 +63,7 @@ namespace operation { // geos::operation
 namespace overlay { // geos::operation::overlay
 
 /// \brief Computes the geometric overlay of two Geometry.
-//
+///
 /// The overlay can be used to determine any
 /// boolean combination of the geometries.
 ///
@@ -72,7 +72,7 @@ class GEOS_DLL OverlayOp: public GeometryGraphOperation {
 public:
 
     ///  \brief The spatial functions supported by this class.
-    //
+    ///
     /// These operations implement various boolean combinations of
     /// the resultants of the overlay.
     ///
@@ -116,13 +116,13 @@ public:
     static bool isResultOfOp(const geomgraph::Label& label, OpCode opCode);
 
     /// \brief This method will handle arguments of Location.NULL correctly
-    //
+    ///
     /// @return true if the locations correspond to the opCode
     ///
     static bool isResultOfOp(geom::Location loc0, geom::Location loc1, OpCode opCode);
 
     /// \brief Construct an OverlayOp with the given Geometry args.
-    //
+    ///
     /// Ownership of passed args will remain to caller, and
     /// the OverlayOp won't change them in any way.
     ///

--- a/include/geos/operation/overlay/snap/LineStringSnapper.h
+++ b/include/geos/operation/overlay/snap/LineStringSnapper.h
@@ -119,7 +119,7 @@ private:
     /// \brief
     /// Finds a src segment which snaps to (is close to) the given snap
     /// point.
-    //
+    ///
     /// Only a single segment is selected for snapping.
     /// This prevents multiple segments snapping to the same snap vertex,
     /// which would almost certainly cause invalid geometry

--- a/include/geos/operation/overlay/validate/FuzzyPointLocator.h
+++ b/include/geos/operation/overlay/validate/FuzzyPointLocator.h
@@ -77,7 +77,7 @@ private:
     std::unique_ptr<geom::Geometry> getLineWork(const geom::Geometry& geom);
 
     /// Extracts linework for polygonal components.
-    //
+    ///
     /// @param geom the geometry from which to extract
     /// @return a lineal geometry containing the extracted linework
     std::unique_ptr<geom::Geometry> extractLineWork(const geom::Geometry& geom);

--- a/include/geos/operation/polygonize/EdgeRing.h
+++ b/include/geos/operation/polygonize/EdgeRing.h
@@ -59,7 +59,7 @@ namespace geos {
 namespace operation { // geos::operation
 namespace polygonize { // geos::operation::polygonize
 
-/**\brief
+/** \brief
  * Represents a ring of PolygonizeDirectedEdge which form
  * a ring of a polygon.  The ring may be either an outer shell or a hole.
  */

--- a/include/geos/operation/sharedpaths/SharedPathsOp.h
+++ b/include/geos/operation/sharedpaths/SharedPathsOp.h
@@ -70,7 +70,7 @@ public:
     typedef std::vector<geom::LineString*> PathList;
 
     /// Find paths shared between two linear geometries
-    //
+    ///
     /// @param g1
     ///   First geometry. Must be linear.
     ///
@@ -93,7 +93,7 @@ public:
                               PathList& oppositeDirection);
 
     /// Constructor
-    //
+    ///
     /// @param g1
     ///   First geometry. Must be linear.
     ///
@@ -103,7 +103,7 @@ public:
     SharedPathsOp(const geom::Geometry& g1, const geom::Geometry& g2);
 
     /// Get shared paths
-    //
+    ///
     /// @param sameDirection
     ///   Shared edges having the same direction are pushed
     ///   onto this vector. They'll be of type geom::LineString.
@@ -122,7 +122,7 @@ public:
 private:
 
     /// Get all the linear intersections
-    //
+    ///
     /// Ownership of linestring pushed to the given container
     /// is transferred to caller. See clearEdges for a deep
     /// release if you need one.
@@ -130,7 +130,7 @@ private:
     void findLinearIntersections(PathList& to);
 
     /// Check if the given edge goes forward or backward on the given line.
-    //
+    ///
     /// PRECONDITION: It is assumed the edge fully lays on the geometry
     ///
     bool isForward(const geom::LineString& edge,

--- a/include/geos/planargraph/Subgraph.h
+++ b/include/geos/planargraph/Subgraph.h
@@ -39,7 +39,7 @@ namespace geos {
 namespace planargraph { // geos.planargraph
 
 /// \brief A subgraph of a PlanarGraph.
-//
+///
 /// A subgraph may contain any subset of {@link Edge}s
 /// from the parent graph.
 /// It will also automatically contain all {@link DirectedEdge}s

--- a/include/geos/precision/PrecisionReducerCoordinateOperation.h
+++ b/include/geos/precision/PrecisionReducerCoordinateOperation.h
@@ -55,7 +55,7 @@ public:
     {}
 
     /// Ownership of returned CoordinateSequence to caller
-    //
+    ///
     /// virtual function
     std::unique_ptr<geom::CoordinateSequence> edit(const geom::CoordinateSequence* coordinates,
                                                    const geom::Geometry* geom) override;

--- a/include/geos/simplify/TaggedLineString.h
+++ b/include/geos/simplify/TaggedLineString.h
@@ -53,9 +53,7 @@ namespace simplify { // geos::simplify
 
 
 /** \brief
- *
- * Contains and owns a list of TaggedLineSegments
- *
+ * Contains and owns a list of TaggedLineSegments.
  */
 class GEOS_DLL TaggedLineString {
 

--- a/include/geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h
+++ b/include/geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h
@@ -30,14 +30,12 @@ namespace quadedge { //geos.triangulate.quadedge
 class QuadEdgeSubdivision;
 
 /** \brief
-* Locates {@link QuadEdge}s in a {@link QuadEdgeSubdivision},
-* optimizing the search by starting in the
-* locality of the last edge found.
-*
-* @author JTS: Martin Davis
-* @author Benjamin Campbell
-*/
-
+ * Locates {@link QuadEdge}s in a {@link QuadEdgeSubdivision}, optimizing the
+ * search by starting in the locality of the last edge found.
+ *
+ * @author JTS: Martin Davis
+ * @author Benjamin Campbell
+ */
 class LastFoundQuadEdgeLocator : public QuadEdgeLocator {
 private:
     QuadEdgeSubdivision* subdiv;

--- a/src/algorithm/Area.cpp
+++ b/src/algorithm/Area.cpp
@@ -48,7 +48,7 @@ Area::ofRingSigned(const std::vector<geom::Coordinate>& ring)
     }
 
     double sum = 0.0;
-    /**
+    /*
      * Based on the Shoelace formula.
      * http://en.wikipedia.org/wiki/Shoelace_formula
      */
@@ -70,10 +70,10 @@ Area::ofRingSigned(const geom::CoordinateSequence* ring)
     if(n < 3) {
         return 0.0;
     }
-    /**
-    * Based on the Shoelace formula.
-    * http://en.wikipedia.org/wiki/Shoelace_formula
-    */
+    /*
+     * Based on the Shoelace formula.
+     * http://en.wikipedia.org/wiki/Shoelace_formula
+     */
     geom::Coordinate p0, p1, p2;
     p1 = ring->getAt(0);
     p2 = ring->getAt(1);

--- a/src/algorithm/ConvexHull.cpp
+++ b/src/algorithm/ConvexHull.cpp
@@ -190,7 +190,7 @@ ConvexHull::reduce(Coordinate::ConstVect& pts)
     Coordinate::ConstSet reducedSet;
     reducedSet.insert(polyPts.begin(), polyPts.end());
 
-    /**
+    /*
      * Add all unique points not in the interior poly.
      * CGAlgorithms.isPointInRing is not defined for points
      * actually on the ring, but this doesn't matter since

--- a/src/algorithm/InteriorPointArea.cpp
+++ b/src/algorithm/InteriorPointArea.cpp
@@ -151,11 +151,11 @@ public:
     {
         vector<double> crossings;
 
-        /**
+        /*
          * This results in returning a null Coordinate
          */
         if (polygon.isEmpty()) return;
-        /**
+        /*
          * set default interior point in case polygon has zero area
          */
         interiorPoint = *polygon.getCoordinate();

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -435,7 +435,7 @@ LineIntersector::computeIntersect(const Coordinate& p1, const Coordinate& p2,
         return computeCollinearIntersection(p1, p2, q1, q2);
     }
 
-    /**
+    /*
      * At this point we know that there is a single intersection point
      * (since the lines are not collinear).
      */
@@ -493,7 +493,7 @@ LineIntersector::computeIntersect(const Coordinate& p1, const Coordinate& p2,
 #endif
         }
 
-        /**
+        /*
          * Now check to see if any endpoint lies on the interior of the other segment.
          */
         else if(Pq1 == 0) {

--- a/src/algorithm/MinimumBoundingCircle.cpp
+++ b/src/algorithm/MinimumBoundingCircle.cpp
@@ -182,10 +182,10 @@ MinimumBoundingCircle::computeCirclePoints()
         return;
     }
 
-    /**
-    * The problem is simplified by reducing to the convex hull.
-    * Computing the convex hull also has the useful effect of eliminating duplicate points
-    */
+    /*
+     * The problem is simplified by reducing to the convex hull.
+     * Computing the convex hull also has the useful effect of eliminating duplicate points
+     */
     std::unique_ptr<Geometry> convexHull(input->convexHull());
 
     std::unique_ptr<CoordinateSequence> cs(convexHull->getCoordinates());
@@ -197,9 +197,9 @@ MinimumBoundingCircle::computeCirclePoints()
         pts.pop_back();
     }
 
-    /**
-    * Optimization for the trivial case where the CH has fewer than 3 points
-    */
+    /*
+     * Optimization for the trivial case where the CH has fewer than 3 points
+     */
     if(pts.size() <= 2) {
         extremalPts = pts;
         return;
@@ -211,13 +211,13 @@ MinimumBoundingCircle::computeCirclePoints()
     // find a point Q such that the angle that PQ makes with the x-axis is minimal
     Coordinate Q = pointWitMinAngleWithX(pts, P);
 
-    /**
-    * Iterate over the remaining points to find
-    * a pair or triplet of points which determine the minimal circle.
-    * By the design of the algorithm,
-    * at most <tt>pts.length</tt> iterations are required to terminate
-    * with a correct result.
-    */
+    /*
+     * Iterate over the remaining points to find
+     * a pair or triplet of points which determine the minimal circle.
+     * By the design of the algorithm,
+     * at most <tt>pts.length</tt> iterations are required to terminate
+     * with a correct result.
+     */
     size_t i = 0, n = pts.size();
     while(i++ < n) {
         Coordinate R = pointWithMinAngleWithSegment(pts, P, Q);

--- a/src/algorithm/MinimumBoundingCircle.cpp
+++ b/src/algorithm/MinimumBoundingCircle.cpp
@@ -275,9 +275,9 @@ MinimumBoundingCircle::pointWitMinAngleWithX(std::vector<Coordinate>& pts, Coord
             continue;
         }
 
-        /**
-        * The sin of the angle is a simpler proxy for the angle itself
-        */
+        /*
+         * The sin of the angle is a simpler proxy for the angle itself
+         */
         double dx = p.x - P.x;
         double dy = p.y - P.y;
         if(dy < 0) {

--- a/src/algorithm/Orientation.cpp
+++ b/src/algorithm/Orientation.cpp
@@ -97,7 +97,7 @@ Orientation::isCCW(const geom::CoordinateSequence* ring)
 
     int disc = Orientation::index(*prev, *hiPt, *next);
 
-    /**
+    /*
      *  If disc is exactly 0, lines are collinear.
      * There are two possible cases:
      *  (1) the lines lie along the x axis in opposite directions

--- a/src/algorithm/distance/DiscreteHausdorffDistance.cpp
+++ b/src/algorithm/distance/DiscreteHausdorffDistance.cpp
@@ -32,7 +32,7 @@ void
 DiscreteHausdorffDistance::MaxDensifiedByFractionDistanceFilter::filter_ro(
     const geom::CoordinateSequence& seq, size_t index)
 {
-    /**
+    /*
      * This logic also handles skipping Point geometries
      */
     if(index == 0) {

--- a/src/algorithm/locate/SimplePointInAreaLocator.cpp
+++ b/src/algorithm/locate/SimplePointInAreaLocator.cpp
@@ -44,7 +44,7 @@ SimplePointInAreaLocator::locate(const Coordinate& p, const Geometry* geom)
         return Location::EXTERIOR;
     }
 
-    /**
+    /*
      * Do a fast check against the geometry envelope first
      */
     if (! geom->getEnvelopeInternal()->intersects(p))

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -303,7 +303,7 @@ Geometry::intersects(const Geometry* g) const
     }
 #endif
 
-    /**
+    /*
      * TODO: (MD) Add optimizations:
      *
      * - for P-A case:
@@ -523,9 +523,9 @@ Geometry::convexHull() const
 std::unique_ptr<Geometry>
 Geometry::intersection(const Geometry* other) const
 {
-    /**
-    * TODO: MD - add optimization for P-A case using Point-In-Polygon
-    */
+    /*
+     * TODO: MD - add optimization for P-A case using Point-In-Polygon
+     */
 
     // special case: if one input is empty ==> empty
     if(isEmpty() || other->isEmpty()) {

--- a/src/geom/prep/PreparedLineStringIntersects.cpp
+++ b/src/geom/prep/PreparedLineStringIntersects.cpp
@@ -35,7 +35,7 @@ namespace prep { // geos.geom.prep
 bool
 PreparedLineStringIntersects::isAnyTestPointInTarget(const geom::Geometry* testGeom) const
 {
-    /**
+    /*
      * This could be optimized by using the segment index on the lineal target.
      * However, it seems like the L/P case would be pretty rare in practice.
      */

--- a/src/geom/prep/PreparedPolygonContainsProperly.cpp
+++ b/src/geom/prep/PreparedPolygonContainsProperly.cpp
@@ -67,7 +67,7 @@ PreparedPolygonContainsProperly::containsProperly(const geom::Geometry* geom)
         return false;
     }
 
-    /**
+    /*
      * Given that no segments intersect, if any vertex of the target
      * is contained in some test component.
      * the test is NOT properly contained.

--- a/src/geom/util/PointExtracter.cpp
+++ b/src/geom/util/PointExtracter.cpp
@@ -33,9 +33,9 @@ PointExtracter::getPoints(const Geometry& geom, Point::ConstVect& ret)
 }
 
 /**
-* Constructs a PointExtracterFilter with a list in which
-* to store Points found.
-*/
+ * Constructs a PointExtracterFilter with a list in which
+ * to store Points found.
+ */
 PointExtracter::PointExtracter(Point::ConstVect& newComps)
     :
     comps(newComps)

--- a/src/geomgraph/DirectedEdgeStar.cpp
+++ b/src/geomgraph/DirectedEdgeStar.cpp
@@ -366,7 +366,7 @@ DirectedEdgeStar::findCoveredLineEdges()
     // Since edges are stored in CCW order around the node,
     // as we move around the ring we move from the right to the left side of the edge
 
-    /**
+    /*
      * Find first DirectedEdge of result area (if any).
      * The interior of the result is on the RHS of the edge,
      * so the start location will be:
@@ -401,7 +401,7 @@ DirectedEdgeStar::findCoveredLineEdges()
         return;
     }
 
-    /**
+    /*
      * move around ring, keeping track of the current location
      * (Interior or Exterior) for the result area.
      * If L edges are found, mark them as covered if they are in the interior

--- a/src/geomgraph/EdgeEndStar.cpp
+++ b/src/geomgraph/EdgeEndStar.cpp
@@ -105,7 +105,7 @@ EdgeEndStar::computeLabelling(std::vector<GeometryGraph*>* geomGraph)
     propagateSideLabels(0);
     propagateSideLabels(1);
 
-    /**
+    /*
      * If there are edges that still have null labels for a geometry
      * this must be because there are no area edges for that geometry
      * incident on this node.
@@ -322,7 +322,7 @@ EdgeEndStar::propagateSideLabels(int geomIndex)
                 currLoc = leftLoc;
             }
             else {
-                /**
+                /*
                  * RHS is null - LHS must be null too.
                  * This must be an edge from the other
                  * geometry, which has no location

--- a/src/geomgraph/Position.cpp
+++ b/src/geomgraph/Position.cpp
@@ -31,9 +31,9 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /**
-* Returns LEFT if the position is RIGHT, RIGHT if the position is LEFT, or the position
-* otherwise.
-*/
+ * Returns LEFT if the position is RIGHT, RIGHT if the position is LEFT, or the position
+ * otherwise.
+ */
 int
 Position::opposite(int position)
 {

--- a/src/geomgraph/index/MonotoneChainIndexer.cpp
+++ b/src/geomgraph/index/MonotoneChainIndexer.cpp
@@ -47,8 +47,8 @@ MonotoneChainIndexer::getChainStartIndices(const CoordinateSequence* pts,
 }
 
 /**
-* @return the index of the last point in the monotone chain
-*/
+ * @return the index of the last point in the monotone chain
+ */
 size_t
 MonotoneChainIndexer::findChainEnd(const CoordinateSequence* pts, size_t start)
 {

--- a/src/geomgraph/index/SimpleSweepLineIntersector.cpp
+++ b/src/geomgraph/index/SimpleSweepLineIntersector.cpp
@@ -132,7 +132,7 @@ SimpleSweepLineIntersector::processOverlaps(size_t start, size_t end, SweepLineE
 
     SweepLineSegment* ss0 = (SweepLineSegment*) ev0->getObject();
 
-    /**
+    /*
      * Since we might need to test for self-intersections,
      * include current insert event object in list of event objects to test.
      * Last index can be skipped, because it must be a Delete event.

--- a/src/index/bintree/Bintree.cpp
+++ b/src/index/bintree/Bintree.cpp
@@ -131,8 +131,8 @@ Bintree::query(double x)
 }
 
 /**
-* min and max may be the same value
-*/
+ * min and max may be the same value
+ */
 vector<void*>*
 Bintree::query(Interval* interval)
 {

--- a/src/index/bintree/Bintree.cpp
+++ b/src/index/bintree/Bintree.cpp
@@ -136,10 +136,10 @@ Bintree::query(double x)
 vector<void*>*
 Bintree::query(Interval* interval)
 {
-    /**
-    * the items that are matched are all items in intervals
-    * which overlap the query interval
-    */
+    /*
+     * the items that are matched are all items in intervals
+     * which overlap the query interval
+     */
     vector<void*>* foundItems = new vector<void*>();
     query(interval, foundItems);
     return foundItems;

--- a/src/index/bintree/Root.cpp
+++ b/src/index/bintree/Root.cpp
@@ -37,13 +37,13 @@ Root::insert(Interval* itemInterval, void* item)
         return;
     }
 
-    /**
+    /*
      * the item must be contained in one interval, so insert it into the
      * tree for that interval (which may not yet exist)
      */
     Node* node = subnode[index];
 
-    /**
+    /*
      *  If the subnode doesn't exist or this item is not contained in it,
      *  have to expand the tree upward to contain the item.
      */
@@ -52,10 +52,10 @@ Root::insert(Interval* itemInterval, void* item)
 //		delete subnode[index];
         subnode[index] = largerNode;
     }
-    /**
-    * At this point we have a subnode which exists and must contain
-    * contains the env for the item.  Insert the item into the tree.
-    */
+    /*
+     * At this point we have a subnode which exists and must contain
+     * contains the env for the item.  Insert the item into the tree.
+     */
     insertContained(subnode[index], itemInterval, item);
     //System.out.println("depth = " + root.depth() + " size = " + root.size());
 }
@@ -67,7 +67,7 @@ Root::insertContained(Node* tree, Interval* itemInterval, void* item)
 
     assert(tree->getInterval()->contains(itemInterval));
 
-    /**
+    /*
      * Do NOT create a new node for zero-area intervals - this would lead
      * to infinite recursion. Instead, use a heuristic of simply returning
      * the smallest existing node containing the query

--- a/src/index/intervalrtree/SortedPackedIntervalRTree.cpp
+++ b/src/index/intervalrtree/SortedPackedIntervalRTree.cpp
@@ -37,10 +37,10 @@ SortedPackedIntervalRTree::init()
     if(root != nullptr)
         return;
 
-    /**
-    * if leaves is empty then nothing has been inserted.
-    * In this case it is safe to leave the tree in an open state
-    */
+    /*
+     * if leaves is empty then nothing has been inserted.
+     * In this case it is safe to leave the tree in an open state
+     */
     if (leaves.empty()) return;
 
     root = buildTree();

--- a/src/index/quadtree/Root.cpp
+++ b/src/index/quadtree/Root.cpp
@@ -116,7 +116,7 @@ Root::insertContained(Node* tree, const Envelope* itemEnv, void* item)
 {
     assert(tree->getEnvelope()->contains(itemEnv));
 
-    /**
+    /*
      * Do NOT create a new quad for zero-area envelopes - this would lead
      * to infinite recursion. Instead, use a heuristic of simply returning
      * the smallest existing quad containing the query

--- a/src/index/strtree/BoundablePair.cpp
+++ b/src/index/strtree/BoundablePair.cpp
@@ -92,7 +92,7 @@ BoundablePair::expandToQueue(BoundablePairQueue& priQ, double minDistance)
     bool isComp1 = isComposite(boundable1);
     bool isComp2 = isComposite(boundable2);
 
-    /**
+    /*
      * HEURISTIC: If both boundables are composite,
      * choose the one with largest area to expand.
      * Otherwise, simply expand whichever is composite.

--- a/src/index/strtree/SIRtree.cpp
+++ b/src/index/strtree/SIRtree.cpp
@@ -128,8 +128,8 @@ SIRtree::createNode(int level)
 }
 
 /**
-* Inserts an item having the given bounds into the tree.
-*/
+ * Inserts an item having the given bounds into the tree.
+ */
 void
 SIRtree::insert(double x1, double x2, void* item)
 {

--- a/src/index/strtree/STRtree.cpp
+++ b/src/index/strtree/STRtree.cpp
@@ -226,7 +226,7 @@ STRtree::nearestNeighbour(BoundablePair* initBndPair, double maxDistance)
         BoundablePair* bndPair = priQ.top();
         double currentDistance = bndPair->getDistance();
 
-        /**
+        /*
          * If the distance for the first node in the queue
          * is >= the current minimum distance, all other nodes
          * in the queue must also have a greater distance.
@@ -239,7 +239,7 @@ STRtree::nearestNeighbour(BoundablePair* initBndPair, double maxDistance)
 
         priQ.pop();
 
-        /**
+        /*
          * If the pair members are leaves
          * then their distance is the exact lower bound.
          * Update the distanceLowerBound to reflect this
@@ -251,7 +251,7 @@ STRtree::nearestNeighbour(BoundablePair* initBndPair, double maxDistance)
             minPair = bndPair;
         }
         else {
-            /**
+            /*
              * Otherwise, expand one side of the pair,
              * (the choice of which side to expand is heuristically determined)
              * and insert the new expanded pairs into the queue
@@ -307,32 +307,32 @@ bool STRtree::isWithinDistance(BoundablePair* initBndPair, double maxDistance)
         BoundablePair* bndPair = priQ.top();
         double currentDistance = bndPair->getDistance();
 
-        /**
-        * If the distance for the first pair in the queue
-        * is >= maxDistance, other pairs
-        * in the queue must also have a greater distance.
-        * So can conclude no items are within the distance
-        * and terminate with false
-        */
+        /*
+         * If the distance for the first pair in the queue
+         * is >= maxDistance, other pairs
+         * in the queue must also have a greater distance.
+         * So can conclude no items are within the distance
+         * and terminate with false
+         */
         if (currentDistance > maxDistance)
             return false;
 
-        /**
-        * There must be some pair of items in the nodes which
-        * are closer than the max distance,
-        * so can terminate with true.
-        *
-        * NOTE: using the Envelope MinMaxDistance would provide a tighter bound,
-        * but not sure how to compute this!
-        */
+        /*
+         * There must be some pair of items in the nodes which
+         * are closer than the max distance,
+         * so can terminate with true.
+         *
+         * NOTE: using the Envelope MinMaxDistance would provide a tighter bound,
+         * but not sure how to compute this!
+         */
         if (bndPair->maximumDistance() <= maxDistance)
             return true;
 
-        /**
-        * If the pair members are leaves
-        * then their distance is an upper bound.
-        * Update the distanceUpperBound to reflect this
-        */
+        /*
+         * If the pair members are leaves
+         * then their distance is an upper bound.
+         * Update the distanceUpperBound to reflect this
+         */
         if (bndPair->isLeaves()) {
             distanceUpperBound = currentDistance;
 
@@ -342,11 +342,11 @@ bool STRtree::isWithinDistance(BoundablePair* initBndPair, double maxDistance)
                 return true;
         }
         else {
-            /**
-            * Otherwise, expand one side of the pair,
-            * and insert the expanded pairs into the queue.
-            * The choice of which side to expand is determined heuristically.
-            */
+            /*
+             * Otherwise, expand one side of the pair,
+             * and insert the expanded pairs into the queue.
+             * The choice of which side to expand is determined heuristically.
+             */
             bndPair->expandToQueue(priQ, distanceUpperBound);
         }
     }

--- a/src/index/sweepline/SweepLineIndex.cpp
+++ b/src/index/sweepline/SweepLineIndex.cpp
@@ -83,7 +83,7 @@ void
 SweepLineIndex::processOverlaps(size_t start, size_t end,
                                 SweepLineInterval* s0, SweepLineOverlapAction* action)
 {
-    /**
+    /*
      * Since we might need to test for self-intersections,
      * include current insert event object in list of event objects to test.
      * Last index can be skipped, because it must be a Delete event.

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -252,11 +252,11 @@ WKTWriter::appendLineStringTaggedText(const LineString* lineString, int p_level,
     appendLineStringText(lineString, p_level, false, writer);
 }
 
-/*
- * Converts a <code>LinearRing</code> to &lt;LinearRing Tagged Text&gt;
+/**
+ * Converts a `LinearRing` to \<LinearRing Tagged Text\>
  * format, then appends it to the writer.
  *
- * @param  linearRing  the <code>LinearRing</code> to process
+ * @param  linearRing  the `LinearRing` to process
  * @param  writer      the output writer to append to
  */
 void

--- a/src/linearref/ExtractLineByLocation.cpp
+++ b/src/linearref/ExtractLineByLocation.cpp
@@ -120,7 +120,7 @@ ExtractLineByLocation::computeLine(const LinearLocation& start, const LinearLoca
         newCoordinateArray.add(start.getCoordinate(line));
     }
 
-    /**
+    /*
      * Ensure there is enough coordinates to build a valid line.
      * Make a 2-point line with duplicate coordinates, if necessary.
      * There will always be at least one coordinate in the coordList.

--- a/src/linearref/LengthIndexOfPoint.cpp
+++ b/src/linearref/LengthIndexOfPoint.cpp
@@ -71,7 +71,7 @@ LengthIndexOfPoint::indexOfAfter(const Coordinate& inputPt, double minIndex) con
     }
 
     double closestAfter = indexOfFromStart(inputPt, minIndex);
-    /**
+    /*
      * Return the minDistanceLocation found.
      * This will not be null, since it was initialized to minLocation
      */

--- a/src/linearref/LengthLocationMap.cpp
+++ b/src/linearref/LengthLocationMap.cpp
@@ -84,7 +84,7 @@ LengthLocationMap::getLocationForward(double length) const
 
     LinearIterator it(linearGeom);
     while(it.hasNext()) {
-        /**
+        /*
          * Special handling is required for the situation when the
          * length references exactly to a component endpoint.
          * In this case, the endpoint location of the current component

--- a/src/linearref/LocationIndexOfPoint.cpp
+++ b/src/linearref/LocationIndexOfPoint.cpp
@@ -113,7 +113,7 @@ LocationIndexOfPoint::indexOfAfter(const Coordinate& inputPt,
     }
 
     LinearLocation closestAfter = indexOfFromStart(inputPt, minIndex);
-    /**
+    /*
      * Return the minDistanceLocation found.
      * This will not be null, since it was initialized to minLocation
      */

--- a/src/noding/IteratedNoder.cpp
+++ b/src/noding/IteratedNoder.cpp
@@ -78,7 +78,7 @@ IteratedNoder::computeNodes(SegmentString::NonConstVect* segStrings)
         nodingIterationCount++;
         int nodesCreated = numInteriorIntersections;
 
-        /**
+        /*
          * Fail if the number of nodes created is not declining.
          * However, allow a few iterations at least before doing this
          */

--- a/src/noding/MCIndexNoder.cpp
+++ b/src/noding/MCIndexNoder.cpp
@@ -75,7 +75,7 @@ MCIndexNoder::intersectChains()
             MonotoneChain* testChain = static_cast<MonotoneChain*>(hit);
             assert(testChain);
 
-            /**
+            /*
              * following test makes sure we only compare each
              * pair of chains once and that we don't compare a
              * chain to itself

--- a/src/noding/NodingIntersectionFinder.cpp
+++ b/src/noding/NodingIntersectionFinder.cpp
@@ -102,7 +102,7 @@ NodingIntersectionFinder::processIntersections(
         return;
     }
 
-    /**
+    /*
      * If enabled, only test end segments (on either segString).
      */
     if(isCheckEndSegmentsOnly) {

--- a/src/noding/snapround/MCIndexPointSnapper.cpp
+++ b/src/noding/snapround/MCIndexPointSnapper.cpp
@@ -53,12 +53,12 @@ public:
     {}
 
     /**
-    * Reports whether the HotPixel caused a node to be added in any target
-    * segmentString (including its own). If so, the HotPixel must be added as a
-    * node as well.
-    *
-    * @return true if a node was added in any target segmentString.
-    */
+     * Reports whether the HotPixel caused a node to be added in any target
+     * segmentString (including its own). If so, the HotPixel must be added as a
+     * node as well.
+     *
+     * @return true if a node was added in any target segmentString.
+     */
     bool
     isNodeAdded() const
     {
@@ -66,12 +66,12 @@ public:
     }
 
     /**
-    * Check if a segment of the monotone chain intersects
-    * the hot pixel vertex and introduce a snap node if so.
-    * Optimized to avoid noding segments which
-    * contain the vertex (which otherwise
-    * would cause every vertex to be noded).
-    */
+     * Check if a segment of the monotone chain intersects
+     * the hot pixel vertex and introduce a snap node if so.
+     * Optimized to avoid noding segments which
+     * contain the vertex (which otherwise
+     * would cause every vertex to be noded).
+     */
     void
     select(chain::MonotoneChain& mc, size_t startIndex) override
     {

--- a/src/operation/buffer/BufferInputLineSimplifier.cpp
+++ b/src/operation/buffer/BufferInputLineSimplifier.cpp
@@ -79,7 +79,7 @@ BufferInputLineSimplifier::simplify(double nDistanceTol)
 bool
 BufferInputLineSimplifier::deleteShallowConcavities()
 {
-    /**
+    /*
      * Do not simplify end line segments of the line string.
      * This ensures that end caps are generated consistently.
      */

--- a/src/operation/buffer/BufferParameters.cpp
+++ b/src/operation/buffer/BufferParameters.cpp
@@ -90,7 +90,7 @@ BufferParameters::setQuadrantSegments(int quadSegs)
 {
     quadrantSegments = quadSegs;
 
-    /**
+    /*
      * Indicates how to construct fillets.
      * If qs >= 1, fillet is round, and qs indicates number of
      * segments to use to approximate a quarter-circle.
@@ -112,7 +112,7 @@ BufferParameters::setQuadrantSegments(int quadSegs)
         quadrantSegments = 1;
     }
 
-    /**
+    /*
      * If join style was set by the quadSegs value,
      * use the default for the actual quadrantSegments value.
      */

--- a/src/operation/buffer/BufferSubgraph.cpp
+++ b/src/operation/buffer/BufferSubgraph.cpp
@@ -108,7 +108,7 @@ BufferSubgraph::add(Node* node, vector<Node*>* nodeStack)
         dirEdgeList.push_back(de);
         DirectedEdge* sym = de->getSym();
         Node* symNode = sym->getNode();
-        /**
+        /*
          * NOTE: this is a depth-first traversal of the graph.
          * This will cause a large depth of recursion.
          * It might be better to do a breadth-first traversal.
@@ -216,7 +216,7 @@ BufferSubgraph::findResultEdges()
     for(size_t i = 0, n = dirEdgeList.size(); i < n; ++i) {
         DirectedEdge* de = dirEdgeList[i];
 
-        /**
+        /*
          * Select edges which have an interior depth on the RHS
          * and an exterior depth on the LHS.
          * Note that because of weird rounding effects there may be

--- a/src/operation/buffer/OffsetCurveSetBuilder.cpp
+++ b/src/operation/buffer/OffsetCurveSetBuilder.cpp
@@ -332,7 +332,7 @@ OffsetCurveSetBuilder::isErodedCompletely(const LinearRing* ring,
         return true;
     }
 
-    /**
+    /*
      * The following is a heuristic test to determine whether an
      * inside buffer will be eroded completely->
      * It is based on the fact that the minimum diameter of the ring

--- a/src/operation/buffer/OffsetSegmentGenerator.cpp
+++ b/src/operation/buffer/OffsetSegmentGenerator.cpp
@@ -84,7 +84,7 @@ OffsetSegmentGenerator::OffsetSegmentGenerator(
     // the points are rounded as they are inserted into the curve line
     filletAngleQuantum = PI / 2.0 / bufParams.getQuadrantSegments();
 
-    /**
+    /*
      * Non-round joins cause issues with short closing segments,
      * so don't use them.  In any case, non-round joins
      * only really make sense for relatively small buffer distances.
@@ -108,7 +108,7 @@ OffsetSegmentGenerator::init(double newDistance)
     segList.reset();
     segList.setPrecisionModel(precisionModel);
 
-    /**
+    /*
      * Choose the min vertex separation as a small fraction of
      * the offset distance.
      */
@@ -322,7 +322,7 @@ OffsetSegmentGenerator::createSquare(const Coordinate& p, double p_distance)
 void
 OffsetSegmentGenerator::addCollinear(bool addStartPoint)
 {
-    /**
+    /*
      * This test could probably be done more efficiently,
      * but the situation of exact collinearity should be fairly rare.
      */
@@ -330,13 +330,13 @@ OffsetSegmentGenerator::addCollinear(bool addStartPoint)
     li.computeIntersection(s0, s1, s1, s2);
     auto numInt = li.getIntersectionNum();
 
-    /**
+    /*
      * if numInt is<2, the lines are parallel and in the same direction.
      * In this case the point can be ignored, since the offset lines
      * will also be parallel.
      */
     if(numInt >= 2) {
-        /**
+        /*
          * Segments are collinear but reversing.
          * Add an "end-cap" fillet
          * all the way around to other direction
@@ -364,7 +364,7 @@ OffsetSegmentGenerator::addCollinear(bool addStartPoint)
 void
 OffsetSegmentGenerator::addOutsideTurn(int orientation, bool addStartPoint)
 {
-    /**
+    /*
      * Heuristic: If offset endpoints are very close together,
      * just use one of them as the corner vertex.
      * This avoids problems with computing mitre corners in the case
@@ -429,13 +429,13 @@ OffsetSegmentGenerator::addInsideTurn(int orientation, bool addStartPoint)
     // (But not too short, since that would defeat it's purpose).
     // This is the purpose of the closingSegLengthFactor heuristic value.
 
-    /**
+    /*
      * The intersection test above is vulnerable to robustness errors;
-    * i.e. it may be that the offsets should intersect very close to
-    * their endpoints, but aren't reported as such due to rounding.
-    * To handle this situation appropriately, we use the following test:
-    * If the offset points are very close, don't add closing segments
-    * but simply use one of the offset points
+     * i.e. it may be that the offsets should intersect very close to
+     * their endpoints, but aren't reported as such due to rounding.
+     * To handle this situation appropriately, we use the following test:
+     * If the offset points are very close, don't add closing segments
+     * but simply use one of the offset points
      */
 
     if(offset0.p1.distance(offset1.p0) <
@@ -481,7 +481,7 @@ OffsetSegmentGenerator::addMitreJoin(const geom::Coordinate& p,
                                      const geom::LineSegment& p_offset1,
                                      double p_distance)
 {
-    /**
+    /*
      * This computation is unstable if the offset segments are nearly collinear.
      * However, this situation should have been eliminated earlier by the check
      * for whether the offset segment endpoints are almost coincident

--- a/src/operation/buffer/SubgraphDepthLocater.cpp
+++ b/src/operation/buffer/SubgraphDepthLocater.cpp
@@ -107,13 +107,13 @@ public:
     int
     compareTo(const DepthSegment& other) const
     {
-        /**
+        /*
          * try and compute a determinate orientation for the segments.
          * Test returns 1 if other is left of this (i.e. this > other)
          */
         int orientIndex = upwardSeg.orientationIndex(&(other.upwardSeg));
 
-        /**
+        /*
          * If comparison between this and other is indeterminate,
          * try the opposite call order.
          * orientationIndex value is 1 if this is left of other,
@@ -213,7 +213,7 @@ SubgraphDepthLocater::findStabbedSegments(
     vector<DepthSegment*>& stabbedSegments)
 {
 
-    /**
+    /*
      * Check all forward DirectedEdges only. This is still general,
      * because each Edge has a forward DirectedEdge.
      */

--- a/src/operation/distance/ConnectedElementPointFilter.cpp
+++ b/src/operation/distance/ConnectedElementPointFilter.cpp
@@ -33,10 +33,10 @@ namespace operation { // geos.operation
 namespace distance { // geos.operation.distance
 
 /**
-* Returns a list containing a Coordinate from each Polygon, LineString, and Point
-* found inside the specified geometry. Thus, if the specified geometry is
-* not a GeometryCollection, an empty list will be returned.
-*/
+ * Returns a list containing a Coordinate from each Polygon, LineString, and Point
+ * found inside the specified geometry. Thus, if the specified geometry is
+ * not a GeometryCollection, an empty list will be returned.
+ */
 vector<const Coordinate*>*
 ConnectedElementPointFilter::getCoordinates(const Geometry* geom)
 {

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -99,10 +99,10 @@ DistanceOp::DistanceOp(const Geometry& g0, const Geometry& g1, double tdist)
 {}
 
 /**
-* Report the distance between the closest points on the input geometries.
-*
-* @return the distance between the geometries
-*/
+ * Report the distance between the closest points on the input geometries.
+ *
+ * @return the distance between the geometries
+ */
 double
 DistanceOp::distance()
 {

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -294,7 +294,7 @@ DistanceOp::computeFacetDistance()
 
     array<unique_ptr<GeometryLocation>, 2> locGeom;
 
-    /**
+    /*
      * Geometries are not wholly inside, so compute distance from lines
      * and points of one to lines and points of the other
      */

--- a/src/operation/distance/GeometryLocation.cpp
+++ b/src/operation/distance/GeometryLocation.cpp
@@ -28,9 +28,9 @@ namespace operation { // geos.operation
 namespace distance { // geos.operation.distance
 
 /**
-* Constructs a GeometryLocation specifying a point on a geometry, as well as the
-* segment that the point is on (or INSIDE_AREA if the point is not on a segment).
-*/
+ * Constructs a GeometryLocation specifying a point on a geometry, as well as the
+ * segment that the point is on (or INSIDE_AREA if the point is not on a segment).
+ */
 GeometryLocation::GeometryLocation(const Geometry* newComponent, size_t newSegIndex, const Coordinate& newPt)
 {
     component = newComponent;
@@ -40,8 +40,8 @@ GeometryLocation::GeometryLocation(const Geometry* newComponent, size_t newSegIn
 }
 
 /**
-* Constructs a GeometryLocation specifying a point inside an area geometry.
-*/
+ * Constructs a GeometryLocation specifying a point inside an area geometry.
+ */
 GeometryLocation::GeometryLocation(const Geometry* newComponent, const Coordinate& newPt)
 {
     component = newComponent;
@@ -51,27 +51,27 @@ GeometryLocation::GeometryLocation(const Geometry* newComponent, const Coordinat
 }
 
 /**
-* Returns the geometry associated with this location.
-*/
+ * Returns the geometry associated with this location.
+ */
 const Geometry*
 GeometryLocation::getGeometryComponent()
 {
     return component;
 }
 /**
-* Returns the segment index for this location. If the location is inside an
-* area, the index will have the value INSIDE_AREA;
-*
-* @return the segment index for the location, or INSIDE_AREA
-*/
+ * Returns the segment index for this location. If the location is inside an
+ * area, the index will have the value INSIDE_AREA;
+ *
+ * @return the segment index for the location, or INSIDE_AREA
+ */
 size_t
 GeometryLocation::getSegmentIndex()
 {
     return segIndex;
 }
 /**
-* Returns the location.
-*/
+ * Returns the location.
+ */
 Coordinate&
 GeometryLocation::getCoordinate()
 {

--- a/src/operation/linemerge/LineMergeEdge.cpp
+++ b/src/operation/linemerge/LineMergeEdge.cpp
@@ -26,8 +26,8 @@ namespace operation { // geos.operation
 namespace linemerge { // geos.operation.linemerge
 
 /**
-* Constructs a LineMergeEdge with vertices given by the specified LineString.
-*/
+ * Constructs a LineMergeEdge with vertices given by the specified LineString.
+ */
 LineMergeEdge::LineMergeEdge(const LineString* newLine):
     line(newLine)
 {

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -73,7 +73,7 @@ LineSequencer::isSequenced(const Geometry* geom)
         const Coordinate* startNode = &(line.getCoordinateN(0));
         const Coordinate* endNode = &(line.getCoordinateN(line.getNumPoints() - 1));
 
-        /**
+        /*
          * If this linestring is connected to a previous subgraph,
          * geom is not sequenced
          */

--- a/src/operation/overlay/OverlayOp.cpp
+++ b/src/operation/overlay/OverlayOp.cpp
@@ -795,7 +795,7 @@ OverlayOp::computeOverlay(OverlayOp::OpCode opCode)
     GEOS_CHECK_FOR_INTERRUPTS();
 
 #ifdef ENABLE_EDGE_NODING_VALIDATOR // {
-    /**
+    /*
      * Check that the noding completed correctly.
      *
      * This test is slow, but necessary in order to catch

--- a/src/operation/overlay/PointBuilder.cpp
+++ b/src/operation/overlay/PointBuilder.cpp
@@ -79,7 +79,7 @@ PointBuilder::extractNonCoveredResultNodes(OverlayOp::OpCode opCode)
         if(n->getEdges()->getDegree() == 0 ||
                 opCode == OverlayOp::opINTERSECTION) {
 
-            /**
+            /*
              * For nodes on edges, only INTERSECTION can result
              * in edge nodes being included even
              * if none of their incident edges are included

--- a/src/operation/overlay/snap/GeometrySnapper.cpp
+++ b/src/operation/overlay/snap/GeometrySnapper.cpp
@@ -161,7 +161,7 @@ GeometrySnapper::computeOverlaySnapTolerance(const geom::Geometry& g)
 {
     double snapTolerance = computeSizeBasedSnapTolerance(g);
 
-    /**
+    /*
      * Overlay is carried out in the precision model
      * of the two inputs.
      * If this precision model is of type FIXED, then the snap tolerance
@@ -199,7 +199,7 @@ GeometrySnapper::snap(const geom::Geometry& g0,
     GeometrySnapper snapper0(g0);
     snapGeom.first = snapper0.snapTo(g1, snapTolerance);
 
-    /**
+    /*
      * Snap the second geometry to the snapped first geometry
      * (this strategy minimizes the number of possible different
      * points in the result)

--- a/src/operation/overlay/snap/LineStringSnapper.cpp
+++ b/src/operation/overlay/snap/LineStringSnapper.cpp
@@ -406,7 +406,7 @@ LineStringSnapper::findSegmentToSnap(
         cerr << " Checking segment " << seg << endl;
 #endif
 
-        /**
+        /*
          * Check if the snap pt is equal to one of
          * the segment endpoints.
          *

--- a/src/operation/polygonize/BuildArea.cpp
+++ b/src/operation/polygonize/BuildArea.cpp
@@ -160,32 +160,32 @@ unique_ptr<geom::Geometry> BuildArea::build(const geom::Geometry* geom) {
     }
 
     /*
-    * Polygonizer returns a polygon for each face in the built topology.
-    *
-    * This means that for any face with holes we'll have other faces
-    * representing each hole. We can imagine a parent-child relationship
-    * between these faces.
-    *
-    * In order to maximize the number of visible rings in output we
-    * only use those faces which have an even number of parents.
-    *
-    * Example:
-    *
-    *   +---------------+
-    *   |     L0        |  L0 has no parents
-    *   |  +---------+  |
-    *   |  |   L1    |  |  L1 is an hole of L0
-    *   |  |  +---+  |  |
-    *   |  |  |L2 |  |  |  L2 is an hole of L1 (which is an hole of L0)
-    *   |  |  |   |  |  |
-    *   |  |  +---+  |  |
-    *   |  +---------+  |
-    *   |               |
-    *   +---------------+
-    *
-    * See http://trac.osgeo.org/postgis/ticket/1806
-    *
-    */
+     * Polygonizer returns a polygon for each face in the built topology.
+     *
+     * This means that for any face with holes we'll have other faces
+     * representing each hole. We can imagine a parent-child relationship
+     * between these faces.
+     *
+     * In order to maximize the number of visible rings in output we
+     * only use those faces which have an even number of parents.
+     *
+     * Example:
+     *
+     *   +---------------+
+     *   |     L0        |  L0 has no parents
+     *   |  +---------+  |
+     *   |  |   L1    |  |  L1 is an hole of L0
+     *   |  |  +---+  |  |
+     *   |  |  |L2 |  |  |  L2 is an hole of L1 (which is an hole of L0)
+     *   |  |  |   |  |  |
+     *   |  |  +---+  |  |
+     *   |  +---------+  |
+     *   |               |
+     *   +---------------+
+     *
+     * See http://trac.osgeo.org/postgis/ticket/1806
+     *
+     */
 
     /* Prepare face structures for later analysis */
     std::vector<std::unique_ptr<Face>> faces;

--- a/src/operation/predicate/RectangleContains.cpp
+++ b/src/operation/predicate/RectangleContains.cpp
@@ -133,7 +133,7 @@ RectangleContains::isLineSegmentContainedInBoundary(const Coordinate& p0,
         }
     }
 
-    /**
+    /*
      * Either
      *   both x and y values are different
      * or

--- a/src/operation/predicate/RectangleIntersects.cpp
+++ b/src/operation/predicate/RectangleIntersects.cpp
@@ -20,7 +20,7 @@
 #include <geos/operation/predicate/RectangleIntersects.h>
 #include <geos/operation/predicate/SegmentIntersectionTester.h>
 
-/// for EnvelopeIntersectsVisitor inheritance
+// for EnvelopeIntersectsVisitor inheritance
 #include <geos/geom/util/ShortCircuitedGeometryVisitor.h>
 #include <geos/geom/util/LinearComponentExtracter.h>
 

--- a/src/operation/relate/EdgeEndBundle.cpp
+++ b/src/operation/relate/EdgeEndBundle.cpp
@@ -69,10 +69,10 @@ EdgeEndBundle::insert(EdgeEnd* e)
 
 
 /**
-* This computes the overall edge label for the set of
-* edges in this EdgeStubBundle.  It essentially merges
-* the ON and side labels for each edge.  These labels must be compatible
-*/
+ * This computes the overall edge label for the set of
+ * edges in this EdgeStubBundle.  It essentially merges
+ * the ON and side labels for each edge.  These labels must be compatible
+ */
 void
 EdgeEndBundle::computeLabel(
     const algorithm::BoundaryNodeRule& boundaryNodeRule)
@@ -134,8 +134,8 @@ EdgeEndBundle::computeLabelOn(int geomIndex, const algorithm::BoundaryNodeRule& 
 
 
 /**
-* Compute the labelling for each side
-*/
+ * Compute the labelling for each side
+ */
 void
 EdgeEndBundle::computeLabelSides(int geomIndex)
 {
@@ -144,19 +144,19 @@ EdgeEndBundle::computeLabelSides(int geomIndex)
 }
 
 /**
-* To compute the summary label for a side, the algorithm is:
-*   FOR all edges
-*     IF any edge's location is INTERIOR for the side, side location = INTERIOR
-*     ELSE IF there is at least one EXTERIOR attribute, side location = EXTERIOR
-*     ELSE  side location = NULL
-*  <br>
-*  Note that it is possible for two sides to have apparently contradictory information
-*  i.e. one edge side may indicate that it is in the interior of a geometry, while
-*  another edge side may indicate the exterior of the same geometry.  This is
-*  not an incompatibility - GeometryCollections may contain two Polygons that touch
-*  along an edge.  This is the reason for Interior-primacy rule above - it
-*  results in the summary label having the Geometry interior on <b>both</b> sides.
-*/
+ * To compute the summary label for a side, the algorithm is:
+ *   FOR all edges
+ *     IF any edge's location is INTERIOR for the side, side location = INTERIOR
+ *     ELSE IF there is at least one EXTERIOR attribute, side location = EXTERIOR
+ *     ELSE  side location = NULL
+ *  <br>
+ *  Note that it is possible for two sides to have apparently contradictory information
+ *  i.e. one edge side may indicate that it is in the interior of a geometry, while
+ *  another edge side may indicate the exterior of the same geometry.  This is
+ *  not an incompatibility - GeometryCollections may contain two Polygons that touch
+ *  along an edge.  This is the reason for Interior-primacy rule above - it
+ *  results in the summary label having the Geometry interior on <b>both</b> sides.
+ */
 void
 EdgeEndBundle::computeLabelSide(int geomIndex, int side)
 {

--- a/src/operation/relate/RelateComputer.cpp
+++ b/src/operation/relate/RelateComputer.cpp
@@ -205,7 +205,7 @@ RelateComputer::computeIM()
 
     labelNodeEdges();
 
-    /**
+    /*
      * Compute the labeling for isolated components.
      * Isolated components are components that do not touch any
      * other components in the graph.
@@ -249,22 +249,22 @@ RelateComputer::computeProperIntersectionIM(SegmentIntersector* intersector, Int
     bool hasProper = intersector->hasProperIntersection();
     bool hasProperInterior = intersector->hasProperInteriorIntersection();
     // For Geometry's of dim 0 there can never be proper intersections.
-    /**
-    * If edge segments of Areas properly intersect, the areas must properly overlap.
-    */
+    /*
+     * If edge segments of Areas properly intersect, the areas must properly overlap.
+     */
     if(dimA == 2 && dimB == 2) {
         if(hasProper) {
             imX->setAtLeast("212101212");
         }
     }
-    /**
-    * If an Line segment properly intersects an edge segment of an Area,
-    * it follows that the Interior of the Line intersects the Boundary of the Area.
-    * If the intersection is a proper <i>interior</i> intersection, then
-    * there is an Interior-Interior intersection too.
-    * Note that it does not follow that the Interior of the Line intersects the Exterior
-    * of the Area, since there may be another Area component which contains the rest of the Line.
-    */
+    /*
+     * If an Line segment properly intersects an edge segment of an Area,
+     * it follows that the Interior of the Line intersects the Boundary of the Area.
+     * If the intersection is a proper *interior* intersection, then
+     * there is an Interior-Interior intersection too.
+     * Note that it does not follow that the Interior of the Line intersects the Exterior
+     * of the Area, since there may be another Area component which contains the rest of the Line.
+     */
     else if(dimA == 2 && dimB == 1) {
         if(hasProper) {
             imX->setAtLeast("FFF0FFFF2");

--- a/src/operation/relate/RelateNodeGraph.cpp
+++ b/src/operation/relate/RelateNodeGraph.cpp
@@ -61,13 +61,13 @@ RelateNodeGraph::build(GeometryGraph* geomGraph)
     // compute nodes for intersections between previously noded edges
     computeIntersectionNodes(geomGraph, 0);
 
-    /**
+    /*
      * Copy the labelling for the nodes in the parent Geometry.  These override
      * any labels determined by intersections.
      */
     copyNodesAndLabels(geomGraph, 0);
 
-    /**
+    /*
      * Build EdgeEnds for all intersections.
      */
     EdgeEndBuilder eeBuilder;

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -99,14 +99,14 @@ namespace geos {
 namespace operation { // geos.operation
 namespace geounion {  // geos.operation.geounion
 
-///////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////
 void
 GeometryListHolder::deleteItem(geom::Geometry* item)
 {
     delete item;
 }
 
-///////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////
 geom::Geometry*
 CascadedPolygonUnion::Union(std::vector<geom::Polygon*>* polys)
 {
@@ -136,7 +136,7 @@ CascadedPolygonUnion::Union()
 
     geomFactory = inputPolys->front()->getFactory();
 
-    /**
+    /*
      * A spatial index to organize the collection
      * into groups of close geometries.
      * This makes unioning more efficient, since vertices are more likely
@@ -160,7 +160,7 @@ geom::Geometry*
 CascadedPolygonUnion::unionTree(
     index::strtree::ItemsList* geomTree)
 {
-    /**
+    /*
      * Recursively unions all subtrees in the list into single geometries.
      * The result is a list of Geometry's only
      */

--- a/src/operation/union/CascadedUnion.cpp
+++ b/src/operation/union/CascadedUnion.cpp
@@ -47,7 +47,7 @@ CascadedUnion::Union()
 
     geomFactory = inputGeoms->front()->getFactory();
 
-    /**
+    /*
      * A spatial index to organize the collection
      * into groups of close geometries.
      * This makes unioning more efficient, since vertices are more likely
@@ -71,7 +71,7 @@ geom::Geometry*
 CascadedUnion::unionTree(
     index::strtree::ItemsList* geomTree)
 {
-    /**
+    /*
      * Recursively unions all subtrees in the list into single geometries.
      * The result is a list of Geometry's only
      */

--- a/src/operation/union/OverlapUnion.cpp
+++ b/src/operation/union/OverlapUnion.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Geometry>
 OverlapUnion::doUnion()
 {
     Envelope overlapEnv = overlapEnvelope(g0, g1);
-    /**
+    /*
      * If no overlap, can just combine the geometries
      */
     if (overlapEnv.isNull()) {
@@ -112,7 +112,7 @@ OverlapUnion::unionFull(const Geometry* geom0, const Geometry* geom1)
         return geom0->Union(geom1);
     }
     catch (geos::util::TopologyException &) {
-        /**
+        /*
          * If the overlay union fails,
          * try a buffer union, which often succeeds
          */

--- a/src/operation/union/UnaryUnionOp.cpp
+++ b/src/operation/union/UnaryUnionOp.cpp
@@ -72,7 +72,7 @@ UnaryUnionOp::Union()
         return ret;
     }
 
-    /**
+    /*
      * For points and lines, only a single union operation is
      * required, since the OGC model allowings self-intersecting
      * MultiPoint and MultiLineStrings.
@@ -115,7 +115,7 @@ UnaryUnionOp::Union()
                             polygons.end()));
     }
 
-    /**
+    /*
      * Performing two unions is somewhat inefficient,
      * but is mitigated by unioning lines and points first
      */

--- a/src/operation/valid/ConnectedInteriorTester.cpp
+++ b/src/operation/valid/ConnectedInteriorTester.cpp
@@ -253,7 +253,7 @@ ConnectedInteriorTester::visitInteriorRing(const LineString* ring, PlanarGraph& 
     const CoordinateSequence* pts = ring->getCoordinatesRO();
     const Coordinate& pt0 = pts->getAt(0);
 
-    /**
+    /*
      * Find first point in coord list different to initial point.
      * Need special check since the first point may be repeated.
      */

--- a/src/operation/valid/ConsistentAreaTester.cpp
+++ b/src/operation/valid/ConsistentAreaTester.cpp
@@ -61,14 +61,14 @@ ConsistentAreaTester::isNodeConsistentArea()
 {
     using geomgraph::index::SegmentIntersector;
 
-    /**
+    /*
      * To fully check validity, it is necessary to
      * compute ALL intersections, including self-intersections within a single edge.
      */
     unique_ptr<SegmentIntersector> intersector(geomGraph->computeSelfNodes(&li, true, true));
-    /**
-    * A proper intersection means that the area is not consistent.
-    */
+    /*
+     * A proper intersection means that the area is not consistent.
+     */
     if(intersector->hasProperIntersection()) {
         invalidPoint = intersector->getProperIntersectionPoint();
         return false;

--- a/src/operation/valid/IndexedNestedRingTester.cpp
+++ b/src/operation/valid/IndexedNestedRingTester.cpp
@@ -63,7 +63,7 @@ IndexedNestedRingTester::isNonNested()
                                          searchRing,
                                          graph);
 
-            /**
+            /*
              * If no non-node pts can be found, this means
              * that the searchRing touches ALL of the innerRing vertices.
              * This indicates an invalid polygon, since either

--- a/src/operation/valid/IsValidOp.cpp
+++ b/src/operation/valid/IsValidOp.cpp
@@ -439,11 +439,11 @@ IsValidOp::checkHolesInShell(const Polygon* p, GeometryGraph* graph)
         if (hole->isEmpty()) continue;
 
         const Coordinate* holePt = findPtNotNode(hole->getCoordinatesRO(), shell, graph);
-        /**
-        * If no non-node hole vertex can be found, the hole must
-        * split the polygon into disconnected interiors.
-        * This will be caught by a subsequent check.
-        */
+        /*
+         * If no non-node hole vertex can be found, the hole must
+         * split the polygon into disconnected interiors.
+         * This will be caught by a subsequent check.
+         */
         if (holePt == nullptr) return;
         bool outside = isShellEmpty || (Location::EXTERIOR == ipial.locate(holePt));
         if (outside) {
@@ -547,7 +547,7 @@ IsValidOp::checkShellNotNested(const LinearRing* shell, const Polygon* p,
         return;
     }
 
-    /**
+    /*
      * Check if the shell is inside one of the holes.
      * This is the case if one of the calls to checkShellInsideHole
      * returns a null coordinate.

--- a/src/planargraph/Edge.cpp
+++ b/src/planargraph/Edge.cpp
@@ -42,9 +42,9 @@ Edge::setDirectedEdges(DirectedEdge* de0, DirectedEdge* de1)
 }
 
 /**
-* Returns one of the DirectedEdges associated with this Edge.
-* @param i 0 or 1
-*/
+ * Returns one of the DirectedEdges associated with this Edge.
+ * @param i 0 or 1
+ */
 DirectedEdge*
 Edge::getDirEdge(int i)
 {
@@ -70,9 +70,9 @@ Edge::getDirEdge(Node* fromNode)
 }
 
 /**
-* If <code>node</code> is one of the two nodes associated with this Edge,
-* returns the other node; otherwise returns null.
-*/
+ * If <code>node</code> is one of the two nodes associated with this Edge,
+ * returns the other node; otherwise returns null.
+ */
 Node*
 Edge::getOppositeNode(Node* node)
 {

--- a/src/precision/GeometryPrecisionReducer.cpp
+++ b/src/precision/GeometryPrecisionReducer.cpp
@@ -46,7 +46,7 @@ GeometryPrecisionReducer::reducePointwise(const Geometry& geom)
 {
     GeometryEditor geomEdit(newFactory);
 
-    /**
+    /*
      * For polygonal geometries, collapses are always removed, in order
      * to produce correct topology
      */
@@ -102,7 +102,7 @@ GeometryPrecisionReducer::GeometryPrecisionReducer(const GeometryFactory& change
 unique_ptr<Geometry>
 GeometryPrecisionReducer::fixPolygonalTopology(const geom::Geometry& geom)
 {
-    /**
+    /*
      * If precision model was *not* changed, need to flip
      * geometry to targetPM, buffer in that model, then flip back
      */

--- a/src/precision/PrecisionReducerCoordinateOperation.cpp
+++ b/src/precision/PrecisionReducerCoordinateOperation.cpp
@@ -59,7 +59,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
     // much as possible.
     std::unique_ptr<CoordinateSequence> noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
 
-    /**
+    /*
      * Check to see if the removal of repeated points
      * collapsed the coordinate List to an invalid length
      * for the type of the parent geometry.

--- a/src/precision/SimpleGeometryPrecisionReducer.cpp
+++ b/src/precision/SimpleGeometryPrecisionReducer.cpp
@@ -135,7 +135,7 @@ SimpleGeometryPrecisionReducer::SimpleGeometryPrecisionReducer(
     //newPrecisionModel = pm;
 }
 
-/**
+/*
  * Sets whether the reduction will result in collapsed components
  * being removed completely, or simply being collapsed to an (invalid)
  * Geometry of the same type.

--- a/src/precision/SimpleGeometryPrecisionReducer.cpp
+++ b/src/precision/SimpleGeometryPrecisionReducer.cpp
@@ -89,7 +89,7 @@ PrecisionReducerCoordinateOperation::edit(const CoordinateSequence* cs,
     // much as possible.
     std::unique_ptr<CoordinateSequence> noRepeatedCoords = operation::valid::RepeatedPointRemover::removeRepeatedPoints(reducedCoords.get());
 
-    /**
+    /*
      * Check to see if the removal of repeated points
      * collapsed the coordinate List to an invalid length
      * for the type of the parent geometry.

--- a/src/simplify/TaggedLineStringSimplifier.cpp
+++ b/src/simplify/TaggedLineStringSimplifier.cpp
@@ -113,7 +113,7 @@ TaggedLineStringSimplifier::simplifySection(std::size_t i,
 
     bool isValidToSimplify = true;
 
-    /**
+    /*
      * Following logic ensures that there is enough points in the
      * output line.
      * If there is already more points than the minimum, there's

--- a/src/triangulate/IncrementalDelaunayTriangulator.cpp
+++ b/src/triangulate/IncrementalDelaunayTriangulator.cpp
@@ -44,7 +44,7 @@ IncrementalDelaunayTriangulator::insertSites(const VertexList& vertices)
 QuadEdge&
 IncrementalDelaunayTriangulator::insertSite(const Vertex& v)
 {
-    /**
+    /*
      * This code is based on Guibas and Stolfi (1985), with minor modifications
      * and a bug fix from Dani Lischinski (Graphic Gems 1993). (The modification
      * I believe is the test for the inserted site falling exactly on an
@@ -68,7 +68,7 @@ IncrementalDelaunayTriangulator::insertSite(const Vertex& v)
         subdiv->remove(e->oNext());
     }
 
-    /**
+    /*
      * Connect the new point to the vertices of the containing triangle
      * (or quadrilateral, if the new point fell on an existing edge.)
      */

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -152,7 +152,7 @@ QuadEdgeSubdivision::locateFromEdge(const Vertex& v,
 
     for(;;) {
         ++iter;
-        /**
+        /*
          * So far it has always been the case that failure to locate indicates an
          * invalid subdivision. So just fail completely. (An alternative would be
          * to perform an exhaustive search for the containing triangle, but this

--- a/tests/bigtest/GeometryTestFactory.cpp
+++ b/tests/bigtest/GeometryTestFactory.cpp
@@ -63,12 +63,12 @@ GeometryTestFactory::createBox(double minx, double miny, int nSide, double segLe
 }
 
 /**
-* Creates a circle
-* @param x the centre x coord
-* @param y the centre y coord
-* @param size the size of the envelope of the star
-* @param nPts the number of points in the star
-*/
+ * Creates a circle
+ * @param x the centre x coord
+ * @param y the centre y coord
+ * @param size the size of the envelope of the star
+ * @param nPts the number of points in the star
+ */
 CoordinateSequence*
 GeometryTestFactory::createCircle(double basex, double basey, double size, int nPts)
 {
@@ -93,14 +93,14 @@ GeometryTestFactory::createCircle(GeometryFactory* fact, double basex, double ba
 }
 
 /**
-* Creates a star from a "circular" sine wave
-* @param basex the centre x coord
-* @param basey the centre y coord
-* @param size the size of the envelope of the star
-* @param armLen the length of an arm of the star
-* @param nArms the number of arms of the star
-* @param nPts the number of points in the star
-*/
+ * Creates a star from a "circular" sine wave
+ * @param basex the centre x coord
+ * @param basey the centre y coord
+ * @param size the size of the envelope of the star
+ * @param armLen the length of an arm of the star
+ * @param nArms the number of arms of the star
+ * @param nPts the number of points in the star
+ */
 CoordinateSequence*
 GeometryTestFactory::createSineStar(double basex, double basey, double size, double armLen, int nArms, int nPts)
 {

--- a/tests/unit/precision/GeometryPrecisionReducerTest.cpp
+++ b/tests/unit/precision/GeometryPrecisionReducerTest.cpp
@@ -109,7 +109,7 @@ void object::test<4>
 ()
 {
     GeometryPtr g1(reader_.read("POLYGON (( 0 0, 0 1.4, .4 .4, .4 0, 0 0 ))"));
-    /**
+    /*
      * For polygonal geometries, collapses are always removed, in order
      * to produce correct topology
      */

--- a/tests/xmltester/BufferResultMatcher.cpp
+++ b/tests/xmltester/BufferResultMatcher.cpp
@@ -41,7 +41,7 @@ BufferResultMatcher::isBufferResultMatch(const geom::Geometry& actualBuffer,
         return true;
     }
 
-    /**
+    /*
      * MD - need some more checks here - symDiffArea won't catch
      * very small holes ("tears")
      * near the edge of computed buffers (which can happen

--- a/tools/astyle/ASBeautifier.cpp
+++ b/tools/astyle/ASBeautifier.cpp
@@ -521,10 +521,10 @@ void ASBeautifier::setSpaceIndentation(int length)
 }
 
 /**
-* indent continuation lines using a number of indents.
-*
-* @param   indent     number of indents per line.
-*/
+ * indent continuation lines using a number of indents.
+ *
+ * @param   indent     number of indents per line.
+ */
 void ASBeautifier::setContinuationIndentation(int indent)
 {
 	continuationIndent = indent;
@@ -586,11 +586,11 @@ void ASBeautifier::setBraceIndent(bool state)
 }
 
 /**
-* set the state of the brace indent VTK option. If true, braces will
-* be indented one additional indent, except for the opening brace.
-*
-* @param   state             state of option.
-*/
+ * set the state of the brace indent VTK option. If true, braces will
+ * be indented one additional indent, except for the opening brace.
+ *
+ * @param   state             state of option.
+ */
 void ASBeautifier::setBraceIndentVtk(bool state)
 {
 	// need to set both of these
@@ -666,10 +666,10 @@ void ASBeautifier::setNamespaceIndent(bool state)
 }
 
 /**
-* set the state of the indent after parens option.
-*
-* @param   state             state of option.
-*/
+ * set the state of the indent after parens option.
+ *
+ * @param   state             state of option.
+ */
 void ASBeautifier::setAfterParenIndent(bool state)
 {
 	shouldIndentAfterParen = state;
@@ -770,10 +770,10 @@ bool ASBeautifier::getForceTabIndentation() const
 }
 
 /**
-* Get the state of the Objective-C align method colon option.
-*
-* @return   state of shouldAlignMethodColon option.
-*/
+ * Get the state of the Objective-C align method colon option.
+ *
+ * @return   state of shouldAlignMethodColon option.
+ */
 bool ASBeautifier::getAlignMethodColon() const
 {
 	return shouldAlignMethodColon;
@@ -800,11 +800,11 @@ bool ASBeautifier::getBraceIndent() const
 }
 
 /**
-* Get the state of the namespace indentation option. If true, blocks
-* of the 'namespace' statement will be indented one additional indent.
-*
-* @return   state of namespaceIndent option.
-*/
+ * Get the state of the namespace indentation option. If true, blocks
+ * of the 'namespace' statement will be indented one additional indent.
+ *
+ * @return   state of namespaceIndent option.
+ */
 bool ASBeautifier::getNamespaceIndent() const
 {
 	return namespaceIndent;
@@ -1349,8 +1349,8 @@ void ASBeautifier::registerContinuationIndent(const string& line, int i, int spa
 }
 
 /**
-* Register a continuation indent for a class header or a class initializer colon.
-*/
+ * Register a continuation indent for a class header or a class initializer colon.
+ */
 void ASBeautifier::registerContinuationIndentColon(const string& line, int i, int tabIncrementIn)
 {
 	assert(line[i] == ':');

--- a/tools/astyle/ASEnhancer.cpp
+++ b/tools/astyle/ASEnhancer.cpp
@@ -246,7 +246,7 @@ size_t ASEnhancer::findCaseColon(const string& line, size_t caseIndex) const
 }
 
 /**
-* indent a line by a given number of tabsets
+ * indent a line by a given number of tabsets
  *    by inserting leading whitespace to the line argument.
  *
  * @param line          a reference to the line to indent.

--- a/tools/astyle/ASFormatter.cpp
+++ b/tools/astyle/ASFormatter.cpp
@@ -2076,13 +2076,13 @@ void ASFormatter::setBreakElseIfsMode(bool state)
 }
 
 /**
-* set comma padding mode.
-* options:
-*    true     statement commas and semicolons will be padded with spaces around them.
-*    false    statement commas and semicolons will not be padded.
-*
-* @param state         the padding mode.
-*/
+ * set comma padding mode.
+ * options:
+ *    true     statement commas and semicolons will be padded with spaces around them.
+ *    false    statement commas and semicolons will not be padded.
+ *
+ * @param state         the padding mode.
+ */
 void ASFormatter::setCommaPaddingMode(bool state)
 {
 	shouldPadCommas = state;
@@ -2177,11 +2177,11 @@ void ASFormatter::setParensUnPaddingMode(bool state)
 }
 
 /**
-* set the state of the preprocessor indentation option.
-* If true, #ifdef blocks at level 0 will be indented.
-*
-* @param   state             state of option.
-*/
+ * set the state of the preprocessor indentation option.
+ * If true, #ifdef blocks at level 0 will be indented.
+ *
+ * @param   state             state of option.
+ */
 void ASFormatter::setPreprocBlockIndent(bool state)
 {
 	shouldIndentPreprocBlock = state;
@@ -2327,17 +2327,17 @@ void ASFormatter::setBreakOneLineBlocksMode(bool state)
 }
 
 /**
-* set one line headers breaking mode
-*/
+ * set one line headers breaking mode
+ */
 void ASFormatter::setBreakOneLineHeadersMode(bool state)
 {
 	shouldBreakOneLineHeaders = state;
 }
 
 /**
-* set option to break/not break lines consisting of multiple statements.
-*
-* @param state        true = break, false = don't break.
+ * set option to break/not break lines consisting of multiple statements.
+ *
+ * @param state        true = break, false = don't break.
 */
 void ASFormatter::setBreakOneLineStatementsMode(bool state)
 {
@@ -3084,10 +3084,10 @@ bool ASFormatter::isNumericVariable(string word) const
 }
 
 /**
-* check if a colon is a class initializer separator
-*
-* @return        whether it is a class initializer separator
-*/
+ * check if a colon is a class initializer separator
+ *
+ * @return        whether it is a class initializer separator
+ */
 bool ASFormatter::isClassInitializer() const
 {
 	assert(currentChar == ':');
@@ -3712,11 +3712,11 @@ bool ASFormatter::isNextCharOpeningBrace(int startChar) const
 }
 
 /**
-* Check if operator and, pointer, and reference padding is disabled.
-* Disabling is done thru a NOPAD tag in an ending comment.
-*
-* @return              true if the formatting on this line is disabled.
-*/
+ * Check if operator and, pointer, and reference padding is disabled.
+ * Disabling is done thru a NOPAD tag in an ending comment.
+ *
+ * @return              true if the formatting on this line is disabled.
+ */
 bool ASFormatter::isOperatorPaddingDisabled() const
 {
 	size_t commentStart = currentLine.find("//", charNum);
@@ -3740,9 +3740,9 @@ bool ASFormatter::isOperatorPaddingDisabled() const
 }
 
 /**
-* Determine if an opening array-type brace should have a leading space pad.
-* This is to identify C++11 uniform initializers.
-*/
+ * Determine if an opening array-type brace should have a leading space pad.
+ * This is to identify C++11 uniform initializers.
+ */
 bool ASFormatter::isUniformInitializerBrace() const
 {
 	if (isCStyle() && !isInEnum && !isImmediatelyPostPreprocessor)
@@ -3756,8 +3756,8 @@ bool ASFormatter::isUniformInitializerBrace() const
 }
 
 /**
-* Determine if there is a following statement on the current line.
-*/
+ * Determine if there is a following statement on the current line.
+ */
 bool ASFormatter::isMultiStatementLine() const
 {
 	assert((isImmediatelyPostHeader || foundClosingHeader));
@@ -4691,11 +4691,11 @@ void ASFormatter::padParens()
 }
 
 /**
-* add or remove space padding to objective-c method prefix (- or +)
-* if this is a '(' it begins a return type
-* these options have precedence over the padParens methods
-* the padParens method has already been called, this method adjusts
-*/
+ * add or remove space padding to objective-c method prefix (- or +)
+ * if this is a '(' it begins a return type
+ * these options have precedence over the padParens methods
+ * the padParens method has already been called, this method adjusts
+ */
 void ASFormatter::padObjCMethodPrefix()
 {
 	assert(isInObjCMethodDefinition && isImmediatelyPostObjCMethodPrefix);
@@ -4735,10 +4735,10 @@ void ASFormatter::padObjCMethodPrefix()
 }
 
 /**
-* add or remove space padding to objective-c parens
-* these options have precedence over the padParens methods
-* the padParens method has already been called, this method adjusts
-*/
+ * add or remove space padding to objective-c parens
+ * these options have precedence over the padParens methods
+ * the padParens method has already been called, this method adjusts
+ */
 void ASFormatter::padObjCReturnType()
 {
 	assert(currentChar == ')' && isInObjCReturnType);
@@ -4785,10 +4785,10 @@ void ASFormatter::padObjCReturnType()
 }
 
 /**
-* add or remove space padding to objective-c parens
-* these options have precedence over the padParens methods
-* the padParens method has already been called, this method adjusts
-*/
+ * add or remove space padding to objective-c parens
+ * these options have precedence over the padParens methods
+ * the padParens method has already been called, this method adjusts
+ */
 void ASFormatter::padObjCParamType()
 {
 	assert((currentChar == '(' || currentChar == ')') && isInObjCMethodDefinition);
@@ -5529,8 +5529,8 @@ void ASFormatter::convertTabToSpaces()
 }
 
 /**
-* is it ok to break this block?
-*/
+ * is it ok to break this block?
+ */
 bool ASFormatter::isOkToBreakBlock(BraceType braceType) const
 {
 	// Actually, there should not be an ARRAY_TYPE brace here.
@@ -5550,8 +5550,8 @@ bool ASFormatter::isOkToBreakBlock(BraceType braceType) const
 }
 
 /**
-* check if a sharp header is a paren or non-paren header
-*/
+ * check if a sharp header is a paren or non-paren header
+ */
 bool ASFormatter::isSharpStyleWithParen(const string* header) const
 {
 	return (isSharpStyle() && peekNextChar() == '('
@@ -6902,12 +6902,12 @@ bool ASFormatter::isStructAccessModified(const string& firstLine, size_t index) 
 }
 
 /**
-* Look ahead in the file to see if a preprocessor block is indentable.
-*
-* @param firstLine     a reference to the line to indent.
-* @param index         the current line index.
-* @return              true if the block is indentable.
-*/
+ * Look ahead in the file to see if a preprocessor block is indentable.
+ *
+ * @param firstLine     a reference to the line to indent.
+ * @param index         the current line index.
+ * @return              true if the block is indentable.
+ */
 bool ASFormatter::isIndentablePreprocessorBlock(const string& firstLine, size_t index)
 {
 	assert(firstLine[index] == '#');

--- a/tools/astyle/ASResource.cpp
+++ b/tools/astyle/ASResource.cpp
@@ -327,11 +327,11 @@ void ASResource::buildIndentableHeaders(vector<const string*>* indentableHeaders
 }
 
 /**
-* Build the vector of indentable macros pairs.
-* Initialized by ASFormatter, used by ONLY ASEnhancer.cpp
-*
-* @param indentableMacros       a reference to the vector to be built.
-*/
+ * Build the vector of indentable macros pairs.
+ * Initialized by ASFormatter, used by ONLY ASEnhancer.cpp
+ *
+ * @param indentableMacros       a reference to the vector to be built.
+ */
 void ASResource::buildIndentableMacros(vector<const pair<const string, const string>* >* indentableMacros)
 {
 	const size_t elements = 10;

--- a/tools/astyle/astyle_main.cpp
+++ b/tools/astyle/astyle_main.cpp
@@ -125,11 +125,11 @@ ASStreamIterator<T>::~ASStreamIterator()
 }
 
 /**
-* get the length of the input stream.
-* streamLength variable is set by the constructor.
-*
-* @return     length of the input file stream, converted to an int.
-*/
+ * get the length of the input stream.
+ * streamLength variable is set by the constructor.
+ *
+ * @return     length of the input file stream, converted to an int.
+ */
 template<typename T>
 int ASStreamIterator<T>::getStreamLength() const
 {


### PR DESCRIPTION
This fix addresses:

- bad indentation on some comment blocks
- add space before doxygen tags
- remove doxygen comment block style (/**) from in-code comment blocks
- trailing spaces in ttmath

If you think we should not poke around in ttmath, I’ll revoke that part.

(this PR is a mirror of https://git.osgeo.org/gitea/geos/geos/pulls/98)