### PR TITLE
Add envelope short circuit to snapping overlay op

### DIFF
--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -453,6 +453,28 @@ public:
      */
     double distance(const Envelope* env) const;
 
+    /** \brief
+     * Computes the distance between one Coordinate and an Envelope
+     * defined by two other Coordinates. The order of the Coordinates
+     * used to define the envelope is not significant.
+     *
+     * @param c the coordinate to from which distance should be found
+     * @param p1 first coordinate defining an envelope
+     * @param p2 second coordinate defining an envelope.
+     */
+    static double distanceToCoordinate(const Coordinate & c, const Coordinate & p1, const Coordinate & p2);
+
+    /** \brief
+     * Computes the squared distance between one Coordinate and an Envelope
+     * defined by two other Coordinates. The order of the Coordinates
+     * used to define the envelope is not significant.
+     *
+     * @param c the coordinate to from which distance should be found
+     * @param p1 first coordinate defining an envelope
+     * @param p2 second coordinate defining an envelope.
+     */
+    static double distanceSquaredToCoordinate(const Coordinate & c, const Coordinate & p1, const Coordinate & p2);
+
     size_t hashCode() const;
 
 private:

--- a/include/geos/geom/Envelope.inl
+++ b/include/geos/geom/Envelope.inl
@@ -19,7 +19,9 @@
 #ifndef GEOS_GEOM_ENVELOPE_INL
 #define GEOS_GEOM_ENVELOPE_INL
 
+#include <algorithm> // std::min, std::max
 #include <cassert>
+#include <numeric> // std::signbit
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/Envelope.h>
 

--- a/include/geos/geom/Envelope.inl
+++ b/include/geos/geom/Envelope.inl
@@ -262,6 +262,25 @@ Envelope::setToNull()
     maxy = -1;
 }
 
+INLINE double
+Envelope::distanceToCoordinate(const Coordinate & c, const Coordinate & p0, const Coordinate & p1) {
+    return std::sqrt(distanceSquaredToCoordinate(c, p0, p1));
+}
+
+INLINE double
+Envelope::distanceSquaredToCoordinate(const Coordinate & c, const Coordinate & p0, const Coordinate & p1) {
+    double xa = c.x - p0.x;
+    double xb = c.x - p1.x;
+    double ya = c.y - p0.y;
+    double yb = c.y - p1.y;
+
+    // If sign of a and b are not the same, then Envelope spans c and distance is zero.
+    double dx = (std::signbit(xa) == std::signbit(xb)) * std::min(std::abs(xa), std::abs(xb));
+    double dy = (std::signbit(ya) == std::signbit(yb)) * std::min(std::abs(ya), std::abs(yb));
+
+    return dx*dx + dy*dy;
+}
+
 } // namespace geos::geom
 } // namespace geos
 

--- a/src/operation/overlay/snap/LineStringSnapper.cpp
+++ b/src/operation/overlay/snap/LineStringSnapper.cpp
@@ -24,6 +24,7 @@
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateList.h>
+#include <geos/geom/Envelope.h>
 #include <geos/util/UniqueCoordinateArrayFilter.h>
 #include <geos/geom/LineSegment.h>
 #include <geos/util/Interrupt.h>
@@ -429,6 +430,10 @@ LineStringSnapper::findSegmentToSnap(
 #endif
                 return too_far;
             }
+        }
+
+        if (Envelope::distanceSquaredToCoordinate(snapPt, seg.p0, seg.p1) >= minDist*minDist) {
+            continue;
         }
 
         double dist = seg.distance(snapPt);

--- a/tests/unit/geom/EnvelopeTest.cpp
+++ b/tests/unit/geom/EnvelopeTest.cpp
@@ -242,5 +242,67 @@ void object::test<9>
     ensure(empty == exemplar);
 }
 
+// Test point-to-envelope distance
+template<>
+template<>
+void object::test<10>
+()
+{
+    using geos::geom::Coordinate;
+    using geos::geom::Envelope;
+
+    // Create a 5x5 grid of points and use them to test various
+    // spatial arrangements of the envelope and test point
+
+    //  0  1  2  3  4
+    //  5  6  7  8  9
+    // 10 11 12 13 14
+    // 15 16 17 18 19
+    // 20 21 22 23 24
+    std::vector<Coordinate> c(25);
+
+    std::cout<<std::endl;
+    for (size_t i = 0; i < c.size(); i++) {
+        c[i].x = static_cast<double>(i % 5);
+        c[i].y = static_cast<double>(5 - (i / 5));
+        std::cout<< c[i] << std::endl;
+    }
+
+    // point contained in envelope
+    ensure_equals( Envelope::distanceToCoordinate(c[18], c[22], c[9]), 0);
+    ensure_equals( Envelope::distanceToCoordinate(c[18], c[14], c[18]), 0);
+    ensure_equals( Envelope::distanceToCoordinate(c[18], c[14], c[17]), 0);
+    ensure_equals( Envelope::distanceToCoordinate(c[18], c[19], c[22]), 0);
+
+    // envelope above point
+    ensure_equals(Envelope::distanceToCoordinate(c[17], c[5], c[4]), 2);
+
+    // envelope below point
+    ensure_equals(Envelope::distanceToCoordinate(c[7], c[20], c[19]), 2);
+
+    // envelope left of point
+    ensure_equals(Envelope::distanceToCoordinate(c[13], c[20], c[11]), 2);
+
+    // envelope right of point
+    ensure_equals(Envelope::distanceToCoordinate(c[5], c[9], c[8]), 3);
+
+    // envelope upper-left of point
+    ensure_equals(Envelope::distanceToCoordinate(c[17], c[6], c[0]),
+            c[17].distance(c[6]));
+
+    // envelope upper-right of point
+    ensure_equals(Envelope::distanceToCoordinate(c[21], c[9], c[13]),
+            c[21].distance(c[13]));
+
+    // envelope lower-left of point
+    ensure_equals(Envelope::distanceToCoordinate(c[3], c[10], c[21]),
+                  c[3].distance(c[11]));
+
+    // envelope lower-right of point
+    ensure_equals(Envelope::distanceToCoordinate(c[6], c[12], c[14]),
+                  c[6].distance(c[12]));
+
+}
+
 } // namespace tut
 


### PR DESCRIPTION
This PR adds an envelope distance check to `LineStringSnapper`. In my test it improves union performance by 35% for a set of polygons that requires snapping.

This code may end up being replaced with the new overlay engine, but there may be other applications for the `Envelope::distanceToCoordinate` method added here.