### PR TITLE
Feature: add support for pkg-config for GEOS C API (only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tests/unit/geos_unit
 tests/xmltester/SimpleWKTTester
 tests/xmltester/XMLTester
 tests/xmltester/testrunner
+tools/geos.pc
 tools/geos-config
 tools/astyle/astyle
 tests/bigtest/TestSweepLineSpeed

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,9 @@ EXTRA_DIST = \
 	cmake/geos-config.cmake \
 	cmake/FindMakeDistCheck.cmake
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = tools/geos.pc
+
 ACLOCAL_AMFLAGS = -I macros
 
 dist-hook: gen-ChangeLog

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Changes in 3.9.0
   - CAPI: GEOSPreparedDistance (#1066, Sandro Santilli)
   - SimpleSTRTree spatial index implementation (Paul Ramsey)
   - SimpleSTRTree used for C API (Paul Ramsey)
+  - Add support for pkg-config for GEOS C API (#1073, Mike Taves)
 
 - Improvements:
   - Stack allocate segments in OverlapUnion (Paul Ramsey)

--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,9 @@ AC_SUBST(CAPI_INTERFACE_CURRENT)
 AC_SUBST(CAPI_INTERFACE_REVISION)
 AC_SUBST(CAPI_INTERFACE_AGE)
 
+dnl pkg-config file -------------------------------------------------------
+AC_CONFIG_FILES([tools/geos.pc])
+
 dnl output stuff ----------------------------------------------------------
 
 AC_OUTPUT([

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -27,6 +27,17 @@ if(NOT MSVC)
       OWNER_READ OWNER_EXECUTE
       GROUP_READ GROUP_EXECUTE
       WORLD_READ WORLD_EXECUTE)
+
+  # pkg-config support
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/geos.pc.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/geos.pc
+    @ONLY)
+
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/geos.pc
+    DESTINATION lib/pkgconfig)
+
 endif()
 
 add_subdirectory(astyle)

--- a/tools/geos.pc.cmake
+++ b/tools/geos.pc.cmake
@@ -1,0 +1,11 @@
+prefix=@ESCAPED_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: GEOS
+Description: Geometry Engine, Open Source - C API
+Requires:
+Version: @GEOS_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgeos_c

--- a/tools/geos.pc.in
+++ b/tools/geos.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: GEOS
+Description: Geometry Engine, Open Source - C API
+Requires:
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgeos_c


### PR DESCRIPTION
This feature adds support for [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/), which is a helper tool used when compiling applications and libraries on *nix systems. It is similar to `geos-config`, but is more widespread and generic.

Take a look what you might already have, which should already include `proj` and `gdal`:
```
pkg-config --list-all
```

Here is how it works from the command line:
```
export PKG_CONFIG_PATH=/path/to/geos/prefix
pkg-config geos --modversion  # same as `geos-config --version`
pkg-config geos --cflags  # same as `geos-config --cflags`
pkg-config geos --libs  # same as `geos-config --clibs`
```
Or from autotools files for a custom project "myapp":
```
# configure.ac
PKG_CHECK_MODULES([GEOS], [geos])

# Makefile.am 
myapp_CFLAGS = $(GEOS_CFLAGS)
myapp_LDADD = $(GEOS_LIBS)
```
----
Some considerations:

- It only links to the GEOS C API, by design
- It can be installed from the autotools or cmake setups, as it's a simple configuration file
- Static compilation has not been investigated yet, but could be. It's just a matter of adding `.private` sections to link in the configuration file to link any other libraries.
- For a future release, consider deprecating `geos-config`, which is a custom tool with a similar purpose.

xref: https://trac.osgeo.org/geos/ticket/1073