### PR TITLE
io: fix parsing of WKT with EMPTY components

### DIFF
--- a/src/io/StringTokenizer.cpp
+++ b/src/io/StringTokenizer.cpp
@@ -135,30 +135,29 @@ int
 StringTokenizer::peekNextToken()
 {
 
-    string::size_type pos;
     string tok = "";
     if(iter == str.end()) {
         return StringTokenizer::TT_EOF;
     }
 
-    pos = str.find_first_not_of(" \r\n\t", iter - str.begin());
+    auto startPos = str.find_first_not_of(" \r\n\t", iter - str.begin());
 
-    if(pos == string::npos) {
+    if(startPos == string::npos) {
         return StringTokenizer::TT_EOF;
     }
-    switch(str[pos]) {
+    switch(str[startPos]) {
     case '(':
     case ')':
     case ',':
-        return str[pos];
+        return str[startPos];
     }
 
     // It's either a Number or a Word, let's
     // see when it ends
 
-    pos = str.find_first_of("\n\r\t() ,", iter - str.begin());
+    auto endPos = str.find_first_of("\n\r\t() ,", startPos);
 
-    if(pos == string::npos) {
+    if(endPos == string::npos) {
         if(iter != str.end()) {
             tok.assign(iter, str.end());
         }
@@ -167,7 +166,7 @@ StringTokenizer::peekNextToken()
         }
     }
     else {
-        tok.assign(iter, str.begin() + pos); //str.end());
+        tok.assign(str.begin() + startPos, str.begin() + endPos); //str.end());
     }
 
     char* stopstring;

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -193,4 +193,17 @@ void object::test<8>
     }
 }
 
+// 9 - check we can read MULTIPOINT containing empty elements
+template<>
+template<>
+void object::test<9>
+()
+{
+    GeomPtr geom(wktreader.read("MULTIPOINT Z (0 1 2, EMPTY, 1 2 3, 3 4 5, EMPTY)"));
+    GeomPtr geom2(wktreader.read("MULTIPOINT Z ((0 1 2), EMPTY, (1 2 3), (3 4 5), EMPTY)"));
+    std::string expected("MULTIPOINT Z (0 1 2, EMPTY, 1 2 3, 3 4 5, EMPTY)");
+    ensure_equals(wktwriter.write(geom.get()), expected);
+    ensure_equals(wktwriter.write(geom2.get()), expected);
+}
+
 } // namespace tut


### PR DESCRIPTION
* Allow WKT to parse EMPTY within MULTIPOINT elements.
* Fix a bug where getNextToken() would not skip forward empty spaces.

Refs: https://github.com/cockroachdb/cockroach/issues/53997