### PR TITLE
remove whitespace at the end of capi version

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -1931,7 +1931,7 @@ extern "C" {
     const char* GEOSversion()
     {
         static char version[256];
-        sprintf(version, "%s ", GEOS_CAPI_VERSION);
+        sprintf(version, "%s", GEOS_CAPI_VERSION);
         return version;
     }
 

--- a/tests/unit/capi/GEOSCAPIDefinesTest.cpp
+++ b/tests/unit/capi/GEOSCAPIDefinesTest.cpp
@@ -55,5 +55,14 @@ void object::test<2>
         std::string(EXPAND_AND_QUOTE(GEOS_VERSION_PATCH)));
 }
 
+// Make sure define is consistent with function
+template<>
+template<>
+void object::test<3>
+()
+{
+    ensure_equals(GEOS_CAPI_VERSION, std::string(GEOSversion()));
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Previously version included git commit hash at the end.
Git commit hash was [removed](https://github.com/libgeos/geos/commit/7699310f0bc7b3f2a6f300e72164d3fab3e76646#diff-8dd96440c9832c59176dcaa7c346b982R3549), but whitespace was left over.
It breaks ruby ffi-geos library that tries to parse capi version using regex :).