### PR TITLE
Fix a few CLang 9 -Wextra warnings

### DIFF
--- a/include/geos/noding/NodingIntersectionFinder.h
+++ b/include/geos/noding/NodingIntersectionFinder.h
@@ -60,8 +60,7 @@ public:
         interiorIntersection(geom::Coordinate::getNull()),
         intersectionCount(0),
         isCheckEndSegmentsOnly(false),
-        findAllIntersections(false),
-        keepIntersections(true)
+        findAllIntersections(false)
     {
     }
 
@@ -168,7 +167,6 @@ private:
     size_t intersectionCount;
     bool isCheckEndSegmentsOnly;
     bool findAllIntersections;
-    bool keepIntersections;
     std::vector<geom::Coordinate> intSegments;
 
     // Declare type as noncopyable

--- a/src/noding/MCIndexSegmentSetMutualIntersector.cpp
+++ b/src/noding/MCIndexSegmentSetMutualIntersector.cpp
@@ -105,8 +105,6 @@ MCIndexSegmentSetMutualIntersector::MCIndexSegmentSetMutualIntersector()
 MCIndexSegmentSetMutualIntersector::~MCIndexSegmentSetMutualIntersector()
 {
     delete index;
-
-    MonoChains::iterator i, e;
 }
 
 /* public */

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -47,6 +47,7 @@
 
 namespace {
 
+#if GEOS_DEBUG
 inline bool
 check_valid(const geos::geom::Geometry& g, const std::string& label, bool doThrow = false, bool validOnly = false)
 {
@@ -92,6 +93,7 @@ check_valid(const geos::geom::Geometry& g, const std::string& label, bool doThro
     }
     return true;
 }
+#endif
 
 } // anonymous namespace
 


### PR DESCRIPTION
- Unused private member --> removed
- Unused method (likely a debugging one) -> protected by #if GEOS_DEBUG
- Unused variables in a destructor -> removed