### PR TITLE
Fix -Wmismatched-tags warning related to WK[T/B][Reader/Writer]

### DIFF
--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -76,7 +76,7 @@ namespace io {
  * representing 3-dimensional coordinates.
  *
  */
-class GEOS_DLL WKBReader {
+struct GEOS_DLL WKBReader {
 
 public:
 

--- a/include/geos/io/WKBWriter.h
+++ b/include/geos/io/WKBWriter.h
@@ -69,7 +69,7 @@ namespace io {
  *
  * @see WKBReader
  */
-class GEOS_DLL WKBWriter {
+struct GEOS_DLL WKBWriter {
 
 public:
     /*

--- a/include/geos/io/WKTReader.h
+++ b/include/geos/io/WKTReader.h
@@ -55,7 +55,7 @@ namespace io {
  * \class WKTReader
  * \brief WKT parser class; see also WKTWriter.
  */
-class GEOS_DLL WKTReader {
+struct GEOS_DLL WKTReader {
 public:
     //WKTReader();
 

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -76,7 +76,7 @@ namespace io {
  * See WKTReader for parsing.
  *
  */
-class GEOS_DLL WKTWriter {
+struct GEOS_DLL WKTWriter {
 public:
     WKTWriter();
     ~WKTWriter() = default;


### PR DESCRIPTION
CLang 9 -Wextra warns about

```
./geos_c.h:1226:9: warning: struct 'WKTReader' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
typedef struct GEOSWKTReader_t GEOSWKTReader;
        ^
../../include/geos/io/WKTReader.h:58:16: note: previous use is here
class GEOS_DLL WKTReader {
               ^
./geos_c.h:1226:9: note: did you mean class here?
typedef struct GEOSWKTReader_t GEOSWKTReader;
        ^~~~~~
        class
```
Similarly for WKTWriter, WKBReader and WKBWriter

This is due to capi/geos_c.cpp having a
```
#define GEOSWKTReader_t geos::io::WKTReader
```
Hence when geos_c.h is included from geos_c.cpp, it is expanded as
typedef struct geos::io::WKTReader GEOSWKTReader;
which conflicts with the class GEOS_DLL WKTReader declaration.

The easy fix is to change the declaration of WKTReader to be a struct.
As the visibility is set to public immediately, this is mostly a no-op
change, and fixes the warning.

Same for the other 3 classes/structs