### PR TITLE
Avoid adding small segment from some buffer operations

### DIFF
--- a/src/operation/buffer/OffsetSegmentGenerator.cpp
+++ b/src/operation/buffer/OffsetSegmentGenerator.cpp
@@ -286,7 +286,7 @@ OffsetSegmentGenerator::addFillet(const Coordinate& p, double startAngle,
 
     double currAngle = initAngle;
     Coordinate pt;
-    while(currAngle < totalAngle) {
+    while(currAngle < totalAngle - 1e-12) { // avoid adding tiny segment
         double angle = startAngle + directionFactor * currAngle;
         pt.x = p.x + radius * cos(angle);
         pt.y = p.y + radius * sin(angle);

--- a/tests/unit/operation/buffer/BufferOpTest.cpp
+++ b/tests/unit/operation/buffer/BufferOpTest.cpp
@@ -91,7 +91,8 @@ void object::test<2>
     ensure_not(gBuffer->isEmpty());
     ensure(gBuffer->isValid());
     ensure_equals(gBuffer->getGeometryTypeId(), geos::geom::GEOS_POLYGON);
-    ensure(gBuffer->getNumPoints() > std::size_t(32));
+    int const segments = default_quadrant_segments;
+    ensure(gBuffer->getNumPoints() == std::size_t(segments * 4 + 1));
 }
 
 template<>
@@ -117,7 +118,7 @@ void object::test<3>
     ensure_not(gBuffer->isEmpty());
     ensure(gBuffer->isValid());
     ensure_equals(gBuffer->getGeometryTypeId(), geos::geom::GEOS_POLYGON);
-    ensure(gBuffer->getNumPoints() > std::size_t(129));
+    ensure(gBuffer->getNumPoints() == std::size_t(segments * 4 + 1));
 }
 
 template<>
@@ -143,7 +144,7 @@ void object::test<4>
         ensure_not(gBuffer->isEmpty());
         ensure(gBuffer->isValid());
         ensure_equals(gBuffer->getGeometryTypeId(), geos::geom::GEOS_POLYGON);
-        ensure(gBuffer->getNumPoints() >= std::size_t(245));
+        ensure(gBuffer->getNumPoints() == std::size_t(243));
     }
 
     // Buffer point with custom parameters: 32 quadrant segments
@@ -156,7 +157,7 @@ void object::test<4>
         ensure_not(gBuffer->isEmpty());
         ensure(gBuffer->isValid());
         ensure_equals(gBuffer->getGeometryTypeId(), geos::geom::GEOS_POLYGON);
-        ensure(gBuffer->getNumPoints() >= std::size_t(318));
+        ensure(gBuffer->getNumPoints() == std::size_t(317));
     }
 }
 


### PR DESCRIPTION
This bug, [described on Trac](https://trac.osgeo.org/geos/ticket/743), has been around since probably the first releases of GEOS, and is also in JTS master.

Some tests needed to be modified, as there are sometimes fewer points with the revised logic.

This change will visible downstream, for instance shapely uses a default quadsegs to 16, which has this rounding error for buffered points. Other geometries and quadseg combinations may yield fewer coordinates.

Fixes [#743](https://trac.osgeo.org/geos/ticket/743)