### PR TITLE
Compiler warning fixes

### DIFF
--- a/src/algorithm/Orientation.cpp
+++ b/src/algorithm/Orientation.cpp
@@ -45,7 +45,7 @@ bool
 Orientation::isCCW(const geom::CoordinateSequence* ring)
 {
     // # of points without closing endpoint
-    int nPts = ring->size() - 1;
+    int nPts = static_cast<int>(ring->size()) - 1;
     // sanity check
     if (nPts < 3)
         throw util::IllegalArgumentException(

--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -409,7 +409,7 @@ WKBReader::readCoordinateSequence(int size)
     if(targetDim > inputDimension) {
         targetDim = inputDimension;
     }
-    for(unsigned int i = 0; i < size; i++) {
+    for(int i = 0; i < size; i++) {
         readCoordinate();
         for(unsigned int j = 0; j < targetDim; j++) {
             seq->setOrdinate(i, j, ordValues[j]);

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -9,10 +9,10 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosgeomsetprecision_data : public capitest::utility {
 
-    GEOSWKTWriter* wktw_;
-    GEOSGeometry* geom1_;
-    GEOSGeometry* geom2_;
-    GEOSGeometry* geom3_;
+    GEOSWKTWriter* wktw_ = nullptr;
+    GEOSGeometry* geom1_ = nullptr;
+    GEOSGeometry* geom2_ = nullptr;
+    GEOSGeometry* geom3_ = nullptr;
 
     GEOSGeometry*
     fromWKT(const char* wkt)
@@ -32,7 +32,6 @@ struct test_capigeosgeomsetprecision_data : public capitest::utility {
     }
 
     test_capigeosgeomsetprecision_data()
-        : geom1_(0), geom2_(0), geom3_(0), wktw_(0)
     {
         wktw_ = GEOSWKTWriter_create();
         GEOSWKTWriter_setTrim(wktw_, 1);


### PR DESCRIPTION
A few unexciting compiler warnings found when building with cmake & gcc 5.5