### PR TITLE
[CMake] Make sure that assert() is disabled for any non-Debug build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,11 @@ else()
     "GEOS: Function inlining DISABLED")
 endif()
 
+# Make sure NDEBUG is defined so that assert() is disabled for
+# any non-debug build. Use a generator expression so that this
+# works with multi-configuration generators.
+target_compile_definitions(geos_cxx_flags INTERFACE $<$<NOT:$<CONFIG:Debug>>:NDEBUG>)
+
 #-----------------------------------------------------------------------------
 # Target geos_cxx_flags: overlayng code
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This is intended to cover the case where a packager builds with an
undefined build type in order to have all compiler flags drawn from the
environment.

From discussion at https://lists.osgeo.org/pipermail/geos-devel/2021-January/010083.html

cc @sebastic