### PR TITLE
Fix QuadEdgeSubdivision remove method

### DIFF
--- a/include/geos/triangulate/quadedge/QuadEdge.h
+++ b/include/geos/triangulate/quadedge/QuadEdge.h
@@ -436,10 +436,10 @@ public:
     std::unique_ptr<geom::LineSegment> toLineSegment() const;
 };
 
+GEOS_DLL std::ostream& operator<< (std::ostream& os, const QuadEdge* e);
 
 } //namespace geos.triangulate.quadedge
 } //namespace geos.triangulate
 } //namespace geos
 
 #endif //GEOS_TRIANGULATE_QUADEDGE_QUADEDGE_H
-

--- a/src/triangulate/quadedge/QuadEdge.cpp
+++ b/src/triangulate/quadedge/QuadEdge.cpp
@@ -118,7 +118,13 @@ QuadEdge::toLineSegment() const
                new geom::LineSegment(vertex.getCoordinate(), dest().getCoordinate()));
 }
 
+std::ostream&
+operator<< (std::ostream& os, const QuadEdge* e)
+{
+    os << "( " << e->orig().getCoordinate() << ", " << e->dest().getCoordinate() << " )";
+    return os;
+}
+
 } //namespace geos.triangulate.quadedge
 } //namespace geos.triangulate
 } //namespace goes
-

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -133,11 +133,8 @@ QuadEdgeSubdivision::remove(QuadEdge& e)
     // rot edges do not need to be tested because they are not removed
     quadEdges.erase(
             std::remove_if(quadEdges.begin(), quadEdges.end(),
-                           [e](QuadEdgeQuartet& es) { return &es.base() == &e; }),
-            quadEdges.end());
-    quadEdges.erase(
-            std::remove_if(quadEdges.begin(), quadEdges.end(),
-                           [e](QuadEdgeQuartet& es) { return &es.base() == &e.sym(); }),
+                           [e](QuadEdgeQuartet& es) {
+                               return &es.base() == &e || &es.base() == &e.sym(); }),
             quadEdges.end());
     //mark these edges as removed
     e.remove();

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -129,11 +129,16 @@ QuadEdgeSubdivision::remove(QuadEdge& e)
     QuadEdge::splice(e.sym(), e.sym().oPrev());
 
     // this is inefficient but this should be called infrequently
+    // check base edge against both edge and sym, since either may be removed
+    // rot edges do not need to be tested because they are not removed
     quadEdges.erase(
             std::remove_if(quadEdges.begin(), quadEdges.end(),
-                           [&e](QuadEdgeQuartet& es) { return &es.base() == &e; }),
+                           [e](QuadEdgeQuartet& es) { return &es.base() == &e; }),
             quadEdges.end());
-
+    quadEdges.erase(
+            std::remove_if(quadEdges.begin(), quadEdges.end(),
+                           [e](QuadEdgeQuartet& es) { return &es.base() == &e.sym(); }),
+            quadEdges.end());
     //mark these edges as removed
     e.remove();
 

--- a/tests/unit/triangulate/DelaunayTest.cpp
+++ b/tests/unit/triangulate/DelaunayTest.cpp
@@ -227,6 +227,34 @@ void object::test<10>
     }
 }
 
+// 11 - Regular grid of points, tol = 0 (see https://trac.osgeo.org/geos/ticket/1035)
+template<>
+template<>
+void object::test<11>
+()
+{
+    const char* wkt =
+"MULTIPOINT ((-10 40), (5 40), (20 40), (-10 55), (5 55), (20 55), (-10 70), (5 70), (20 70))";
+    const char* expectedEdges =
+        "GEOMETRYCOLLECTION (POLYGON ((5 70, 20 70, 20 55, 5 70)), POLYGON ((5 55, 20 55, 20 40, 5 55)), POLYGON ((5 55, 5 70, 20 55, 5 55)), POLYGON ((5 40, 5 55, 20 40, 5 40)), POLYGON ((-10 70, 5 70, 5 55, -10 70)), POLYGON ((-10 55, 5 55, 5 40, -10 55)), POLYGON ((-10 55, -10 70, 5 55, -10 55)), POLYGON ((-10 40, -10 55, 5 40, -10 40)))";
+    if(sizeof(long double) > sizeof(double)) {
+        runDelaunay(wkt, true, expectedEdges, 0.0);
+    }
+}
+
+// 12 - Regular grid of points, tol > 0 (see https://trac.osgeo.org/geos/ticket/1035)
+template<>
+template<>
+void object::test<12>
+()
+{
+    const char* wkt =
+"MULTIPOINT ((-10 40), (5 40), (20 40), (-10 55), (5 55), (20 55), (-10 70), (5 70), (20 70))";
+    const char* expectedEdges =
+        "GEOMETRYCOLLECTION (POLYGON ((5 70, 20 70, 20 55, 5 70)), POLYGON ((5 55, 20 55, 20 40, 5 55)), POLYGON ((5 55, 5 70, 20 55, 5 55)), POLYGON ((5 40, 5 55, 20 40, 5 40)), POLYGON ((-10 70, 5 70, 5 55, -10 70)), POLYGON ((-10 55, 5 55, 5 40, -10 55)), POLYGON ((-10 55, -10 70, 5 55, -10 55)), POLYGON ((-10 40, -10 55, 5 40, -10 40)))";
+    if(sizeof(long double) > sizeof(double)) {
+        runDelaunay(wkt, true, expectedEdges, 0.01);
+    }
+}
 
 } // namespace tut
-


### PR DESCRIPTION
This fixes this GEOS [issue](https://trac.osgeo.org/geos/ticket/1035) which causes an infinite loop for grids of regularly spaced points.  The problem was caused by two bugs in the `QuadEdgeSubdivision::remove` method:

1. Since the method argument can be an edge in either base or sym orientation, the code to remove the corresponding `QuadEdgeQuartet` needs to check if the quartet base matches the arg edge OR its sym
1. The lambda capture clause must specify the edge parameter as `e`, not `&e`, since it is already a reference
