### PR TITLE
Some MonotoneChain improvements

### DIFF
--- a/benchmarks/ClassSizes.cpp
+++ b/benchmarks/ClassSizes.cpp
@@ -38,6 +38,7 @@
 #include <geos/noding/NodedSegmentString.h>
 #include <geos/profiler.h>
 #include <geos/constants.h>
+#include <geos/index/chain/MonotoneChain.h>
 #include <iostream>
 #include <geos/geomgraph/index/SweepLineEvent.h>
 #include <geos/triangulate/quadedge/QuadEdge.h>
@@ -60,6 +61,7 @@ main()
     check(geomgraph::PlanarGraph);
     check(geomgraph::TopologyLocation);
     check(geomgraph::index::SweepLineEvent);
+    check(index::chain::MonotoneChain);
     check(noding::NodedSegmentString);
     check(geom::Geometry);
     check(geom::Point);

--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -23,6 +23,7 @@
 #include <geos/export.h>
 #include <geos/inline.h>
 #include <geos/geom/Coordinate.h>
+#include <geos/geom/Quadrant.h>
 
 #include <string>
 #include <vector>
@@ -85,6 +86,15 @@ public:
      * @param  p2  the second Coordinate
      */
     Envelope(const Coordinate& p1, const Coordinate& p2);
+
+    /** \brief
+     * Creates an Envelope for a region defined by two Coordinates.
+     *
+     * @param  p1  the first Coordinate
+     * @param  p2  the second Coordinate
+     * @param  q   the Quadrant occupied by the segment p1-p2
+     */
+    Envelope(const Coordinate& p1, const Coordinate& p2, const Quadrant& q);
 
     /** \brief
      * Creates an Envelope for a region defined by a single Coordinate.

--- a/include/geos/geom/Envelope.inl
+++ b/include/geos/geom/Envelope.inl
@@ -52,6 +52,35 @@ Envelope::Envelope(const Coordinate& p1, const Coordinate& p2)
     init(p1, p2);
 }
 
+INLINE
+Envelope::Envelope(const Coordinate& p1, const Coordinate& p2, const Quadrant& q) {
+    switch(q) {
+        case Quadrant::NE:
+            minx = p1.x;
+            miny = p1.y;
+            maxx = p2.x;
+            maxy = p2.y;
+            break;
+        case Quadrant::NW:
+            minx = p2.x;
+            miny = p1.y;
+            maxx = p1.x;
+            maxy = p2.y;
+            break;
+        case Quadrant::SE:
+            minx = p1.x;
+            miny = p2.y;
+            maxx = p2.x;
+            maxy = p1.y;
+            break;
+        case Quadrant::SW:
+            minx = p2.x;
+            miny = p2.y;
+            maxx = p1.x;
+            maxy = p1.y;
+    }
+}
+
 /*public*/
 INLINE
 Envelope::Envelope(const Coordinate& p)

--- a/include/geos/geom/Makefile.am
+++ b/include/geos/geom/Makefile.am
@@ -50,5 +50,6 @@ geos_HEADERS = \
     PrecisionModel.h \
     PrecisionModel.inl \
     Quadrant.h \
-    Quadrant.inl \
+    Quadrants.h \
+    Quadrants.inl \
     Triangle.h

--- a/include/geos/geom/Quadrant.h
+++ b/include/geos/geom/Quadrant.h
@@ -17,93 +17,26 @@
  *
  **********************************************************************/
 
-
 #ifndef GEOS_GEOM_QUADRANT_H
 #define GEOS_GEOM_QUADRANT_H
 
 #include <geos/export.h>
-#include <string>
-
-#include <geos/inline.h>
-
-// Forward declarations
-namespace geos {
-namespace geom {
-class Coordinate;
-}
-}
+#include <ostream>
 
 namespace geos {
 namespace geom { // geos.geom
 
-/** \brief
- * Utility functions for working with quadrants.
- *
- * The quadrants are numbered as follows:
- * <pre>
- * 1 | 0
- * --+--
- * 2 | 3
- * </pre>
- *
- */
-class GEOS_DLL Quadrant {
-
-public:
-
-    static const int NE = 0;
-    static const int NW = 1;
-    static const int SW = 2;
-    static const int SE = 3;
-
-    /**
-     * Returns the quadrant of a directed line segment
-     * (specified as x and y displacements, which cannot both be 0).
-     *
-     * @throws IllegalArgumentException if the displacements are both 0
-     */
-    static int quadrant(double dx, double dy);
-
-    /**
-     * Returns the quadrant of a directed line segment from p0 to p1.
-     *
-     * @throws IllegalArgumentException if the points are equal
-     */
-    static int quadrant(const geom::Coordinate& p0,
-                        const geom::Coordinate& p1);
-
-    /**
-     * Returns true if the quadrants are 1 and 3, or 2 and 4
-     */
-    static bool isOpposite(int quad1, int quad2);
-
-    /*
-     * Returns the right-hand quadrant of the halfplane defined by
-     * the two quadrants,
-     * or -1 if the quadrants are opposite, or the quadrant if they
-     * are identical.
-     */
-    static int commonHalfPlane(int quad1, int quad2);
-
-    /**
-     * Returns whether the given quadrant lies within the given halfplane
-     * (specified by its right-hand quadrant).
-     */
-    static bool isInHalfPlane(int quad, int halfPlane);
-
-    /**
-     * Returns true if the given quadrant is 0 or 1.
-     */
-    static bool isNorthern(int quad);
+enum class GEOS_DLL Quadrant : char {
+    NE = 0,
+    NW = 1,
+    SW = 2,
+    SE = 3
 };
 
+GEOS_DLL std::ostream& operator<<(std::ostream& os, const Quadrant& quadrant);
 
 } // namespace geos.geom
 } // namespace geos
-
-#ifdef GEOS_INLINE
-# include "geos/geom/Quadrant.inl"
-#endif
 
 #endif // ifndef GEOS_GEOM_QUADRANT_H
 

--- a/include/geos/geom/Quadrants.h
+++ b/include/geos/geom/Quadrants.h
@@ -1,0 +1,78 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2005-2006 Refractions Research Inc.
+ * Copyright (C) 2001-2002 Vivid Solutions Inc.
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: geom/Quadrant.java rev. 1.8 (JTS-1.10)
+ *
+ **********************************************************************/
+
+#ifndef GEOS_GEOM_QUADRANTS_H
+#define GEOS_GEOM_QUADRANTS_H
+
+#include <geos/export.h>
+#include <geos/inline.h>
+
+#include <geos/geom/Quadrant.h>
+
+// Forward declarations
+namespace geos {
+namespace geom {
+class Coordinate;
+}
+}
+
+namespace geos {
+namespace geom { // geos.geom
+
+class GEOS_DLL Quadrants {
+    /** \brief
+     * Utility functions for working with quadrants.
+     */
+public:
+    /**
+     * Returns the quadrant of a directed line segment
+     * (specified as x and y displacements, which cannot both be 0).
+     *
+     * @throws IllegalArgumentException if the displacements are both 0
+     */
+    static Quadrant quadrant(double dx, double dy);
+
+    /**
+     * Returns the quadrant of a directed line segment from p0 to p1.
+     *
+     * @throws IllegalArgumentException if the points are equal
+     */
+    static Quadrant quadrant(const geom::Coordinate &p0, const geom::Coordinate &p1);
+
+    /**
+     * Returns true if the quadrants are 1 and 3, or 2 and 4
+     */
+    static bool isOpposite(Quadrant quad1, Quadrant quad2);
+
+    /**
+     * Returns true if the given quadrant is 0 or 1.
+     */
+    static bool isNorthern(Quadrant quad);
+
+};
+
+} // namespace geos.geom
+} // namespace geos
+
+#ifdef GEOS_INLINE
+# include "geos/geom/Quadrants.inl"
+#endif
+
+#endif // ifndef GEOS_GEOM_QUADRANT_H
+

--- a/include/geos/geom/Quadrants.inl
+++ b/include/geos/geom/Quadrants.inl
@@ -20,7 +20,7 @@
 #ifndef GEOS_GEOM_QUADRANT_INL
 #define GEOS_GEOM_QUADRANT_INL
 
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/util/IllegalArgumentException.h>
 
@@ -30,79 +30,79 @@ namespace geos {
 namespace geom {
 
 /* public static */
-INLINE int
-Quadrant::quadrant(double dx, double dy)
+INLINE Quadrant
+Quadrants::quadrant(double dx, double dy)
 {
     if(dx == 0.0 && dy == 0.0) {
         std::ostringstream s;
         s << "Cannot compute the quadrant for point ";
         s << "(" << dx << "," << dy << ")" << std::endl;
-        throw util::IllegalArgumentException(s.str());
+        throw geos::util::IllegalArgumentException(s.str());
     }
     if(dx >= 0) {
         if(dy >= 0) {
-            return NE;
+            return Quadrant::NE;
         }
         else {
-            return SE;
+            return Quadrant::SE;
         }
     }
     else {
         if(dy >= 0) {
-            return NW;
+            return Quadrant::NW;
         }
         else {
-            return SW;
+            return Quadrant::SW;
         }
     }
 }
 
 /* public static */
-INLINE int
-Quadrant::quadrant(const geom::Coordinate& p0, const geom::Coordinate& p1)
+INLINE Quadrant
+Quadrants::quadrant(const geom::Coordinate& p0, const geom::Coordinate& p1)
 {
     if(p1.x == p0.x && p1.y == p0.y) {
-        throw util::IllegalArgumentException("Cannot compute the quadrant for two identical points " + p0.toString());
+        throw geos::util::IllegalArgumentException("Cannot compute the quadrant for two identical points " + p0.toString());
     }
 
     if(p1.x >= p0.x) {
         if(p1.y >= p0.y) {
-            return NE;
+            return Quadrant::NE;
         }
         else {
-            return SE;
+            return Quadrant::SE;
         }
     }
     else {
         if(p1.y >= p0.y) {
-            return NW;
+            return Quadrant::NW;
         }
         else {
-            return SW;
+            return Quadrant::SW;
         }
     }
 }
 
 /* public static */
 INLINE bool
-Quadrant::isOpposite(int quad1, int quad2)
+Quadrants::isOpposite(Quadrant quad1, Quadrant quad2)
 {
-    if(quad1 == quad2) {
-        return false;
+    switch(quad1) {
+        case Quadrant::NE: return quad2 == Quadrant::SW;
+        case Quadrant::SE: return quad2 == Quadrant::NW;
+        case Quadrant::SW: return quad2 == Quadrant::NE;
+        case Quadrant::NW: return quad2 == Quadrant::SE;
+        default:
+            // never get here
+            return false;
     }
-    int diff = (quad1 - quad2 + 4) % 4;
-    // if quadrants are not adjacent, they are opposite
-    if(diff == 2) {
-        return true;
-    }
-    return false;
 }
 
 /* public static */
 INLINE bool
-Quadrant::isNorthern(int quad)
+Quadrants::isNorthern(Quadrant quad)
 {
-    return quad == NE || quad == NW;
+    return quad == Quadrant::NE || quad == Quadrant::NW;
 }
 
 }

--- a/include/geos/geomgraph/EdgeEnd.h
+++ b/include/geos/geomgraph/EdgeEnd.h
@@ -24,6 +24,7 @@
 
 #include <geos/export.h>
 #include <geos/geom/Coordinate.h>  // for p0,p1
+#include <geos/geom/Quadrant.h>
 #include <geos/geomgraph/Label.h>  // for composition
 #include <geos/inline.h>
 
@@ -115,7 +116,7 @@ public:
 
     virtual geom::Coordinate& getDirectedCoordinate();
 
-    virtual int getQuadrant();
+    virtual geom::Quadrant getQuadrant();
 
     virtual double getDx();
 
@@ -171,7 +172,7 @@ private:
     /// the direction vector for this edge from its starting point
     double dx, dy;
 
-    int quadrant;
+    geom::Quadrant quadrant;
 };
 
 std::ostream& operator<< (std::ostream&, const EdgeEnd&);

--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -208,8 +208,8 @@ private:
 
 
     // Declare type as noncopyable
-    MonotoneChain(const MonotoneChain& other) = delete;
-    MonotoneChain& operator=(const MonotoneChain& rhs) = delete;
+    // MonotoneChain(const MonotoneChain& other) = delete;
+    // MonotoneChain& operator=(const MonotoneChain& rhs) = delete;
 };
 
 } // namespace geos::index::chain

--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -95,7 +95,7 @@ public:
     ///   Ownership left to caller, this class holds a reference.
     ///
     MonotoneChain(const geom::CoordinateSequence& pts,
-                  std::size_t start, std::size_t end, void* context);
+                  std::size_t start, std::size_t end, geom::Quadrant quadrant, void* context);
 
     ~MonotoneChain() = default;
 
@@ -159,6 +159,11 @@ public:
         return context;
     }
 
+    geom::Quadrant
+    getQuadrant() const {
+        return quadrant;
+    }
+
 private:
 
     void computeSelect(const geom::Envelope& searchEnv,
@@ -191,12 +196,15 @@ private:
     /// Index of chain end vertex into the CoordinateSequence, 0 based.
     std::size_t end;
 
-    /// Owned by this class
-    geom::Envelope env;
+    geom::Quadrant quadrant;
+
     bool envIsSet;
 
     /// useful for optimizing chain comparisons
     int id;
+
+    /// Owned by this class
+    geom::Envelope env;
 
 
     // Declare type as noncopyable

--- a/include/geos/index/chain/MonotoneChainBuilder.h
+++ b/include/geos/index/chain/MonotoneChainBuilder.h
@@ -20,6 +20,7 @@
 #define GEOS_IDX_CHAIN_MONOTONECHAINBUILDER_H
 
 #include <geos/export.h>
+#include <geos/geom/Quadrant.h>
 #include <memory>
 #include <vector>
 #include <cstddef>
@@ -102,8 +103,8 @@ private:
      *
      * @note aborts if 'start' is >= pts.getSize()
      */
-    static std::size_t findChainEnd(const geom::CoordinateSequence& pts,
-                                    std::size_t start);
+    static std::pair<std::size_t, geom::Quadrant> findChainEnd(const geom::CoordinateSequence& pts,
+                                                         std::size_t start);
 };
 
 } // namespace geos::index::chain

--- a/include/geos/index/chain/MonotoneChainBuilder.h
+++ b/include/geos/index/chain/MonotoneChainBuilder.h
@@ -51,13 +51,13 @@ class GEOS_DLL MonotoneChainBuilder {
 
 public:
 
-    MonotoneChainBuilder() {}
+    MonotoneChainBuilder() = default;
 
     /** \brief
      * Return a newly-allocated vector of newly-allocated
      * MonotoneChain objects for the given CoordinateSequence.
      */
-    static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> getChains(
+    static std::vector<MonotoneChain> getChains(
         const geom::CoordinateSequence* pts,
         void* context);
 
@@ -71,13 +71,7 @@ public:
      */
     static void getChains(const geom::CoordinateSequence* pts,
                           void* context,
-                          std::vector<std::unique_ptr<MonotoneChain>>& mcList);
-
-    static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>>
-    getChains(const geom::CoordinateSequence* pts)
-    {
-        return getChains(pts, nullptr);
-    }
+                          std::vector<MonotoneChain>& mcList);
 
     /**
      * Disable copy construction and assignment. Apparently needed to make this
@@ -99,12 +93,12 @@ private:
      * @param pts the points to scan
      * @param start the index of the start of this chain
      * @return the index of the last point in the monotone chain
-     *         starting at <code>start</code>.
+     *         starting at <code>start</code> and the Quadrant
+     *         associated with this chain.
      *
      * @note aborts if 'start' is >= pts.getSize()
      */
-    static std::pair<std::size_t, geom::Quadrant> findChainEnd(const geom::CoordinateSequence& pts,
-                                                         std::size_t start);
+    static std::pair<std::size_t, geom::Quadrant> findChainEnd(const geom::CoordinateSequence& pts, std::size_t start);
 };
 
 } // namespace geos::index::chain

--- a/include/geos/noding/MCIndexNoder.h
+++ b/include/geos/noding/MCIndexNoder.h
@@ -24,6 +24,7 @@
 #include <geos/inline.h>
 
 #include <geos/index/chain/MonotoneChainOverlapAction.h> // for inheritance
+#include <geos/index/chain/MonotoneChain.h>
 #include <geos/noding/SinglePassNoder.h> // for inheritance
 #include <geos/index/strtree/SimpleSTRtree.h> // for composition
 #include <geos/util.h>
@@ -65,7 +66,7 @@ namespace noding { // geos.noding
 class GEOS_DLL MCIndexNoder : public SinglePassNoder {
 
 private:
-    std::vector<index::chain::MonotoneChain*> monoChains;
+    std::vector<std::vector<index::chain::MonotoneChain>> monoChains;
     index::strtree::SimpleSTRtree index;
     int idCounter;
     std::vector<SegmentString*>* nodedSegStrings;
@@ -89,13 +90,6 @@ public:
     {}
 
     ~MCIndexNoder() override;
-
-    /// \brief Return a reference to this instance's std::vector of MonotoneChains
-    std::vector<index::chain::MonotoneChain*>&
-    getMonotoneChains()
-    {
-        return monoChains;
-    }
 
     index::SpatialIndex& getIndex();
 

--- a/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
+++ b/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
@@ -96,7 +96,7 @@ public:
 
 private:
 
-    typedef std::vector<std::unique_ptr<index::chain::MonotoneChain>> MonoChains;
+    typedef std::vector<index::chain::MonotoneChain> MonoChains;
     MonoChains monoChains;
 
     /*
@@ -113,7 +113,7 @@ private:
     /* memory management helper, holds MonotoneChain objects used
      * in the SpatialIndex. It's cleared when the SpatialIndex is
      */
-    MonoChains chainStore;
+    std::vector<MonoChains> chainStore;
 
     void addToIndex(SegmentString* segStr);
 

--- a/include/geos/planargraph/DirectedEdge.h
+++ b/include/geos/planargraph/DirectedEdge.h
@@ -19,6 +19,7 @@
 #include <geos/export.h>
 #include <geos/planargraph/GraphComponent.h> // for inheritance
 #include <geos/geom/Coordinate.h> // for composition
+#include <geos/geom/Quadrant.h>
 
 #include <vector> // for typedefs
 #include <list> // for typedefs
@@ -60,7 +61,7 @@ protected:
     geom::Coordinate p0, p1;
     DirectedEdge* sym;  // optional
     bool edgeDirection;
-    int quadrant;
+    geom::Quadrant quadrant;
     double angle;
 public:
 
@@ -121,10 +122,10 @@ public:
     void setEdge(Edge* newParentEdge);
 
     /**
-     * \brief Returns 0, 1, 2, or 3, indicating the quadrant in which
+     * \brief Returns the  quadrant in which
      * this DirectedEdge's orientation lies.
      */
-    int getQuadrant() const;
+    geom::Quadrant getQuadrant() const;
 
     /**
      * \brief Returns a point to which an imaginary line is drawn

--- a/src/edgegraph/HalfEdge.cpp
+++ b/src/edgegraph/HalfEdge.cpp
@@ -22,7 +22,7 @@
 
 #include <geos/algorithm/Orientation.h>
 #include <geos/edgegraph/HalfEdge.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/util/Assert.h>
 
@@ -188,8 +188,8 @@ HalfEdge::compareAngularDirection(const HalfEdge* e) const
     if (dx == dx2 && dy == dy2)
         return 0;
 
-    int quadrant = geom::Quadrant::quadrant(dx, dy);
-    int quadrant2 = geom::Quadrant::quadrant(dx2, dy2);
+    auto quadrant = geom::Quadrants::quadrant(dx, dy);
+    auto quadrant2 = geom::Quadrants::quadrant(dx2, dy2);
 
     /**
     * If the direction vectors are in different quadrants,

--- a/src/geom/Quadrant.cpp
+++ b/src/geom/Quadrant.cpp
@@ -22,48 +22,28 @@
 # include <geos/geom/Quadrant.inl>
 #endif
 
-using namespace geos::geom;
-
 namespace geos {
 namespace geom { // geos.geom
 
-/* public static */
-int
-Quadrant::commonHalfPlane(int quad1, int quad2)
+std::ostream&
+operator<<(std::ostream& os, const Quadrant& quadrant)
 {
-    // if quadrants are the same they do not determine a unique
-    // common halfplane.
-    // Simply return one of the two possibilities
-    if(quad1 == quad2) {
-        return quad1;
+    switch(quadrant) {
+        case Quadrant::NE:
+            os << "NE";
+            break;
+        case Quadrant::SE:
+            os << "SE";
+            break;
+        case Quadrant::SW:
+            os << "SW";
+            break;
+        case Quadrant::NW:
+            os << "NW";
+            break;
     }
-    int diff = (quad1 - quad2 + 4) % 4;
-    // if quadrants are not adjacent, they do not share a common halfplane
-    if(diff == 2) {
-        return -1;
-    }
-    //
-    int min = (quad1 < quad2) ? quad1 : quad2;
-    int max = (quad1 > quad2) ? quad1 : quad2;
-    // for this one case, the righthand plane is NOT the minimum index;
-    if(min == 0 && max == 3) {
-        return 3;
-    }
-    // in general, the halfplane index is the minimum of the two
-    // adjacent quadrants
-    return min;
+    return os;
 }
-
-/* public static */
-bool
-Quadrant::isInHalfPlane(int quad, int halfPlane)
-{
-    if(halfPlane == SE) {
-        return quad == SE || quad == SW;
-    }
-    return quad == halfPlane || quad == halfPlane + 1;
-}
-
 
 } // namespace geos.geom
 } // namespace geos

--- a/src/geomgraph/DirectedEdgeStar.cpp
+++ b/src/geomgraph/DirectedEdgeStar.cpp
@@ -25,7 +25,7 @@
 #include <geos/geomgraph/DirectedEdge.h>
 #include <geos/geomgraph/EdgeRing.h>
 #include <geos/geom/Position.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 #include <geos/geom/Location.h>
 #include <geos/util/TopologyException.h>
 #include <geos/util.h>
@@ -105,13 +105,13 @@ DirectedEdgeStar::getRightmostEdge()
     DirectedEdge* deLast = detail::down_cast<DirectedEdge*>(*it);
 
     assert(de0);
-    int quad0 = de0->getQuadrant();
+    auto quad0 = de0->getQuadrant();
     assert(deLast);
-    int quad1 = deLast->getQuadrant();
-    if(Quadrant::isNorthern(quad0) && Quadrant::isNorthern(quad1)) {
+    auto quad1 = deLast->getQuadrant();
+    if(Quadrants::isNorthern(quad0) && Quadrants::isNorthern(quad1)) {
         return de0;
     }
-    else if(!Quadrant::isNorthern(quad0) && !Quadrant::isNorthern(quad1)) {
+    else if(!Quadrants::isNorthern(quad0) && !Quadrants::isNorthern(quad1)) {
         return deLast;
     }
     else {

--- a/src/geomgraph/EdgeEnd.cpp
+++ b/src/geomgraph/EdgeEnd.cpp
@@ -22,7 +22,7 @@
 #include <geos/geomgraph/Node.h> // for assertions
 #include <geos/algorithm/Orientation.h>
 #include <geos/geomgraph/Label.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 #include <geos/geom/Coordinate.h>
 
 #include <typeinfo>
@@ -47,7 +47,7 @@ EdgeEnd::EdgeEnd()
     node(nullptr),
     dx(0.0),
     dy(0.0),
-    quadrant(0)
+    quadrant(Quadrant::NE)
 {
 }
 
@@ -59,7 +59,7 @@ EdgeEnd::EdgeEnd(Edge* newEdge)
     node(nullptr),
     dx(0.0),
     dy(0.0),
-    quadrant(0)
+    quadrant(Quadrant::NE)
 {
 }
 
@@ -72,7 +72,7 @@ EdgeEnd::EdgeEnd(Edge* newEdge, const Coordinate& newP0,
     node(nullptr),
     dx(0.0),
     dy(0.0),
-    quadrant(0)
+    quadrant(Quadrant::NE)
 {
     init(newP0, newP1);
 }
@@ -86,7 +86,7 @@ EdgeEnd::EdgeEnd(Edge* newEdge, const Coordinate& newP0,
     node(nullptr),
     dx(0.0),
     dy(0.0),
-    quadrant(0)
+    quadrant(Quadrant::NE)
 {
     init(newP0, newP1);
 }
@@ -99,7 +99,7 @@ EdgeEnd::init(const Coordinate& newP0, const Coordinate& newP1)
     p1 = newP1;
     dx = p1.x - p0.x;
     dy = p1.y - p0.y;
-    quadrant = Quadrant::quadrant(dx, dy);
+    quadrant = Quadrants::quadrant(dx, dy);
 
     // "EdgeEnd with identical endpoints found");
     assert(!(dx == 0 && dy == 0));
@@ -113,7 +113,7 @@ EdgeEnd::getDirectedCoordinate()
 }
 
 /*public*/
-int
+Quadrant
 EdgeEnd::getQuadrant()
 {
     return quadrant;

--- a/src/geomgraph/PlanarGraph.cpp
+++ b/src/geomgraph/PlanarGraph.cpp
@@ -29,7 +29,7 @@
 #include <geos/geomgraph/DirectedEdge.h>
 #include <geos/geomgraph/DirectedEdgeStar.h>
 #include <geos/geomgraph/NodeMap.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 
 #include <geos/algorithm/Orientation.h>
 
@@ -356,7 +356,7 @@ PlanarGraph::matchInSameDirection(const Coordinate& p0, const Coordinate& p1,
     }
 
     if(Orientation::index(p0, p1, ep1) == Orientation::COLLINEAR
-            && Quadrant::quadrant(p0, p1) == Quadrant::quadrant(ep0, ep1)) {
+            && Quadrants::quadrant(p0, p1) == Quadrants::quadrant(ep0, ep1)) {
         return true;
     }
     return false;

--- a/src/geomgraph/index/MonotoneChainIndexer.cpp
+++ b/src/geomgraph/index/MonotoneChainIndexer.cpp
@@ -18,7 +18,7 @@
 #include <geos/geomgraph/index/MonotoneChainIndexer.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateSequence.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 
 
 using namespace geos::geom;
@@ -53,12 +53,12 @@ size_t
 MonotoneChainIndexer::findChainEnd(const CoordinateSequence* pts, std::size_t start)
 {
     // determine quadrant for chain
-    auto chainQuad = Quadrant::quadrant(pts->getAt(start), pts->getAt(start + 1));
+    auto chainQuad = Quadrants::quadrant(pts->getAt(start), pts->getAt(start + 1));
     auto last = start + 1;
     auto sz = pts->size(); // virtual call, doesn't inline
     while(last < sz) {
         // compute quadrant for next possible segment in chain
-        auto quad = Quadrant::quadrant(pts->getAt(last - 1), pts->getAt(last));
+        auto quad = Quadrants::quadrant(pts->getAt(last - 1), pts->getAt(last));
         if(quad != chainQuad) {
             break;
         }

--- a/src/index/chain/MonotoneChain.cpp
+++ b/src/index/chain/MonotoneChain.cpp
@@ -23,6 +23,7 @@
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/LineSegment.h>
 #include <geos/geom/Envelope.h>
+#include <geos/geom/Quadrants.h>
 #include <geos/util.h>
 
 using namespace geos::geom;
@@ -32,15 +33,17 @@ namespace index { // geos.index
 namespace chain { // geos.index.chain
 
 MonotoneChain::MonotoneChain(const geom::CoordinateSequence& newPts,
-                             std::size_t nstart, std::size_t nend, void* nContext)
+                             std::size_t nstart, std::size_t nend,
+                             geom::Quadrant p_Quadrant, void* nContext)
     :
     pts(newPts),
     context(nContext),
     start(nstart),
     end(nend),
-    env(newPts[nstart], newPts[nend]),
     envIsSet(false),
-    id(-1)
+    id(-1),
+    quadrant(p_Quadrant),
+    env(newPts[start], newPts[end], quadrant)
 {
 }
 
@@ -54,7 +57,6 @@ const Envelope&
 MonotoneChain::getEnvelope(double expansionDistance)
 {
     if (!envIsSet) {
-        env.init(pts[start], pts[end]);
         if (expansionDistance > 0.0) {
             env.expandBy(expansionDistance);
         }

--- a/src/index/chain/MonotoneChain.cpp
+++ b/src/index/chain/MonotoneChain.cpp
@@ -40,9 +40,9 @@ MonotoneChain::MonotoneChain(const geom::CoordinateSequence& newPts,
     context(nContext),
     start(nstart),
     end(nend),
+    quadrant(p_Quadrant),
     envIsSet(false),
     id(-1),
-    quadrant(p_Quadrant),
     env(newPts[start], newPts[end], quadrant)
 {
 }

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -57,17 +57,17 @@ MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
 {
     std::size_t chainStart = 0;
     do {
-        std::size_t chainEnd = findChainEnd(*pts, chainStart);
-        MonotoneChain *mc = new MonotoneChain(*pts, chainStart, chainEnd, context);
+        auto chainEnd = findChainEnd(*pts, chainStart);
+        MonotoneChain *mc = new MonotoneChain(*pts, chainStart, chainEnd.first, chainEnd.second, context);
         mcList.emplace_back(mc);
-        chainStart = chainEnd;
+        chainStart = chainEnd.first;
     }
     while (chainStart < (pts->size() - 1));
 }
 
 
 /* private static */
-std::size_t
+std::pair<std::size_t, Quadrant>
 MonotoneChainBuilder::findChainEnd(const CoordinateSequence& pts, std::size_t start)
 {
 
@@ -88,7 +88,7 @@ MonotoneChainBuilder::findChainEnd(const CoordinateSequence& pts, std::size_t st
 
     // check if there are NO non-zero-length segments
     if(safeStart >= npts - 1) {
-        return npts - 1;
+        return std::make_pair(npts - 1, Quadrant::NE);
     }
 
     // determine overall quadrant for chain
@@ -108,7 +108,7 @@ MonotoneChainBuilder::findChainEnd(const CoordinateSequence& pts, std::size_t st
             // compute quadrant for next possible segment in chain
             auto quad = Quadrants::quadrant(*prev, *curr);
             if(quad != chainQuad) {
-                return last - 1;
+                return std::make_pair(last - 1, chainQuad);
             }
         }
     }
@@ -116,7 +116,7 @@ MonotoneChainBuilder::findChainEnd(const CoordinateSequence& pts, std::size_t st
     std::cerr << "MonotoneChainBuilder::findChainEnd() returning" << std::endl;
 #endif
 
-    return npts - 1;
+    return std::make_pair(npts - 1, chainQuad);
 }
 
 } // namespace geos.index.chain

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -19,7 +19,7 @@
 #include <geos/index/chain/MonotoneChainBuilder.h>
 #include <geos/index/chain/MonotoneChain.h>
 #include <geos/geom/CoordinateSequence.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 
 #include <cassert>
 #include <cstdio>
@@ -93,7 +93,7 @@ MonotoneChainBuilder::findChainEnd(const CoordinateSequence& pts, std::size_t st
 
     // determine overall quadrant for chain
     // (which is the starting quadrant)
-    int chainQuad = Quadrant::quadrant(pts[safeStart],
+    auto chainQuad = Quadrants::quadrant(pts[safeStart],
                                        pts[safeStart + 1]);
 
     const Coordinate* prev; // avoid repeated coordinate access by index (virtual call)
@@ -106,7 +106,7 @@ MonotoneChainBuilder::findChainEnd(const CoordinateSequence& pts, std::size_t st
         // skip zero-length segments, but include them in the chain
         if(!prev->equals2D(*curr)) {
             // compute quadrant for next possible segment in chain
-            int quad = Quadrant::quadrant(*prev, *curr);
+            auto quad = Quadrants::quadrant(*prev, *curr);
             if(quad != chainQuad) {
                 return last - 1;
             }

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -41,26 +41,27 @@ namespace index { // geos.index
 namespace chain { // geos.index.chain
 
 /* static public */
-std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>>
+std::vector<MonotoneChain>
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context)
 {
-    // TODO clean this up with std::make_unique (C++14)
-    std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> mcList{new std::vector<std::unique_ptr<MonotoneChain>>()};
-    getChains(pts, context, *mcList);
+    std::vector<MonotoneChain> mcList;
+    getChains(pts, context, mcList);
     return mcList;
 }
 
 /* static public */
 void
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
-                                std::vector<std::unique_ptr<MonotoneChain>>& mcList)
+                                std::vector<MonotoneChain>& mcList)
 {
     std::size_t chainStart = 0;
     do {
-        auto chainEnd = findChainEnd(*pts, chainStart);
-        MonotoneChain *mc = new MonotoneChain(*pts, chainStart, chainEnd.first, chainEnd.second, context);
-        mcList.emplace_back(mc);
-        chainStart = chainEnd.first;
+        auto end = findChainEnd(*pts, chainStart);
+        std::size_t& chainEnd = end.first;
+        Quadrant& chainQuad = end.second;
+        MonotoneChain mc(*pts, chainStart, chainEnd, chainQuad, context);
+        mcList.push_back(mc);
+        chainStart = chainEnd;
     }
     while (chainStart < (pts->size() - 1));
 }

--- a/src/inlines.cpp
+++ b/src/inlines.cpp
@@ -61,7 +61,7 @@
 #include <geos/geom/CoordinateArraySequenceFactory.inl>
 #include <geos/geomgraph/Depth.inl>
 #include <geos/geomgraph/Label.inl>
-#include <geos/geom/Quadrant.inl>
+#include <geos/geom/Quadrants.inl>
 #include <geos/geomgraph/TopologyLocation.inl>
 #include <geos/geomgraph/index/SegmentIntersector.inl>
 #include <geos/noding/snapround/HotPixel.inl>

--- a/src/planargraph/DirectedEdge.cpp
+++ b/src/planargraph/DirectedEdge.cpp
@@ -14,7 +14,7 @@
 
 #include <geos/planargraph/DirectedEdge.h>
 #include <geos/planargraph/Node.h>
-#include <geos/geom/Quadrant.h>
+#include <geos/geom/Quadrants.h>
 #include <geos/algorithm/Orientation.h>
 
 #include <cmath>
@@ -57,7 +57,7 @@ DirectedEdge::DirectedEdge(Node* newFrom, Node* newTo,
     p1 = directionPt;
     double dx = p1.x - p0.x;
     double dy = p1.y - p0.y;
-    quadrant = geom::Quadrant::quadrant(dx, dy);
+    quadrant = geom::Quadrants::quadrant(dx, dy);
     angle = atan2(dy, dx);
     //Assert.isTrue(! (dx == 0 && dy == 0), "EdgeEnd with identical endpoints found");
 }
@@ -77,7 +77,7 @@ DirectedEdge::setEdge(Edge* newParentEdge)
 }
 
 /*public*/
-int
+Quadrant
 DirectedEdge::getQuadrant() const
 {
     return quadrant;


### PR DESCRIPTION
This PR makes `Quadrant` into an `enum class`, allowing us to specify a smaller type (`char`) and carry it around for for free on `MonotoneChain` objects (because of struct packing.) It also has a type-safety benefit. The stored `Quadrant` is taken advantage of to speed up envelope initialization for a chain, and could possibly be used later in the overlap checking. The PR also avoids individual heap-allocations of the chains in `MonotoneChainBuilder`.

Net benefit is minor, about 4% of a union operation. So maybe not worth writing, but unfortunately by the time you find that out it's already written. On the other hand, the 3-4% changes can and do add up.