### PR TITLE
Remove no-op code from QESubdiv::remove

### DIFF
--- a/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
@@ -93,6 +93,10 @@ public:
                                  const QuadEdge* triEdge[3]);
 
 private:
+    /**
+     * Use a deque to ensure QuadEdge pointers are stable.
+     * Note that it is NOT safe to erase entries from the deque.
+     */
     std::deque<QuadEdgeQuartet> quadEdges;
     std::array<QuadEdge*, 3> startingEdges;
     double tolerance;

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -128,17 +128,10 @@ QuadEdgeSubdivision::remove(QuadEdge& e)
     QuadEdge::splice(e, e.oPrev());
     QuadEdge::splice(e.sym(), e.sym().oPrev());
 
-    // this is inefficient but this should be called infrequently
-    // check base edge against both edge and sym, since either may be removed
-    // rot edges do not need to be tested because they are not removed
-    quadEdges.erase(
-            std::remove_if(quadEdges.begin(), quadEdges.end(),
-                           [e](QuadEdgeQuartet& es) {
-                               return &es.base() == &e || &es.base() == &e.sym(); }),
-            quadEdges.end());
-    //mark these edges as removed
-    e.remove();
+    // because QuadEdge pointers must be stable, do not remove edge from quadedges container
+    // This is fine since they are detached from the subdivision
 
+    e.remove();
 }
 
 QuadEdge*


### PR DESCRIPTION
As discussed in #342, the use of `erase` to remove detached `QuadEdges` is incorrect, since it causes `QuadEdge` addresses to change.  Instead, it is fine to simply leave them in the `quadEdges` container marked as non-live.
