### PR TITLE
DoubleBits, avoid garbage value

### DIFF
--- a/include/geos/index/quadtree/DoubleBits.h
+++ b/include/geos/index/quadtree/DoubleBits.h
@@ -92,7 +92,7 @@ private:
 
     double x;
 
-    int64 xBits;
+    int64 xBits = 0;
 };
 
 } // namespace geos::index::quadtree

--- a/include/geos/index/quadtree/DoubleBits.h
+++ b/include/geos/index/quadtree/DoubleBits.h
@@ -92,7 +92,7 @@ private:
 
     double x;
 
-    int64 xBits = 0;
+    int64 xBits;
 };
 
 } // namespace geos::index::quadtree

--- a/src/index/quadtree/DoubleBits.cpp
+++ b/src/index/quadtree/DoubleBits.cpp
@@ -24,21 +24,14 @@
 #include <cstring>
 #include <bitset>
 
-#if __STDC_IEC_559__
-#define ASSUME_IEEE_DOUBLE 1
-#else
-#define ASSUME_IEEE_DOUBLE 0
-#endif
-
-#if ! ASSUME_IEEE_DOUBLE
-#include <cmath>
-#endif
-
 namespace geos {
 namespace index { // geos.index
 namespace quadtree { // geos.index.quadtree
 
 using namespace std;
+
+static_assert(std::numeric_limits<double>::is_iec559,
+              "Failed to meet IEEE 754 floating point standard requirement");
 
 double
 DoubleBits::powerOf2(int exp)
@@ -46,15 +39,11 @@ DoubleBits::powerOf2(int exp)
     if(exp > 1023 || exp < -1022) {
         throw util::IllegalArgumentException("Exponent out of bounds");
     }
-#if ASSUME_IEEE_DOUBLE
     int64 expBias = exp + EXPONENT_BIAS;
     int64 bits = expBias << 52;
     double ret;
     memcpy(&ret, &bits, sizeof(int64));
     return ret;
-#else
-    return pow(2.0, exp);
-#endif
 }
 
 int
@@ -98,9 +87,7 @@ DoubleBits::maximumCommonMantissa(double d1, double d2)
 /*public*/
 DoubleBits::DoubleBits(double nx)
 {
-#if ASSUME_IEEE_DOUBLE
     memcpy(&xBits, &nx, sizeof(double));
-#endif
     x = nx;
 }
 
@@ -125,14 +112,7 @@ DoubleBits::biasedExponent() const
 int
 DoubleBits::getExponent() const
 {
-#if ASSUME_IEEE_DOUBLE
     return static_cast<int>(biasedExponent() - EXPONENT_BIAS);
-#else
-    if(x <= 0) {
-        return 0;    // EDOM || ERANGE
-    }
-    return (int)((log(x) / log(2.0)) + (x < 1 ? -0.9 : 0.00000000001));
-#endif
 }
 
 /*public*/


### PR DESCRIPTION
After the merging of the PR https://github.com/libgeos/geos/pull/238, there remain only one issue checking with xcode static analyser (xcode 10.2.1):

```
/geos/src/index/quadtree/DoubleBits.cpp:144:11: warning: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage
    xBits &= mask;
    ~~~~~ ^
/geos/src/index/quadtree/DoubleBits.cpp:152:19: warning: The left operand of '&' is a garbage value
    return (xBits & mask) != 0 ? 1 : 0;
            ~~~~~ ^
2 warnings generated.
```

This fix addresses this.