### PR TITLE
Address clang warnings

### DIFF
--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -37,7 +37,11 @@ namespace geom {
         std::unique_ptr<CoordinateSequence> clone() const final override {
             auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>(dimension);
             seq->m_data = m_data;
+#if defined __GNUC__ && ((__GNUC__ == 4) && (__GNUC_MINOR__ == 8))
             return std::move(seq); // move needed for gcc 4.8
+#else
+            return seq;
+#endif
         }
 
         const Coordinate& getAt(size_t i) const final override {

--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -76,6 +76,8 @@ public:
 
     virtual ~LineSegment();
 
+    const LineSegment& operator=(const LineSegment& ls);
+
     void setCoordinates(const Coordinate& c0, const Coordinate& c1);
 
     // obsoleted, use operator[] instead

--- a/include/geos/geom/LineSegment.inl
+++ b/include/geos/geom/LineSegment.inl
@@ -65,6 +65,16 @@ LineSegment::~LineSegment()
 {
 }
 
+INLINE const LineSegment&
+LineSegment::operator=(const LineSegment& ls)
+{
+    if (this != &ls) {
+        p0 = ls.p0;
+        p1 = ls.p1;
+    }
+    return *this;
+}
+
 INLINE double
 LineSegment::distancePerpendicular(const Coordinate& p) const
 {

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -163,6 +163,8 @@ public:
     /// destructor
     ~PrecisionModel(void);
 
+    // copy operator
+    const PrecisionModel& operator=(const PrecisionModel& pm);
 
     /// The maximum precise value representable in a double.
     //

--- a/src/geom/PrecisionModel.cpp
+++ b/src/geom/PrecisionModel.cpp
@@ -146,6 +146,16 @@ PrecisionModel::PrecisionModel(const PrecisionModel& pm)
 #endif
 }
 
+const PrecisionModel&
+PrecisionModel::operator=(const PrecisionModel& pm)
+{
+    if (this != &pm) {
+        this->modelType = pm.modelType;
+        this->scale = pm.scale;
+    }
+    return *this;
+}
+
 /*public*/
 bool
 PrecisionModel::isFloating() const

--- a/src/noding/MCIndexSegmentSetMutualIntersector.cpp
+++ b/src/noding/MCIndexSegmentSetMutualIntersector.cpp
@@ -103,8 +103,6 @@ MCIndexSegmentSetMutualIntersector::MCIndexSegmentSetMutualIntersector()
 MCIndexSegmentSetMutualIntersector::~MCIndexSegmentSetMutualIntersector()
 {
     delete index;
-
-    MonoChains::iterator i, e;
 }
 
 /* public */

--- a/src/operation/buffer/BufferInputLineSimplifier.cpp
+++ b/src/operation/buffer/BufferInputLineSimplifier.cpp
@@ -136,7 +136,11 @@ BufferInputLineSimplifier::collapseLine() const
         }
     }
 
-    return std::move(coordList);
+#if defined __GNUC__ && ((__GNUC__ == 4) && (__GNUC_MINOR__ == 8))
+    return std::move(coordList); // move needed for gcc 4.8
+#else
+    return coordList;
+#endif
 }
 
 /* private */

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -45,56 +45,6 @@
 //#define GEOS_DEBUG_CASCADED_UNION 1
 //#define GEOS_DEBUG_CASCADED_UNION_PRINT_INVALID 1
 
-namespace {
-
-inline bool
-check_valid(const geos::geom::Geometry& g, const std::string& label, bool doThrow = false, bool validOnly = false)
-{
-    using namespace geos;
-
-    if(g.isLineal()) {
-        if(! validOnly) {
-            operation::IsSimpleOp sop(g, algorithm::BoundaryNodeRule::getBoundaryEndPoint());
-            if(! sop.isSimple()) {
-                if(doThrow) {
-                    throw geos::util::TopologyException(
-                        label + " is not simple");
-                }
-                return false;
-            }
-        }
-    }
-    else {
-        operation::valid::IsValidOp ivo(&g);
-        if(! ivo.isValid()) {
-            using operation::valid::TopologyValidationError;
-            TopologyValidationError* err = ivo.getValidationError();
-#ifdef GEOS_DEBUG_CASCADED_UNION
-            std::cerr << label << " is INVALID: "
-                      << err->toString()
-                      << " (" << std::setprecision(20)
-                      << err->getCoordinate() << ")"
-                      << std::endl
-#ifdef GEOS_DEBUG_CASCADED_UNION_PRINT_INVALID
-                      << "<a>" << std::endl
-                      << g.toString() << std::endl
-                      << "</a>" << std::endl
-#endif
-                      ;
-#endif // GEOS_DEBUG_CASCADED_UNION
-            if(doThrow) {
-                throw geos::util::TopologyException(
-                    label + " is invalid: " + err->toString(),
-                    err->getCoordinate());
-            }
-            return false;
-        }
-    }
-    return true;
-}
-
-} // anonymous namespace
-
 namespace geos {
 namespace operation { // geos.operation
 namespace geounion {  // geos.operation.geounion


### PR DESCRIPTION
They come from building with scan-build with -Wall and -Wextra and clang version 9.0.0.