### PR TITLE
Use !std::isfinite() to exclude nan and infinite values

### DIFF
--- a/src/algorithm/CGAlgorithmsDD.cpp
+++ b/src/algorithm/CGAlgorithmsDD.cpp
@@ -63,7 +63,7 @@ CGAlgorithmsDD::orientationIndex(const Coordinate& p1,
                                  const Coordinate& p2,
                                  const Coordinate& q)
 {
-    if(std::isnan(q.x) || std::isnan(q.y) || !std::isfinite(q.x) || !std::isfinite(q.y)) {
+    if(!std::isfinite(q.x) || !std::isfinite(q.y)) {
         throw util::IllegalArgumentException("CGAlgorithmsDD::orientationIndex encountered NaN/Inf numbers");
     }
 
@@ -99,8 +99,7 @@ CGAlgorithmsDD::signOfDet2x2(const DD& x1, const DD& y1, const DD& x2, const DD&
 int
 CGAlgorithmsDD::signOfDet2x2(double dx1, double dy1, double dx2, double dy2)
 {
-    if(std::isnan(dx1)    ||  std::isnan(dy1)    ||  std::isnan(dx2)    ||  std::isnan(dy2) ||
-            !std::isfinite(dx1) || !std::isfinite(dy1) || !std::isfinite(dx2) || !std::isfinite(dy2)) {
+    if(!std::isfinite(dx1) || !std::isfinite(dy1) || !std::isfinite(dx2) || !std::isfinite(dy2)) {
         throw util::IllegalArgumentException("CGAlgorithmsDD::signOfDet2x2 encountered NaN/Inf numbers");
     }
     DD x1(dx1);
@@ -178,8 +177,7 @@ CGAlgorithmsDD::intersection(const Coordinate& p1, const Coordinate& p2,
 
     Coordinate rv;
 
-    if (std::isnan(xInt) || std::isnan(yInt) ||
-        std::isinf(xInt) || std::isinf(yInt)) {
+    if (!std::isfinite(xInt) || !std::isfinite(yInt)) {
         rv.setNull();
         return rv;
     }

--- a/src/algorithm/Intersection.cpp
+++ b/src/algorithm/Intersection.cpp
@@ -71,8 +71,7 @@ Intersection::intersection(const geom::Coordinate& p1, const geom::Coordinate& p
     double yInt = y/w;
     geom::Coordinate rv;
     // check for parallel lines
-    if (std::isnan(xInt) || std::isnan(yInt) ||
-        std::isinf(xInt) || std::isinf(yInt)) {
+    if (!std::isfinite(xInt) || !std::isfinite(yInt)) {
         rv.setNull();
         return rv;
     }


### PR DESCRIPTION
- std::isnan() is useless when !std::isfinite() is tested
- std::isnan() || std::isinf() can be replaced by !std::isfinite()