### PR TITLE
Exclude vendored libs from GEOS compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-arcs -ftest-coverage")
 # Target geos: C++ API library
 #-----------------------------------------------------------------------------
 add_library(geos "")
-target_link_libraries(geos PUBLIC geos_cxx_flags)
+target_link_libraries(geos PUBLIC geos_cxx_flags PRIVATE ryu)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,8 @@ set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-arcs -ftest-coverage")
 #-----------------------------------------------------------------------------
 add_library(geos "")
 target_link_libraries(geos PUBLIC geos_cxx_flags PRIVATE $<BUILD_INTERFACE:ryu>)
+# ryu is an object library, nothing is actually being linked here. The BUILD_INTERFACE
+# switch was necessary to build on AppVeyor (CMake 3.16.2) but not locally (CMake 3.16.3)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-arcs -ftest-coverage")
 # Target geos: C++ API library
 #-----------------------------------------------------------------------------
 add_library(geos "")
-target_link_libraries(geos PUBLIC geos_cxx_flags PRIVATE ryu)
+target_link_libraries(geos PUBLIC geos_cxx_flags PRIVATE $<BUILD_INTERFACE:ryu>)
 add_subdirectory(include)
 add_subdirectory(src)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,18 +60,16 @@ init:
 
 before_build:
   - ps: 'Write-Host "Running $env:BUILDER with $env:GENERATOR" -ForegroundColor Magenta'
-  - if "%BUILDER%"=="CMake" cmake.exe -G "%GENERATOR%" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=%CONFIGURATION% %APPVEYOR_BUILD_FOLDER%
-  - if "%BUILDER%"=="NMake" .\autogen.bat
+  - cmake --version
+  - cmake -G "%GENERATOR%" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=%CONFIGURATION% %APPVEYOR_BUILD_FOLDER%
 
 build_script:
   - ps: 'Write-Host "Running $env:BUILDER:" -ForegroundColor Magenta'
-  - if "%BUILDER%"=="CMake" cmake --build . --config %CONFIGURATION%
-  - if "%BUILDER%"=="NMake" nmake /f makefile.vc
+  - cmake --build . --config %CONFIGURATION%
 
 test_script:
   - ps: 'Write-Host "Running tests:" -ForegroundColor Magenta'
-  - if "%BUILDER%"=="CMake" ctest --output-on-failure -C %CONFIGURATION%
-  - if "%BUILDER%"=="NMake" echo *** NMake does NOT build tests ***
+  - ctest --output-on-failure -C %CONFIGURATION%
 
 # If you need to debug AppVeyor session (https://www.appveyor.com/docs/how-to/rdp-to-build-worker), then:
 # 1. Uncomment the on_finish section below:

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -9,7 +9,9 @@
 # See the COPYING file for more information.
 ################################################################################
 file(GLOB_RECURSE _sources ${CMAKE_CURRENT_LIST_DIR}/*.c  CONFIGURE_DEPEND)
-target_sources(geos PRIVATE ${_sources})
+add_library(ryu OBJECT ${_sources})
+target_include_directories(ryu PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+set_target_properties(ryu PROPERTIES POSITION_INDEPENDENT_CODE ON)
 unset(_sources)
 
 target_include_directories(geos

--- a/tests/xmltester/CMakeLists.txt
+++ b/tests/xmltester/CMakeLists.txt
@@ -13,16 +13,24 @@
 add_executable(test_simplewkttester SimpleWKTTester.cpp)
 target_link_libraries(test_simplewkttester PRIVATE geos)
 
+# Setup tinyxml as a separate library so we can avoid picking up GEOS compile flags
+add_library(tinyxml2 OBJECT
+        tinyxml2/tinyxml2.h
+        tinyxml2/tinyxml2.cpp)
+target_compile_options(
+        tinyxml2 PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-conversion>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-conversion>
+)
+
 add_executable(test_xmltester
     XMLTester.cpp
     BufferResultMatcher.cpp
-    SingleSidedBufferResultMatcher.cpp
-    tinyxml2/tinyxml2.h
-    tinyxml2/tinyxml2.cpp)
-target_link_libraries(test_xmltester PRIVATE geos)
+    SingleSidedBufferResultMatcher.cpp)
+target_link_libraries(test_xmltester PRIVATE geos tinyxml2)
 target_include_directories(test_xmltester
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/tinyxml)
+  SYSTEM PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/tinyxml2)
 
 # Scan the directories of XML tests and create a test for each.
 foreach(_testdir general issue misc robust validate)

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -18,7 +18,7 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/PrecisionModel.h>
 #include <geos/profiler.h>
-#include "tinyxml2/tinyxml2.h"
+#include <tinyxml2.h>
 
 using namespace geos;
 


### PR DESCRIPTION
This PR is an attempt to stop the propagation of GEOS diagnostic flags to vendored libraries (tinyxml, ryu). The vendored code is moved into `OBJECT` libraries that are treated as separate entities in CMake but end up rolled into the consuming targets (`ryu` sources end up in `libgeos`; there is no `libryu` emitted.) 