### PR TITLE
include/: add deleted copy constructors and assignment operators

### DIFF
--- a/include/geos/geomgraph/PlanarGraph.h
+++ b/include/geos/geomgraph/PlanarGraph.h
@@ -194,6 +194,9 @@ private:
                               const geom::Coordinate& p1,
                               const geom::Coordinate& ep0,
                               const geom::Coordinate& ep1);
+
+    PlanarGraph(const PlanarGraph&) = delete;
+    PlanarGraph& operator=(const PlanarGraph&) = delete;
 };
 
 

--- a/include/geos/index/bintree/Bintree.h
+++ b/include/geos/index/bintree/Bintree.h
@@ -115,6 +115,9 @@ private:
     double minExtent;
 
     void collectStats(Interval* interval);
+
+    Bintree(const Bintree&) = delete;
+    Bintree& operator=(const Bintree&) = delete;
 };
 
 } // namespace geos::index::bintree

--- a/include/geos/index/bintree/NodeBase.h
+++ b/include/geos/index/bintree/NodeBase.h
@@ -70,6 +70,12 @@ protected:
     Node* subnode[2];
 
     virtual bool isSearchMatch(Interval* interval) = 0;
+
+private:
+
+    NodeBase(const NodeBase&) = delete;
+    NodeBase& operator=(const NodeBase&) = delete;
+
 };
 
 } // namespace geos::index::bintree

--- a/include/geos/index/strtree/AbstractSTRtree.h
+++ b/include/geos/index/strtree/AbstractSTRtree.h
@@ -163,6 +163,9 @@ private:
 
     ItemsList* itemsTree(AbstractNode* node);
 
+    AbstractSTRtree(const AbstractSTRtree&) = delete;
+    AbstractSTRtree& operator=(const AbstractSTRtree&) = delete;
+
 protected:
 
     /** \brief

--- a/include/geos/operation/buffer/OffsetSegmentString.h
+++ b/include/geos/operation/buffer/OffsetSegmentString.h
@@ -77,6 +77,8 @@ private:
         return false;
     }
 
+    OffsetSegmentString(const OffsetSegmentString&) = delete;
+    OffsetSegmentString& operator=(const OffsetSegmentString&) = delete;
 
 public:
 

--- a/include/geos/operation/overlay/EdgeSetNoder.h
+++ b/include/geos/operation/overlay/EdgeSetNoder.h
@@ -48,6 +48,10 @@ class GEOS_DLL EdgeSetNoder {
 private:
     algorithm::LineIntersector* li;
     std::vector<geomgraph::Edge*>* inputEdges;
+
+    EdgeSetNoder(const EdgeSetNoder&) = delete;
+    EdgeSetNoder& operator=(const EdgeSetNoder&) = delete;
+
 public:
     EdgeSetNoder(algorithm::LineIntersector* newLi)
         :

--- a/include/geos/operation/overlay/PointBuilder.h
+++ b/include/geos/operation/overlay/PointBuilder.h
@@ -78,6 +78,9 @@ private:
     /// it from build()
     std::vector<geom::Point*>* resultPointList;
 
+    PointBuilder(const PointBuilder&) = delete;
+    PointBuilder& operator=(const PointBuilder&) = delete;
+
 public:
 
     PointBuilder(OverlayOp* newOp,

--- a/include/geos/operation/relate/RelateNodeGraph.h
+++ b/include/geos/operation/relate/RelateNodeGraph.h
@@ -87,6 +87,10 @@ public:
 private:
 
     geomgraph::NodeMap* nodes;
+
+    RelateNodeGraph(const RelateNodeGraph&) = delete;
+    RelateNodeGraph& operator=(const RelateNodeGraph&) = delete;
+
 };
 
 

--- a/include/geos/operation/valid/SweeplineNestedRingTester.h
+++ b/include/geos/operation/valid/SweeplineNestedRingTester.h
@@ -69,6 +69,9 @@ private:
     geom::Coordinate* nestedPt;
     void buildIndex();
 
+    SweeplineNestedRingTester(const SweeplineNestedRingTester&) = delete;
+    SweeplineNestedRingTester& operator=(const SweeplineNestedRingTester&) = delete;
+
 public:
 
     SweeplineNestedRingTester(geomgraph::GeometryGraph* newGraph)

--- a/include/geos/planargraph/Node.h
+++ b/include/geos/planargraph/Node.h
@@ -143,6 +143,11 @@ public:
         return deStar->getIndex(edge);
     }
 
+private:
+
+    Node(const Node&) = delete;
+    Node& operator=(const Node&) = delete;
+
 };
 
 /// Print a Node

--- a/include/geos/precision/CommonBitsRemover.h
+++ b/include/geos/precision/CommonBitsRemover.h
@@ -45,6 +45,9 @@ private:
 
     CommonCoordinateFilter* ccFilter;
 
+    CommonBitsRemover(const CommonBitsRemover&) = delete;
+    CommonBitsRemover& operator=(const CommonBitsRemover&) = delete;
+
 public:
 
     CommonBitsRemover();


### PR DESCRIPTION
cppcheck spots classes that have pointer member variables, but lack an
explicit copy constructor and assignment operator. The default behaviour
of bitwise copy is dangerous, so add explicit '= delete'