### PR TITLE
Minor debug code fixes

### DIFF
--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -866,7 +866,7 @@ LineIntersector::intersection(const Coordinate& p1, const Coordinate& p2,
         intPtOut = nearestEndpoint(p1, p2, q1, q2);
 #if GEOS_DEBUG
         cerr << "Intersection outside segment envelopes, snapped to "
-             << intPt.toString() << endl;
+             << intPtOut.toString() << endl;
 #endif
     }
 

--- a/src/geomgraph/index/SegmentIntersector.cpp
+++ b/src/geomgraph/index/SegmentIntersector.cpp
@@ -33,7 +33,9 @@
 #define GEOS_DEBUG 0
 #endif
 
+#ifndef DEBUG_INTERSECT
 #define DEBUG_INTERSECT 0
+#endif
 
 #if GEOS_DEBUG || DEBUG_INTERSECT
 #include <iostream>


### PR DESCRIPTION
- Fixes a compile-time error when `GEOS_DEBUG` is defined.
- Fixes redefining `DEBUG_INTERSECT` with 0 regardless of its value.