### PR TITLE
Provide location for GEOSNode failure

### DIFF
--- a/include/geos/noding/IntersectionAdder.h
+++ b/include/geos/noding/IntersectionAdder.h
@@ -32,9 +32,6 @@
 
 // Forward declarations
 namespace geos {
-namespace geom {
-class Coordinate;
-}
 namespace noding {
 class SegmentString;
 }
@@ -71,7 +68,7 @@ private:
     bool hasInterior;
 
     // the proper intersection point found
-    const geom::Coordinate* properIntersectionPoint;
+    geom::Coordinate properIntersectionPoint;
 
     algorithm::LineIntersector& li;
     // bool isSelfIntersection;
@@ -105,7 +102,7 @@ public:
         hasProper(false),
         hasProperInterior(false),
         hasInterior(false),
-        properIntersectionPoint(nullptr),
+        properIntersectionPoint(),
         li(newLi),
         numIntersections(0),
         numInteriorIntersections(0),
@@ -120,10 +117,10 @@ public:
     }
 
     /**
-     * @return the proper intersection point, or `NULL`
+     * @return the proper intersection point, or `Coordinate::getNull()`
      *         if none was found
      */
-    const geom::Coordinate*
+    const geom::Coordinate&
     getProperIntersectionPoint()
     {
         return properIntersectionPoint;

--- a/include/geos/noding/IteratedNoder.h
+++ b/include/geos/noding/IteratedNoder.h
@@ -68,7 +68,8 @@ private:
      * and create the split edges between the nodes
      */
     void node(std::vector<SegmentString*>* segStrings,
-              int* numInteriorIntersections);
+              int& numInteriorIntersections,
+              geom::Coordinate& intersectionPoint);
 
 public:
 

--- a/src/noding/IntersectionAdder.cpp
+++ b/src/noding/IntersectionAdder.cpp
@@ -88,7 +88,6 @@ IntersectionAdder::processIntersections(
     numIntersections++;
 
     if(li.isInteriorIntersection()) {
-
         numInteriorIntersections++;
         hasInterior = true;
     }
@@ -110,7 +109,7 @@ IntersectionAdder::processIntersections(
             numProperIntersections++;
             //Debug.println(li.toString());
             //Debug.println(li.getIntersection(0));
-//properIntersectionPoint = (Coordinate) li.getIntersection(0).clone();
+            properIntersectionPoint = li.getIntersection(0);
             hasProper = true;
             hasProperInterior = true;
         }

--- a/src/noding/IteratedNoder.cpp
+++ b/src/noding/IteratedNoder.cpp
@@ -31,7 +31,6 @@
 #define GEOS_DEBUG 0
 #endif
 
-using namespace std;
 using namespace geos::geom;
 
 namespace geos {
@@ -39,16 +38,20 @@ namespace noding { // geos.noding
 
 /* private */
 void
-IteratedNoder::node(vector<SegmentString*>* segStrings,
-                    int* numInteriorIntersections)
+IteratedNoder::node(std::vector<SegmentString*>* segStrings,
+                    int& numInteriorIntersections,
+                    Coordinate& intersectionPoint)
 {
     IntersectionAdder si(li);
     MCIndexNoder noder;
     noder.setSegmentIntersector(&si);
     noder.computeNodes(segStrings);
     nodedSegStrings = noder.getNodedSubstrings();
-    *numInteriorIntersections = si.numInteriorIntersections;
-//System.out.println("# intersection tests: " + si.numTests);
+    numInteriorIntersections = si.numInteriorIntersections;
+
+    if (si.hasProperInteriorIntersection()) {
+        intersectionPoint = si.getProperIntersectionPoint();
+    }
 }
 
 /* public */
@@ -60,11 +63,12 @@ IteratedNoder::computeNodes(SegmentString::NonConstVect* segStrings)
     nodedSegStrings = segStrings;
     int nodingIterationCount = 0;
     int lastNodesCreated = -1;
-    vector<SegmentString*>* lastStrings = nullptr;
-    do {
+    std::vector<SegmentString*>* lastStrings = nullptr;
+    Coordinate intersectionPoint = Coordinate::getNull();
 
+    do {
         // NOTE: will change this.nodedSegStrings
-        node(nodedSegStrings, &numInteriorIntersections);
+        node(nodedSegStrings, numInteriorIntersections, intersectionPoint);
 
         // Delete noded strings from previous iteration
         if(lastStrings) {
@@ -86,9 +90,19 @@ IteratedNoder::computeNodes(SegmentString::NonConstVect* segStrings)
         if(lastNodesCreated > 0
                 && nodesCreated >= lastNodesCreated
                 && nodingIterationCount > maxIter) {
-            stringstream s;
+
+            // Delete noded strings from previous iteration
+            if(lastStrings) {
+                for(auto& s : *lastStrings) {
+                    delete s;
+                }
+                delete lastStrings;
+            }
+
+            std::stringstream s;
             s << "Iterated noding failed to converge after " <<
-              nodingIterationCount << " iterations";
+              nodingIterationCount << " iterations (near " <<
+              intersectionPoint << ")";
             throw util::TopologyException(s.str());
         }
         lastNodesCreated = nodesCreated;

--- a/tests/unit/capi/GEOSNodeTest.cpp
+++ b/tests/unit/capi/GEOSNodeTest.cpp
@@ -123,6 +123,24 @@ void object::test<3>
                  );
 }
 
+// https://gis.stackexchange.com/questions/345341/get-location-of-postgis-geos-topology-exception/345482#345482
+template<>
+template<>
+void object::test<4>
+()
+{
+    std::string wkb = "010500000002000000010200000003000000dc874d65fcc25ec176032c6b350c5341b336429ffec25ec1f962bbd"
+                      "9480c5341fc849518ffc25ec15be20f5f500c5341010200000006000000fa9bbfd3fcc25ec1b978232f390c5341"
+                      "b336429ffec25ec1f962bbd9480c5341a77e6be5fec25ec1357c21334d0c5341c3eba27bfec25ec11be5a4c34a0"
+                      "c5341b61d8cacfcc25ec1bcf273143c0c5341fa9bbfd3fcc25ec1b978232f390c5341";
+
+    geom1_ = GEOSGeomFromHEX_buf((const unsigned char*) wkb.c_str(), wkb.size());
+    geom2_ = GEOSNode(geom1_);
+
+    // Noding currently fails for this case.
+    // ensure(geom2_);
+}
+
 
 } // namespace tut
 


### PR DESCRIPTION
This PR modifies `IteratedNoder` to provide an intersection coordinate for a failed noding, e.g.

`TopologyException: Iterated noding failed to converge after 6 iterations (near -8.064e+06 4.99333e+06)`

It also resolves a memory leak for the error case.

cc @mappingvermont