### PR TITLE
Remove OverlapUnion from CascadedPolygonUnion

### DIFF
--- a/include/geos/operation/union/OverlapUnion.h
+++ b/include/geos/operation/union/OverlapUnion.h
@@ -89,6 +89,8 @@ namespace geounion {  // geos::operation::geounion
  * in other APIs (e.g. GEOS) due to more aggressive snapping.
  * And it will be more likely to happen if a snap-rounding overlay is used.
  *
+ * DEPRECATED: This optimization has been removed, since it impairs performance.
+ *
  * @author mbdavis
  *
  */

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -262,13 +262,7 @@ geom::Geometry*
 CascadedPolygonUnion::unionActual(geom::Geometry* g0, geom::Geometry* g1)
 {
     std::unique_ptr<geom::Geometry> ug;
-    if (unionFunction->isFloatingPrecision()) {
-        OverlapUnion unionOp(g0, g1, unionFunction);
-        ug = unionOp.doUnion();
-    }
-    else {
-        ug = unionFunction->Union(g0, g1);
-    }
+    ug = unionFunction->Union(g0, g1);
     return restrictToPolygons(std::move(ug)).release();
 }
 


### PR DESCRIPTION
The OverlapUnion optimization actually slows things down, so is being removed.
