### PR TITLE
Rename geos::M_PI to less intrusive MATH_PI 

### DIFF
--- a/doc/example.cpp
+++ b/doc/example.cpp
@@ -443,7 +443,7 @@ do_all()
     geoms->push_back(create_rectangle(-5, -5, 10, 10)); // a square
     geoms->push_back(create_rectangle(-5, -5, 10, 20)); // a rectangle
     // The upper-right quarter of a vertical ellipse
-    geoms->push_back(create_arc(0, 0, 10, 20, 0, M_PI / 2));
+    geoms->push_back(create_arc(0, 0, 10, 20, 0, MATH_PI / 2));
     geoms->push_back(create_sinestar(10, 10, 100, 5, 2).release()); // a sine star
 #endif
 

--- a/include/geos/constants.h
+++ b/include/geos/constants.h
@@ -32,14 +32,11 @@ typedef __int64 int64;
 #include <cinttypes>
 
 
-#ifdef M_PI
-#undef M_PI
-#endif
 typedef int64_t int64;
 
 namespace geos {
 
-constexpr double M_PI = 3.14159265358979323846;
+constexpr double MATH_PI = 3.14159265358979323846;
 
 
 

--- a/src/geom/util/SineStarFactory.cpp
+++ b/src/geom/util/SineStarFactory.cpp
@@ -65,7 +65,7 @@ SineStarFactory::createSineStar() const
 
         // the angle for the current arm - in [0,2Pi]
         // (each arm is a complete sine wave cycle)
-        double armAng = 2 * M_PI * armAngFrac;
+        double armAng = 2 * MATH_PI * armAngFrac;
         // the current length of the arm
         double armLenFrac = (cos(armAng) + 1.0) / 2.0;
 
@@ -73,7 +73,7 @@ SineStarFactory::createSineStar() const
         double curveRadius = insideRadius + armMaxLen * armLenFrac;
 
         // the current angle of the curve
-        double ang = i * (2 * M_PI / nPts);
+        double ang = i * (2 * MATH_PI / nPts);
         double x = curveRadius * cos(ang) + centreX;
         double y = curveRadius * sin(ang) + centreY;
         pts[iPt++] = coord(x, y);

--- a/src/operation/buffer/BufferParameters.cpp
+++ b/src/operation/buffer/BufferParameters.cpp
@@ -125,7 +125,7 @@ BufferParameters::setQuadrantSegments(int quadSegs)
 double
 BufferParameters::bufferDistanceError(int quadSegs)
 {
-    double alpha = M_PI / 2.0 / quadSegs;
+    double alpha = MATH_PI / 2.0 / quadSegs;
     return 1 - cos(alpha / 2.0);
 }
 

--- a/src/util/GeometricShapeFactory.cpp
+++ b/src/util/GeometricShapeFactory.cpp
@@ -161,8 +161,8 @@ GeometricShapeFactory::createArc(double startAng, double angExtent)
     env.reset();
 
     double angSize = angExtent;
-    if(angSize <= 0.0 || angSize > 2 * M_PI) {
-        angSize = 2 * M_PI;
+    if(angSize <= 0.0 || angSize > 2 * MATH_PI) {
+        angSize = 2 * MATH_PI;
     }
     double angInc = angSize / (nPts - 1);
 
@@ -191,8 +191,8 @@ GeometricShapeFactory::createArcPolygon(double startAng, double angExtent)
     env.reset();
 
     double angSize = angExtent;
-    if(angSize <= 0.0 || angSize > 2 * M_PI) {
-        angSize = 2 * M_PI;
+    if(angSize <= 0.0 || angSize > 2 * MATH_PI) {
+        angSize = 2 * MATH_PI;
     }
     double angInc = angSize / (nPts - 1);
 

--- a/tests/unit/capi/GEOSDistanceTest.cpp
+++ b/tests/unit/capi/GEOSDistanceTest.cpp
@@ -92,7 +92,7 @@ random_polygon(double x, double y, double r, size_t num_points)
 
 
     for(size_t i = 0; i < num_points; i++) {
-        angle[i] = 2 * geos::M_PI * std::rand() / RAND_MAX;
+        angle[i] = 2 * geos::MATH_PI * std::rand() / RAND_MAX;
         radius[i] = r * std::rand() / RAND_MAX;
     }
 


### PR DESCRIPTION
That don't collide with standard #include <cmath> define.
#undef M_PI public headers is not good idea IMHO.