### PR TITLE
Read unsigned integers in WKBReader

### DIFF
--- a/benchmarks/ClassSizes.cpp
+++ b/benchmarks/ClassSizes.cpp
@@ -76,6 +76,6 @@ main()
     check(triangulate::quadedge::QuadEdge);
     check(triangulate::quadedge::QuadEdgeQuartet);
     check(triangulate::quadedge::Vertex);
-    check(int64);
+    check(int64_t);
 }
 

--- a/include/geos/constants.h
+++ b/include/geos/constants.h
@@ -31,9 +31,6 @@ typedef __int64 int64;
 #include <limits>
 #include <cinttypes>
 
-
-typedef int64_t int64;
-
 namespace geos {
 
 constexpr double MATH_PI = 3.14159265358979323846;

--- a/include/geos/io/ByteOrderDataInStream.h
+++ b/include/geos/io/ByteOrderDataInStream.h
@@ -21,6 +21,7 @@
 #define GEOS_IO_BYTEORDERDATAINSTREAM_H
 
 #include <geos/export.h>
+#include <cstdint>
 
 //#include <geos/io/ParseException.h>
 //#include <geos/io/ByteOrderValues.h>
@@ -50,9 +51,11 @@ public:
 
     unsigned char readByte(); // throws ParseException
 
-    int readInt(); // throws ParseException
+    int32_t readInt(); // throws ParseException
 
-    long readLong(); // throws ParseException
+    uint32_t readUnsigned(); // throws ParseException
+
+    int64_t readLong(); // throws ParseException
 
     double readDouble(); // throws ParseException
 

--- a/include/geos/io/ByteOrderDataInStream.inl
+++ b/include/geos/io/ByteOrderDataInStream.inl
@@ -61,7 +61,7 @@ ByteOrderDataInStream::readByte() // throws ParseException
     return ret;
 }
 
-INLINE int
+INLINE int32_t
 ByteOrderDataInStream::readInt()
 {
     if(size() < 4) {
@@ -72,14 +72,25 @@ ByteOrderDataInStream::readInt()
     return ret;
 }
 
-INLINE long
+INLINE uint32_t
+ByteOrderDataInStream::readUnsigned()
+{
+    if(size() < 4) {
+        throw ParseException("Unexpected EOF parsing WKB");
+    }
+    auto ret =  ByteOrderValues::getUnsigned(buf , byteOrder);
+    buf += 4;
+    return ret;
+}
+
+INLINE int64_t
 ByteOrderDataInStream::readLong()
 {
     if(size() < 8) {
         throw ParseException("Unexpected EOF parsing WKB");
     }
 
-    auto ret = static_cast<long>(ByteOrderValues::getLong(buf, byteOrder));
+    auto ret = ByteOrderValues::getLong(buf, byteOrder);
     buf += 8;
     return ret;
 }

--- a/include/geos/io/ByteOrderValues.h
+++ b/include/geos/io/ByteOrderValues.h
@@ -21,7 +21,7 @@
 #define GEOS_IO_BYTEORDERVALUES_H
 
 #include <geos/export.h>
-#include <geos/constants.h>
+#include <cstdint>
 
 namespace geos {
 namespace io {
@@ -43,11 +43,14 @@ public:
         ENDIAN_LITTLE = 1
     };
 
-    static int getInt(const unsigned char* buf, int byteOrder);
-    static void putInt(int intValue, unsigned char* buf, int byteOrder);
+    static int32_t getInt(const unsigned char* buf, int byteOrder);
+    static void putInt(int32_t intValue, unsigned char* buf, int byteOrder);
 
-    static int64 getLong(const unsigned char* buf, int byteOrder);
-    static void putLong(int64 longValue, unsigned char* buf, int byteOrder);
+    static uint32_t getUnsigned(const unsigned char* buf, int byteOrder);
+    static void putUnsigned(uint32_t intValue, unsigned char* buf, int byteOrder);
+
+    static int64_t getLong(const unsigned char* buf, int byteOrder);
+    static void putLong(int64_t longValue, unsigned char* buf, int byteOrder);
 
     static double getDouble(const unsigned char* buf, int byteOrder);
     static void putDouble(double doubleValue, unsigned char* buf, int byteOrder);

--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -156,7 +156,7 @@ private:
 
     std::unique_ptr<geom::GeometryCollection> readGeometryCollection();
 
-    std::unique_ptr<geom::CoordinateSequence> readCoordinateSequence(int); // throws IOException
+    std::unique_ptr<geom::CoordinateSequence> readCoordinateSequence(unsigned int); // throws IOException
 
     void readCoordinate(); // throws IOException
 

--- a/include/geos/precision/CommonBits.h
+++ b/include/geos/precision/CommonBits.h
@@ -16,7 +16,7 @@
 #define GEOS_PRECISION_COMMONBITS_H
 
 #include <geos/export.h>
-#include <geos/constants.h> // for int64
+#include <cstdint>
 
 namespace geos {
 namespace precision { // geos.precision
@@ -38,9 +38,9 @@ private:
 
     int commonMantissaBitsCount;
 
-    int64 commonBits;
+    int64_t commonBits;
 
-    int64 commonSignExp;
+    int64_t commonSignExp;
 
 public:
 
@@ -51,7 +51,7 @@ public:
      * @param num
      * @return the bit pattern for the sign and exponent
      */
-    static int64 signExpBits(int64 num);
+    static int64_t signExpBits(int64_t num);
 
     /** \brief
      * This computes the number of common most-significant
@@ -65,7 +65,7 @@ public:
      * @param num2
      * @return the number of common most-significant mantissa bits
      */
-    static int numCommonMostSigMantissaBits(int64 num1, int64 num2);
+    static int numCommonMostSigMantissaBits(int64_t num1, int64_t num2);
 
     /** \brief
      * Zeroes the lower n bits of a bitstring.
@@ -74,7 +74,7 @@ public:
      * @param nBits the number of bits to zero
      * @return the zeroed bitstring
      */
-    static int64 zeroLowerBits(int64 bits, int nBits);
+    static int64_t zeroLowerBits(int64_t bits, int nBits);
 
     /** \brief
      * Extracts the i'th bit of a bitstring.
@@ -83,7 +83,7 @@ public:
      * @param i the bit to extract
      * @return the value of the extracted bit
      */
-    static int getBit(int64 bits, int i);
+    static int getBit(int64_t bits, int i);
 
     CommonBits();
 

--- a/src/io/ByteOrderValues.cpp
+++ b/src/io/ByteOrderValues.cpp
@@ -31,27 +31,46 @@
 namespace geos {
 namespace io { // geos.io
 
-int
+int32_t
 ByteOrderValues::getInt(const unsigned char* buf, int byteOrder)
 {
     if(byteOrder == ENDIAN_BIG) {
-        return ((int)(buf[0] & 0xff) << 24) |
-               ((int)(buf[1] & 0xff) << 16) |
-               ((int)(buf[2] & 0xff) << 8) |
-               ((int)(buf[3] & 0xff));
+        return ((int32_t)(buf[0] & 0xff) << 24) |
+               ((int32_t)(buf[1] & 0xff) << 16) |
+               ((int32_t)(buf[2] & 0xff) << 8) |
+               ((int32_t)(buf[3] & 0xff));
     }
     else { // ENDIAN_LITTLE
         assert(byteOrder == ENDIAN_LITTLE);
 
-        return ((int)(buf[3] & 0xff) << 24) |
-               ((int)(buf[2] & 0xff) << 16) |
-               ((int)(buf[1] & 0xff) << 8) |
-               ((int)(buf[0] & 0xff));
+        return ((int32_t)(buf[3] & 0xff) << 24) |
+               ((int32_t)(buf[2] & 0xff) << 16) |
+               ((int32_t)(buf[1] & 0xff) << 8) |
+               ((int32_t)(buf[0] & 0xff));
+    }
+}
+
+uint32_t
+ByteOrderValues::getUnsigned(const unsigned char* buf, int byteOrder)
+{
+    if(byteOrder == ENDIAN_BIG) {
+        return ((uint32_t)(buf[0] & 0xff) << 24) |
+               ((uint32_t)(buf[1] & 0xff) << 16) |
+               ((uint32_t)(buf[2] & 0xff) << 8) |
+               ((uint32_t)(buf[3] & 0xff));
+    }
+    else { // ENDIAN_LITTLE
+        assert(byteOrder == ENDIAN_LITTLE);
+
+        return ((uint32_t)(buf[3] & 0xff) << 24) |
+               ((uint32_t)(buf[2] & 0xff) << 16) |
+               ((uint32_t)(buf[1] & 0xff) << 8) |
+               ((uint32_t)(buf[0] & 0xff));
     }
 }
 
 void
-ByteOrderValues::putInt(int intValue, unsigned char* buf, int byteOrder)
+ByteOrderValues::putInt(int32_t intValue, unsigned char* buf, int byteOrder)
 {
     if(byteOrder == ENDIAN_BIG) {
         buf[0] = (unsigned char)(intValue >> 24);
@@ -69,37 +88,56 @@ ByteOrderValues::putInt(int intValue, unsigned char* buf, int byteOrder)
     }
 }
 
-int64
+void
+ByteOrderValues::putUnsigned(uint32_t intValue, unsigned char* buf, int byteOrder)
+{
+    if(byteOrder == ENDIAN_BIG) {
+        buf[0] = (unsigned char)(intValue >> 24);
+        buf[1] = (unsigned char)(intValue >> 16);
+        buf[2] = (unsigned char)(intValue >> 8);
+        buf[3] = (unsigned char) intValue;
+    }
+    else { // ENDIAN_LITTLE
+        assert(byteOrder == ENDIAN_LITTLE);
+
+        buf[3] = (unsigned char)(intValue >> 24);
+        buf[2] = (unsigned char)(intValue >> 16);
+        buf[1] = (unsigned char)(intValue >> 8);
+        buf[0] = (unsigned char) intValue;
+    }
+}
+
+int64_t
 ByteOrderValues::getLong(const unsigned char* buf, int byteOrder)
 {
     if(byteOrder == ENDIAN_BIG) {
         return
-            (int64)(buf[0]) << 56
-            | (int64)(buf[1] & 0xff) << 48
-            | (int64)(buf[2] & 0xff) << 40
-            | (int64)(buf[3] & 0xff) << 32
-            | (int64)(buf[4] & 0xff) << 24
-            | (int64)(buf[5] & 0xff) << 16
-            | (int64)(buf[6] & 0xff) <<  8
-            | (int64)(buf[7] & 0xff);
+            (int64_t)(buf[0]) << 56
+            | (int64_t)(buf[1] & 0xff) << 48
+            | (int64_t)(buf[2] & 0xff) << 40
+            | (int64_t)(buf[3] & 0xff) << 32
+            | (int64_t)(buf[4] & 0xff) << 24
+            | (int64_t)(buf[5] & 0xff) << 16
+            | (int64_t)(buf[6] & 0xff) <<  8
+            | (int64_t)(buf[7] & 0xff);
     }
     else { // ENDIAN_LITTLE
         assert(byteOrder == ENDIAN_LITTLE);
 
         return
-            (int64)(buf[7]) << 56
-            | (int64)(buf[6] & 0xff) << 48
-            | (int64)(buf[5] & 0xff) << 40
-            | (int64)(buf[4] & 0xff) << 32
-            | (int64)(buf[3] & 0xff) << 24
-            | (int64)(buf[2] & 0xff) << 16
-            | (int64)(buf[1] & 0xff) <<  8
-            | (int64)(buf[0] & 0xff);
+            (int64_t)(buf[7]) << 56
+            | (int64_t)(buf[6] & 0xff) << 48
+            | (int64_t)(buf[5] & 0xff) << 40
+            | (int64_t)(buf[4] & 0xff) << 32
+            | (int64_t)(buf[3] & 0xff) << 24
+            | (int64_t)(buf[2] & 0xff) << 16
+            | (int64_t)(buf[1] & 0xff) <<  8
+            | (int64_t)(buf[0] & 0xff);
     }
 }
 
 void
-ByteOrderValues::putLong(int64 longValue, unsigned char* buf, int byteOrder)
+ByteOrderValues::putLong(int64_t longValue, unsigned char* buf, int byteOrder)
 {
     if(byteOrder == ENDIAN_BIG) {
         buf[0] = (unsigned char)(longValue >> 56);
@@ -128,7 +166,7 @@ ByteOrderValues::putLong(int64 longValue, unsigned char* buf, int byteOrder)
 double
 ByteOrderValues::getDouble(const unsigned char* buf, int byteOrder)
 {
-    int64 longValue = getLong(buf, byteOrder);
+    int64_t longValue = getLong(buf, byteOrder);
     double ret;
     std::memcpy(&ret, &longValue, sizeof(double));
     return ret;
@@ -137,7 +175,7 @@ ByteOrderValues::getDouble(const unsigned char* buf, int byteOrder)
 void
 ByteOrderValues::putDouble(double doubleValue, unsigned char* buf, int byteOrder)
 {
-    int64 longValue;
+    int64_t longValue;
     std::memcpy(&longValue, &doubleValue, sizeof(double));
 #if DEBUG_BYTEORDER_VALUES
     std::cout << "ByteOrderValues::putDouble(" << doubleValue <<

--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -67,7 +67,7 @@ WKBReader::printHEX(std::istream& is, std::ostream& os)
 
     char each = 0;
     while(is.read(&each, 1)) {
-        const unsigned char c = each;
+        const unsigned char c = static_cast<unsigned char>(each);
         int low = (c & 0x0F);
         int high = (c >> 4);
         os << hex[high] << hex[low];
@@ -157,7 +157,7 @@ WKBReader::readHEX(std::istream& is)
         const unsigned char result_low = ASCIIHexToUChar(low);
 
         const unsigned char value =
-            static_cast<char>((result_high << 4) + result_low);
+            static_cast<unsigned char>((result_high << 4) + result_low);
 
 #if DEBUG_HEX_READER
         std::size_t << "HEX " << high << low << " -> DEC " << (int)value << std::endl;
@@ -177,7 +177,7 @@ WKBReader::read(std::istream& is)
     auto size = is.tellg();
     is.seekg(0, std::ios::beg);
 
-    std::vector<unsigned char> buf(size);
+    std::vector<unsigned char> buf(static_cast<size_t>(size));
     is.read((char*) buf.data(), size);
 
     return read(buf.data(), buf.size());
@@ -208,13 +208,13 @@ WKBReader::readGeometry()
         dis.setOrder(ByteOrderValues::ENDIAN_BIG);
     }
 
-    int typeInt = dis.readInt();
+    uint32_t typeInt = dis.readUnsigned();
     /* Pick up both ISO and SFSQL geometry type */
-    int geometryType = (typeInt & 0xffff) % 1000;
+    uint32_t geometryType = (typeInt & 0xffff) % 1000;
     /* ISO type range 1000 is Z, 2000 is M, 3000 is ZM */
-    int isoTypeRange = (typeInt & 0xffff) / 1000;
-    int isoHasZ = (isoTypeRange == 1) || (isoTypeRange == 3);
-    int isoHasM = (isoTypeRange == 2) || (isoTypeRange == 3);
+    uint32_t isoTypeRange = (typeInt & 0xffff) / 1000;
+    bool isoHasZ = (isoTypeRange == 1) || (isoTypeRange == 3);
+    bool isoHasM = (isoTypeRange == 2) || (isoTypeRange == 3);
     /* SFSQL high bit flag for Z, next bit for M */
     int sfsqlHasZ = (typeInt & 0x80000000) != 0;
     int sfsqlHasM = (typeInt & 0x40000000) != 0;
@@ -309,7 +309,7 @@ WKBReader::readPoint()
 std::unique_ptr<LineString>
 WKBReader::readLineString()
 {
-    int size = dis.readInt();
+    uint32_t size = dis.readUnsigned();
 #if DEBUG_WKB_READER
     std::size_t << "WKB npoints: " << size << std::endl;
 #endif
@@ -320,7 +320,7 @@ WKBReader::readLineString()
 std::unique_ptr<LinearRing>
 WKBReader::readLinearRing()
 {
-    int size = dis.readInt();
+    uint32_t size = dis.readUnsigned();
 #if DEBUG_WKB_READER
     std::size_t << "WKB npoints: " << size << std::endl;
 #endif
@@ -331,7 +331,7 @@ WKBReader::readLinearRing()
 std::unique_ptr<Polygon>
 WKBReader::readPolygon()
 {
-    int numRings = dis.readInt();
+    uint32_t numRings = dis.readUnsigned();
 
 #if DEBUG_WKB_READER
     std::size_t << "WKB numRings: " << numRings << std::endl;
@@ -348,7 +348,7 @@ WKBReader::readPolygon()
 
     if(numRings > 1) {
         std::vector<std::unique_ptr<LinearRing>> holes(numRings - 1);
-        for(int i = 0; i < numRings - 1; i++) {
+        for(uint32_t i = 0; i < numRings - 1; i++) {
             holes[i] = readLinearRing();
         }
 
@@ -360,10 +360,10 @@ WKBReader::readPolygon()
 std::unique_ptr<MultiPoint>
 WKBReader::readMultiPoint()
 {
-    int numGeoms = dis.readInt();
+    uint32_t numGeoms = dis.readUnsigned();
     std::vector<std::unique_ptr<Geometry>> geoms(numGeoms);
 
-    for(int i = 0; i < numGeoms; i++) {
+    for(uint32_t i = 0; i < numGeoms; i++) {
         geoms[i] = readGeometry();
         if(!dynamic_cast<Point*>(geoms[i].get())) {
             std::stringstream err;
@@ -378,10 +378,10 @@ WKBReader::readMultiPoint()
 std::unique_ptr<MultiLineString>
 WKBReader::readMultiLineString()
 {
-    int numGeoms = dis.readInt();
+    uint32_t numGeoms = dis.readUnsigned();
     std::vector<std::unique_ptr<Geometry>> geoms(numGeoms);
 
-    for(int i = 0; i < numGeoms; i++) {
+    for(uint32_t i = 0; i < numGeoms; i++) {
         geoms[i] = readGeometry();
         if(!dynamic_cast<LineString*>(geoms[i].get())) {
             std::stringstream err;
@@ -396,10 +396,10 @@ WKBReader::readMultiLineString()
 std::unique_ptr<MultiPolygon>
 WKBReader::readMultiPolygon()
 {
-    int numGeoms = dis.readInt();
+    uint32_t numGeoms = dis.readUnsigned();
     std::vector<std::unique_ptr<Geometry>> geoms(numGeoms);
 
-    for(int i = 0; i < numGeoms; i++) {
+    for(uint32_t i = 0; i < numGeoms; i++) {
         geoms[i] = readGeometry();
         if(!dynamic_cast<Polygon*>(geoms[i].get())) {
             std::stringstream err;
@@ -414,10 +414,10 @@ WKBReader::readMultiPolygon()
 std::unique_ptr<GeometryCollection>
 WKBReader::readGeometryCollection()
 {
-    int numGeoms = dis.readInt();
+    uint32_t numGeoms = dis.readUnsigned();
     std::vector<std::unique_ptr<Geometry>> geoms(numGeoms);
 
-    for(int i = 0; i < numGeoms; i++) {
+    for(uint32_t i = 0; i < numGeoms; i++) {
         geoms[i] = readGeometry();
     }
 
@@ -425,14 +425,14 @@ WKBReader::readGeometryCollection()
 }
 
 std::unique_ptr<CoordinateSequence>
-WKBReader::readCoordinateSequence(int size)
+WKBReader::readCoordinateSequence(uint32_t size)
 {
     unsigned int targetDim = 2 + (hasZ ? 1 : 0);
     auto seq = factory.getCoordinateSequenceFactory()->create(size, targetDim);
     if(targetDim > inputDimension) {
         targetDim = inputDimension;
     }
-    for(int i = 0; i < size; i++) {
+    for(uint32_t i = 0; i < size; i++) {
         readCoordinate();
         for(unsigned int j = 0; j < targetDim; j++) {
             seq->setOrdinate(i, j, ordValues[j]);

--- a/src/precision/CommonBits.cpp
+++ b/src/precision/CommonBits.cpp
@@ -13,22 +13,21 @@
  *
  **********************************************************************/
 
-#include <geos/constants.h> // for int64
 #include <geos/precision/CommonBits.h>
 
 namespace geos {
 namespace precision { // geos.precision
 
 /*static public*/
-int64
-CommonBits::signExpBits(int64 num)
+int64_t
+CommonBits::signExpBits(int64_t num)
 {
     return num >> 52;
 }
 
 /*static public*/
 int
-CommonBits::numCommonMostSigMantissaBits(int64 num1, int64 num2)
+CommonBits::numCommonMostSigMantissaBits(int64_t num1, int64_t num2)
 {
     int count = 0;
     for(int i = 52; i >= 0; i--) {
@@ -41,22 +40,22 @@ CommonBits::numCommonMostSigMantissaBits(int64 num1, int64 num2)
 }
 
 /*static public*/
-int64
-CommonBits::zeroLowerBits(int64 bits, int nBits)
+int64_t
+CommonBits::zeroLowerBits(int64_t bits, int nBits)
 {
     if (nBits >= 64 || nBits < 0) return 0;
     const uint64_t bits_ = static_cast<uint64_t>(bits);
     const uint64_t invMask = (1ull << nBits) - 1;
     const uint64_t mask = ~ invMask;
     const uint64_t zeroed = bits_ & mask;
-    return static_cast<int64>(zeroed);
+    return static_cast<int64_t>(zeroed);
 }
 
 /*static public*/
 int
-CommonBits::getBit(int64 bits, int i)
+CommonBits::getBit(int64_t bits, int i)
 {
-    int64 mask = (1ull << i);
+    int64_t mask = (1ull << i);
     return (bits & mask) != 0 ? 1 : 0;
 }
 
@@ -72,14 +71,14 @@ CommonBits::CommonBits()
 void
 CommonBits::add(double num)
 {
-    int64 numBits = (int64)num;
+    int64_t numBits = (int64_t) num;
     if(isFirst) {
         commonBits = numBits;
         commonSignExp = signExpBits(commonBits);
         isFirst = false;
         return;
     }
-    int64 numSignExp = signExpBits(numBits);
+    int64_t numSignExp = signExpBits(numBits);
     if(numSignExp != commonSignExp) {
         commonBits = 0;
         return;

--- a/tests/unit/io/ByteOrderValuesTest.cpp
+++ b/tests/unit/io/ByteOrderValuesTest.cpp
@@ -146,6 +146,37 @@ void object::test<3>
     ensure_equals("getLong little endian", out, in);
 }
 
+// 4 - Read/write an unsigned int
+template<>
+template<>
+void object::test<4>()
+{
+    using geos::io::ByteOrderValues;
+
+    unsigned char buf[4];
+    uint32_t in = 3210000003;
+    uint32_t out;
+
+    ByteOrderValues::putUnsigned(in, buf, ByteOrderValues::ENDIAN_BIG);
+    ensure("putUnsigned big endian[0]", buf[0] == 0xbf);
+    ensure("putUnsigned big endian[1]", buf[1] == 0x54);
+    ensure("putUnsigned big endian[2]", buf[2] == 0xb6);
+    ensure("putUnsigned big endian[3]", buf[3] == 0x83);
+
+    out = ByteOrderValues::getUnsigned(buf,
+                                  geos::io::ByteOrderValues::ENDIAN_BIG);
+    ensure_equals("getInt big endian", out, in);
+
+    ByteOrderValues::putUnsigned(in, buf, geos::io::ByteOrderValues::ENDIAN_LITTLE);
+    ensure("putUnsigned little endian[0]", buf[0] == 0x83);
+    ensure("putUnsigned little endian[1]", buf[1] == 0xb6);
+    ensure("putUnsigned little endian[2]", buf[2] == 0x54);
+    ensure("pUtnsigned little endian[3]", buf[3] == 0xbf);
+
+    out = ByteOrderValues::getUnsigned(buf,
+                                  ByteOrderValues::ENDIAN_LITTLE);
+    ensure_equals("getInt little endian", out, in);
+}
 
 } // namespace tut
 

--- a/tests/unit/precision/CommonBitsTest.cpp
+++ b/tests/unit/precision/CommonBitsTest.cpp
@@ -24,7 +24,7 @@ template<>
 void object::test<1>
 ()
 {
-    constexpr int64 val = 0ull;
+    constexpr int64_t val = 0ull;
     for(int i = 0; i < 64; i++) {
         ensure_equals(CommonBits::getBit(val, i), 0);
     }
@@ -36,7 +36,7 @@ template<>
 void object::test<2>
 ()
 {
-    constexpr int64 val = 0xffffffffffffffffull;
+    constexpr int64_t val = 0xffffffffffffffffull;
     for(int i = 0; i < 64; i++) {
         ensure_equals(CommonBits::getBit(val, i), 1);
     }
@@ -48,7 +48,7 @@ template<>
 void object::test<3>
 ()
 {
-    constexpr int64 val = 0xffffffff00000000ull;
+    constexpr int64_t val = 0xffffffff00000000ull;
     ensure_equals(CommonBits::getBit(val, 0), 0);
     ensure_equals(CommonBits::getBit(val, 63), 1);
 }
@@ -58,7 +58,7 @@ template<>
 template<>
 void object::test<4>()
 {
-    constexpr int64 val = static_cast<int64>(0xffffffffffffffffull);
+    constexpr int64_t val = static_cast<int64_t>(0xffffffffffffffffull);
     ensure_equals(sizeof(val), 8u);
 
     ensure_equals(CommonBits::zeroLowerBits(val, -1), 0);


### PR DESCRIPTION
OGC WKB spec specifies that the integers are unsigned. Use of signed
integers is probably a carryover from Java, which does not have unsigned
integers. Clear type conversion warnings in WKBReader and use C++11
int64_t type.