### PR TITLE
Add final keyword in class declarations wherever possible

### DIFF
--- a/include/geos/algorithm/NotRepresentableException.h
+++ b/include/geos/algorithm/NotRepresentableException.h
@@ -32,7 +32,7 @@ namespace algorithm { // geos::algorithm
  * @version 1.4
  * @see HCoordinate
  */
-class GEOS_DLL NotRepresentableException: public util::GEOSException {
+class GEOS_DLL NotRepresentableException final: public util::GEOSException {
 public:
     NotRepresentableException();
     NotRepresentableException(std::string msg);

--- a/include/geos/algorithm/SimplePointInRing.h
+++ b/include/geos/algorithm/SimplePointInRing.h
@@ -31,7 +31,7 @@ class CoordinateSequence;
 namespace geos {
 namespace algorithm { // geos::algorithm
 
-class GEOS_DLL SimplePointInRing: public PointInRing {
+class GEOS_DLL SimplePointInRing final: public PointInRing {
 public:
     SimplePointInRing(geom::LinearRing* ring);
     ~SimplePointInRing() override = default;

--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -154,7 +154,7 @@ public:
         return ptDist.getCoordinates();
     }
 
-    class MaxPointDistanceFilter : public geom::CoordinateFilter {
+    class MaxPointDistanceFilter final: public geom::CoordinateFilter {
     public:
         MaxPointDistanceFilter(const geom::Geometry& p_geom)
             :
@@ -188,7 +188,7 @@ public:
     };
 
     class MaxDensifiedByFractionDistanceFilter
-        : public geom::CoordinateSequenceFilter {
+        final: public geom::CoordinateSequenceFilter {
     public:
 
         MaxDensifiedByFractionDistanceFilter(

--- a/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
+++ b/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
@@ -49,7 +49,7 @@ namespace locate { // geos::algorithm::locate
  *
  * Polygonal and [LinearRing](@ref geom::LinearRing) geometries are supported.
  */
-class IndexedPointInAreaLocator : public PointOnGeometryLocator {
+class IndexedPointInAreaLocator final: public PointOnGeometryLocator {
 private:
     class IntervalIndexedGeometry {
     private:
@@ -69,7 +69,7 @@ private:
     };
 
 
-    class SegmentVisitor : public index::ItemVisitor {
+    class SegmentVisitor final: public index::ItemVisitor {
     private:
         algorithm::RayCrossingCounter* counter;
 

--- a/include/geos/algorithm/locate/SimplePointInAreaLocator.h
+++ b/include/geos/algorithm/locate/SimplePointInAreaLocator.h
@@ -44,7 +44,7 @@ namespace locate { // geos::algorithm::locate
  * This algorithm is suitable for use in cases where only a few points will be tested.
  * If many points will be tested, IndexedPointInAreaLocator may provide better performance.
  */
-class SimplePointInAreaLocator : public PointOnGeometryLocator {
+class SimplePointInAreaLocator final: public PointOnGeometryLocator {
 
 public:
 

--- a/include/geos/algorithm/ttmath/ttmathint.h
+++ b/include/geos/algorithm/ttmath/ttmathint.h
@@ -60,7 +60,7 @@ namespace ttmath
 	value_size = 1,2,3,4,5,6....
 */
 template<uint value_size>
-class Int : public UInt<value_size>
+class Int final: public UInt<value_size>
 {
 public:
 

--- a/include/geos/algorithm/ttmath/ttmathtypes.h
+++ b/include/geos/algorithm/ttmath/ttmathtypes.h
@@ -601,7 +601,7 @@ namespace ttmath
 		the name and the line of a file where the macro TTMATH_REFERENCE_ASSERT
 		was used)
 	*/
-	class ReferenceError : public std::logic_error, public ExceptionInfo
+	class ReferenceError final: public std::logic_error, public ExceptionInfo
 	{
 	public:
 
@@ -633,7 +633,7 @@ namespace ttmath
 		the name and the line of a file where the macro TTMATH_ASSERT
 		was used)
 	*/
-	class RuntimeError : public std::runtime_error, public ExceptionInfo
+	class RuntimeError final: public std::runtime_error, public ExceptionInfo
 	{
 	public:
 

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -34,7 +34,7 @@ namespace geos {
 namespace geom { // geos.geom
 
 /// The default implementation of CoordinateSequence
-class GEOS_DLL CoordinateArraySequence : public CoordinateSequence {
+class GEOS_DLL CoordinateArraySequence final: public CoordinateSequence {
 public:
 
     CoordinateArraySequence(const CoordinateArraySequence& cl);

--- a/include/geos/geom/CoordinateArraySequenceFactory.h
+++ b/include/geos/geom/CoordinateArraySequenceFactory.h
@@ -40,7 +40,7 @@ namespace geom { // geos::geom
  * Creates CoordinateSequences internally represented as an array of
  * Coordinates.
  */
-class GEOS_DLL CoordinateArraySequenceFactory: public CoordinateSequenceFactory {
+class GEOS_DLL CoordinateArraySequenceFactory final: public CoordinateSequenceFactory {
 
 public:
     std::unique_ptr<CoordinateSequence> create() const override;

--- a/include/geos/geom/DefaultCoordinateSequenceFactory.h
+++ b/include/geos/geom/DefaultCoordinateSequenceFactory.h
@@ -22,7 +22,7 @@
 namespace geos {
 namespace geom {
 
-class GEOS_DLL DefaultCoordinateSequenceFactory : public CoordinateSequenceFactory {
+class GEOS_DLL DefaultCoordinateSequenceFactory final: public CoordinateSequenceFactory {
 public:
 
     std::unique_ptr<CoordinateSequence> create() const final override {

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -30,37 +30,37 @@ namespace geos {
 namespace geom {
 
     template<size_t N>
-    class FixedSizeCoordinateSequence : public CoordinateSequence {
+    class FixedSizeCoordinateSequence final: public CoordinateSequence {
     public:
         explicit FixedSizeCoordinateSequence(size_t dimension_in = 0) : dimension(dimension_in) {}
 
-        std::unique_ptr<CoordinateSequence> clone() const final override {
+        std::unique_ptr<CoordinateSequence> clone() const override {
             auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>(dimension);
             seq->m_data = m_data;
             return std::move(seq); // move needed for gcc 4.8
         }
 
-        const Coordinate& getAt(size_t i) const final override {
+        const Coordinate& getAt(size_t i) const override {
             return m_data[i];
         }
 
-        void getAt(size_t i, Coordinate& c) const final override {
+        void getAt(size_t i, Coordinate& c) const override {
             c = m_data[i];
         }
 
-        size_t getSize() const final override {
+        size_t getSize() const override {
             return N;
         }
 
-        bool isEmpty() const final override {
+        bool isEmpty() const override {
             return N == 0;
         }
 
-        void setAt(const Coordinate & c, size_t pos) final override {
+        void setAt(const Coordinate & c, size_t pos) override {
             m_data[pos] = c;
         }
 
-        void setOrdinate(size_t index, size_t ordinateIndex, double value) final override
+        void setOrdinate(size_t index, size_t ordinateIndex, double value) override
         {
             switch(ordinateIndex) {
                 case CoordinateSequence::X:
@@ -81,7 +81,7 @@ namespace geom {
             }
         }
 
-        size_t getDimension() const final override {
+        size_t getDimension() const override {
             if(dimension != 0) {
                 return dimension;
             }
@@ -100,20 +100,20 @@ namespace geom {
             return dimension;
         }
 
-        void toVector(std::vector<Coordinate> & out) const final override {
+        void toVector(std::vector<Coordinate> & out) const override {
             out.insert(out.end(), m_data.begin(), m_data.end());
         }
 
-        void setPoints(const std::vector<Coordinate> & v) final override {
+        void setPoints(const std::vector<Coordinate> & v) override {
             std::copy(v.begin(), v.end(), m_data.begin());
         }
 
-        void apply_ro(CoordinateFilter* filter) const final override {
+        void apply_ro(CoordinateFilter* filter) const override {
             std::for_each(m_data.begin(), m_data.end(),
                     [&filter](const Coordinate & c) { filter->filter_ro(&c); });
         }
 
-        void apply_rw(const CoordinateFilter* filter) final override {
+        void apply_rw(const CoordinateFilter* filter) override {
             std::for_each(m_data.begin(), m_data.end(),
                     [&filter](Coordinate &c) { filter->filter_rw(&c); });
             dimension = 0; // re-check (see http://trac.osgeo.org/geos/ticket/435)

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -920,7 +920,7 @@ protected:
 
 private:
 
-    class GEOS_DLL GeometryChangedFilter : public GeometryComponentFilter {
+    class GEOS_DLL GeometryChangedFilter final: public GeometryComponentFilter {
     public:
         void filter_rw(Geometry* geom) override;
     };

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -52,7 +52,7 @@ namespace geom { // geos::geom
  * represented by GeometryCollection subclasses MultiPoint,
  * MultiLineString, MultiPolygon.
  */
-class GEOS_DLL GeometryCollection : public Geometry {
+class GEOS_DLL GeometryCollection /*non-final*/: public Geometry {
 
 public:
     friend class GeometryFactory;

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -65,7 +65,7 @@ namespace geom { // geos::geom
  *  If these conditions are not met, the constructors throw
  *  an {@link util::IllegalArgumentException}.
  */
-class GEOS_DLL LineString: public Geometry {
+class GEOS_DLL LineString /*non-final*/: public Geometry {
 
 public:
 

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -51,7 +51,7 @@ namespace geom { // geos::geom
  * must be equal (in 2D). If these conditions are not met, the constructors
  * throw an {@link geos::util::IllegalArgumentException}
  */
-class GEOS_DLL LinearRing : public LineString {
+class GEOS_DLL LinearRing final: public LineString {
 
 public:
 

--- a/include/geos/geom/MultiLineString.h
+++ b/include/geos/geom/MultiLineString.h
@@ -48,7 +48,7 @@ namespace geom { // geos::geom
 #endif
 
 /// Models a collection of [LineStrings](@ref geom::LineString).
-class GEOS_DLL MultiLineString: public GeometryCollection {
+class GEOS_DLL MultiLineString final: public GeometryCollection {
 
 public:
 

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -51,7 +51,7 @@ namespace geom { // geos::geom
  *
  * Any collection of Points is a valid MultiPoint.
  */
-class GEOS_DLL MultiPoint: public GeometryCollection {
+class GEOS_DLL MultiPoint final: public GeometryCollection {
 
 public:
 

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -56,7 +56,7 @@ namespace geom { // geos::geom
 /// This allows the topological point-set semantics
 /// to be well-defined.
 ///
-class GEOS_DLL MultiPolygon: public GeometryCollection {
+class GEOS_DLL MultiPolygon final: public GeometryCollection {
 public:
 
     friend class GeometryFactory;

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -63,7 +63,7 @@ namespace geom { // geos::geom
  *   (i.e does not have an NaN X or Y ordinate)
  *
  */
-class GEOS_DLL Point : public Geometry {
+class GEOS_DLL Point final: public Geometry {
 
 public:
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -61,7 +61,7 @@ namespace geom { // geos::geom
  *  Specification for SQL</A> .
  *
  */
-class GEOS_DLL Polygon: public Geometry {
+class GEOS_DLL Polygon final: public Geometry {
 
 public:
 

--- a/include/geos/geom/prep/AbstractPreparedPolygonContains.h
+++ b/include/geos/geom/prep/AbstractPreparedPolygonContains.h
@@ -62,7 +62,7 @@ namespace prep { // geos::geom::prep
  * @author Martin Davis
  *
  */
-class AbstractPreparedPolygonContains : public PreparedPolygonPredicate {
+class AbstractPreparedPolygonContains /*non-final*/: public PreparedPolygonPredicate {
 private:
     // information about geometric situation
     bool hasSegmentIntersection;

--- a/include/geos/geom/prep/BasicPreparedGeometry.h
+++ b/include/geos/geom/prep/BasicPreparedGeometry.h
@@ -56,7 +56,7 @@ namespace prep { // geos::geom::prep
  * @author Martin Davis
  *
  */
-class BasicPreparedGeometry: public PreparedGeometry {
+class BasicPreparedGeometry /*non-final*/: public PreparedGeometry {
 private:
     const geom::Geometry* baseGeom;
     Coordinate::ConstVect representativePts;

--- a/include/geos/geom/prep/PreparedLineString.h
+++ b/include/geos/geom/prep/PreparedLineString.h
@@ -37,7 +37,7 @@ namespace prep { // geos::geom::prep
  * @author mbdavis
  *
  */
-class PreparedLineString : public BasicPreparedGeometry {
+class PreparedLineString final: public BasicPreparedGeometry {
 private:
     std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;
     mutable noding::SegmentString::ConstVect segStrings;

--- a/include/geos/geom/prep/PreparedPoint.h
+++ b/include/geos/geom/prep/PreparedPoint.h
@@ -33,7 +33,7 @@ namespace prep { // geos::geom::prep
  * @author Martin Davis
  *
  */
-class PreparedPoint: public BasicPreparedGeometry {
+class PreparedPoint final: public BasicPreparedGeometry {
 private:
 protected:
 public:

--- a/include/geos/geom/prep/PreparedPolygon.h
+++ b/include/geos/geom/prep/PreparedPolygon.h
@@ -47,7 +47,7 @@ namespace prep { // geos::geom::prep
  * @author mbdavis
  *
  */
-class PreparedPolygon : public BasicPreparedGeometry {
+class PreparedPolygon final: public BasicPreparedGeometry {
 private:
     bool isRectangle;
     mutable std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;

--- a/include/geos/geom/prep/PreparedPolygonContains.h
+++ b/include/geos/geom/prep/PreparedPolygonContains.h
@@ -51,7 +51,7 @@ namespace prep { // geos::geom::prep
  * @author Martin Davis
  *
  */
-class PreparedPolygonContains : public AbstractPreparedPolygonContains {
+class PreparedPolygonContains final: public AbstractPreparedPolygonContains {
 public:
 
     /**

--- a/include/geos/geom/prep/PreparedPolygonContainsProperly.h
+++ b/include/geos/geom/prep/PreparedPolygonContainsProperly.h
@@ -56,7 +56,7 @@ namespace prep { // geos::geom::prep
  *
  * @author Martin Davis
  */
-class PreparedPolygonContainsProperly : public PreparedPolygonPredicate {
+class PreparedPolygonContainsProperly final: public PreparedPolygonPredicate {
 private:
 protected:
 public:

--- a/include/geos/geom/prep/PreparedPolygonCovers.h
+++ b/include/geos/geom/prep/PreparedPolygonCovers.h
@@ -52,7 +52,7 @@ namespace prep { // geos::geom::prep
  * @author Martin Davis
  *
  */
-class PreparedPolygonCovers : public AbstractPreparedPolygonContains {
+class PreparedPolygonCovers final: public AbstractPreparedPolygonContains {
 private:
 protected:
     /**

--- a/include/geos/geom/prep/PreparedPolygonIntersects.h
+++ b/include/geos/geom/prep/PreparedPolygonIntersects.h
@@ -47,7 +47,7 @@ namespace prep { // geos::geom::prep
  * @author Martin Davis
  *
  */
-class PreparedPolygonIntersects : public PreparedPolygonPredicate {
+class PreparedPolygonIntersects final: public PreparedPolygonPredicate {
 private:
 protected:
 public:

--- a/include/geos/geom/util/ComponentCoordinateExtracter.h
+++ b/include/geos/geom/util/ComponentCoordinateExtracter.h
@@ -34,7 +34,7 @@ namespace util { // geos::geom::util
  *
  * @version 1.9
  */
-class ComponentCoordinateExtracter : public GeometryComponentFilter {
+class ComponentCoordinateExtracter final: public GeometryComponentFilter {
 public:
     /**
      * Push the linear components from a single geometry into

--- a/include/geos/geom/util/CoordinateOperation.h
+++ b/include/geos/geom/util/CoordinateOperation.h
@@ -38,7 +38,7 @@ namespace util { // geos.geom.util
  * Geometry.
  * Operates on Geometry subclasses which contains a single coordinate list.
  */
-class GEOS_DLL CoordinateOperation: public GeometryEditorOperation {
+class GEOS_DLL CoordinateOperation /*non-final*/: public GeometryEditorOperation {
 
 public:
 

--- a/include/geos/geom/util/Densifier.h
+++ b/include/geos/geom/util/Densifier.h
@@ -69,7 +69,7 @@ private:
     static std::unique_ptr<Coordinate::Vect> densifyPoints(const Coordinate::Vect pts, double distanceTolerance,
             const PrecisionModel* precModel);
 
-    class GEOS_DLL DensifyTransformer: public GeometryTransformer {
+    class GEOS_DLL DensifyTransformer final: public GeometryTransformer {
     public:
         DensifyTransformer(double distanceTolerance);
         double distanceTolerance;

--- a/include/geos/geom/util/GeometryExtracter.h
+++ b/include/geos/geom/util/GeometryExtracter.h
@@ -61,7 +61,7 @@ public:
 private:
 
     template <class ComponentType, class TargetContainer>
-    struct Extracter: public GeometryFilter {
+    struct Extracter final: public GeometryFilter {
 
         /**
          * Constructs a filter with a list in which to store the elements found.

--- a/include/geos/geom/util/LinearComponentExtracter.h
+++ b/include/geos/geom/util/LinearComponentExtracter.h
@@ -31,7 +31,7 @@ namespace util { // geos.geom.util
 /**
  * Extracts all the 1-dimensional (LineString) components from a Geometry.
  */
-class GEOS_DLL LinearComponentExtracter: public GeometryComponentFilter {
+class GEOS_DLL LinearComponentExtracter final: public GeometryComponentFilter {
 
 private:
 

--- a/include/geos/geom/util/PointExtracter.h
+++ b/include/geos/geom/util/PointExtracter.h
@@ -28,7 +28,7 @@ namespace util { // geos.geom.util
 /**
  * Extracts all the 0-dimensional (Point) components from a Geometry.
  */
-class GEOS_DLL PointExtracter: public GeometryFilter {
+class GEOS_DLL PointExtracter final: public GeometryFilter {
 
 public:
     /**

--- a/include/geos/geom/util/PolygonExtracter.h
+++ b/include/geos/geom/util/PolygonExtracter.h
@@ -28,7 +28,7 @@ namespace util { // geos.geom.util
 /**
  * Extracts all the 2-dimensional (Polygon) components from a Geometry.
  */
-class GEOS_DLL PolygonExtracter: public GeometryFilter {
+class GEOS_DLL PolygonExtracter final: public GeometryFilter {
 
 public:
 

--- a/include/geos/geom/util/SineStarFactory.h
+++ b/include/geos/geom/util/SineStarFactory.h
@@ -55,7 +55,7 @@ namespace util { // geos::geom::util
  * @author Martin Davis
  *
  */
-class GEOS_DLL SineStarFactory : public geos::util::GeometricShapeFactory  {
+class GEOS_DLL SineStarFactory final: public geos::util::GeometricShapeFactory  {
 
 protected:
 

--- a/include/geos/geomgraph/DirectedEdge.h
+++ b/include/geos/geomgraph/DirectedEdge.h
@@ -42,7 +42,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /// A directed EdgeEnd
-class GEOS_DLL DirectedEdge: public EdgeEnd {
+class GEOS_DLL DirectedEdge final: public EdgeEnd {
 
 public:
 

--- a/include/geos/geomgraph/DirectedEdgeStar.h
+++ b/include/geos/geomgraph/DirectedEdgeStar.h
@@ -52,7 +52,7 @@ namespace geomgraph { // geos.geomgraph
  * MaximalEdgeRings and MinimalEdgeRings.
  *
  */
-class GEOS_DLL DirectedEdgeStar: public EdgeEndStar {
+class GEOS_DLL DirectedEdgeStar final: public EdgeEndStar {
 
 public:
 

--- a/include/geos/geomgraph/Edge.h
+++ b/include/geos/geomgraph/Edge.h
@@ -63,7 +63,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /** The edge component of a geometry graph */
-class GEOS_DLL Edge: public GraphComponent {
+class GEOS_DLL Edge final: public GraphComponent {
     using GraphComponent::updateIM;
 
 private:

--- a/include/geos/geomgraph/GeometryGraph.h
+++ b/include/geos/geomgraph/GeometryGraph.h
@@ -71,7 +71,7 @@ namespace geomgraph { // geos.geomgraph
 /** \brief
  * A GeometryGraph is a graph that models a given Geometry.
  */
-class GEOS_DLL GeometryGraph: public PlanarGraph {
+class GEOS_DLL GeometryGraph final: public PlanarGraph {
     using PlanarGraph::add;
     using PlanarGraph::findEdge;
 

--- a/include/geos/geomgraph/Node.h
+++ b/include/geos/geomgraph/Node.h
@@ -59,7 +59,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /** \brief The node component of a geometry graph. */
-class GEOS_DLL Node: public GraphComponent {
+class GEOS_DLL Node /*non-final*/: public GraphComponent {
     using GraphComponent::setLabel;
 
 public:

--- a/include/geos/geomgraph/index/MonotoneChain.h
+++ b/include/geos/geomgraph/index/MonotoneChain.h
@@ -42,7 +42,7 @@ namespace index { // geos::geomgraph::index
 /**
  * A chain in a MonotoneChainEdge
  */
-class GEOS_DLL MonotoneChain: public SweepLineEventOBJ {
+class GEOS_DLL MonotoneChain final: public SweepLineEventOBJ {
 private:
     MonotoneChainEdge* mce;
     size_t chainIndex;

--- a/include/geos/geomgraph/index/SimpleEdgeSetIntersector.h
+++ b/include/geos/geomgraph/index/SimpleEdgeSetIntersector.h
@@ -40,7 +40,7 @@ namespace index { // geos::geomgraph::index
 ///
 /// \note This algorithm is too slow for production use, but is useful for
 /// testing purposes.
-class GEOS_DLL SimpleEdgeSetIntersector: public EdgeSetIntersector {
+class GEOS_DLL SimpleEdgeSetIntersector final: public EdgeSetIntersector {
 
 public:
 

--- a/include/geos/geomgraph/index/SimpleMCSweepLineIntersector.h
+++ b/include/geos/geomgraph/index/SimpleMCSweepLineIntersector.h
@@ -50,7 +50,7 @@ namespace index { // geos::geomgraph::index
  * The use of MonotoneChains as the items in the index
  * seems to offer an improvement in performance over a sweep-line alone.
  */
-class GEOS_DLL SimpleMCSweepLineIntersector: public EdgeSetIntersector {
+class GEOS_DLL SimpleMCSweepLineIntersector final: public EdgeSetIntersector {
 
 public:
 

--- a/include/geos/geomgraph/index/SimpleSweepLineIntersector.h
+++ b/include/geos/geomgraph/index/SimpleSweepLineIntersector.h
@@ -48,7 +48,7 @@ namespace index { // geos::geomgraph::index
  * While still O(n^2) in the worst case, this algorithm
  * drastically improves the average-case time.
  */
-class GEOS_DLL SimpleSweepLineIntersector: public EdgeSetIntersector {
+class GEOS_DLL SimpleSweepLineIntersector final: public EdgeSetIntersector {
 
 public:
 

--- a/include/geos/geomgraph/index/SweepLineSegment.h
+++ b/include/geos/geomgraph/index/SweepLineSegment.h
@@ -37,7 +37,7 @@ namespace geos {
 namespace geomgraph { // geos::geomgraph
 namespace index { // geos::geomgraph::index
 
-class GEOS_DLL SweepLineSegment: public SweepLineEventOBJ {
+class GEOS_DLL SweepLineSegment final: public SweepLineEventOBJ {
 public:
     SweepLineSegment(Edge* newEdge, size_t newPtIndex);
     ~SweepLineSegment() override = default;

--- a/include/geos/index/bintree/Node.h
+++ b/include/geos/index/bintree/Node.h
@@ -32,7 +32,7 @@ namespace index { // geos::index
 namespace bintree { // geos::index::bintree
 
 /// A node of a Bintree.
-class GEOS_DLL Node: public NodeBase {
+class GEOS_DLL Node final: public NodeBase {
 
 public:
 

--- a/include/geos/index/bintree/Root.h
+++ b/include/geos/index/bintree/Root.h
@@ -38,7 +38,7 @@ namespace bintree { // geos::index::bintree
  * It is centred at the origin,
  * and does not have a defined extent.
  */
-class GEOS_DLL Root: public NodeBase {
+class GEOS_DLL Root final: public NodeBase {
 
 private:
 

--- a/include/geos/index/intervalrtree/IntervalRTreeBranchNode.h
+++ b/include/geos/index/intervalrtree/IntervalRTreeBranchNode.h
@@ -32,7 +32,7 @@ namespace geos {
 namespace index {
 namespace intervalrtree {
 
-class IntervalRTreeBranchNode : public IntervalRTreeNode {
+class IntervalRTreeBranchNode final: public IntervalRTreeNode {
 private:
     const IntervalRTreeNode* node1;
     const IntervalRTreeNode* node2;

--- a/include/geos/index/intervalrtree/IntervalRTreeLeafNode.h
+++ b/include/geos/index/intervalrtree/IntervalRTreeLeafNode.h
@@ -32,7 +32,7 @@ namespace geos {
 namespace index {
 namespace intervalrtree {
 
-class IntervalRTreeLeafNode : public IntervalRTreeNode {
+class IntervalRTreeLeafNode final: public IntervalRTreeNode {
 private:
     /// externally owned
     void* item;

--- a/include/geos/index/quadtree/Node.h
+++ b/include/geos/index/quadtree/Node.h
@@ -52,7 +52,7 @@ namespace quadtree { // geos::index::quadtree
  * the node's position in the quadtree.
  *
  */
-class GEOS_DLL Node: public NodeBase {
+class GEOS_DLL Node final: public NodeBase {
 
 private:
 

--- a/include/geos/index/quadtree/Quadtree.h
+++ b/include/geos/index/quadtree/Quadtree.h
@@ -68,7 +68,7 @@ namespace quadtree { // geos::index::quadtree
  * This data structure is also known as an <i>MX-CIF quadtree</i>
  * following the usage of Samet and others.
  */
-class GEOS_DLL Quadtree: public SpatialIndex {
+class GEOS_DLL Quadtree final: public SpatialIndex {
 
 private:
 

--- a/include/geos/index/quadtree/Root.h
+++ b/include/geos/index/quadtree/Root.h
@@ -46,7 +46,7 @@ namespace quadtree { // geos::index::quadtree
  * QuadRoot is the root of a single Quadtree.  It is centred at the origin,
  * and does not have a defined extent.
  */
-class GEOS_DLL Root: public NodeBase {
+class GEOS_DLL Root final: public NodeBase {
 //friend class Unload;
 
 private:

--- a/include/geos/index/strtree/AbstractNode.h
+++ b/include/geos/index/strtree/AbstractNode.h
@@ -41,7 +41,7 @@ namespace strtree { // geos::index::strtree
  * then we say that this node is a "leaf node".
  *
  */
-class GEOS_DLL AbstractNode: public Boundable {
+class GEOS_DLL AbstractNode /*non-final*/: public Boundable {
 private:
     std::vector<Boundable*> childBoundables;
     int level;

--- a/include/geos/index/strtree/AbstractSTRtree.h
+++ b/include/geos/index/strtree/AbstractSTRtree.h
@@ -91,7 +91,7 @@ public:
     } item;
 };
 
-class ItemsList : public std::vector<ItemsListItem> {
+class ItemsList final: public std::vector<ItemsListItem> {
 private:
     typedef std::vector<ItemsListItem> base_type;
 

--- a/include/geos/index/strtree/GeometryItemDistance.h
+++ b/include/geos/index/strtree/GeometryItemDistance.h
@@ -25,7 +25,7 @@
 namespace geos {
 namespace index {
 namespace strtree {
-class GEOS_DLL GeometryItemDistance : public ItemDistance {
+class GEOS_DLL GeometryItemDistance final: public ItemDistance {
 public:
     /**
      * Computes the distance between two {@link Geometry} items,

--- a/include/geos/index/strtree/ItemBoundable.h
+++ b/include/geos/index/strtree/ItemBoundable.h
@@ -29,7 +29,7 @@ namespace strtree { // geos::index::strtree
  *
  * \todo TODO: It's unclear who takes ownership of passed newBounds and newItem objects.
  */
-class GEOS_DLL ItemBoundable: public Boundable {
+class GEOS_DLL ItemBoundable final: public Boundable {
 public:
 
     ItemBoundable(const void* newBounds, void* newItem) : bounds(newBounds), item(newItem) {}

--- a/include/geos/index/strtree/SIRtree.h
+++ b/include/geos/index/strtree/SIRtree.h
@@ -38,7 +38,7 @@ namespace strtree { // geos::index::strtree
  *
  * @see STRtree
  */
-class GEOS_DLL SIRtree: public AbstractSTRtree {
+class GEOS_DLL SIRtree final: public AbstractSTRtree {
     using AbstractSTRtree::insert;
     using AbstractSTRtree::query;
 
@@ -91,7 +91,7 @@ public:
 
 protected:
 
-    class SIRIntersectsOp: public AbstractSTRtree::IntersectsOp {
+    class SIRIntersectsOp final: public AbstractSTRtree::IntersectsOp {
     public:
         bool intersects(const void* aBounds, const void* bBounds) override;
     };

--- a/include/geos/index/strtree/STRtree.h
+++ b/include/geos/index/strtree/STRtree.h
@@ -61,12 +61,12 @@ namespace strtree { // geos::index::strtree
  * Databases With Application To GIS. Morgan Kaufmann, San Francisco, 2002.
  *
  */
-class GEOS_DLL STRtree: public AbstractSTRtree, public SpatialIndex {
+class GEOS_DLL STRtree final: public AbstractSTRtree, public SpatialIndex {
     using AbstractSTRtree::insert;
     using AbstractSTRtree::query;
 
 private:
-    class GEOS_DLL STRIntersectsOp: public AbstractSTRtree::IntersectsOp {
+    class GEOS_DLL STRIntersectsOp final: public AbstractSTRtree::IntersectsOp {
     public:
         bool intersects(const void* aBounds, const void* bBounds) override;
     };

--- a/include/geos/io/ParseException.h
+++ b/include/geos/io/ParseException.h
@@ -31,7 +31,7 @@ namespace io {
  * \class ParseException
  * \brief Notifies a parsing error
  */
-class GEOS_DLL ParseException : public util::GEOSException {
+class GEOS_DLL ParseException final: public util::GEOSException {
 
 public:
 

--- a/include/geos/noding/BasicSegmentString.h
+++ b/include/geos/noding/BasicSegmentString.h
@@ -41,7 +41,7 @@ namespace noding { // geos.noding
  * useful for preserving topological or parentage information.
  * All noded substrings are initialized with the same context object.
  */
-class GEOS_DLL BasicSegmentString : public SegmentString {
+class GEOS_DLL BasicSegmentString final: public SegmentString {
 
 public:
 

--- a/include/geos/noding/FastSegmentSetIntersectionFinder.h
+++ b/include/geos/noding/FastSegmentSetIntersectionFinder.h
@@ -31,7 +31,6 @@ namespace geos {
 namespace noding {
 class SegmentIntersectionDetector;
 class SegmentSetMutualIntersector;
-//class MCIndexSegmentSetMutualIntersector : public SegmentSetMutualIntersector;
 }
 }
 

--- a/include/geos/noding/IntersectionAdder.h
+++ b/include/geos/noding/IntersectionAdder.h
@@ -54,7 +54,7 @@ namespace noding { // geos.noding
  * This class is an example of the *Strategy* pattern.
  *
  */
-class GEOS_DLL IntersectionAdder: public SegmentIntersector {
+class GEOS_DLL IntersectionAdder final: public SegmentIntersector {
 
 private:
 

--- a/include/geos/noding/IntersectionFinderAdder.h
+++ b/include/geos/noding/IntersectionFinderAdder.h
@@ -50,7 +50,7 @@ namespace noding { // geos.noding
  * and adds them as nodes.
  *
  */
-class GEOS_DLL IntersectionFinderAdder: public SegmentIntersector {
+class GEOS_DLL IntersectionFinderAdder final: public SegmentIntersector {
 
 public:
 

--- a/include/geos/noding/IteratedNoder.h
+++ b/include/geos/noding/IteratedNoder.h
@@ -52,7 +52,7 @@ namespace noding { // geos::noding
  * Clients can choose to rerun the noding using a lower precision model.
  *
  */
-class GEOS_DLL IteratedNoder : public Noder { // implements Noder
+class GEOS_DLL IteratedNoder final: public Noder { // implements Noder
 
 private:
     static const int MAX_ITER = 5;

--- a/include/geos/noding/MCIndexNoder.h
+++ b/include/geos/noding/MCIndexNoder.h
@@ -61,7 +61,7 @@ namespace noding { // geos.noding
  *
  * Last port: noding/MCIndexNoder.java rev. 1.4 (JTS-1.7)
  */
-class GEOS_DLL MCIndexNoder : public SinglePassNoder {
+class GEOS_DLL MCIndexNoder final: public SinglePassNoder {
 
 private:
     std::vector<index::chain::MonotoneChain*> monoChains;
@@ -100,7 +100,7 @@ public:
 
     void computeNodes(std::vector<SegmentString*>* inputSegmentStrings) override;
 
-    class SegmentOverlapAction : public index::chain::MonotoneChainOverlapAction {
+    class SegmentOverlapAction final: public index::chain::MonotoneChainOverlapAction {
     public:
         SegmentOverlapAction(SegmentIntersector& newSi)
             :

--- a/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
+++ b/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
@@ -52,7 +52,7 @@ namespace noding { // geos::noding
  *
  * @version 1.7
  */
-class MCIndexSegmentSetMutualIntersector : public SegmentSetMutualIntersector {
+class MCIndexSegmentSetMutualIntersector final: public SegmentSetMutualIntersector {
 public:
 
     MCIndexSegmentSetMutualIntersector();
@@ -70,7 +70,7 @@ public:
     // NOTE: re-populates the MonotoneChain vector with newly created chains
     void process(SegmentString::ConstVect* segStrings) override;
 
-    class SegmentOverlapAction : public index::chain::MonotoneChainOverlapAction {
+    class SegmentOverlapAction final: public index::chain::MonotoneChainOverlapAction {
     private:
         SegmentIntersector& si;
 

--- a/include/geos/noding/NodableSegmentString.h
+++ b/include/geos/noding/NodableSegmentString.h
@@ -34,7 +34,7 @@ namespace noding { // geos::noding
  *
  * @author Martin Davis
  */
-class GEOS_DLL NodableSegmentString : public SegmentString {
+class GEOS_DLL NodableSegmentString /*non-final*/: public SegmentString {
 private:
 protected:
 public:

--- a/include/geos/noding/NodedSegmentString.h
+++ b/include/geos/noding/NodedSegmentString.h
@@ -54,7 +54,7 @@ namespace noding { // geos::noding
  * All noded substrings are initialized with the same context object.
  *
  */
-class GEOS_DLL NodedSegmentString : public NodableSegmentString {
+class GEOS_DLL NodedSegmentString final: public NodableSegmentString {
 public:
 
     // TODO: provide a templated method using an output iterator

--- a/include/geos/noding/NodingIntersectionFinder.h
+++ b/include/geos/noding/NodingIntersectionFinder.h
@@ -44,7 +44,7 @@ namespace noding { // geos.noding
  *
  * @version 1.7
  */
-class NodingIntersectionFinder: public SegmentIntersector {
+class NodingIntersectionFinder final: public SegmentIntersector {
 
 public:
 

--- a/include/geos/noding/ScaledNoder.h
+++ b/include/geos/noding/ScaledNoder.h
@@ -58,7 +58,7 @@ namespace noding { // geos.noding
  * available precision.
  *
  */
-class GEOS_DLL ScaledNoder : public Noder { // , public geom::CoordinateFilter { // implements Noder
+class GEOS_DLL ScaledNoder final: public Noder { // , public geom::CoordinateFilter { // implements Noder
 
 public:
 

--- a/include/geos/noding/SegmentIntersectionDetector.h
+++ b/include/geos/noding/SegmentIntersectionDetector.h
@@ -39,7 +39,7 @@ namespace noding { // geos::noding
  *
  * @version 1.7
  */
-class SegmentIntersectionDetector : public SegmentIntersector {
+class SegmentIntersectionDetector final: public SegmentIntersector {
 private:
     algorithm::LineIntersector* li;
 

--- a/include/geos/noding/SimpleNoder.h
+++ b/include/geos/noding/SimpleNoder.h
@@ -48,7 +48,7 @@ namespace noding { // geos.noding
  *
  * @version 1.7
  */
-class GEOS_DLL SimpleNoder: public SinglePassNoder {
+class GEOS_DLL SimpleNoder final: public SinglePassNoder {
 private:
     std::vector<SegmentString*>* nodedSegStrings;
     virtual void computeIntersects(SegmentString* e0, SegmentString* e1);

--- a/include/geos/noding/SinglePassNoder.h
+++ b/include/geos/noding/SinglePassNoder.h
@@ -48,7 +48,7 @@ namespace noding { // geos.noding
  * TODO: Noder inheritance (that's just an interface!)
  *
  */
-class GEOS_DLL SinglePassNoder : public Noder { // implements Noder
+class GEOS_DLL SinglePassNoder /*non-final*/: public Noder { // implements Noder
 
 protected:
 

--- a/include/geos/noding/snapround/MCIndexSnapRounder.h
+++ b/include/geos/noding/snapround/MCIndexSnapRounder.h
@@ -71,7 +71,7 @@ namespace snapround { // geos::noding::snapround
  * It will function with non-integer precision models, but the
  * results are not 100% guaranteed to be correctly noded.
  */
-class GEOS_DLL MCIndexSnapRounder: public Noder { // implments Noder
+class GEOS_DLL MCIndexSnapRounder final: public Noder { // implments Noder
 
 public:
 

--- a/include/geos/noding/snapround/SimpleSnapRounder.h
+++ b/include/geos/noding/snapround/SimpleSnapRounder.h
@@ -70,7 +70,7 @@ namespace snapround { // geos::noding::snapround
  * results are not 100% guaranteed to be correctly noded.
  *
  */
-class GEOS_DLL SimpleSnapRounder: public Noder { // implements NoderIface
+class GEOS_DLL SimpleSnapRounder final: public Noder { // implements NoderIface
 
 public:
 

--- a/include/geos/operation/distance/ConnectedElementLocationFilter.h
+++ b/include/geos/operation/distance/ConnectedElementLocationFilter.h
@@ -46,7 +46,7 @@ namespace distance { // geos::operation::distance
  *
  * The elements of the list are GeometryLocation.
  */
-class GEOS_DLL ConnectedElementLocationFilter: public geom::GeometryFilter {
+class GEOS_DLL ConnectedElementLocationFilter final: public geom::GeometryFilter {
 private:
 
     std::vector<std::unique_ptr<GeometryLocation>> locations;

--- a/include/geos/operation/distance/ConnectedElementPointFilter.h
+++ b/include/geos/operation/distance/ConnectedElementPointFilter.h
@@ -44,7 +44,7 @@ namespace distance { // geos::operation::distance
  * (e.g. a polygon, linestring or point)
  * and returns them in a list
  */
-class GEOS_DLL ConnectedElementPointFilter: public geom::GeometryFilter {
+class GEOS_DLL ConnectedElementPointFilter final: public geom::GeometryFilter {
 
 private:
     std::vector<const geom::Coordinate*>* pts;

--- a/include/geos/operation/linemerge/LineMergeDirectedEdge.h
+++ b/include/geos/operation/linemerge/LineMergeDirectedEdge.h
@@ -44,7 +44,7 @@ namespace linemerge { // geos::operation::linemerge
  * A [DirectedEdge](@ref planargraph::DirectedEdge) of a LineMergeGraph.
  *
  */
-class GEOS_DLL LineMergeDirectedEdge: public planargraph::DirectedEdge {
+class GEOS_DLL LineMergeDirectedEdge final: public planargraph::DirectedEdge {
 public:
     /** \brief
      * Constructs a LineMergeDirectedEdge connecting the `from`

--- a/include/geos/operation/linemerge/LineMergeEdge.h
+++ b/include/geos/operation/linemerge/LineMergeEdge.h
@@ -40,7 +40,7 @@ namespace linemerge { // geos::operation::linemerge
  * An edge of a LineMergeGraph. The <code>marked</code> field indicates
  * whether this Edge has been logically deleted from the graph.
  */
-class GEOS_DLL LineMergeEdge: public planargraph::Edge {
+class GEOS_DLL LineMergeEdge final: public planargraph::Edge {
 private:
     const geom::LineString* line;
 public:

--- a/include/geos/operation/linemerge/LineMergeGraph.h
+++ b/include/geos/operation/linemerge/LineMergeGraph.h
@@ -56,7 +56,7 @@ namespace linemerge { // geos::operation::linemerge
  * and planargraph::Node indicates whether they have been
  * logically deleted from the graph.
  */
-class GEOS_DLL LineMergeGraph: public planargraph::PlanarGraph {
+class GEOS_DLL LineMergeGraph final: public planargraph::PlanarGraph {
 
 private:
 

--- a/include/geos/operation/overlay/ElevationMatrix.h
+++ b/include/geos/operation/overlay/ElevationMatrix.h
@@ -58,7 +58,7 @@ namespace overlay { // geos::operation::overlay
  * values to the matrix.
  * filter_rw is used to actually elevate Geometries.
  */
-class GEOS_DLL ElevationMatrixFilter: public geom::CoordinateFilter {
+class GEOS_DLL ElevationMatrixFilter final: public geom::CoordinateFilter {
 public:
     ElevationMatrixFilter(ElevationMatrix& em);
     ~ElevationMatrixFilter() override = default;

--- a/include/geos/operation/overlay/MaximalEdgeRing.h
+++ b/include/geos/operation/overlay/MaximalEdgeRing.h
@@ -63,7 +63,7 @@ namespace overlay { // geos::operation::overlay
  *
  * @see com.vividsolutions.jts.operation.overlay.MinimalEdgeRing
  */
-class GEOS_DLL MaximalEdgeRing: public geomgraph::EdgeRing {
+class GEOS_DLL MaximalEdgeRing final: public geomgraph::EdgeRing {
 
 public:
 

--- a/include/geos/operation/overlay/MinimalEdgeRing.h
+++ b/include/geos/operation/overlay/MinimalEdgeRing.h
@@ -53,7 +53,7 @@ namespace overlay { // geos::operation::overlay
  * @see operation::overlay::MaximalEdgeRing
  *
  */
-class GEOS_DLL MinimalEdgeRing: public geomgraph::EdgeRing {
+class GEOS_DLL MinimalEdgeRing final: public geomgraph::EdgeRing {
 
 public:
 

--- a/include/geos/operation/overlay/OverlayNodeFactory.h
+++ b/include/geos/operation/overlay/OverlayNodeFactory.h
@@ -43,7 +43,7 @@ namespace overlay { // geos::operation::overlay
  * Creates nodes for use in the geomgraph::PlanarGraph constructed during
  * overlay operations. NOTE: also used by operation::valid
  */
-class GEOS_DLL OverlayNodeFactory: public geomgraph::NodeFactory {
+class GEOS_DLL OverlayNodeFactory final: public geomgraph::NodeFactory {
 public:
     OverlayNodeFactory(): geomgraph::NodeFactory() {}
     geomgraph::Node* createNode(const geom::Coordinate& coord) const override;

--- a/include/geos/operation/overlay/OverlayOp.h
+++ b/include/geos/operation/overlay/OverlayOp.h
@@ -67,7 +67,7 @@ namespace overlay { // geos::operation::overlay
 /// The overlay can be used to determine any
 /// boolean combination of the geometries.
 ///
-class GEOS_DLL OverlayOp: public GeometryGraphOperation {
+class GEOS_DLL OverlayOp final: public GeometryGraphOperation {
 
 public:
 

--- a/include/geos/operation/polygonize/PolygonizeDirectedEdge.h
+++ b/include/geos/operation/polygonize/PolygonizeDirectedEdge.h
@@ -51,7 +51,7 @@ namespace polygonize { // geos::operation::polygonize
  * May be logically deleted from the graph by setting the
  * <code>marked</code> flag.
  */
-class GEOS_DLL PolygonizeDirectedEdge: public planargraph::DirectedEdge {
+class GEOS_DLL PolygonizeDirectedEdge final: public planargraph::DirectedEdge {
 
 private:
 

--- a/include/geos/operation/polygonize/PolygonizeEdge.h
+++ b/include/geos/operation/polygonize/PolygonizeEdge.h
@@ -41,7 +41,7 @@ namespace polygonize { // geos::operation::polygonize
  *
  * @version 1.4
  */
-class GEOS_DLL PolygonizeEdge: public planargraph::Edge {
+class GEOS_DLL PolygonizeEdge final: public planargraph::Edge {
 private:
     // Externally owned
     const geom::LineString* line;

--- a/include/geos/operation/polygonize/PolygonizeGraph.h
+++ b/include/geos/operation/polygonize/PolygonizeGraph.h
@@ -66,7 +66,7 @@ namespace polygonize { // geos::operation::polygonize
  * has be logically deleted from the graph.
  *
  */
-class GEOS_DLL PolygonizeGraph: public planargraph::PlanarGraph {
+class GEOS_DLL PolygonizeGraph final: public planargraph::PlanarGraph {
 
 public:
 

--- a/include/geos/operation/polygonize/Polygonizer.h
+++ b/include/geos/operation/polygonize/Polygonizer.h
@@ -85,7 +85,7 @@ private:
     /**
      * Add every linear element in a geometry into the polygonizer graph.
      */
-    class GEOS_DLL LineStringAdder: public geom::GeometryComponentFilter {
+    class GEOS_DLL LineStringAdder final: public geom::GeometryComponentFilter {
     public:
         Polygonizer* pol;
         explicit LineStringAdder(Polygonizer* p);

--- a/include/geos/operation/relate/EdgeEndBundle.h
+++ b/include/geos/operation/relate/EdgeEndBundle.h
@@ -44,7 +44,7 @@ namespace relate { // geos::operation::relate
  * A collection of geomgraph::EdgeEnd objects which
  * originate at the same point and have the same direction.
  */
-class GEOS_DLL EdgeEndBundle: public geomgraph::EdgeEnd {
+class GEOS_DLL EdgeEndBundle final: public geomgraph::EdgeEnd {
 public:
     EdgeEndBundle(geomgraph::EdgeEnd* e);
     ~EdgeEndBundle() override;

--- a/include/geos/operation/relate/EdgeEndBundleStar.h
+++ b/include/geos/operation/relate/EdgeEndBundleStar.h
@@ -45,7 +45,7 @@ namespace relate { // geos::operation::relate
  * around the node
  * for efficient lookup and topology building.
  */
-class GEOS_DLL EdgeEndBundleStar: public geomgraph::EdgeEndStar {
+class GEOS_DLL EdgeEndBundleStar final: public geomgraph::EdgeEndStar {
 public:
 
     /// Creates a new empty EdgeEndBundleStar

--- a/include/geos/operation/relate/RelateNode.h
+++ b/include/geos/operation/relate/RelateNode.h
@@ -43,7 +43,7 @@ namespace relate { // geos::operation::relate
  * Represents a node in the topological graph used to compute spatial
  * relationships.
  */
-class GEOS_DLL RelateNode: public geomgraph::Node {
+class GEOS_DLL RelateNode final: public geomgraph::Node {
 
 public:
 

--- a/include/geos/operation/relate/RelateNodeFactory.h
+++ b/include/geos/operation/relate/RelateNodeFactory.h
@@ -41,7 +41,7 @@ namespace relate { // geos::operation::relate
 /** \brief
  * Used by the geomgraph::NodeMap in a RelateNodeGraph to create RelateNode objects.
  */
-class GEOS_DLL RelateNodeFactory: public geomgraph::NodeFactory {
+class GEOS_DLL RelateNodeFactory final: public geomgraph::NodeFactory {
 public:
     geomgraph::Node* createNode(const geom::Coordinate& coord) const override;
     static const geomgraph::NodeFactory& instance();

--- a/include/geos/operation/relate/RelateOp.h
+++ b/include/geos/operation/relate/RelateOp.h
@@ -54,7 +54,7 @@ namespace relate { // geos::operation::relate
  * computed by a custom Boundary Node Rule.
  *
  */
-class GEOS_DLL RelateOp: public GeometryGraphOperation {
+class GEOS_DLL RelateOp final: public GeometryGraphOperation {
 
 public:
 

--- a/include/geos/operation/union/GeometryListHolder.h
+++ b/include/geos/operation/union/GeometryListHolder.h
@@ -31,7 +31,7 @@ namespace geounion {  // geos::operation::geounion
  * \brief Helper class holding Geometries, part of which are held by reference
  *        others are held exclusively.
  */
-class GeometryListHolder : public std::vector<geom::Geometry*> {
+class GeometryListHolder final: public std::vector<geom::Geometry*> {
 private:
     typedef std::vector<geom::Geometry*> base_type;
 

--- a/include/geos/operation/valid/SweeplineNestedRingTester.h
+++ b/include/geos/operation/valid/SweeplineNestedRingTester.h
@@ -104,7 +104,7 @@ public:
 
     bool isNonNested();
     bool isInside(geom::LinearRing* innerRing, geom::LinearRing* searchRing);
-    class OverlapAction: public index::sweepline::SweepLineOverlapAction {
+    class OverlapAction final: public index::sweepline::SweepLineOverlapAction {
     public:
         bool isNonNested;
         OverlapAction(SweeplineNestedRingTester* p);

--- a/include/geos/planargraph/DirectedEdge.h
+++ b/include/geos/planargraph/DirectedEdge.h
@@ -43,7 +43,7 @@ namespace planargraph { // geos.planargraph
  * will subclass DirectedEdge to add its own application-specific
  * data and methods.
  */
-class GEOS_DLL DirectedEdge: public GraphComponent {
+class GEOS_DLL DirectedEdge /*non-final*/: public GraphComponent {
 
 public:
 

--- a/include/geos/planargraph/Edge.h
+++ b/include/geos/planargraph/Edge.h
@@ -51,7 +51,7 @@ namespace planargraph { // geos.planargraph
  * Usually a client using a PlanarGraph will subclass Edge
  * to add its own application-specific data and methods.
  */
-class GEOS_DLL Edge: public GraphComponent {
+class GEOS_DLL Edge /*non-final*/: public GraphComponent {
 
 public:
 

--- a/include/geos/planargraph/Node.h
+++ b/include/geos/planargraph/Node.h
@@ -42,7 +42,7 @@ namespace planargraph { // geos.planargraph
  * data and methods.
  *
  */
-class GEOS_DLL Node: public GraphComponent {
+class GEOS_DLL Node final: public GraphComponent {
 protected:
 
     /// The location of this Node

--- a/include/geos/simplify/TaggedLineSegment.h
+++ b/include/geos/simplify/TaggedLineSegment.h
@@ -51,7 +51,7 @@ namespace simplify { // geos::simplify
  * Used to index the segments in a geometry and recover the segment locations
  * from the index.
  */
-class GEOS_DLL TaggedLineSegment: public geom::LineSegment {
+class GEOS_DLL TaggedLineSegment final: public geom::LineSegment {
 
 public:
 

--- a/include/geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h
+++ b/include/geos/triangulate/quadedge/LastFoundQuadEdgeLocator.h
@@ -36,7 +36,7 @@ class QuadEdgeSubdivision;
  * @author JTS: Martin Davis
  * @author Benjamin Campbell
  */
-class LastFoundQuadEdgeLocator : public QuadEdgeLocator {
+class LastFoundQuadEdgeLocator final: public QuadEdgeLocator {
 private:
     QuadEdgeSubdivision* subdiv;
     QuadEdge*			lastEdge;

--- a/include/geos/triangulate/quadedge/LocateFailureException.h
+++ b/include/geos/triangulate/quadedge/LocateFailureException.h
@@ -27,7 +27,7 @@ namespace geos {
 namespace triangulate { //geos.triangulate
 namespace quadedge { //geos.triangulate.quadedge
 
-class GEOS_DLL LocateFailureException : public geos::util::GEOSException {
+class GEOS_DLL LocateFailureException final: public geos::util::GEOSException {
 public:
     LocateFailureException(std::string const& msg);
 };

--- a/include/geos/util/AssertionFailedException.h
+++ b/include/geos/util/AssertionFailedException.h
@@ -27,7 +27,7 @@ namespace util { // geos.util
 /** \class AssertionFailedException util.h geos.h
  * \brief Indicates a bug in GEOS code.
  */
-class GEOS_DLL AssertionFailedException: public GEOSException {
+class GEOS_DLL AssertionFailedException final: public GEOSException {
 
 public:
 

--- a/include/geos/util/CoordinateArrayFilter.h
+++ b/include/geos/util/CoordinateArrayFilter.h
@@ -33,7 +33,7 @@ namespace util { // geos::util
  *
  * Last port: util/CoordinateArrayFilter.java rev. 1.15
  */
-class GEOS_DLL CoordinateArrayFilter: public geom::CoordinateFilter {
+class GEOS_DLL CoordinateArrayFilter final: public geom::CoordinateFilter {
 private:
     geom::Coordinate::ConstVect& pts; // target vector reference
 public:

--- a/include/geos/util/GEOSException.h
+++ b/include/geos/util/GEOSException.h
@@ -35,7 +35,7 @@ namespace util { // geos.util
  *
  * Use what() to get a readable message.
  */
-class GEOS_DLL GEOSException: public std::runtime_error {
+class GEOS_DLL GEOSException /*non-final*/: public std::runtime_error {
 
 public:
 

--- a/include/geos/util/IllegalArgumentException.h
+++ b/include/geos/util/IllegalArgumentException.h
@@ -31,7 +31,7 @@ namespace util { // geos::util
  * trying to apply set-theoretic methods to a
  * GeometryCollection object.
  */
-class GEOS_DLL IllegalArgumentException: public GEOSException {
+class GEOS_DLL IllegalArgumentException final: public GEOSException {
 public:
     IllegalArgumentException()
         :

--- a/include/geos/util/IllegalStateException.h
+++ b/include/geos/util/IllegalStateException.h
@@ -24,7 +24,7 @@ namespace geos {
 namespace util { // geos::util
 
 /// Indicates an illegal state
-class GEOS_DLL IllegalStateException: public GEOSException {
+class GEOS_DLL IllegalStateException final: public GEOSException {
 public:
     IllegalStateException()
         :

--- a/include/geos/util/TopologyException.h
+++ b/include/geos/util/TopologyException.h
@@ -32,7 +32,7 @@ namespace util { // geos.util
  * Indicates an invalid or inconsistent topological situation encountered
  * during processing
  */
-class GEOS_DLL TopologyException: public GEOSException {
+class GEOS_DLL TopologyException final: public GEOSException {
 public:
     TopologyException()
         :

--- a/include/geos/util/UniqueCoordinateArrayFilter.h
+++ b/include/geos/util/UniqueCoordinateArrayFilter.h
@@ -39,7 +39,7 @@ namespace util { // geos::util
  *
  *  Last port: util/UniqueCoordinateArrayFilter.java rev. 1.17
  */
-class GEOS_DLL UniqueCoordinateArrayFilter: public geom::CoordinateFilter {
+class GEOS_DLL UniqueCoordinateArrayFilter final: public geom::CoordinateFilter {
 public:
     /**
      * Constructs a CoordinateArrayFilter.

--- a/include/geos/util/UnsupportedOperationException.h
+++ b/include/geos/util/UnsupportedOperationException.h
@@ -33,7 +33,7 @@ namespace util { // geos::util
  * This exception is thrown - for example - when requesting the
  * X or Y member of an empty Point
  */
-class GEOS_DLL UnsupportedOperationException: public GEOSException {
+class GEOS_DLL UnsupportedOperationException final: public GEOSException {
 public:
     UnsupportedOperationException()
         :

--- a/src/algorithm/BoundaryNodeRule.cpp
+++ b/src/algorithm/BoundaryNodeRule.cpp
@@ -41,7 +41,7 @@ namespace {
  * @author Martin Davis
  * @version 1.7
  */
-class Mod2BoundaryNodeRule : public BoundaryNodeRule {
+class Mod2BoundaryNodeRule final: public BoundaryNodeRule {
 public:
     bool
     isInBoundary(int boundaryCount) const override
@@ -79,7 +79,7 @@ public:
  * @author Martin Davis
  * @version 1.7
  */
-class EndPointBoundaryNodeRule : public BoundaryNodeRule {
+class EndPointBoundaryNodeRule final: public BoundaryNodeRule {
     bool
     isInBoundary(int boundaryCount) const override
     {
@@ -97,7 +97,7 @@ class EndPointBoundaryNodeRule : public BoundaryNodeRule {
  * @author Martin Davis
  * @version 1.7
  */
-class MultiValentEndPointBoundaryNodeRule : public BoundaryNodeRule {
+class MultiValentEndPointBoundaryNodeRule final: public BoundaryNodeRule {
     bool
     isInBoundary(int boundaryCount) const override
     {
@@ -114,7 +114,7 @@ class MultiValentEndPointBoundaryNodeRule : public BoundaryNodeRule {
  * @author Martin Davis
  * @version 1.7
  */
-class MonoValentEndPointBoundaryNodeRule : public BoundaryNodeRule {
+class MonoValentEndPointBoundaryNodeRule final: public BoundaryNodeRule {
     bool
     isInBoundary(int boundaryCount) const override
     {

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -60,7 +60,7 @@ namespace geom { // geos::geom
 
 namespace {
 
-class gfCoordinateOperation: public util::CoordinateOperation {
+class gfCoordinateOperation final: public util::CoordinateOperation {
     using CoordinateOperation::edit;
     const CoordinateSequenceFactory* _gsf;
 public:

--- a/src/geom/prep/PreparedPolygonPredicate.cpp
+++ b/src/geom/prep/PreparedPolygonPredicate.cpp
@@ -38,7 +38,7 @@ namespace prep { // geos.geom.prep
 //
 // protected:
 //
-struct LocationMatchingFilter : public GeometryComponentFilter {
+struct LocationMatchingFilter final: public GeometryComponentFilter {
     explicit LocationMatchingFilter(algorithm::locate::PointOnGeometryLocator* locator, Location loc) :
         pt_locator(locator), test_loc(loc), found(false) {}
 
@@ -60,7 +60,7 @@ struct LocationMatchingFilter : public GeometryComponentFilter {
     }
 };
 
-struct LocationNotMatchingFilter : public GeometryComponentFilter {
+struct LocationNotMatchingFilter final: public GeometryComponentFilter {
     explicit LocationNotMatchingFilter(algorithm::locate::PointOnGeometryLocator* locator, Location loc) :
             pt_locator(locator), test_loc(loc), found(false) {}
 
@@ -82,7 +82,7 @@ struct LocationNotMatchingFilter : public GeometryComponentFilter {
     }
 };
 
-struct OutermostLocationFilter : public GeometryComponentFilter {
+struct OutermostLocationFilter final: public GeometryComponentFilter {
     explicit OutermostLocationFilter(algorithm::locate::PointOnGeometryLocator* locator) :
     pt_locator(locator),
     outermost_loc(geom::Location::UNDEF),

--- a/src/index/strtree/SIRtree.cpp
+++ b/src/index/strtree/SIRtree.cpp
@@ -86,7 +86,7 @@ SIRtree::~SIRtree()
 }
 
 
-class SIRAbstractNode: public AbstractNode {
+class SIRAbstractNode final: public AbstractNode {
 public:
     SIRAbstractNode(int p_level, size_t capacity)
         :

--- a/src/index/strtree/STRtree.cpp
+++ b/src/index/strtree/STRtree.cpp
@@ -354,7 +354,7 @@ bool STRtree::isWithinDistance(BoundablePair* initBndPair, double maxDistance)
 }
 
 
-class STRAbstractNode: public AbstractNode {
+class STRAbstractNode final: public AbstractNode {
 public:
 
     STRAbstractNode(int p_level, size_t capacity)

--- a/src/noding/GeometryNoder.cpp
+++ b/src/noding/GeometryNoder.cpp
@@ -47,7 +47,7 @@ namespace {
 /**
  * Add every linear element in a geometry into SegmentString vector
  */
-class SegmentStringExtractor: public geom::GeometryComponentFilter {
+class SegmentStringExtractor final: public geom::GeometryComponentFilter {
 public:
     SegmentStringExtractor(SegmentString::NonConstVect& to)
         : _to(to)

--- a/src/noding/ScaledNoder.cpp
+++ b/src/noding/ScaledNoder.cpp
@@ -74,7 +74,7 @@ sqlPrint(const std::string& table, std::vector<SegmentString*>& ssv)
 
 } // anonym namespace
 
-class ScaledNoder::Scaler : public geom::CoordinateFilter {
+class ScaledNoder::Scaler final: public geom::CoordinateFilter {
 public:
     const ScaledNoder& sn;
     Scaler(const ScaledNoder& n): sn(n)
@@ -101,7 +101,7 @@ private:
     Scaler& operator=(const Scaler& rhs) = delete;
 };
 
-class ScaledNoder::ReScaler: public geom::CoordinateFilter {
+class ScaledNoder::ReScaler final: public geom::CoordinateFilter {
 public:
     const ScaledNoder& sn;
     ReScaler(const ScaledNoder& n): sn(n)

--- a/src/noding/snapround/MCIndexPointSnapper.cpp
+++ b/src/noding/snapround/MCIndexPointSnapper.cpp
@@ -37,7 +37,7 @@ namespace geos {
 namespace noding { // geos.noding
 namespace snapround { // geos.noding.snapround
 
-class HotPixelSnapAction: public index::chain::MonotoneChainSelectAction {
+class HotPixelSnapAction final: public index::chain::MonotoneChainSelectAction {
 
 public:
 
@@ -104,7 +104,7 @@ private:
     HotPixelSnapAction& operator=(const HotPixelSnapAction& rhs) = delete;
 };
 
-class MCIndexPointSnapperVisitor: public ItemVisitor {
+class MCIndexPointSnapperVisitor final: public ItemVisitor {
 
 public:
     MCIndexPointSnapperVisitor(const Envelope& nPixelEnv, HotPixelSnapAction& nAction)

--- a/src/operation/distance/FacetSequenceTreeBuilder.cpp
+++ b/src/operation/distance/FacetSequenceTreeBuilder.cpp
@@ -47,7 +47,7 @@ FacetSequenceTreeBuilder::computeFacetSequences(const Geometry* g)
     std::unique_ptr<std::vector<FacetSequence*> > sections(new std::vector<FacetSequence*>());
 
     class FacetSequenceAdder;
-    class FacetSequenceAdder : public geom::GeometryComponentFilter {
+    class FacetSequenceAdder final: public geom::GeometryComponentFilter {
         std::vector<FacetSequence*>*  m_sections;
 
     public :

--- a/src/operation/distance/IndexedFacetDistance.cpp
+++ b/src/operation/distance/IndexedFacetDistance.cpp
@@ -27,7 +27,7 @@ using namespace geos::index::strtree;
 namespace geos {
 namespace operation {
 namespace distance {
-struct Deleter : public index::ItemVisitor {
+struct Deleter final: public index::ItemVisitor {
     void
     visitItem(void* item) override
     {
@@ -54,7 +54,7 @@ IndexedFacetDistance::nearestPoints(const geom::Geometry* g1, const geom::Geomet
 double
 IndexedFacetDistance::distance(const Geometry* g) const
 {
-    struct : public ItemDistance {
+    struct final: public ItemDistance {
         double
         distance(const ItemBoundable* item1, const ItemBoundable* item2) override
         {
@@ -81,7 +81,7 @@ IndexedFacetDistance::distance(const Geometry* g) const
 std::vector<GeometryLocation>
 IndexedFacetDistance::nearestLocations(const geom::Geometry* g) const
 {
-    struct : public ItemDistance {
+    struct final: public ItemDistance {
         double
         distance(const ItemBoundable* item1, const ItemBoundable* item2) override
         {

--- a/src/operation/linemerge/LineMerger.cpp
+++ b/src/operation/linemerge/LineMerger.cpp
@@ -65,7 +65,7 @@ LineMerger::~LineMerger()
 }
 
 
-struct LMGeometryComponentFilter: public GeometryComponentFilter {
+struct LMGeometryComponentFilter final: public GeometryComponentFilter {
     LineMerger* lm;
 
     LMGeometryComponentFilter(LineMerger* newLm): lm(newLm) {}

--- a/src/operation/overlay/OverlayOp.cpp
+++ b/src/operation/overlay/OverlayOp.cpp
@@ -998,7 +998,7 @@ OverlayOp::computeLabelsFromDepths()
     }
 }
 
-struct PointCoveredByAny: public geom::CoordinateFilter {
+struct PointCoveredByAny final: public geom::CoordinateFilter {
     const vector<const Geometry*>& geoms;
     PointLocator locator;
     PointCoveredByAny(const vector<const Geometry*>& nGeoms)

--- a/src/operation/overlay/snap/GeometrySnapper.cpp
+++ b/src/operation/overlay/snap/GeometrySnapper.cpp
@@ -44,7 +44,7 @@ namespace snap { // geos.operation.overlay.snap
 
 const double GeometrySnapper::snapPrecisionFactor = 1e-9;
 
-class SnapTransformer: public geos::geom::util::GeometryTransformer {
+class SnapTransformer final: public geos::geom::util::GeometryTransformer {
 
 private:
 

--- a/src/operation/predicate/RectangleIntersects.cpp
+++ b/src/operation/predicate/RectangleIntersects.cpp
@@ -44,7 +44,7 @@ namespace predicate { // geos.operation.predicate
 // EnvelopeIntersectsVisitor
 //----------------------------------------------------------------
 
-class EnvelopeIntersectsVisitor: public geom::util::ShortCircuitedGeometryVisitor {
+class EnvelopeIntersectsVisitor final: public geom::util::ShortCircuitedGeometryVisitor {
 private:
 
     const geom::Envelope& rectEnv;
@@ -125,7 +125,7 @@ public:
  * Tests whether it can be concluded
  * that a geometry contains a corner point of a rectangle.
  */
-class ContainsPointVisitor: public geom::util::ShortCircuitedGeometryVisitor {
+class ContainsPointVisitor final: public geom::util::ShortCircuitedGeometryVisitor {
 private:
 
     const geom::Envelope& rectEnv;
@@ -201,7 +201,7 @@ public:
 // LineIntersectsVisitor
 //----------------------------------------------------------------
 
-class LineIntersectsVisitor: public geom::util::ShortCircuitedGeometryVisitor {
+class LineIntersectsVisitor final: public geom::util::ShortCircuitedGeometryVisitor {
 private:
 
     //const geom::Polygon& rectangle;

--- a/src/operation/union/OverlapUnion.cpp
+++ b/src/operation/union/OverlapUnion.cpp
@@ -215,7 +215,7 @@ containsProperly(const Envelope& env, const Coordinate& p0, const Coordinate& p1
 void
 OverlapUnion::extractBorderSegments(const Geometry* geom, const Envelope& penv, std::vector<LineSegment>& psegs)
 {
-    class BorderSegmentFilter : public CoordinateSequenceFilter {
+    class BorderSegmentFilter final: public CoordinateSequenceFilter {
 
     private:
         const Envelope env;

--- a/src/precision/CommonBitsRemover.cpp
+++ b/src/precision/CommonBitsRemover.cpp
@@ -36,7 +36,7 @@ using namespace geos::geom;
 namespace geos {
 namespace precision { // geos.precision
 
-class Translater: public geom::CoordinateFilter {
+class Translater final: public geom::CoordinateFilter {
 
 private:
 
@@ -65,7 +65,7 @@ public:
 };
 
 
-class CommonCoordinateFilter: public geom::CoordinateFilter {
+class CommonCoordinateFilter final: public geom::CoordinateFilter {
 private:
     CommonBits commonBitsX;
     CommonBits commonBitsY;

--- a/src/precision/MinimumClearance.cpp
+++ b/src/precision/MinimumClearance.cpp
@@ -57,7 +57,7 @@ MinimumClearance::getLine()
 void
 MinimumClearance::compute()
 {
-    class MinClearanceDistance : public ItemDistance {
+    class MinClearanceDistance final: public ItemDistance {
     private:
         double minDist;
         std::vector<Coordinate> minPts;
@@ -165,7 +165,7 @@ MinimumClearance::compute()
         }
     };
 
-    struct ItemDeleter : public index::ItemVisitor {
+    struct ItemDeleter final: public index::ItemVisitor {
         void
         visitItem(void* item) override
         {

--- a/src/simplify/DouglasPeuckerSimplifier.cpp
+++ b/src/simplify/DouglasPeuckerSimplifier.cpp
@@ -43,7 +43,7 @@ using namespace geos::geom;
 namespace geos {
 namespace simplify { // geos::simplify
 
-class DPTransformer: public geom::util::GeometryTransformer {
+class DPTransformer final: public geom::util::GeometryTransformer {
 
 public:
 

--- a/src/simplify/LineSegmentIndex.cpp
+++ b/src/simplify/LineSegmentIndex.cpp
@@ -46,7 +46,7 @@ namespace simplify { // geos::simplify
 /**
  * ItemVisitor subclass to reduce volume of query results.
  */
-class LineSegmentVisitor: public index::ItemVisitor {
+class LineSegmentVisitor final: public index::ItemVisitor {
 
 // MD - only seems to make about a 10% difference in overall time.
 

--- a/src/simplify/TopologyPreservingSimplifier.cpp
+++ b/src/simplify/TopologyPreservingSimplifier.cpp
@@ -46,7 +46,7 @@ using LinesMap = std::unordered_map<const geom::Geometry*, TaggedLineString*>;
 
 namespace { // module-statics
 
-class LineStringTransformer: public geom::util::GeometryTransformer {
+class LineStringTransformer final: public geom::util::GeometryTransformer {
 
 public:
 
@@ -185,7 +185,7 @@ LineStringTransformer::transformCoordinates(
  * TODO: Consider container of unique_ptr
  *
  */
-class LineStringMapBuilderFilter: public geom::GeometryComponentFilter {
+class LineStringMapBuilderFilter final: public geom::GeometryComponentFilter {
 
 public:
 

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -360,7 +360,7 @@ QuadEdgeSubdivision::fetchTriangleToVisit(QuadEdge* edge,
 }
 
 class
-    QuadEdgeSubdivision::TriangleCoordinatesVisitor : public TriangleVisitor {
+    QuadEdgeSubdivision::TriangleCoordinatesVisitor final: public TriangleVisitor {
 private:
     QuadEdgeSubdivision::TriList* triCoords;
     CoordinateArraySequenceFactory coordSeqFact;
@@ -385,7 +385,7 @@ public:
 
 
 class
-    QuadEdgeSubdivision::TriangleCircumcentreVisitor : public TriangleVisitor {
+    QuadEdgeSubdivision::TriangleCircumcentreVisitor final: public TriangleVisitor {
 public:
     void
     visit(QuadEdge* triEdges[3]) override

--- a/src/util/Interrupt.cpp
+++ b/src/util/Interrupt.cpp
@@ -25,7 +25,7 @@ geos::util::Interrupt::Callback* callback = nullptr;
 namespace geos {
 namespace util { // geos::util
 
-class GEOS_DLL InterruptedException: public GEOSException {
+class GEOS_DLL InterruptedException final: public GEOSException {
 public:
     InterruptedException() :
         GEOSException("InterruptedException", "Interrupted!") {}


### PR DESCRIPTION
Two advantages:
- Helps the compiler to generate better code by de-virtualizing
  some calls
- Better document the inheritance diagram

Also tag with a /*non-final*/ comment classes that are later derived.

Candidates found with 'grep ": public" . | grep final"