### PR TITLE
Use SnapRoundingNoder in BufferOp

### DIFF
--- a/tests/unit/operation/buffer/BufferOpTest.cpp
+++ b/tests/unit/operation/buffer/BufferOpTest.cpp
@@ -440,7 +440,7 @@ void object::test<14>
     double const distance = 0.5;
     GeomPtr gBuffer(op.getResultGeometry(distance));
 
-    std::cout << wktwriter.write(gBuffer.get()) << std::endl;
+    // std::cout << wktwriter.write(gBuffer.get()) << std::endl;
 
     ensure_not(gBuffer->isEmpty());
     ensure(gBuffer->isValid());


### PR DESCRIPTION
This avoids doing a precision reduction on the input geometry.
It maps more closely to the implementation in JTS.
It still does an increasing loop of larger tolerance,
in the event of a failure.
This is to address the regression reported by GEOSwift
downstream on 3.9.0beta1