### PR TITLE
Remove default arguments for Coordinate constructor

### DIFF
--- a/include/geos/geom/Coordinate.h
+++ b/include/geos/geom/Coordinate.h
@@ -91,7 +91,9 @@ public:
 
     bool isNull() const;
 
-    Coordinate(double xNew = 0.0, double yNew = 0.0, double zNew = DoubleNotANumber);
+    Coordinate();
+
+    Coordinate(double xNew, double yNew, double zNew = DoubleNotANumber);
 
     bool equals2D(const Coordinate& other) const;
 

--- a/include/geos/geom/Coordinate.inl
+++ b/include/geos/geom/Coordinate.inl
@@ -39,6 +39,10 @@ Coordinate::isNull() const
 }
 
 INLINE
+Coordinate::Coordinate() : x(0.0), y(0.0), z(DoubleNotANumber)
+{}
+
+INLINE
 Coordinate::Coordinate(double xNew, double yNew, double zNew)
     :
     x(xNew),


### PR DESCRIPTION
The previously defined constructor allowed a Coordinate to be constructed
from only a single value, i.e. `Coordinate(3)` would produce `(3, 0, NaN)`.
It's not clear what the use for this is, and it allowed further
complications like `Envelope(3)` compiling by implicitly constructing the
coordinate above.

This commit adds a no-argument constructor to preserve the behavior of
`Coordinate()` producing `(0, 0, NaN)`.