### PR TITLE
CMake: Use GNUInstallDirs to set install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ add_subdirectory(doc)
 # Install and export targets - support 'make install' or equivalent
 #-----------------------------------------------------------------------------
 include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/geos-config-version.cmake"
@@ -310,43 +311,43 @@ configure_file(cmake/geos-config.cmake
 
 install(TARGETS geos geos_cxx_flags
   EXPORT geos-targets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 
 install(TARGETS geos_c
   EXPORT geos-targets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 
 install(EXPORT geos-targets
   FILE geos-targets.cmake
   NAMESPACE GEOS::
-  DESTINATION lib/cmake/GEOS)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GEOS)
 
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/geos-config.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/geos-config-version.cmake"
-  DESTINATION lib/cmake/GEOS)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GEOS)
 install(DIRECTORY
   "${CMAKE_CURRENT_LIST_DIR}/include/geos"
   "${CMAKE_CURRENT_BINARY_DIR}/include/geos"
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   FILES_MATCHING PATTERN "*.h")
 if(NOT DISABLE_GEOS_INLINE)
   install(DIRECTORY
     "${CMAKE_CURRENT_LIST_DIR}/include/geos"
     "${CMAKE_CURRENT_BINARY_DIR}/include/geos"
-    DESTINATION include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.inl")
 endif()
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/capi/geos_c.h"
-  DESTINATION include)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 add_subdirectory(tools)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT MSVC)
 
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/geos-config
-    DESTINATION bin
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
     PERMISSIONS
       OWNER_READ OWNER_EXECUTE
       GROUP_READ GROUP_EXECUTE
@@ -36,7 +36,7 @@ if(NOT MSVC)
 
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/geos.pc
-    DESTINATION lib/pkgconfig)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 endif()
 


### PR DESCRIPTION
This PR is intended to satisfy a request from @sebastic that we

> Make the CMake build adhere to CMAKE_INSTALL_LIBDIR so that multiarch
keeps working, see this recent example:

> https://github.com/openstreetmap/OSM-binary/issues/54

> A quick look at the CMakeLists.txt for GEOS shows it using hardcoded
paths in its install() calls as well.