### PR TITLE
DD: Address clang warning

### DIFF
--- a/include/geos/math/DD.h
+++ b/include/geos/math/DD.h
@@ -119,7 +119,6 @@ class GEOS_DLL DD {
     public:
         DD(double p_hi, double p_lo) : hi(p_hi), lo(p_lo) {};
         DD(double x) : hi(x), lo(0.0) {};
-        DD(const DD &dd) : hi(dd.hi), lo(dd.lo) {};
         DD() : hi(0.0), lo(0.0) {};
 
         bool operator==(const DD &rhs) const


### PR DESCRIPTION
Minimal PR to silence clang (clang version 10.0.1):

```
In file included from DD.cpp:18:
../../include/geos/math/DD.h:122:9: error: definition of implicit copy assignment operator for 'DD' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
        DD(const DD &dd) : hi(dd.hi), lo(dd.lo) {};
        ^
DD.cpp:389:15: note: in implicit copy assignment operator for 'geos::math::DD' first required here
            r = r*r;
```