### PR TITLE
Fix return error code of GEOSCoordSeq_setOrdinate (closes #1078)

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2164,7 +2164,7 @@ extern "C" {
     GEOSCoordSeq_setOrdinate_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs,
                                unsigned int idx, unsigned int dim, double val)
     {
-        return execute(extHandle, 1, [&]() {
+        return execute(extHandle, 0, [&]() {
             cs->setOrdinate(idx, dim, val);
             return 1;
         });

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -74,7 +74,7 @@ namespace geom {
                     break;
                 default: {
                     std::stringstream ss;
-                    ss << "Unknown ordinate index " << index;
+                    ss << "Unknown ordinate index " << ordinateIndex;
                     throw geos::util::IllegalArgumentException(ss.str());
                     break;
                 }

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -228,7 +228,7 @@ CoordinateArraySequence::setOrdinate(size_t index, size_t ordinateIndex,
         break;
     default: {
         std::stringstream ss;
-        ss << "Unknown ordinate index " << index;
+        ss << "Unknown ordinate index " << ordinateIndex;
         throw util::IllegalArgumentException(ss.str());
         break;
     }

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -151,9 +151,9 @@ void object::test<3>
     double z = 12;
 
     // X, Y, Z
-    GEOSCoordSeq_setOrdinate(cs_, 0, 0, x);
-    GEOSCoordSeq_setOrdinate(cs_, 0, 1, y);
-    GEOSCoordSeq_setOrdinate(cs_, 0, 2, z);
+    ensure(0 != GEOSCoordSeq_setOrdinate(cs_, 0, 0, x));
+    ensure(0 != GEOSCoordSeq_setOrdinate(cs_, 0, 1, y));
+    ensure(0 != GEOSCoordSeq_setOrdinate(cs_, 0, 2, z));
 
     double xcheck, ycheck, zcheck;
     ensure(0 != GEOSCoordSeq_getOrdinate(cs_, 0, 1, &ycheck));
@@ -163,6 +163,9 @@ void object::test<3>
     ensure_equals(xcheck, x);
     ensure_equals(ycheck, y);
     ensure_equals(zcheck, z);
+
+    // correct error on wrong ordinate index
+    ensure(0 == GEOSCoordSeq_setOrdinate(cs_, 0, 3, z));
 }
 
 // Test swapped setX calls (see bug #133, fixed)


### PR DESCRIPTION
Closes https://trac.osgeo.org/geos/ticket/1078

And at the same time, also fixed the error message (showing the ordinate index, instead of coordinate index)