### PR TITLE
Remove redundant EditorConfig properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,8 +37,6 @@ end_of_line = crlf
 [CMakeLists.txt]
 indent_style = space
 indent_size = 2
-trim_trailing_whitespace = true
-insert_final_newline = true
 
 # CMake modules
 [*.cmake]


### PR DESCRIPTION
The `insert_final_newline` and `trim_trailing_whitespace` properties do not have to be enabled for `CMakeLists.txt` as they are already enabled for all files.