### PR TITLE
Install inl files if DISABLE_GEOS_INLINE is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,13 @@ install(DIRECTORY
   "${CMAKE_CURRENT_BINARY_DIR}/include/geos"
   DESTINATION include
   FILES_MATCHING PATTERN "*.h")
+if(NOT DISABLE_GEOS_INLINE)
+  install(DIRECTORY
+    "${CMAKE_CURRENT_LIST_DIR}/include/geos"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/geos"
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.inl")
+endif()
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/capi/geos_c.h"
   DESTINATION include)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -8,7 +8,11 @@
 # by the Free Software Foundation.
 # See the COPYING file for more information.
 ################################################################################
-file(GLOB_RECURSE _headers ${CMAKE_CURRENT_LIST_DIR}/*.h  CONFIGURE_DEPEND)
+if(DISABLE_GEOS_INLINE)
+  file(GLOB_RECURSE _headers ${CMAKE_CURRENT_LIST_DIR}/*.h  CONFIGURE_DEPEND)
+else()
+  file(GLOB_RECURSE _headers ${CMAKE_CURRENT_LIST_DIR}/*.h  ${CMAKE_CURRENT_LIST_DIR}/*.inl CONFIGURE_DEPEND)
+endif()
 target_sources(geos PRIVATE ${_headers})
 unset(_headers)
 


### PR DESCRIPTION
Currently, if `DISABLE_GEOS_INLINE` is `OFF` (the default value) then the `.inl` files are not installed along which causes an issue for consumers down the line.

This PR fixes that behaviour by installing the `.inl` files if required.