### PR TITLE
MonotoneChain handling performance

### DIFF
--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -193,11 +193,11 @@ private:
 
     /// Owned by this class
     geom::Envelope env;
-    bool envIsSet;
 
     /// useful for optimizing chain comparisons
     int id;
 
+    bool envIsSet;
 
     // Declare type as noncopyable
     // XXXXXX uncomment for MSVC support

--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -200,8 +200,9 @@ private:
 
 
     // Declare type as noncopyable
-    MonotoneChain(const MonotoneChain& other) = delete;
-    MonotoneChain& operator=(const MonotoneChain& rhs) = delete;
+    // XXXXXX uncomment for MSVC support
+    // MonotoneChain(const MonotoneChain& other) = delete;
+    // MonotoneChain& operator=(const MonotoneChain& rhs) = delete;
 };
 
 } // namespace geos::index::chain

--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -141,18 +141,6 @@ public:
     void computeOverlaps(MonotoneChain* mc, double overlapTolerance,
                          MonotoneChainOverlapAction* mco);
 
-    void
-    setId(int nId)
-    {
-        id = nId;
-    }
-
-    inline int
-    getId() const
-    {
-        return id;
-    }
-
     void*
     getContext()
     {
@@ -193,11 +181,6 @@ private:
 
     /// Owned by this class
     geom::Envelope env;
-
-    /// useful for optimizing chain comparisons
-    int id;
-
-    bool envIsSet;
 
     // Declare type as noncopyable
     // XXXXXX uncomment for MSVC support

--- a/include/geos/index/chain/MonotoneChainBuilder.h
+++ b/include/geos/index/chain/MonotoneChainBuilder.h
@@ -53,14 +53,6 @@ public:
     MonotoneChainBuilder() {}
 
     /** \brief
-     * Return a newly-allocated vector of newly-allocated
-     * MonotoneChain objects for the given CoordinateSequence.
-     */
-    static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> getChains(
-        const geom::CoordinateSequence* pts,
-        void* context);
-
-    /** \brief
      * Computes a list of the {@link MonotoneChain}s for a list of coordinates,
      * attaching a context data object to each.
      *
@@ -70,13 +62,7 @@ public:
      */
     static void getChains(const geom::CoordinateSequence* pts,
                           void* context,
-                          std::vector<std::unique_ptr<MonotoneChain>>& mcList);
-
-    static std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>>
-    getChains(const geom::CoordinateSequence* pts)
-    {
-        return getChains(pts, nullptr);
-    }
+                          std::vector<MonotoneChain>& mcList);
 
     /**
      * Disable copy construction and assignment. Apparently needed to make this

--- a/include/geos/noding/MCIndexNoder.h
+++ b/include/geos/noding/MCIndexNoder.h
@@ -24,6 +24,7 @@
 #include <geos/inline.h>
 
 #include <geos/index/chain/MonotoneChainOverlapAction.h> // for inheritance
+#include <geos/index/chain/MonotoneChain.h>
 #include <geos/noding/SinglePassNoder.h> // for inheritance
 #include <geos/index/strtree/SimpleSTRtree.h> // for composition
 #include <geos/util.h>
@@ -65,13 +66,14 @@ namespace noding { // geos.noding
 class GEOS_DLL MCIndexNoder : public SinglePassNoder {
 
 private:
-    std::vector<index::chain::MonotoneChain*> monoChains;
+    std::vector<index::chain::MonotoneChain> monoChains;
     index::strtree::SimpleSTRtree index;
     int idCounter;
     std::vector<SegmentString*>* nodedSegStrings;
     // statistics
     int nOverlaps;
     double overlapTolerance;
+    bool indexBuilt;
 
     void intersectChains();
 
@@ -80,18 +82,19 @@ private:
 public:
 
     MCIndexNoder(SegmentIntersector* nSegInt = nullptr, double p_overlapTolerance = 0.0)
-        :
-        SinglePassNoder(nSegInt),
-        idCounter(0),
-        nodedSegStrings(nullptr),
-        nOverlaps(0),
-        overlapTolerance(p_overlapTolerance)
+        : SinglePassNoder(nSegInt)
+        , idCounter(0)
+        , nodedSegStrings(nullptr)
+        , nOverlaps(0)
+        , overlapTolerance(p_overlapTolerance)
+        , indexBuilt(false)
     {}
 
-    ~MCIndexNoder() override;
+    ~MCIndexNoder() override {};
+
 
     /// \brief Return a reference to this instance's std::vector of MonotoneChains
-    std::vector<index::chain::MonotoneChain*>&
+    std::vector<index::chain::MonotoneChain>&
     getMonotoneChains()
     {
         return monoChains;

--- a/include/geos/noding/MCIndexNoder.h
+++ b/include/geos/noding/MCIndexNoder.h
@@ -68,7 +68,6 @@ class GEOS_DLL MCIndexNoder : public SinglePassNoder {
 private:
     std::vector<index::chain::MonotoneChain> monoChains;
     index::strtree::SimpleSTRtree index;
-    int idCounter;
     std::vector<SegmentString*>* nodedSegStrings;
     // statistics
     int nOverlaps;
@@ -83,7 +82,6 @@ public:
 
     MCIndexNoder(SegmentIntersector* nSegInt = nullptr, double p_overlapTolerance = 0.0)
         : SinglePassNoder(nSegInt)
-        , idCounter(0)
         , nodedSegStrings(nullptr)
         , nOverlaps(0)
         , overlapTolerance(p_overlapTolerance)

--- a/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
+++ b/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
@@ -22,13 +22,14 @@
 
 #include <geos/noding/SegmentSetMutualIntersector.h> // inherited
 #include <geos/index/chain/MonotoneChainOverlapAction.h> // inherited
+#include <geos/index/chain/MonotoneChain.h> // inherited
+#include <geos/index/strtree/SimpleSTRtree.h> // inherited
 
 namespace geos {
 namespace index {
 class SpatialIndex;
 
 namespace chain {
-class MonotoneChain;
 }
 namespace strtree {
 //class STRtree;
@@ -55,14 +56,22 @@ namespace noding { // geos::noding
 class MCIndexSegmentSetMutualIntersector : public SegmentSetMutualIntersector {
 public:
 
-    MCIndexSegmentSetMutualIntersector();
+    MCIndexSegmentSetMutualIntersector()
+        : monoChains()
+        , index(new index::strtree::SimpleSTRtree())
+        , indexCounter(0)
+        , processCounter(0)
+        , nOverlaps(0)
+        , indexBuilt(false)
+    {}
 
-    ~MCIndexSegmentSetMutualIntersector() override;
+    ~MCIndexSegmentSetMutualIntersector() override
+    {};
 
     index::SpatialIndex*
     getIndex()
     {
-        return index;
+        return index.get();
     }
 
     void setBaseSegments(SegmentString::ConstVect* segStrings) override;
@@ -96,7 +105,7 @@ public:
 
 private:
 
-    typedef std::vector<std::unique_ptr<index::chain::MonotoneChain>> MonoChains;
+    typedef std::vector<index::chain::MonotoneChain> MonoChains;
     MonoChains monoChains;
 
     /*
@@ -104,7 +113,7 @@ private:
      * envelope (range) queries efficiently (such as a index::quadtree::Quadtree
      * or index::strtree::STRtree).
      */
-    index::SpatialIndex* index;
+    std::unique_ptr<index::SpatialIndex> index;
     int indexCounter;
     int processCounter;
     // statistics
@@ -113,7 +122,8 @@ private:
     /* memory management helper, holds MonotoneChain objects used
      * in the SpatialIndex. It's cleared when the SpatialIndex is
      */
-    MonoChains chainStore;
+    bool indexBuilt;
+    MonoChains indexChains;
 
     void addToIndex(SegmentString* segStr);
 

--- a/src/index/chain/MonotoneChain.cpp
+++ b/src/index/chain/MonotoneChain.cpp
@@ -37,9 +37,7 @@ MonotoneChain::MonotoneChain(const geom::CoordinateSequence& newPts,
     , context(nContext)
     , start(nstart)
     , end(nend)
-    , env(newPts[nstart], newPts[nend])
-    , id(-1)
-    , envIsSet(false)
+    , env()
 {}
 
 const Envelope&
@@ -51,12 +49,11 @@ MonotoneChain::getEnvelope()
 const Envelope&
 MonotoneChain::getEnvelope(double expansionDistance)
 {
-    if (!envIsSet) {
+    if (env.isNull()) {
         env.init(pts[start], pts[end]);
         if (expansionDistance > 0.0) {
             env.expandBy(expansionDistance);
         }
-        envIsSet = true;
     }
     return env;
 }

--- a/src/index/chain/MonotoneChain.cpp
+++ b/src/index/chain/MonotoneChain.cpp
@@ -33,16 +33,14 @@ namespace chain { // geos.index.chain
 
 MonotoneChain::MonotoneChain(const geom::CoordinateSequence& newPts,
                              std::size_t nstart, std::size_t nend, void* nContext)
-    :
-    pts(newPts),
-    context(nContext),
-    start(nstart),
-    end(nend),
-    env(newPts[nstart], newPts[nend]),
-    envIsSet(false),
-    id(-1)
-{
-}
+    : pts(newPts)
+    , context(nContext)
+    , start(nstart)
+    , end(nend)
+    , env(newPts[nstart], newPts[nend])
+    , id(-1)
+    , envIsSet(false)
+{}
 
 const Envelope&
 MonotoneChain::getEnvelope()

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -40,26 +40,16 @@ namespace geos {
 namespace index { // geos.index
 namespace chain { // geos.index.chain
 
-/* static public */
-std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>>
-MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context)
-{
-    // TODO clean this up with std::make_unique (C++14)
-    std::unique_ptr<std::vector<std::unique_ptr<MonotoneChain>>> mcList{new std::vector<std::unique_ptr<MonotoneChain>>()};
-    getChains(pts, context, *mcList);
-    return mcList;
-}
 
 /* static public */
 void
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
-                                std::vector<std::unique_ptr<MonotoneChain>>& mcList)
+                                std::vector<MonotoneChain>& mcList)
 {
     std::size_t chainStart = 0;
     do {
         std::size_t chainEnd = findChainEnd(*pts, chainStart);
-        MonotoneChain *mc = new MonotoneChain(*pts, chainStart, chainEnd, context);
-        mcList.emplace_back(mc);
+        mcList.emplace_back(*pts, chainStart, chainEnd, context);
         chainStart = chainEnd;
     }
     while (chainStart < (pts->size() - 1));

--- a/src/noding/MCIndexNoder.cpp
+++ b/src/noding/MCIndexNoder.cpp
@@ -55,7 +55,6 @@ MCIndexNoder::computeNodes(SegmentString::NonConstVect* inputSegStrings)
 
     if (!indexBuilt) {
         for(auto& mc : monoChains) {
-            mc.setId(idCounter++);
             index.insert(&(mc.getEnvelope(overlapTolerance)), &mc);
         }
         indexBuilt = true;
@@ -89,7 +88,7 @@ MCIndexNoder::intersectChains()
              * pair of chains once and that we don't compare a
              * chain to itself
              */
-            if(testChain->getId() > queryChain.getId()) {
+            if(testChain > &queryChain) {
                 queryChain.computeOverlaps(testChain, overlapTolerance, &overlapAction);
                 nOverlaps++;
             }

--- a/src/noding/MCIndexSegmentSetMutualIntersector.cpp
+++ b/src/noding/MCIndexSegmentSetMutualIntersector.cpp
@@ -51,11 +51,6 @@ MCIndexSegmentSetMutualIntersector::addToMonoChains(SegmentString* segStr)
     MonotoneChainBuilder::getChains(segStr->getCoordinates(),
                                     segStr, monoChains);
 
-    // std::size_t n = segChains.size();
-    // monoChains.reserve(monoChains.size() + n);
-    for(auto& mc : monoChains) {
-        mc.setId(processCounter++);
-    }
 }
 
 
@@ -102,7 +97,6 @@ MCIndexSegmentSetMutualIntersector::process(SegmentString::ConstVect* segStrings
 {
     if (!indexBuilt) {
         for (auto& mc: indexChains) {
-            mc.setId(indexCounter++);
             index->insert(&(mc.getEnvelope()), &mc);
         }
         indexBuilt = true;

--- a/src/noding/MCIndexSegmentSetMutualIntersector.cpp
+++ b/src/noding/MCIndexSegmentSetMutualIntersector.cpp
@@ -33,20 +33,28 @@ using namespace geos::index::chain;
 namespace geos {
 namespace noding { // geos::noding
 
+
 /*private*/
 void
 MCIndexSegmentSetMutualIntersector::addToIndex(SegmentString* segStr)
 {
-    MonoChains segChains;
     MonotoneChainBuilder::getChains(segStr->getCoordinates(),
-                                    segStr, segChains);
+                                    segStr, indexChains);
 
-    MonoChains::size_type n = segChains.size();
-    chainStore.reserve(chainStore.size() + n);
-    for(auto& mc : segChains) {
-        mc->setId(indexCounter++);
-        index->insert(&(mc->getEnvelope()), mc.get());
-        chainStore.push_back(std::move(mc));
+}
+
+
+/*private*/
+void
+MCIndexSegmentSetMutualIntersector::addToMonoChains(SegmentString* segStr)
+{
+    MonotoneChainBuilder::getChains(segStr->getCoordinates(),
+                                    segStr, monoChains);
+
+    // std::size_t n = segChains.size();
+    // monoChains.reserve(monoChains.size() + n);
+    for(auto& mc : monoChains) {
+        mc.setId(processCounter++);
     }
 }
 
@@ -58,15 +66,15 @@ MCIndexSegmentSetMutualIntersector::intersectChains()
     MCIndexSegmentSetMutualIntersector::SegmentOverlapAction overlapAction(*segInt);
 
     std::vector<void*> overlapChains;
-    for(const auto& queryChain : monoChains) {
+    for(auto& queryChain : monoChains) {
         overlapChains.clear();
 
-        index->query(&(queryChain->getEnvelope()), overlapChains);
+        index->query(&(queryChain.getEnvelope()), overlapChains);
 
         for(std::size_t j = 0, nj = overlapChains.size(); j < nj; j++) {
             MonotoneChain* testChain = (MonotoneChain*)(overlapChains[j]);
 
-            queryChain->computeOverlaps(testChain, &overlapAction);
+            queryChain.computeOverlaps(testChain, &overlapAction);
             nOverlaps++;
             if(segInt->isDone()) {
                 return;
@@ -75,37 +83,6 @@ MCIndexSegmentSetMutualIntersector::intersectChains()
     }
 }
 
-/*private*/
-void
-MCIndexSegmentSetMutualIntersector::addToMonoChains(SegmentString* segStr)
-{
-    MonoChains segChains;
-    MonotoneChainBuilder::getChains(segStr->getCoordinates(),
-                                    segStr, segChains);
-
-    MonoChains::size_type n = segChains.size();
-    monoChains.reserve(monoChains.size() + n);
-    for(auto& mc : segChains) {
-        mc->setId(processCounter++);
-        monoChains.push_back(std::move(mc));
-    }
-}
-
-/* public */
-MCIndexSegmentSetMutualIntersector::MCIndexSegmentSetMutualIntersector()
-    :	monoChains(),
-      index(new geos::index::strtree::SimpleSTRtree()),
-      indexCounter(0),
-      processCounter(0),
-      nOverlaps(0)
-{
-}
-
-/* public */
-MCIndexSegmentSetMutualIntersector::~MCIndexSegmentSetMutualIntersector()
-{
-    delete index;
-}
 
 /* public */
 void
@@ -113,8 +90,7 @@ MCIndexSegmentSetMutualIntersector::setBaseSegments(SegmentString::ConstVect* se
 {
     // NOTE - mloskot: const qualifier is removed silently, dirty.
 
-    for(std::size_t i = 0, n = segStrings->size(); i < n; i++) {
-        const SegmentString* css = (*segStrings)[i];
+    for(const SegmentString* css: *segStrings) {
         SegmentString* ss = const_cast<SegmentString*>(css);
         addToIndex(ss);
     }
@@ -124,14 +100,22 @@ MCIndexSegmentSetMutualIntersector::setBaseSegments(SegmentString::ConstVect* se
 void
 MCIndexSegmentSetMutualIntersector::process(SegmentString::ConstVect* segStrings)
 {
+    if (!indexBuilt) {
+        for (auto& mc: indexChains) {
+            mc.setId(indexCounter++);
+            index->insert(&(mc.getEnvelope()), &mc);
+        }
+        indexBuilt = true;
+    }
+
+    // Reset counters for new inputs
+    monoChains.clear();
     processCounter = indexCounter + 1;
     nOverlaps = 0;
 
-    monoChains.clear();
-
-    for(SegmentString::ConstVect::size_type i = 0, n = segStrings->size(); i < n; i++) {
-        SegmentString* seg = (SegmentString*)((*segStrings)[i]);
-        addToMonoChains(seg);
+    for(const SegmentString* css: *segStrings) {
+        SegmentString* ss = const_cast<SegmentString*>(css);
+        addToMonoChains(ss);
     }
     intersectChains();
 }


### PR DESCRIPTION
Overlays start with an MCIndexedNoder, so making that faster should affect all overlays quite a lot. 

Current behaviour heap allocates a lot of wee MonotoneChain objects, and takes copies of vectors of pointers to those objects. With a little change in workflow, we can place the MonotoneChain objects directly into a vector that is stack-allocated in the object that actually uses the MonotoneChains (either the MCIndexNoder or MCIndexSegmentSetMutualIntersector).

For the Vancouver Island watershed union, this change provides a 9% speed-up.