### PR TITLE
Retain component order in MultiLineString::reverse

### DIFF
--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -125,14 +125,16 @@ MultiLineString::reverse() const
         return clone();
     }
 
-    size_t nLines = geometries.size();
-    std::vector<std::unique_ptr<Geometry>> revLines(nLines);
+    std::vector<std::unique_ptr<Geometry>> reversed(geometries.size());
 
-    for(size_t i = 0; i < nLines; ++i) {
-        const LineString* iLS = static_cast<LineString*>(geometries[i].get());
-        revLines[nLines - 1 - i] = iLS->reverse();
-    }
-    return getFactory()->createMultiLineString(std::move(revLines));
+    std::transform(geometries.begin(),
+                   geometries.end(),
+                   reversed.begin(),
+                   [](const std::unique_ptr<Geometry> & g) {
+                       return g->reverse();
+                   });
+
+    return getFactory()->createMultiLineString(std::move(reversed));
 }
 
 const LineString*

--- a/tests/unit/capi/GEOSReverseTest.cpp
+++ b/tests/unit/capi/GEOSReverseTest.cpp
@@ -95,7 +95,7 @@ void object::test<4>
 ()
 {
     testReverse("MULTILINESTRING ((1 1, 2 2), (3 3, 4 4))",
-                "MULTILINESTRING ((4 4, 3 3), (2 2, 1 1))");
+                "MULTILINESTRING ((2 2, 1 1), (4 4, 3 3))");
 }
 
 template<>

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -331,7 +331,7 @@ void object::test<16>
 ()
 {
     checkExtractLine("MULTILINESTRING ((0 0, 10 0), (20 0, 25 0, 30 0))",
-                     19, 1, "MULTILINESTRING ((29 0, 25 0, 20 0), (10 0, 1 0))");
+                     19, 1, "MULTILINESTRING ((10 0, 1 0), (29 0, 25 0, 20 0))");
 }
 
 // testExtractLineNegative()


### PR DESCRIPTION
Updated for consistency with the behavior of other geometry types (as changed in https://github.com/locationtech/jts/pull/513)

I am inclined to backport this to 3.7.x (where `GEOSReverse` was introduced) since I doubt there are many users of this function and it's difficult to recommend new users (https://github.com/r-spatial/sf/issues/1246) if behavior among GEOS versions is not consistent.