### PR TITLE
Fix -Wmismatched-tags warning related to WK[T/B][Reader/Writer]

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -39,10 +39,10 @@
 #define GEOSPreparedGeometry geos::geom::prep::PreparedGeometry
 #define GEOSCoordSequence geos::geom::CoordinateSequence
 #define GEOSSTRtree geos::index::strtree::STRtree
-#define GEOSWKTReader_t geos::io::WKTReader
-#define GEOSWKTWriter_t geos::io::WKTWriter
-#define GEOSWKBReader_t geos::io::WKBReader
-#define GEOSWKBWriter_t geos::io::WKBWriter
+#define GEOSWKTReader geos::io::WKTReader
+#define GEOSWKTWriter geos::io::WKTWriter
+#define GEOSWKBReader geos::io::WKBReader
+#define GEOSWKBWriter geos::io::WKBWriter
 typedef struct GEOSBufParams_t GEOSBufferParams;
 
 #include "geos_c.h"

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1223,11 +1223,12 @@ extern int GEOS_DLL GEOSOrientationIndex_r(GEOSContextHandle_t handle,
  *
  ***********************************************************************/
 
+#ifndef GEOSWKTReader
 typedef struct GEOSWKTReader_t GEOSWKTReader;
 typedef struct GEOSWKTWriter_t GEOSWKTWriter;
 typedef struct GEOSWKBReader_t GEOSWKBReader;
 typedef struct GEOSWKBWriter_t GEOSWKBWriter;
-
+#endif
 
 /* WKT Reader */
 extern GEOSWKTReader GEOS_DLL *GEOSWKTReader_create_r(


### PR DESCRIPTION
CLang 9 -Wextra warns about
```
./geos_c.h:1226:9: warning: struct 'WKTReader' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
typedef struct GEOSWKTReader_t GEOSWKTReader;
        ^
../../include/geos/io/WKTReader.h:58:16: note: previous use is here
class GEOS_DLL WKTReader {
               ^
./geos_c.h:1226:9: note: did you mean class here?
typedef struct GEOSWKTReader_t GEOSWKTReader;
        ^~~~~~
        class
```
Similarly for WKTWriter, WKBReader and WKBWriter

This is due to capi/geos_c.cpp having a
```
#define GEOSWKTReader_t geos::io::WKTReader
```

Adopt the same solution as for GEOSGeom and other C++ classes
exposed in C API

(Alternative to https://github.com/libgeos/geos/pull/276)