### PR TITLE
Enforce utf-8 charset when building astyle

### DIFF
--- a/tools/astyle/CMakeLists.txt
+++ b/tools/astyle/CMakeLists.txt
@@ -12,5 +12,8 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 file(GLOB_RECURSE astyle_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_executable(astyle ${astyle_SOURCES})
+if(MSVC)
+  target_compile_options(astyle PRIVATE /source-charset:utf-8)
+endif()
 # message(STATUS "Enable AStyle")
 


### PR DESCRIPTION
I encountered a build issue while attempting to build geos with MSVC on a PC with a Chinese locale. I found this [comment](https://github.com/libusb/libusb/issues/207#issuecomment-288664124) on a similar problem that points to a deeper explanation of the issue and a solution :)

This PR enables the `/source-charset:utf-8` for the `astyle` target in CMake which solves this particular issue.