### PR TITLE
Fix windows compilation issues.

### DIFF
--- a/include/geos/operation/overlayng/IntersectionPointBuilder.h
+++ b/include/geos/operation/overlayng/IntersectionPointBuilder.h
@@ -87,8 +87,8 @@ public:
 
     std::vector<std::unique_ptr<geom::Point>> getPoints();
 
-
-
+    IntersectionPointBuilder(const IntersectionPointBuilder&) = delete;
+    IntersectionPointBuilder& operator=(const IntersectionPointBuilder&) = delete;
 };
 
 

--- a/include/geos/operation/overlayng/LineBuilder.h
+++ b/include/geos/operation/overlayng/LineBuilder.h
@@ -154,6 +154,8 @@ public:
         , hasResultArea(p_hasResultArea)
         , inputAreaIndex(inputGeom->getAreaIndex()) {}
 
+    LineBuilder(const LineBuilder&) = delete;
+    LineBuilder& operator=(const LineBuilder&) = delete;
 
     std::vector<std::unique_ptr<geom::LineString>> getLines();
 

--- a/include/geos/operation/overlayng/OverlayGraph.h
+++ b/include/geos/operation/overlayng/OverlayGraph.h
@@ -62,6 +62,7 @@ private:
     // Locally store the OverlayEdge and OverlayLabel
     std::deque<OverlayEdge> ovEdgeQue;
     std::deque<OverlayLabel> ovLabelQue;
+
     std::vector<std::unique_ptr<const geom::CoordinateSequence>> csQue;
 
     // Methods
@@ -88,6 +89,9 @@ public:
     * Creates a new graph for a set of noded, labelled {@link Edge}s.
     */
     OverlayGraph();
+
+    OverlayGraph(const OverlayGraph& g) = delete;
+    OverlayGraph& operator=(const OverlayGraph& g) = delete;
 
     /**
     * Adds an edge between the coordinates orig and dest

--- a/include/geos/operation/overlayng/OverlayPoints.h
+++ b/include/geos/operation/overlayng/OverlayPoints.h
@@ -98,6 +98,8 @@ public:
         , pm(p_pm)
         , geometryFactory(p_geom0->getFactory()) {}
 
+    OverlayPoints(const OverlayPoints&) = delete;
+    OverlayPoints& operator=(const OverlayPoints&) = delete;
 
     /**
     * Performs an overlay operation on inputs which are both point geometries.

--- a/include/geos/operation/overlayng/PolygonBuilder.h
+++ b/include/geos/operation/overlayng/PolygonBuilder.h
@@ -134,6 +134,9 @@ public:
         buildRings(resultAreaEdges);
     }
 
+    PolygonBuilder(const PolygonBuilder&) = delete;
+    PolygonBuilder& operator=(const PolygonBuilder&) = delete;
+
     // Methods
     std::vector<std::unique_ptr<geom::Polygon>> getPolygons();
     std::vector<OverlayEdgeRing*> getShellRings();

--- a/src/operation/overlayng/OverlayGraph.cpp
+++ b/src/operation/overlayng/OverlayGraph.cpp
@@ -89,7 +89,7 @@ OverlayGraph::addEdge(Edge* edge)
 OverlayEdge*
 OverlayGraph::createEdgePair(const CoordinateSequence *pts, OverlayLabel *lbl)
 {
-    csQue.emplace_back(pts);
+    csQue.emplace_back(const_cast<CoordinateSequence *>(pts));
     OverlayEdge* e0 = createOverlayEdge(pts, lbl, true);
     OverlayEdge* e1 = createOverlayEdge(pts, lbl, false);
     e0->link(e1);

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -170,7 +170,7 @@ tolower(std::string& str)
         str.begin(),
         str.end(),
         str.begin(),
-        [](unsigned char c){ return std::tolower(c); }
+        [](char c){ return (char)std::tolower(c); }
         );
 }
 


### PR DESCRIPTION
So, this is confusing, but here's the explanation:

IF you create a class that you're dllexport'ing, the compiler tries to instantiate all the implicit functions that the class needs at the time that it sees the class. This seems to happen even if you never use those functions or instantiate the class. This is to allow the version in the DLL to be used by the dynamic linker.

Anyway, you can't copy or assign a class with vector<unique_ptr<foo>>, so the compiler complains when it attempts to instantiate the implicit functions that are part of the class.  These changes stop the compiler from trying to create the implicit assign operator and copy ctor.