### PR TITLE
Use spatial index to check shell nesting in IsValidOp

### DIFF
--- a/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
+++ b/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
@@ -104,6 +104,10 @@ public:
      */
     IndexedPointInAreaLocator(const geom::Geometry& g);
 
+    const geom::Geometry&  getGeometry() const {
+        return areaGeom;
+    }
+
     /** \brief
      * Determines the [Location](@ref geom::Location) of a point in an areal
      * [Geometry](@ref geom::Geometry).

--- a/include/geos/geomgraph/GeometryGraph.h
+++ b/include/geos/geomgraph/GeometryGraph.h
@@ -187,7 +187,7 @@ public:
     /// Returned object is owned by this GeometryGraph
     geom::CoordinateSequence* getBoundaryPoints();
 
-    Edge* findEdge(const geom::LineString* line);
+    Edge* findEdge(const geom::LineString* line) const;
 
     void computeSplitEdges(std::vector<Edge*>* edgelist);
 

--- a/include/geos/operation/valid/IndexedNestedShellTester.h
+++ b/include/geos/operation/valid/IndexedNestedShellTester.h
@@ -1,0 +1,108 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2001-2002 Vivid Solutions Inc.
+ * Copyright (C) 2005 Refractions Research Inc.
+ * Copyright (C) 2010 Safe Software Inc.
+ * Copyright (C) 2010 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2019 Daniel Baston <dbaston@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#ifndef GEOS_OP_VALID_INDEXEDNESTEDSHELLTESTER_H
+#define GEOS_OP_VALID_INDEXEDNESTEDSHELLTESTER_H
+
+#include <geos/geom/Polygon.h>
+#include <geos/index/SpatialIndex.h>
+
+#include <cstddef>
+#include <memory>
+
+// Forward declarations
+namespace geos {
+namespace algorithm {
+namespace locate {
+    class IndexedPointInAreaLocator;
+}
+}
+namespace geom {
+    class Polygon;
+}
+namespace geomgraph {
+    class GeometryGraph;
+}
+namespace operation {
+namespace valid {
+    class PolygonIndexedLocators;
+}
+}
+}
+
+namespace geos {
+namespace operation {
+namespace valid {
+
+class IndexedNestedShellTester {
+
+public:
+    IndexedNestedShellTester(const geomgraph::GeometryGraph& g, size_t initialCapacity);
+
+    void add(const geom::Polygon& p) {
+        polys.push_back(&p);
+    }
+
+    const geom::Coordinate* getNestedPoint();
+
+    bool isNonNested();
+
+private:
+    void compute();
+
+    /**
+     * Check if a shell is incorrectly nested within a polygon.
+     * This is the case if the shell is inside the polygon shell,
+     * but not inside a polygon hole.
+     * (If the shell is inside a polygon hole, the nesting is valid.)
+     *
+     * The algorithm used relies on the fact that the rings must be
+     * properly contained.
+     * E.g. they cannot partially overlap (this has been previously
+     * checked by <code>checkRelateConsistency</code>
+     */
+    void checkShellNotNested(const geom::LinearRing* shell, PolygonIndexedLocators & locs);
+
+    /**
+     * This routine checks to see if a shell is properly contained
+     * in a hole.
+     * It assumes that the edges of the shell and hole do not
+     * properly intersect.
+     *
+     * @return <code>null</code> if the shell is properly contained, or
+     *   a Coordinate which is not inside the hole if it is not
+     */
+    const geom::Coordinate* checkShellInsideHole(const geom::LinearRing* shell,
+            algorithm::locate::IndexedPointInAreaLocator & holeLoc);
+
+    /// Externally owned
+    const geomgraph::GeometryGraph& graph;
+
+    std::vector<const geom::Polygon*> polys;
+
+    // Externally owned, if not null
+    const geom::Coordinate* nestedPt;
+
+    bool processed;
+};
+
+}
+}
+}
+
+#endif //GEOS_INDEXEDNESTEDSHELLTESTER_H

--- a/include/geos/operation/valid/IsValidOp.h
+++ b/include/geos/operation/valid/IsValidOp.h
@@ -149,35 +149,6 @@ private:
     void checkShellsNotNested(const geom::MultiPolygon* mp,
                               geomgraph::GeometryGraph* graph);
 
-    /**
-     * Check if a shell is incorrectly nested within a polygon.
-     * This is the case if the shell is inside the polygon shell,
-     * but not inside a polygon hole.
-     * (If the shell is inside a polygon hole, the nesting is valid.)
-     *
-     * The algorithm used relies on the fact that the rings must be
-     * properly contained.
-     * E.g. they cannot partially overlap (this has been previously
-     * checked by <code>checkRelateConsistency</code>
-     */
-    void checkShellNotNested(const geom::LinearRing* shell,
-                             const geom::Polygon* p,
-                             geomgraph::GeometryGraph* graph);
-
-    /**
-     * This routine checks to see if a shell is properly contained
-     * in a hole.
-     * It assumes that the edges of the shell and hole do not
-     * properly intersect.
-     *
-     * @return <code>null</code> if the shell is properly contained, or
-     *   a Coordinate which is not inside the hole if it is not
-     *
-     */
-    const geom::Coordinate* checkShellInsideHole(
-        const geom::LinearRing* shell,
-        const geom::LinearRing* hole,
-        geomgraph::GeometryGraph* graph);
 
     void checkConnectedInteriors(geomgraph::GeometryGraph& graph);
 
@@ -201,7 +172,7 @@ public:
     static const geom::Coordinate* findPtNotNode(
         const geom::CoordinateSequence* testCoords,
         const geom::LinearRing* searchRing,
-        geomgraph::GeometryGraph* graph);
+        const geomgraph::GeometryGraph* graph);
 
     /** \brief
      * Checks whether a coordinate is valid for processing.

--- a/include/geos/operation/valid/Makefile.am
+++ b/include/geos/operation/valid/Makefile.am
@@ -11,6 +11,7 @@ geos_HEADERS = \
     ConnectedInteriorTester.h   \
     ConsistentAreaTester.h      \
     IsValidOp.h                 \
+    IndexedNestedShellTester.h  \
     MakeValid.h                 \
     QuadtreeNestedRingTester.h  \
     RepeatedPointRemover.h      \

--- a/src/geomgraph/GeometryGraph.cpp
+++ b/src/geomgraph/GeometryGraph.cpp
@@ -147,7 +147,7 @@ GeometryGraph::getBoundaryPoints()
 }
 
 Edge*
-GeometryGraph::findEdge(const LineString* line)
+GeometryGraph::findEdge(const LineString* line) const
 {
     return lineEdgeMap.find(line)->second;
 }

--- a/src/operation/valid/IndexedNestedRingTester.h
+++ b/src/operation/valid/IndexedNestedRingTester.h
@@ -19,6 +19,7 @@
 #ifndef GEOS_OP_VALID_OFFSETCURVEVERTEXLIST_H
 #define GEOS_OP_VALID_OFFSETCURVEVERTEXLIST_H
 
+#include <cstddef>
 #include <vector> // for composition
 
 // Forward declarations

--- a/src/operation/valid/IndexedNestedShellTester.cpp
+++ b/src/operation/valid/IndexedNestedShellTester.cpp
@@ -1,0 +1,214 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2019 Daniel Baston <dbaston@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/algorithm/PointLocation.h>
+#include <geos/algorithm/locate/IndexedPointInAreaLocator.h>
+#include <geos/geom/Polygon.h>
+#include <geos/index/strtree/STRtree.h>
+#include <geos/operation/valid/IndexedNestedShellTester.h>
+#include <geos/operation/valid/IsValidOp.h>
+
+#include <deque>
+
+namespace geos {
+namespace operation {
+namespace valid {
+
+class PolygonIndexedLocators {
+
+public:
+    using Locator = algorithm::locate::IndexedPointInAreaLocator;
+
+    PolygonIndexedLocators(const geom::Polygon & p) :
+        poly(p),
+        shellLoc(*poly.getExteriorRing())
+    {
+        auto n = poly.getNumInteriorRing();
+        for (size_t i = 0; i < n; i++) {
+            ringLoc.emplace_back(*poly.getInteriorRingN(i));
+        }
+    }
+
+    Locator& getShellLocator() {
+        return shellLoc;
+    }
+
+    Locator& getHoleLocator(size_t holeNum) {
+        return ringLoc[holeNum];
+    }
+
+    const geom::Polygon* getPolygon() const {
+        return &poly;
+    }
+
+    const geom::LinearRing* getInteriorRingN(size_t n) const {
+        return poly.getInteriorRingN(n);
+    }
+
+private:
+    const geom::Polygon& poly;
+    Locator shellLoc;
+    std::deque<Locator> ringLoc;
+};
+
+IndexedNestedShellTester::IndexedNestedShellTester(const geos::geomgraph::GeometryGraph &g, size_t initialCapacity) :
+    graph(g),
+    nestedPt(nullptr),
+    processed(false)
+{
+    polys.reserve(initialCapacity);
+}
+
+bool
+IndexedNestedShellTester::isNonNested() {
+    return getNestedPoint() == nullptr;
+}
+
+const geom::Coordinate*
+IndexedNestedShellTester::getNestedPoint() {
+    compute();
+
+    return nestedPt;
+}
+
+void
+IndexedNestedShellTester::compute() {
+    if (processed) {
+        return;
+    }
+
+    processed = true;
+
+    index::strtree::STRtree tree;
+    for (const auto& p : polys) {
+        tree.insert(p->getEnvelopeInternal(), (void*) p->getExteriorRing());
+    }
+
+    std::vector<void*> hits;
+    for (const auto& outerPoly : polys) {
+        hits.clear();
+
+        PolygonIndexedLocators locs(*outerPoly);
+        const geom::LinearRing* outerShell = outerPoly->getExteriorRing();
+
+        tree.query(outerShell->getEnvelopeInternal(), hits);
+
+        for (const auto& hit : hits) {
+            const geom::LinearRing* potentialInnerShell = static_cast<const geom::LinearRing*>(hit);
+
+            if (potentialInnerShell == outerShell) {
+                continue;
+            }
+
+            // check if p1 can possibly by inside p2
+            if (!outerShell->getEnvelopeInternal()->covers(potentialInnerShell->getEnvelopeInternal())) {
+                continue;
+            }
+
+            checkShellNotNested(potentialInnerShell, locs);
+
+            if (nestedPt != nullptr) {
+                return;
+            }
+        }
+
+    }
+}
+
+/*private*/
+void
+IndexedNestedShellTester::checkShellNotNested(const geom::LinearRing* shell, PolygonIndexedLocators & locs)
+{
+    const geom::CoordinateSequence* shellPts = shell->getCoordinatesRO();
+
+    // test if shell is inside polygon shell
+    const geom::LinearRing* polyShell = locs.getPolygon()->getExteriorRing();
+    const geom::Coordinate* shellPt = IsValidOp::findPtNotNode(shellPts, polyShell, &graph);
+
+    // if no point could be found, we can assume that the shell
+    // is outside the polygon
+    if(shellPt == nullptr) {
+        return;
+    }
+
+    bool insidePolyShell = locs.getShellLocator().locate(shellPt) != geom::Location::EXTERIOR;
+    if(!insidePolyShell) {
+        return;
+    }
+
+    auto nholes = locs.getPolygon()->getNumInteriorRing();
+    if (nholes == 0) {
+        nestedPt = shellPt;
+        return;
+    }
+
+    // Check if the shell is inside one of the holes.
+    // This is the case if one of the calls to checkShellInsideHole
+    // returns a null coordinate.
+    // Otherwise, the shell is not properly contained in a hole, which is
+    // an error.
+    const geom::Coordinate* badNestedPt = nullptr;
+    for (size_t i = 0; i < nholes; i++) {
+        const geom::LinearRing* hole = locs.getPolygon()->getInteriorRingN(i);
+
+        if (hole->getEnvelopeInternal()->covers(shell->getEnvelopeInternal())) {
+            badNestedPt = checkShellInsideHole(shell, locs.getHoleLocator(i));
+            if(badNestedPt == nullptr) {
+                return;
+            }
+
+        }
+    }
+
+    nestedPt = badNestedPt;
+}
+
+
+const geom::Coordinate*
+IndexedNestedShellTester::checkShellInsideHole(const geom::LinearRing* shell,
+        algorithm::locate::IndexedPointInAreaLocator & holeLoc) {
+
+    const geom::CoordinateSequence* shellPts = shell->getCoordinatesRO();
+    const geom::LinearRing* hole = static_cast<const geom::LinearRing*>(&holeLoc.getGeometry());
+    const geom::CoordinateSequence* holePts = hole->getCoordinatesRO();
+
+    const geom::Coordinate* shellPtNotOnHole = IsValidOp::findPtNotNode(shellPts, hole, &graph);
+
+    if (shellPtNotOnHole) {
+        // Found a point not on the hole boundary. Is it outside the hole?
+        if (holeLoc.locate(shellPtNotOnHole) == geom::Location::EXTERIOR) {
+            return shellPtNotOnHole;
+        }
+    }
+
+    const geom::Coordinate* holePt = IsValidOp::findPtNotNode(holePts, shell, &graph);
+    // if point is on hole but not on shell, check that the hole is outside the shell
+
+    if (holePt != nullptr) {
+        if (algorithm::PointLocation::isInRing(*holePt, shellPts)) {
+            return holePt;
+        }
+
+        return nullptr;
+    }
+
+    // should never reach here: points in hole and shell appear to be equal
+    // TODO throw?
+    return nullptr;
+}
+
+}
+}
+}
+

--- a/src/operation/valid/IsValidOp.cpp
+++ b/src/operation/valid/IsValidOp.cpp
@@ -41,6 +41,7 @@
 #include <geos/operation/valid/ConnectedInteriorTester.h>
 #include <geos/operation/valid/ConsistentAreaTester.h>
 #include <geos/operation/valid/IsValidOp.h>
+#include <geos/operation/valid/IndexedNestedShellTester.h>
 #include <geos/util/UnsupportedOperationException.h>
 
 
@@ -66,7 +67,7 @@ namespace valid { // geos.operation.valid
  */
 const Coordinate*
 IsValidOp::findPtNotNode(const CoordinateSequence* testCoords,
-                         const LinearRing* searchRing, GeometryGraph* graph)
+                         const LinearRing* searchRing, const GeometryGraph* graph)
 {
     // find edge corresponding to searchRing.
     Edge* searchEdge = graph->findEdge(searchRing);
@@ -488,121 +489,21 @@ IsValidOp::checkHolesNotNested(const Polygon* p, GeometryGraph* graph)
 void
 IsValidOp::checkShellsNotNested(const MultiPolygon* mp, GeometryGraph* graph)
 {
-    for (size_t i = 0, ngeoms = mp->getNumGeometries(); i < ngeoms; ++i) {
-        const Polygon* p = mp->getGeometryN(i);
+    auto ngeoms = mp->getNumGeometries();
 
-        const LinearRing* shell = p->getExteriorRing();
+    IndexedNestedShellTester tester(*graph, ngeoms);
 
-        if (shell->isEmpty()) return;
-
-        for (size_t j = 0; j < ngeoms; ++j) {
-            if (i == j) {
-                continue;
-            }
-
-            const Polygon* p2 = mp->getGeometryN(j);
-
-            if (p2->isEmpty()) {
-                continue;
-            }
-
-            checkShellNotNested(shell, p2, graph);
-
-            if (validErr != nullptr) {
-                return;
-            }
-        }
+    for (size_t i = 0; i < ngeoms; ++i) {
+        tester.add(*mp->getGeometryN(i));
     }
+
+    if (!tester.isNonNested()) {
+        validErr = new TopologyValidationError(TopologyValidationError::eNestedShells,
+                *tester.getNestedPoint());
+    }
+
 }
 
-/*private*/
-void
-IsValidOp::checkShellNotNested(const LinearRing* shell, const Polygon* p,
-                               GeometryGraph* graph)
-{
-    const CoordinateSequence* shellPts = shell->getCoordinatesRO();
-
-    // test if shell is inside polygon shell
-    const LinearRing* polyShell = p->getExteriorRing();
-    const CoordinateSequence* polyPts = polyShell->getCoordinatesRO();
-    const Coordinate* shellPt = findPtNotNode(shellPts, polyShell, graph);
-
-    // if no point could be found, we can assume that the shell
-    // is outside the polygon
-    if(shellPt == nullptr) {
-        return;
-    }
-
-    bool insidePolyShell = PointLocation::isInRing(*shellPt, polyPts);
-    if(!insidePolyShell) {
-        return;
-    }
-
-    // if no holes, this is an error!
-    auto nholes = p->getNumInteriorRing();
-    if(nholes <= 0) {
-        validErr = new TopologyValidationError(
-            TopologyValidationError::eNestedShells,
-            *shellPt);
-        return;
-    }
-
-    /*
-     * Check if the shell is inside one of the holes.
-     * This is the case if one of the calls to checkShellInsideHole
-     * returns a null coordinate.
-     * Otherwise, the shell is not properly contained in a hole, which is
-     * an error.
-     */
-    const Coordinate* badNestedPt = nullptr;
-    for(size_t i = 0; i < nholes; ++i) {
-        const LinearRing* hole = p->getInteriorRingN(i);
-        badNestedPt = checkShellInsideHole(shell, hole, graph);
-        if(badNestedPt == nullptr) {
-            return;
-        }
-    }
-    validErr = new TopologyValidationError(
-        TopologyValidationError::eNestedShells, *badNestedPt
-    );
-}
-
-/*private*/
-const Coordinate*
-IsValidOp::checkShellInsideHole(const LinearRing* shell,
-                                const LinearRing* hole,
-                                GeometryGraph* graph)
-{
-    const CoordinateSequence* shellPts = shell->getCoordinatesRO();
-    const CoordinateSequence* holePts = hole->getCoordinatesRO();
-
-    // TODO: improve performance of this - by sorting pointlists
-    // for instance?
-    const Coordinate* shellPt = findPtNotNode(shellPts, hole, graph);
-
-    // if point is on shell but not hole, check that the shell is
-    // inside the hole
-    if(shellPt) {
-        bool insideHole = PointLocation::isInRing(*shellPt, holePts);
-        if(!insideHole) {
-            return shellPt;
-        }
-    }
-
-    const Coordinate* holePt = findPtNotNode(holePts, shell, graph);
-
-    // if point is on hole but not shell, check that the hole is
-    // outside the shell
-    if(holePt) {
-        bool insideShell = PointLocation::isInRing(*holePt, shellPts);
-        if(insideShell) {
-            return holePt;
-        }
-        return nullptr;
-    }
-    assert(0); // points in shell and hole appear to be equal
-    return nullptr;
-}
 
 /*private*/
 void

--- a/src/operation/valid/IsValidOp.cpp
+++ b/src/operation/valid/IsValidOp.cpp
@@ -326,7 +326,9 @@ IsValidOp::checkValid(const MultiPolygon* g)
         }
     }
 
-    checkShellsNotNested(g, &graph);
+    if (ngeoms > 1) {
+        checkShellsNotNested(g, &graph);
+    }
     if(validErr != nullptr) {
         return;
     }

--- a/src/operation/valid/Makefile.am
+++ b/src/operation/valid/Makefile.am
@@ -23,6 +23,7 @@ libopvalid_la_SOURCES = \
     TopologyValidationError.cpp \
     IndexedNestedRingTester.cpp \
     IndexedNestedRingTester.h \
+    IndexedNestedShellTester.cpp \
     MakeValid.cpp
 
 libopvalid_la_LIBADD =


### PR DESCRIPTION
This PR introduces an `IndexedNestedShellTester` class, modelled after
`IndexedNestedRingTester`, to check shell nesting as part of MultiPolygon
validity checking. Relevant methods are yanked out of `IsValidOp`
then updated to use indexes to locate rings relative to each other 
(STRtree) and to check point containment within a ring
(IndexedPointOnAreaLocator).

You need the right geometry for this to matter.

This commit **reduces GEOSisValid runtime for a test geometry (GADM
boundary of Australia) from about 85 seconds to less than 1 second**. It
does not appreciably change runtime for TIGER counties, HydroBASINS
Level 5, or a sample parcel dataset.