### PR TITLE
Store SegmentNode values directly in SegmentNodeList

### DIFF
--- a/include/geos/noding/Makefile.am
+++ b/include/geos/noding/Makefile.am
@@ -1,5 +1,5 @@
 #
-# This file is part of project GEOS (http://trac.osgeo.org/geos/) 
+# This file is part of project GEOS (http://trac.osgeo.org/geos/)
 #
 SUBDIRS = \
 	snapround \
@@ -31,6 +31,7 @@ geos_HEADERS = \
 	SegmentIntersectionDetector.h \
 	SegmentIntersector.h \
 	SegmentNode.h \
+	SegmentNode.inl \
 	SegmentNodeList.h \
 	SegmentPointComparator.h \
 	SegmentSetMutualIntersector.h \

--- a/include/geos/noding/NodedSegmentString.h
+++ b/include/geos/noding/NodedSegmentString.h
@@ -111,39 +111,6 @@ public:
 
     ~NodedSegmentString() override = default;
 
-    /** \brief
-     * Adds an intersection node for a given point and segment to this segment string.
-     *
-     * If an intersection already exists for this exact location, the existing
-     * node will be returned.
-     *
-     * @param intPt the location of the intersection
-     * @param segmentIndex the index of the segment containing the intersection
-     * @return the intersection node for the point
-     */
-    SegmentNode*
-    addIntersectionNode(geom::Coordinate* intPt, std::size_t segmentIndex)
-    {
-        std::size_t normalizedSegmentIndex = segmentIndex;
-
-        // normalize the intersection point location
-        std::size_t nextSegIndex = normalizedSegmentIndex + 1;
-        if(nextSegIndex < size()) {
-            geom::Coordinate const& nextPt =
-                getCoordinate(nextSegIndex);
-
-            // Normalize segment index if intPt falls on vertex
-            // The check for point equality is 2D only - Z values are ignored
-            if(intPt->equals2D(nextPt)) {
-                normalizedSegmentIndex = nextSegIndex;
-            }
-        }
-
-        // Add the intersection point to edge intersection list.
-        SegmentNode* ei = getNodeList().add(*intPt, normalizedSegmentIndex);
-        return ei;
-    }
-
     SegmentNodeList& getNodeList();
 
     const SegmentNodeList& getNodeList() const;

--- a/include/geos/noding/NodedSegmentString.h
+++ b/include/geos/noding/NodedSegmentString.h
@@ -85,7 +85,7 @@ public:
     static SegmentString::NonConstVect* getNodedSubstrings(
         const SegmentString::NonConstVect& segStrings);
 
-    std::unique_ptr<std::vector<geom::Coordinate>> getNodedCoordinates();
+    std::vector<geom::Coordinate> getNodedCoordinates();
 
 
     /** \brief

--- a/include/geos/noding/SegmentNode.h
+++ b/include/geos/noding/SegmentNode.h
@@ -46,15 +46,11 @@ namespace noding { // geos.noding
  */
 class GEOS_DLL SegmentNode {
 private:
-    const NodedSegmentString& segString;
+    const NodedSegmentString* segString;
 
     int segmentOctant;
 
     bool isInteriorVar;
-
-    // Declare type as noncopyable
-    SegmentNode(const SegmentNode& other) = delete;
-    SegmentNode& operator=(const SegmentNode& rhs) = delete;
 
 public:
     friend std::ostream& operator<< (std::ostream& os, const SegmentNode& n);

--- a/include/geos/noding/SegmentNode.h
+++ b/include/geos/noding/SegmentNode.h
@@ -103,7 +103,7 @@ public:
      * @return 1 this EdgeIntersection is located after the
      *           argument location
      */
-    int compareTo(const SegmentNode& other);
+    int compareTo(const SegmentNode& other) const;
 
     //string print() const;
 };
@@ -115,6 +115,12 @@ struct GEOS_DLL  SegmentNodeLT {
     operator()(SegmentNode* s1, SegmentNode* s2) const
     {
         return s1->compareTo(*s2) < 0;
+    }
+
+    bool
+    operator()(const SegmentNode& s1, const SegmentNode& s2) const
+    {
+        return s1.compareTo(s2) < 0;
     }
 };
 

--- a/include/geos/noding/SegmentNode.h
+++ b/include/geos/noding/SegmentNode.h
@@ -124,4 +124,8 @@ struct GEOS_DLL  SegmentNodeLT {
 } // namespace geos.noding
 } // namespace geos
 
+#ifdef GEOS_INLINE
+# include "geos/noding/SegmentNode.inl"
+#endif
+
 #endif // GEOS_NODING_SEGMENTNODE_H

--- a/include/geos/noding/SegmentNode.inl
+++ b/include/geos/noding/SegmentNode.inl
@@ -1,0 +1,90 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2006      Refractions Research Inc.
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: noding/SegmentNode.java 4667170ea (JTS-1.17)
+ *
+ **********************************************************************/
+
+#ifndef GEOS_NODING_SEGMENTNODE_INL
+#define GEOS_NODING_SEGMENTNODE_INL
+
+#include <geos/noding/SegmentNode.h>
+#include <geos/geom/Coordinate.h>
+#include <geos/noding/SegmentPointComparator.h>
+
+namespace geos {
+namespace noding {
+
+INLINE bool
+SegmentNode::isEndPoint(unsigned int maxSegmentIndex) const
+{
+    if(segmentIndex == 0 && ! isInteriorVar) {
+        return true;
+    }
+    if(segmentIndex == maxSegmentIndex) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @return -1 this EdgeIntersection is located before the argument location
+ * @return 0 this EdgeIntersection is at the argument location
+ * @return 1 this EdgeIntersection is located after the argument location
+ */
+INLINE int
+SegmentNode::compareTo(const SegmentNode& other) const
+{
+    if(segmentIndex < other.segmentIndex) {
+        return -1;
+    }
+    if(segmentIndex > other.segmentIndex) {
+        return 1;
+    }
+
+#if GEOS_DEBUG
+    std::cerr << setprecision(17) << "compareTo: " << *this << ", " << other << std::endl;
+#endif
+
+    if(coord.equals2D(other.coord)) {
+
+#if GEOS_DEBUG
+        std::cerr << " Coordinates equal!" << std::endl;
+#endif
+
+        return 0;
+    }
+
+#if GEOS_DEBUG
+    std::cerr << " Coordinates do not equal!" << std::endl;
+#endif
+
+    // an exterior node is the segment start point,
+    // so always sorts first
+    // this guards against a robustness problem
+    // where the octants are not reliable
+    if (! isInteriorVar) return -1;
+    if (! other.isInteriorVar) return 1;
+
+    return SegmentPointComparator::compare(segmentOctant, coord,
+                                           other.coord);
+}
+
+
+
+}
+}
+
+#endif
+

--- a/include/geos/noding/SegmentNodeList.h
+++ b/include/geos/noding/SegmentNodeList.h
@@ -55,8 +55,7 @@ namespace noding { // geos::noding
  */
 class GEOS_DLL SegmentNodeList {
 private:
-    std::set<SegmentNode*, SegmentNodeLT> nodeMap;
-    std::deque<SegmentNode> nodeQue;
+    std::set<SegmentNode, SegmentNodeLT> nodeMap;
 
     // the parent edge
     const NodedSegmentString& edge;
@@ -131,7 +130,8 @@ public:
 
     friend std::ostream& operator<< (std::ostream& os, const SegmentNodeList& l);
 
-    typedef std::set<SegmentNode*, SegmentNodeLT> container;
+    using container = decltype(nodeMap);
+
     typedef container::iterator iterator;
     typedef container::const_iterator const_iterator;
 
@@ -157,23 +157,12 @@ public:
      * @param intPt the intersection Coordinate, will be copied
      * @param segmentIndex
      */
-    SegmentNode* add(const geom::Coordinate& intPt, std::size_t segmentIndex);
+    void add(const geom::Coordinate& intPt, std::size_t segmentIndex);
 
-    SegmentNode*
+    void
     add(const geom::Coordinate* intPt, std::size_t segmentIndex)
     {
-        return add(*intPt, segmentIndex);
-    }
-
-    /*
-     * returns the set of SegmentNodes
-     */
-    //replaces iterator()
-    // TODO: obsolete this function
-    std::set<SegmentNode*, SegmentNodeLT>*
-    getNodes()
-    {
-        return &nodeMap;
+        add(*intPt, segmentIndex);
     }
 
     /// Return the number of nodes in this list

--- a/include/geos/noding/SegmentNodeList.h
+++ b/include/geos/noding/SegmentNodeList.h
@@ -124,29 +124,28 @@ private:
     void findCollapsesFromInsertedNodes(
         std::vector<std::size_t>& collapsedVertexIndexes) const;
 
-    bool findCollapseIndex(const SegmentNode& ei0, const SegmentNode& ei1,
-                           size_t& collapsedVertexIndex) const;
+    static bool findCollapseIndex(const SegmentNode& ei0, const SegmentNode& ei1,
+                           size_t& collapsedVertexIndex);
 
     void addEdgeCoordinates(const SegmentNode* ei0, const SegmentNode* ei1, std::vector<geom::Coordinate>& coordList) const;
+
+public:
 
     // Declare type as noncopyable
     SegmentNodeList(const SegmentNodeList& other) = delete;
     SegmentNodeList& operator=(const SegmentNodeList& rhs) = delete;
 
-public:
-
     friend std::ostream& operator<< (std::ostream& os, const SegmentNodeList& l);
 
     using container = decltype(nodeMap);
+    using iterator = container::iterator;
+    using const_iterator = container::const_iterator;
 
-    typedef container::iterator iterator;
-    typedef container::const_iterator const_iterator;
+    explicit SegmentNodeList(const NodedSegmentString* newEdge): edge(*newEdge) {}
 
-    SegmentNodeList(const NodedSegmentString* newEdge): edge(*newEdge) {}
+    explicit SegmentNodeList(const NodedSegmentString& newEdge): edge(newEdge) {}
 
-    SegmentNodeList(const NodedSegmentString& newEdge): edge(newEdge) {}
-
-    ~SegmentNodeList();
+    ~SegmentNodeList() = default;
 
     const NodedSegmentString&
     getEdge() const
@@ -180,13 +179,25 @@ public:
         return nodeMap.size();
     }
 
-    iterator begin();
+    iterator begin() {
+        prepare();
+        return nodeMap.begin();
+    }
 
-    const_iterator begin() const;
+    const_iterator begin() const {
+        prepare();
+        return nodeMap.begin();
+    }
 
-    iterator end();
+    iterator end() {
+        prepare();
+        return nodeMap.end();
+    }
 
-    const_iterator end() const;
+    const_iterator end() const {
+        prepare();
+        return nodeMap.end();
+    }
 
     /**
      * Adds entries for the first and last points of the edge to the list
@@ -217,7 +228,7 @@ public:
     * @return an array of Coordinates
     *
     */
-    std::unique_ptr<std::vector<geom::Coordinate>> getSplitCoordinates();
+    std::vector<geom::Coordinate> getSplitCoordinates();
 
 
 };

--- a/include/geos/noding/SegmentNodeList.h
+++ b/include/geos/noding/SegmentNodeList.h
@@ -55,7 +55,14 @@ namespace noding { // geos::noding
  */
 class GEOS_DLL SegmentNodeList {
 private:
-    std::set<SegmentNode, SegmentNodeLT> nodeMap;
+    // Since we are adding frequently to the SegmentNodeList and iterating infrequently,
+    // it is faster to store all the SegmentNodes in a vector and sort/remove duplicates
+    // before iteration, rather than storing them in a set and continuously maintaining
+    // a sorted order.
+    mutable std::vector<SegmentNode> nodeMap;
+    mutable bool ready = false;
+
+    void prepare() const;
 
     // the parent edge
     const NodedSegmentString& edge;
@@ -169,29 +176,17 @@ public:
     size_t
     size() const
     {
+        prepare();
         return nodeMap.size();
     }
 
-    container::iterator
-    begin()
-    {
-        return nodeMap.begin();
-    }
-    container::const_iterator
-    begin() const
-    {
-        return nodeMap.begin();
-    }
-    container::iterator
-    end()
-    {
-        return nodeMap.end();
-    }
-    container::const_iterator
-    end() const
-    {
-        return nodeMap.end();
-    }
+    iterator begin();
+
+    const_iterator begin() const;
+
+    iterator end();
+
+    const_iterator end() const;
 
     /**
      * Adds entries for the first and last points of the edge to the list

--- a/include/geos/noding/snapround/SnapRoundingNoder.h
+++ b/include/geos/noding/snapround/SnapRoundingNoder.h
@@ -96,8 +96,6 @@ private:
     */
     void addIntersectionPixels(std::vector<SegmentString*>& segStrings);
 
-    void round(const geom::Coordinate& pt, geom::Coordinate& ptOut);
-
     /**
     * Gets a list of the rounded coordinates.
     * Duplicate (collapsed) coordinates are removed.
@@ -105,7 +103,7 @@ private:
     * @param pts the coordinates to round
     * @return array of rounded coordinates
     */
-    std::unique_ptr<std::vector<geom::Coordinate>> round(const std::vector<geom::Coordinate>& pts);
+    std::vector<geom::Coordinate> round(const std::vector<geom::Coordinate>& pts) const;
 
     /**
     * Computes new segment strings which are rounded and contain

--- a/src/noding/NodedSegmentString.cpp
+++ b/src/noding/NodedSegmentString.cpp
@@ -133,7 +133,7 @@ NodedSegmentString::getNodedSubstrings(
 }
 
 /* public */
-std::unique_ptr<std::vector<Coordinate>>
+std::vector<Coordinate>
 NodedSegmentString::getNodedCoordinates() {
     return nodeList.getSplitCoordinates();
 }

--- a/src/noding/SegmentNode.cpp
+++ b/src/noding/SegmentNode.cpp
@@ -73,7 +73,7 @@ SegmentNode::isEndPoint(unsigned int maxSegmentIndex) const
  * @return 1 this EdgeIntersection is located after the argument location
  */
 int
-SegmentNode::compareTo(const SegmentNode& other)
+SegmentNode::compareTo(const SegmentNode& other) const
 {
     if(segmentIndex < other.segmentIndex) {
         return -1;

--- a/src/noding/SegmentNode.cpp
+++ b/src/noding/SegmentNode.cpp
@@ -41,16 +41,16 @@ namespace noding { // geos.noding
 SegmentNode::SegmentNode(const NodedSegmentString& ss, const Coordinate& nCoord,
                          std::size_t nSegmentIndex, int nSegmentOctant)
     :
-    segString(ss),
+    segString(&ss),
     segmentOctant(nSegmentOctant),
     coord(nCoord),
     segmentIndex(nSegmentIndex)
 {
     // Number of points in NodedSegmentString is one-more number of segments
-    assert(segmentIndex < segString.size());
+    assert(segmentIndex < segString->size());
 
     isInteriorVar = \
-                    !coord.equals2D(segString.getCoordinate(segmentIndex));
+                    !coord.equals2D(segString->getCoordinate(segmentIndex));
 
 }
 

--- a/src/noding/SegmentNode.cpp
+++ b/src/noding/SegmentNode.cpp
@@ -26,7 +26,6 @@
 #include <iomanip>
 
 #include <geos/noding/SegmentNode.h>
-#include <geos/noding/SegmentPointComparator.h>
 #include <geos/noding/NodedSegmentString.h>
 #include <geos/geom/Coordinate.h>
 
@@ -36,81 +35,25 @@ using namespace geos::geom;
 namespace geos {
 namespace noding { // geos.noding
 
-
 /*public*/
-SegmentNode::SegmentNode(const NodedSegmentString& ss, const Coordinate& nCoord,
+SegmentNode::SegmentNode(const NodedSegmentString& ss, const geom::Coordinate& nCoord,
                          std::size_t nSegmentIndex, int nSegmentOctant)
-    :
-    segString(&ss),
-    segmentOctant(nSegmentOctant),
-    coord(nCoord),
-    segmentIndex(nSegmentIndex)
+        :
+        segString(&ss),
+        segmentOctant(nSegmentOctant),
+        coord(nCoord),
+        segmentIndex(nSegmentIndex)
 {
     // Number of points in NodedSegmentString is one-more number of segments
     assert(segmentIndex < segString->size());
 
     isInteriorVar = \
-                    !coord.equals2D(segString->getCoordinate(segmentIndex));
+            !coord.equals2D(segString->getCoordinate(segmentIndex));
 
 }
 
 
-bool
-SegmentNode::isEndPoint(unsigned int maxSegmentIndex) const
-{
-    if(segmentIndex == 0 && ! isInteriorVar) {
-        return true;
-    }
-    if(segmentIndex == maxSegmentIndex) {
-        return true;
-    }
-    return false;
-}
-
-/**
- * @return -1 this EdgeIntersection is located before the argument location
- * @return 0 this EdgeIntersection is at the argument location
- * @return 1 this EdgeIntersection is located after the argument location
- */
-int
-SegmentNode::compareTo(const SegmentNode& other) const
-{
-    if(segmentIndex < other.segmentIndex) {
-        return -1;
-    }
-    if(segmentIndex > other.segmentIndex) {
-        return 1;
-    }
-
-#if GEOS_DEBUG
-    std::cerr << setprecision(17) << "compareTo: " << *this << ", " << other << std::endl;
-#endif
-
-    if(coord.equals2D(other.coord)) {
-
-#if GEOS_DEBUG
-        std::cerr << " Coordinates equal!" << std::endl;
-#endif
-
-        return 0;
-    }
-
-#if GEOS_DEBUG
-    std::cerr << " Coordinates do not equal!" << std::endl;
-#endif
-
-    // an exterior node is the segment start point,
-    // so always sorts first
-    // this guards against a robustness problem
-    // where the octants are not reliable
-    if (! isInteriorVar) return -1;
-    if (! other.isInteriorVar) return 1;
-
-    return SegmentPointComparator::compare(segmentOctant, coord,
-                                           other.coord);
-}
-
-std::ostream&
+    std::ostream&
 operator<< (std::ostream& os, const SegmentNode& n)
 {
     return os << n.coord << " seg#=" << n.segmentIndex << " octant#=" << n.segmentOctant << std::endl;
@@ -118,4 +61,8 @@ operator<< (std::ostream& os, const SegmentNode& n)
 
 } // namespace geos.noding
 } // namespace geos
+
+#ifndef GEOS_INLINE
+# include "geos/noding/SegmentNode.inl"
+#endif
 

--- a/src/noding/SegmentNodeList.cpp
+++ b/src/noding/SegmentNodeList.cpp
@@ -50,24 +50,11 @@ static Profiler* profiler = Profiler::instance();
 #endif
 
 
-SegmentNode*
+void
 SegmentNodeList::add(const Coordinate& intPt, std::size_t segmentIndex)
 {
-    nodeQue.emplace_back(edge, intPt, segmentIndex, edge.getSegmentOctant(segmentIndex));
-    SegmentNode* eiNew = &(nodeQue.back());
-
-    std::pair<SegmentNodeList::iterator, bool> p = nodeMap.insert(eiNew);
-    if(p.second) {    // new SegmentNode inserted
-        return eiNew;
-    }
-    else {
-        // sanity check
-        assert(eiNew->coord.equals2D(intPt));
-        nodeQue.pop_back();
-        return *(p.first);
-    }
+    nodeMap.emplace(edge, intPt, segmentIndex, edge.getSegmentOctant(segmentIndex));
 }
-
 
 SegmentNodeList::~SegmentNodeList()
 {
@@ -126,10 +113,10 @@ SegmentNodeList::findCollapsesFromInsertedNodes(
     // there should always be at least two entries in the list,
     // since the endpoints are nodes
     iterator it = begin();
-    SegmentNode* eiPrev = *it;
+    const SegmentNode* eiPrev = &(*it);
     ++it;
     for(iterator itEnd = end(); it != itEnd; ++it) {
-        SegmentNode* ei = *it;
+        const SegmentNode* ei = &(*it);
         bool isCollapsed = findCollapseIndex(*eiPrev, *ei,
                                              collapsedVertexIndex);
         if(isCollapsed) {
@@ -185,11 +172,11 @@ SegmentNodeList::addSplitEdges(std::vector<SegmentString*>& edgeList)
     // there should always be at least two entries in the list
     // since the endpoints are nodes
     iterator it = begin();
-    SegmentNode* eiPrev = *it;
+    const SegmentNode* eiPrev = &(*it);
     assert(eiPrev);
     ++it;
     for(iterator itEnd = end(); it != itEnd; ++it) {
-        SegmentNode* ei = *it;
+        const SegmentNode* ei = &(*it);
         assert(ei);
 
         if(! ei->compareTo(*eiPrev)) {
@@ -295,9 +282,9 @@ SegmentNodeList::getSplitCoordinates()
     std::unique_ptr<std::vector<Coordinate>> coordList(new std::vector<Coordinate>);
     // there should always be at least two entries in the list, since the endpoints are nodes
     iterator it = begin();
-    SegmentNode* eiPrev = *it;
+    const SegmentNode* eiPrev = &(*it);
     for(iterator itEnd = end(); it != itEnd; ++it) {
-        SegmentNode* ei = *it;
+        const SegmentNode* ei = &(*it);
         addEdgeCoordinates(eiPrev, ei, *coordList);
         eiPrev = ei;
     }
@@ -323,8 +310,8 @@ operator<< (std::ostream& os, const SegmentNodeList& nlist)
 {
     os << "Intersections: (" << nlist.nodeMap.size() << "):" << std::endl;
 
-    for(const SegmentNode* ei: nlist.nodeMap) {
-        os << " " << *ei;
+    for(const SegmentNode& ei: nlist.nodeMap) {
+        os << " " << ei;
     }
     return os;
 }

--- a/src/noding/SegmentNodeList.cpp
+++ b/src/noding/SegmentNodeList.cpp
@@ -58,10 +58,6 @@ SegmentNodeList::add(const Coordinate& intPt, std::size_t segmentIndex)
     ready = false;
 }
 
-SegmentNodeList::~SegmentNodeList()
-{
-}
-
 void SegmentNodeList::prepare() const {
     if (!ready) {
         std::sort(nodeMap.begin(), nodeMap.end(), [](const SegmentNode& s1, const SegmentNode& s2) {
@@ -74,34 +70,6 @@ void SegmentNodeList::prepare() const {
 
         ready = true;
     }
-}
-
-SegmentNodeList::iterator
-SegmentNodeList::begin()
-{
-    prepare();
-    return nodeMap.begin();
-}
-
-SegmentNodeList::const_iterator
-SegmentNodeList::begin() const
-{
-    prepare();
-    return nodeMap.begin();
-}
-
-SegmentNodeList::iterator
-SegmentNodeList::end()
-{
-    prepare();
-    return nodeMap.end();
-}
-
-SegmentNodeList::const_iterator
-SegmentNodeList::end() const
-{
-    prepare();
-    return nodeMap.end();
 }
 
 void
@@ -174,7 +142,7 @@ SegmentNodeList::findCollapsesFromInsertedNodes(
 /* private */
 bool
 SegmentNodeList::findCollapseIndex(const SegmentNode& ei0, const SegmentNode& ei1,
-                                   size_t& collapsedVertexIndex) const
+                                   size_t& collapsedVertexIndex)
 {
     assert(ei1.segmentIndex >= ei0.segmentIndex);
     // only looking for equal nodes
@@ -215,11 +183,11 @@ SegmentNodeList::addSplitEdges(std::vector<SegmentString*>& edgeList)
 
     // there should always be at least two entries in the list
     // since the endpoints are nodes
-    iterator it = begin();
+    auto it = begin();
     const SegmentNode* eiPrev = &(*it);
     assert(eiPrev);
     ++it;
-    for(iterator itEnd = end(); it != itEnd; ++it) {
+    for(auto itEnd = end(); it != itEnd; ++it) {
         const SegmentNode* ei = &(*it);
         assert(ei);
 
@@ -313,23 +281,22 @@ SegmentNodeList::createSplitEdgePts(const SegmentNode* ei0, const SegmentNode* e
     if (useIntPt1) {
         pts.emplace_back(ei1->coord);
     }
-    return;
 }
 
 
 /*public*/
-std::unique_ptr<std::vector<Coordinate>>
+std::vector<Coordinate>
 SegmentNodeList::getSplitCoordinates()
 {
     // ensure that the list has entries for the first and last point of the edge
     addEndpoints();
-    std::unique_ptr<std::vector<Coordinate>> coordList(new std::vector<Coordinate>);
+    std::vector<Coordinate> coordList;
     // there should always be at least two entries in the list, since the endpoints are nodes
-    iterator it = begin();
+    auto it = begin();
     const SegmentNode* eiPrev = &(*it);
-    for(iterator itEnd = end(); it != itEnd; ++it) {
+    for(auto itEnd = end(); it != itEnd; ++it) {
         const SegmentNode* ei = &(*it);
-        addEdgeCoordinates(eiPrev, ei, *coordList);
+        addEdgeCoordinates(eiPrev, ei, coordList);
         eiPrev = ei;
     }
     return coordList;

--- a/src/noding/snapround/SnapRoundingNoder.cpp
+++ b/src/noding/snapround/SnapRoundingNoder.cpp
@@ -157,8 +157,8 @@ SnapRoundingNoder::computeSegmentSnaps(NodedSegmentString* ss)
     * The coordinates are now rounded to the grid,
     * in preparation for snapping to the Hot Pixels
     */
-    std::unique_ptr<std::vector<Coordinate>> pts = ss->getNodedCoordinates();
-    std::unique_ptr<std::vector<Coordinate>> ptsRoundVec = round(*pts);
+    std::vector<Coordinate> pts = ss->getNodedCoordinates();
+    std::unique_ptr<std::vector<Coordinate>> ptsRoundVec = round(pts);
     std::unique_ptr<geom::CoordinateArraySequence> ptsRound(new CoordinateArraySequence(ptsRoundVec.release()));
 
     // if complete collapse this edge can be eliminated
@@ -169,20 +169,20 @@ SnapRoundingNoder::computeSegmentSnaps(NodedSegmentString* ss)
     NodedSegmentString* snapSS = new NodedSegmentString(ptsRound.release(), ss->getData());
 
     std::size_t snapSSindex = 0;
-    for (std::size_t i = 0, sz = pts->size()-1; i < sz; i++ ) {
+    for (std::size_t i = 0, sz = pts.size()-1; i < sz; i++ ) {
 
         const geom::Coordinate& currSnap = snapSS->getCoordinate(snapSSindex);
 
         /**
         * If the segment has collapsed completely, skip it
         */
-        Coordinate p1 = (*pts)[i+1];
+        Coordinate p1 = pts[i+1];
         Coordinate p1Round;
         round(p1, p1Round);
         if (p1Round.equals2D(currSnap))
             continue;
 
-        Coordinate p0 = (*pts)[i];
+        Coordinate p0 = pts[i];
 
         /**
         * Add any Hot Pixel intersections with *original* segment to rounded segment.


### PR DESCRIPTION
SegmentNodeList went to great pains to create SegmentNodes with stable
addresses so that pointers to the created SegmentNodes could be passed
to callers. However, the returned pointers were never used. This commit
simplifies SegmentNodeList by storing SegmentNodes directly in nodeMap.

Improves overlay performance by maybe 5%.