### PR TITLE
Docs update

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2124,12 +2124,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2142,15 +2136,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/include/geos/geom/prep/PreparedGeometry.h
+++ b/include/geos/geom/prep/PreparedGeometry.h
@@ -55,14 +55,14 @@ public:
     virtual
     ~PreparedGeometry() {}
 
-    /**
+    /** \brief
      * Gets the original {@link Geometry} which has been prepared.
      *
      * @return the base geometry
      */
     virtual const geom::Geometry& getGeometry() const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} contains a given geometry.
      *
      * @param geom the Geometry to test
@@ -113,7 +113,7 @@ public:
      */
     virtual bool containsProperly(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} is covered by a given geometry.
      *
      * @param geom the Geometry to test
@@ -123,7 +123,7 @@ public:
      */
     virtual bool coveredBy(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} covers a given geometry.
      *
      * @param geom the Geometry to test
@@ -133,7 +133,7 @@ public:
      */
     virtual bool covers(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} crosses a given geometry.
      *
      * @param geom the Geometry to test
@@ -143,7 +143,7 @@ public:
      */
     virtual bool crosses(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} is disjoint from a given geometry.
      *
      * @param geom the Geometry to test
@@ -153,7 +153,7 @@ public:
      */
     virtual bool disjoint(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} intersects a given geometry.
      *
      * @param geom the Geometry to test
@@ -163,7 +163,7 @@ public:
      */
     virtual bool intersects(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} overlaps a given geometry.
      *
      * @param geom the Geometry to test
@@ -173,7 +173,7 @@ public:
      */
     virtual bool overlaps(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} touches a given geometry.
      *
      * @param geom the Geometry to test
@@ -183,7 +183,7 @@ public:
      */
     virtual bool touches(const geom::Geometry* geom) const = 0;
 
-    /**
+    /** \brief
      * Tests whether the base {@link Geometry} is within a given geometry.
      *
      * @param geom the Geometry to test

--- a/include/geos/geom/prep/PreparedGeometry.h
+++ b/include/geos/geom/prep/PreparedGeometry.h
@@ -84,26 +84,26 @@ public:
      * - The DE-9IM Intersection Matrix for the two geometries matches
      *   <code>[T**FF*FF*]</code>
      *
-         * In other words, if the test geometry has any interaction with
+     * In other words, if the test geometry has any interaction with
      * the boundary of the target
-         * geometry the result of <tt>containsProperly</tt> is <tt>false</tt>.
-         * This is different semantics to the {@link Geometry::contains}
-     * predicate, * in which test geometries can intersect the target's
+     * geometry the result of <tt>containsProperly</tt> is <tt>false</tt>.
+     * This is different semantics to the {@link Geometry::contains}
+     * predicate, in which test geometries can intersect the target's
      * boundary and still be contained.
      *
-         * The advantage of using this predicate is that it can be computed
-         * efficiently, since it avoids the need to compute the full
+     * The advantage of using this predicate is that it can be computed
+     * efficiently, since it avoids the need to compute the full
      * topological relationship of the input boundaries in cases where
      * they intersect.
      *
-         * An example use case is computing the intersections
-         * of a set of geometries with a large polygonal geometry.
-         * Since <tt>intersection</tt> is a fairly slow operation, it can
+     * An example use case is computing the intersections
+     * of a set of geometries with a large polygonal geometry.
+     * Since <tt>intersection</tt> is a fairly slow operation, it can
      * be more efficient
-         * to use <tt>containsProperly</tt> to filter out test geometries
+     * to use <tt>containsProperly</tt> to filter out test geometries
      * which lie
-         * wholly inside the area.  In these cases the intersection is
-         * known <i>a priori</i> to be exactly the original test geometry.
+     * wholly inside the area.  In these cases the intersection is
+     * known <i>a priori</i> to be exactly the original test geometry.
      *
      * @param geom the Geometry to test
      * @return true if this Geometry properly contains the given Geometry

--- a/include/geos/geom/prep/PreparedGeometryFactory.h
+++ b/include/geos/geom/prep/PreparedGeometryFactory.h
@@ -55,11 +55,11 @@ class GEOS_DLL PreparedGeometryFactory {
 public:
 
     /**
-    * Creates a new {@link PreparedGeometry} appropriate for the argument {@link Geometry}.
-    *
-    * @param geom the geometry to prepare
-    * @return the prepared geometry
-    */
+     * Creates a new {@link PreparedGeometry} appropriate for the argument {@link Geometry}.
+     *
+     * @param geom the geometry to prepare
+     * @return the prepared geometry
+     */
     static std::unique_ptr<PreparedGeometry>
     prepare(const geom::Geometry* geom)
     {
@@ -68,10 +68,10 @@ public:
     }
 
     /**
-    * Destroys {@link PreparedGeometry} allocated with the factory.
-    *
-    * @param geom to be deallocated
-    */
+     * Destroys {@link PreparedGeometry} allocated with the factory.
+     *
+     * @param geom to be deallocated
+     */
     static void
     destroy(const PreparedGeometry* geom)
     {
@@ -79,11 +79,11 @@ public:
     }
 
     /**
-    * Creates a new {@link PreparedGeometry} appropriate for the argument {@link Geometry}.
-    *
-    * @param geom the geometry to prepare
-    * @return the prepared geometry
-    */
+     * Creates a new {@link PreparedGeometry} appropriate for the argument {@link Geometry}.
+     *
+     * @param geom the geometry to prepare
+     * @return the prepared geometry
+     */
     std::unique_ptr<PreparedGeometry> create(const geom::Geometry* geom) const;
 
 };

--- a/include/geos/geom/prep/PreparedPolygonContainsProperly.h
+++ b/include/geos/geom/prep/PreparedPolygonContainsProperly.h
@@ -60,7 +60,7 @@ class PreparedPolygonContainsProperly : public PreparedPolygonPredicate {
 private:
 protected:
 public:
-    /**
+    /** \brief
      * Computes the <tt>containsProperly</tt> predicate between a {@link PreparedPolygon}
      * and a {@link Geometry}.
      *
@@ -76,7 +76,7 @@ public:
         return polyInt.containsProperly(geom);
     }
 
-    /**
+    /** \brief
      * Creates an instance of this operation.
      *
      * @param prep the PreparedPolygon to evaluate
@@ -85,7 +85,7 @@ public:
         :	PreparedPolygonPredicate(prep)
     { }
 
-    /**
+    /** \brief
      * Tests whether this PreparedPolygon containsProperly a given geometry.
      *
      * @param geom the test geometry

--- a/include/geos/geom/prep/PreparedPolygonCovers.h
+++ b/include/geos/geom/prep/PreparedPolygonCovers.h
@@ -65,7 +65,7 @@ protected:
     bool fullTopologicalPredicate(const geom::Geometry* geom) override;
 
 public:
-    /**
+    /** \brief
      * Computes the <tt>covers</tt> predicate between a {@link PreparedPolygon}
      * and a {@link Geometry}.
      *
@@ -80,7 +80,7 @@ public:
         return polyInt.covers(geom);
     }
 
-    /**
+    /** \brief
      * Creates an instance of this operation.
      *
      * @param prep the PreparedPolygon to evaluate
@@ -89,7 +89,7 @@ public:
         :	AbstractPreparedPolygonContains(prep, false)
     { }
 
-    /**
+    /** \brief
      * Tests whether this PreparedPolygon <tt>covers</tt> a given geometry.
      *
      * @param geom the test geometry

--- a/include/geos/geom/prep/PreparedPolygonIntersects.h
+++ b/include/geos/geom/prep/PreparedPolygonIntersects.h
@@ -51,7 +51,7 @@ class PreparedPolygonIntersects : public PreparedPolygonPredicate {
 private:
 protected:
 public:
-    /**
+    /** \brief
      * Computes the intersects predicate between a {@link PreparedPolygon}
      * and a {@link Geometry}.
      *
@@ -66,7 +66,7 @@ public:
         return polyInt.intersects(geom);
     }
 
-    /**
+    /** \brief
      * Creates an instance of this operation.
      *
      * @param prep the PreparedPolygon to evaluate
@@ -75,7 +75,7 @@ public:
         :	PreparedPolygonPredicate(prep)
     { }
 
-    /**
+    /** \brief
      * Tests whether this PreparedPolygon intersects a given geometry.
      *
      * @param geom the test geometry

--- a/include/geos/geom/prep/PreparedPolygonPredicate.h
+++ b/include/geos/geom/prep/PreparedPolygonPredicate.h
@@ -121,7 +121,7 @@ protected:
                                         const geom::Coordinate::ConstVect* targetRepPts) const;
 
 public:
-    /**
+    /** \brief
      * Creates an instance of this operation.
      *
      * @param p_prepPoly the PreparedPolygon to evaluate

--- a/include/geos/operation/distance/IndexedFacetDistance.h
+++ b/include/geos/operation/distance/IndexedFacetDistance.h
@@ -24,19 +24,78 @@
 namespace geos {
 namespace operation {
 namespace distance {
+
+/// \brief Computes the distance between the facets (segments and vertices)
+/// of two [Geometrys](\ref geom::Geometry) using a Branch-and-Bound algorithm.
+///
+/// The Branch-and-Bound algorithm operates over a traversal of R-trees built
+/// on the target and the query geometries.
+///
+/// This approach provides the following benefits:
+///
+/// - Performance is dramatically improved due to the use of the R-tree index
+///   and the pruning due to the Branch-and-Bound approach
+/// - The spatial index on the target geometry is cached which allow reuse in
+///   an repeated query situation.
+///
+/// Using this technique is usually much more performant than using the
+/// brute-force \ref geom::Geometry::distance(const Geometry* g) const when one
+/// or both input geometries are large, or when evaluating many distance
+/// computations against a single geometry.
+///
+/// \author Martin Davis
 class GEOS_DLL IndexedFacetDistance {
 public:
+
+    /// \brief Creates a new distance-finding instance for a given target geom::Geometry.
+    ///
+    /// Distances will be computed to all facets of the input geometry.
+    /// The facets of the geometry are the discrete segments and points
+    /// contained in its components.
+    /// In the case of lineal and puntal inputs, this is equivalent to computing
+    /// the conventional distance.
+    /// In the case of polygonal inputs, this is equivalent to computing the
+    /// distance to the polygon boundaries.
+    ///
+    /// \param g a Geometry, which may be of any type.
     IndexedFacetDistance(const geom::Geometry* g) :
         cachedTree(FacetSequenceTreeBuilder::build(g))
     {}
 
+    /// \brief Computes the distance between facets of two geometries.
+    ///
+    /// For geometries with many segments or points, this can be faster than
+    /// using a simple distance algorithm.
+    ///
+    /// \param g1 a geometry
+    /// \param g2 a geometry
+    /// \return the distance between facets of the geometries
     static double distance(const geom::Geometry* g1, const geom::Geometry* g2);
 
+    /// \brief Computes the nearest points of the facets of two geometries.
+    ///
+    /// \param g1 a geometry
+    /// \param g2 a geometry
+    /// \return the nearest points on the facets of the geometries
     static std::vector<geom::Coordinate> nearestPoints(const geom::Geometry* g1, const geom::Geometry* g2);
 
+    /// \brief Computes the distance from the base geometry to the given geometry.
+    ///
+    /// \param g the geometry to compute the distance to
+    ///
+    /// \return the computed distance
     double distance(const geom::Geometry* g) const;
 
+    /// \brief Computes the nearest locations on the base geometry and the given geometry.
+    ///
+    /// \param g the geometry to compute the nearest location to
+    /// \return the nearest locations
     std::vector<GeometryLocation> nearestLocations(const geom::Geometry* g) const;
+
+    /// \brief Compute the nearest locations on the target geometry and the given geometry.
+    ///
+    /// \param g the geometry to compute the nearest point to
+    /// \return the nearest points
     std::vector<geom::Coordinate> nearestPoints(const geom::Geometry* g) const;
 
     ~IndexedFacetDistance();


### PR DESCRIPTION
This PR addresses two independent issues with doxygen documentations:

- adds documentation to `IndexedFacetDistance`

- removes the doxygen tags `PERL_PATH` and `MSCGEN_PATH` from Doxyfile.in. The tags are with Doxygen 1.8.16 obsolete, and have not been used in GEOS docs anyway. They will most probably not be missed with earlier versions either.

I'm not sure though, whether the IndexedFacetDistance class description statement that the class is thread-safe also is true for GEOS.

Update:
Additionally, I corrected some bad comment indentation and added some missing brief tags.