### PR TITLE
Clear warnings about deprecated assignment operator 

### DIFF
--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -67,14 +67,10 @@ public:
 
     LineSegment();
 
-    LineSegment(const LineSegment& ls);
-
     /// Constructs a LineSegment with the given start and end Coordinates.
     LineSegment(const Coordinate& c0, const Coordinate& c1);
 
     LineSegment(double x0, double y0, double x1, double y1);
-
-    virtual ~LineSegment();
 
     void setCoordinates(const Coordinate& c0, const Coordinate& c1);
 

--- a/include/geos/geom/LineSegment.inl
+++ b/include/geos/geom/LineSegment.inl
@@ -32,14 +32,6 @@ namespace geos {
 namespace geom { // geos::geom
 
 INLINE
-LineSegment::LineSegment(const LineSegment& ls)
-    :
-    p0(ls.p0),
-    p1(ls.p1)
-{
-}
-
-INLINE
 LineSegment::LineSegment(const Coordinate& c0, const Coordinate& c1)
     :
     p0(c0),
@@ -57,11 +49,6 @@ LineSegment::LineSegment(double x0, double y0, double x1, double y1)
 
 INLINE
 LineSegment::LineSegment()
-{
-}
-
-INLINE
-LineSegment::~LineSegment()
 {
 }
 

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -157,13 +157,6 @@ public:
      */
     PrecisionModel(double newScale);
 
-    // copy constructor
-    PrecisionModel(const PrecisionModel& pm);
-
-    /// destructor
-    ~PrecisionModel(void);
-
-
     /// The maximum precise value representable in a double.
     ///
     /// Since IEE754 double-precision numbers allow 53 bits of mantissa,

--- a/include/geos/geom/PrecisionModel.inl
+++ b/include/geos/geom/PrecisionModel.inl
@@ -28,12 +28,6 @@ namespace geos {
 namespace geom { // geos::geom
 
 /*public*/
-INLINE
-PrecisionModel::~PrecisionModel(void)
-{
-}
-
-/*public*/
 INLINE void
 PrecisionModel::makePrecise(Coordinate* coord) const
 {

--- a/src/geom/PrecisionModel.cpp
+++ b/src/geom/PrecisionModel.cpp
@@ -135,17 +135,6 @@ PrecisionModel::PrecisionModel(double newScale)
     setScale(newScale);
 }
 
-
-PrecisionModel::PrecisionModel(const PrecisionModel& pm)
-    :
-    modelType(pm.modelType),
-    scale(pm.scale)
-{
-#if GEOS_DEBUG
-    cerr << "PrecisionModel[" << this << "] ctor(pm[" << &pm << "])" << endl;
-#endif
-}
-
 /*public*/
 bool
 PrecisionModel::isFloating() const


### PR DESCRIPTION
The LineSegment and PrecisionModel assignment operators were implicitly
declared because these classes have declared destructors and/or copy
constructors. Since the destructors and copy constructors are not needed,
the warning can be removed by deleting them.