### PR TITLE
Fix uninialized info member of ttmath::Big class

### DIFF
--- a/include/geos/algorithm/ttmath/ttmathbig.h
+++ b/include/geos/algorithm/ttmath/ttmathbig.h
@@ -86,7 +86,7 @@ public:
 
 Int<exp>  exponent;
 UInt<man> mantissa;
-unsigned char info;
+unsigned char info = 0;
 
 
 /*!


### PR DESCRIPTION
Fix the following warning raised by gcc 5.5 -O2:
```
In file included from ../../../include/geos/algorithm/ttmath/ttmath.h:58:0,
                 from ../../../include/geos/algorithm/CGAlgorithmsDD.h:22,
                 from ../../../src/algorithm/CGAlgorithmsDD.cpp:20:
../../../include/geos/algorithm/ttmath/ttmathbig.h: In static member function ‘static int geos::algorithm::CGAlgorithmsDD::signOfDet2x2(double, double, double, double)’:
../../../include/geos/algorithm/ttmath/ttmathbig.h:238:15: warning: ‘*((void*)& x1 +24)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   info = info | bit;
               ^
../../../src/algorithm/CGAlgorithmsDD.cpp:105:8: note: ‘x1’ was declared here
     DD x1(dx1);
        ^
```