### PR TITLE
Minor IndexedFacetDistance optimizations

### DIFF
--- a/include/geos/operation/distance/FacetSequenceTreeBuilder.h
+++ b/include/geos/operation/distance/FacetSequenceTreeBuilder.h
@@ -38,25 +38,19 @@ private:
 
     static void addFacetSequences(const geom::Geometry* geom,
                                   const geom::CoordinateSequence* pts,
-                                  std::vector<std::unique_ptr<FacetSequence>> & sections);
-    static std::vector<std::unique_ptr<FacetSequence>> computeFacetSequences(const geom::Geometry* g);
+                                  std::vector<FacetSequence> & sections);
+    static std::vector<FacetSequence> computeFacetSequences(const geom::Geometry* g);
 
     class FacetSequenceTree : public geos::index::strtree::STRtree {
-
-        using geos::index::strtree::STRtree::STRtree;
-
-        struct Deleter : public index::ItemVisitor {
-            void
-            visitItem(void* item) override
-            {
-                delete static_cast<FacetSequence*>(item);
-            }
-        } deleter;
-
     public:
-        ~FacetSequenceTree() override {
-            iterate(deleter);
+        FacetSequenceTree(std::vector<FacetSequence> &&seq) : STRtree(STR_TREE_NODE_CAPACITY), sequences(seq) {
+            for (auto& fs : sequences) {
+                STRtree::insert(fs.getEnvelope(), &fs);
+            }
         }
+
+    private:
+        std::vector<FacetSequence> sequences;
     };
 
 public:

--- a/src/operation/distance/FacetSequence.cpp
+++ b/src/operation/distance/FacetSequence.cpp
@@ -170,6 +170,11 @@ FacetSequence::computeDistanceLineLine(const FacetSequence& facetSeq, std::vecto
         if (p0 == p1)
             continue;
 
+        Envelope pEnv(p0, p1);
+        if (pEnv.distanceSquared(*facetSeq.getEnvelope()) > minDistance*minDistance) {
+            continue;
+        }
+
         for(size_t j = facetSeq.start; j < facetSeq.end - 1; j++) {
             const Coordinate& q0 = facetSeq.pts->getAt(j);
             const Coordinate& q1 = facetSeq.pts->getAt(j + 1);
@@ -177,6 +182,11 @@ FacetSequence::computeDistanceLineLine(const FacetSequence& facetSeq, std::vecto
             // Avoid calculating distance to zero-length segment
             if (q0 == q1)
                 continue;
+
+            Envelope qEnv(q0, q1);
+            if (pEnv.distanceSquared(qEnv) > minDistance*minDistance) {
+                continue;
+            }
 
             double dist = Distance::segmentToSegment(p0, p1, q0, q1);
             if(dist <= minDistance) {

--- a/src/operation/distance/FacetSequence.cpp
+++ b/src/operation/distance/FacetSequence.cpp
@@ -206,7 +206,7 @@ FacetSequence::computeEnvelope()
 {
     env = Envelope();
     for(size_t i = start; i < end; i++) {
-        env.expandToInclude(pts->getX(i), pts->getY(i));
+        env.expandToInclude(pts->getAt(i));
     }
 }
 

--- a/src/operation/distance/FacetSequence.cpp
+++ b/src/operation/distance/FacetSequence.cpp
@@ -161,17 +161,24 @@ double
 FacetSequence::computeDistanceLineLine(const FacetSequence& facetSeq, std::vector<GeometryLocation> *locs) const
 {
     double minDistance = std::numeric_limits<double>::infinity();
-    double dist;
 
     for(size_t i = start; i < end - 1; i++) {
         const Coordinate& p0 = pts->getAt(i);
         const Coordinate& p1 = pts->getAt(i + 1);
 
+        // Avoid calculating distance from zero-length segment
+        if (p0 == p1)
+            continue;
+
         for(size_t j = facetSeq.start; j < facetSeq.end - 1; j++) {
             const Coordinate& q0 = facetSeq.pts->getAt(j);
             const Coordinate& q1 = facetSeq.pts->getAt(j + 1);
 
-            dist = Distance::segmentToSegment(p0, p1, q0, q1);
+            // Avoid calculating distance to zero-length segment
+            if (q0 == q1)
+                continue;
+
+            double dist = Distance::segmentToSegment(p0, p1, q0, q1);
             if(dist <= minDistance) {
                 minDistance = dist;
                 if(locs != nullptr) {

--- a/src/operation/distance/FacetSequenceTreeBuilder.cpp
+++ b/src/operation/distance/FacetSequenceTreeBuilder.cpp
@@ -30,28 +30,22 @@ namespace distance {
 std::unique_ptr<STRtree>
 FacetSequenceTreeBuilder::build(const Geometry* g)
 {
-    auto tree = std::unique_ptr<STRtree>(new FacetSequenceTree(STR_TREE_NODE_CAPACITY));
-    std::vector<std::unique_ptr<FacetSequence>> sections(computeFacetSequences(g));
-
-    for(auto& section : sections) {
-        const Envelope* e = section->getEnvelope();
-        tree->insert(e, section.release());
-    }
+    auto tree = std::unique_ptr<STRtree>(new FacetSequenceTree(computeFacetSequences(g)));
 
     tree->build();
     return tree;
 }
 
-std::vector<std::unique_ptr<FacetSequence>>
+std::vector<FacetSequence>
 FacetSequenceTreeBuilder::computeFacetSequences(const Geometry* g)
 {
-    std::vector<std::unique_ptr<FacetSequence>> sections;
+    std::vector<FacetSequence> sections;
 
     class FacetSequenceAdder : public geom::GeometryComponentFilter {
-        std::vector<std::unique_ptr<FacetSequence>>&  m_sections;
+        std::vector<FacetSequence>&  m_sections;
 
     public :
-        FacetSequenceAdder(std::vector<std::unique_ptr<FacetSequence>> & p_sections) :
+        FacetSequenceAdder(std::vector<FacetSequence> & p_sections) :
             m_sections(p_sections) {}
         void
         filter_ro(const Geometry* geom) override
@@ -75,7 +69,7 @@ FacetSequenceTreeBuilder::computeFacetSequences(const Geometry* g)
 
 void
 FacetSequenceTreeBuilder::addFacetSequences(const Geometry* geom, const CoordinateSequence* pts,
-        std::vector<std::unique_ptr<FacetSequence>> & sections)
+        std::vector<FacetSequence> & sections)
 {
     size_t i = 0;
     size_t size = pts->size();
@@ -87,8 +81,7 @@ FacetSequenceTreeBuilder::addFacetSequences(const Geometry* geom, const Coordina
         if(end >= size - 1) {
             end = size;
         }
-        std::unique_ptr<FacetSequence> sect = detail::make_unique<FacetSequence>(geom, pts, i, end);
-        sections.emplace_back(std::move(sect));
+        sections.emplace_back(geom, pts, i, end);
         i += FACET_SEQUENCE_SIZE;
     }
 }


### PR DESCRIPTION
- avoid heap allocations, virtual calls
- avoid distance calcs against zero-length segments
- check envelope distance before calculating segment distance

Net gain ~15%.