### PR TITLE
Update the link to the geos-docker repository

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -1,6 +1,6 @@
 # This is for the dronie 1.0 agent
 # https://docs.drone.io/user-guide/pipeline/steps/ https://docs.drone.io/user-guide/pipeline/migrating/
-# See https://git.osgeo.org/gogs/geos/geos-docker
+# See https://git.osgeo.org/gitea/geos/geos-docker
 test-image: &test-image docker.kbt.io/geos/build-test:alpine
 
 kind: pipeline


### PR DESCRIPTION
The repository uses Gitea instead of Gogs these days.