### PR TITLE
Recover scan-build Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,17 +103,20 @@ matrix:
       env:
         - E="TOOL=cmake && BUILD_TYPE=Release && CXX=clang++ && ARCH=-m64 && CC=clang"
 
-#    - os: linux
-#      cache:
-#        apt: true
-#        directories:
-#          - $HOME/.ccache
-#      addons:
-#        apt:
-#          sources: *sources
-#          packages: ['clang','ccache','doxygen']
-#      env:
-#        - E="TOOL=autotools_scanbuild && BUILD_TYPE=Release && ARCH=-m64
+    - os: linux
+      cache:
+        apt: true
+        directories:
+          - $HOME/.ccache
+      addons:
+        apt:
+          sources: *sources
+          packages: ['clang','ccache','doxygen']
+      env:
+        - E="TOOL=autotools_scanbuild && BUILD_TYPE=Release && ARCH=-m64"
+
+  allow_failures:
+    - env: E="TOOL=autotools_scanbuild && BUILD_TYPE=Release && ARCH=-m64"
 
 before_install:
   - eval "${E}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,8 +110,11 @@ matrix:
           - $HOME/.ccache
       addons:
         apt:
-          sources: *sources
-          packages: ['clang','ccache','doxygen']
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages: ['clang-9', 'clang-tools-9', 'ccache','doxygen']
       env:
         - E="TOOL=autotools_scanbuild && BUILD_TYPE=Release && ARCH=-m64"
 

--- a/tools/ci/script_autotools_scanbuild.sh
+++ b/tools/ci/script_autotools_scanbuild.sh
@@ -21,5 +21,5 @@ fi
 cd ${TRAVIS_BUILD_DIR}
 ./autogen.sh
 cd -
-${TRAVIS_BUILD_DIR}/configure CC=clang CXX=clang++
+${TRAVIS_BUILD_DIR}/configure CC=clang CXX=clang++ CXXFLAGS="-std=c++11"
 scan-build --status-bugs make -j2

--- a/tools/ci/script_autotools_scanbuild.sh
+++ b/tools/ci/script_autotools_scanbuild.sh
@@ -21,5 +21,5 @@ fi
 cd ${TRAVIS_BUILD_DIR}
 ./autogen.sh
 cd -
-${TRAVIS_BUILD_DIR}/configure CC=clang CXX=clang++ CXXFLAGS="-std=c++11"
-scan-build --status-bugs make -j2
+scan-build ${TRAVIS_BUILD_DIR}/configure CC=clang-9 CXX=clang++-9 CXXFLAGS="-std=c++11"
+scan-build --keep-cc --status-bugs make -j2


### PR DESCRIPTION
Recover the Travis scan-build job. With the update to clang-9 and the fixes applied previously, the build is clean (`scan-build: No bugs found.`).

I've set it up as `allow_failures` as requested when it was disabled. I'm not 100% sure if it should be simply enabled (no failures allowed) or not, on one hand it would detect bugs before they are introduced, but on the other hand code/commits that break the build might go into the project without using this CI (thus breaking subsequent PRs). In any case, either if failing is allowed I think it is a good thing to have in the CI as it isn't something usually checked during development.
