### PR TITLE
Make polygon comparison compare shell and holes

### DIFF
--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -134,8 +134,6 @@ public:
 
     std::unique_ptr<Geometry> reverse() const override;
 
-    int compareToSameClass(const Geometry* p) const override; //was protected
-
     const Coordinate* getCoordinate() const override;
 
     double getArea() const override;
@@ -149,6 +147,8 @@ protected:
 
 
     Polygon(const Polygon& p);
+
+    int compareToSameClass(const Geometry* p) const override;
 
     /**
      * Constructs a <code>Polygon</code> with the given exterior

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -334,8 +334,8 @@ Polygon::compareToSameClass(const Geometry* g) const
         return shellComp;
     }
 
-    int nHole1 = getNumInteriorRing();
-    int nHole2 = p->getNumInteriorRing();
+    size_t nHole1 = getNumInteriorRing();
+    size_t nHole2 = p->getNumInteriorRing();
     if (nHole1 < nHole2) {
         return -1;
     }
@@ -343,12 +343,10 @@ Polygon::compareToSameClass(const Geometry* g) const
         return 1;
     }
 
-    const LinearRing *lr1, *lr2;
     int holeComp = 0;
-    for (int i=0; i < nHole1; i++) {
-        lr1 = dynamic_cast<const LinearRing*>(getInteriorRingN(i));
-        lr2 = dynamic_cast<const LinearRing*>(p->getInteriorRingN(i));
-        holeComp = lr1->compareToSameClass(lr2);
+    for (size_t i=0; i < nHole1; i++) {
+        const LinearRing *lr = p->getInteriorRingN(i);
+        holeComp = getInteriorRingN(i)->compareToSameClass(lr);
         if (holeComp != 0) {
             return holeComp;
         }

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -329,7 +329,32 @@ int
 Polygon::compareToSameClass(const Geometry* g) const
 {
     const Polygon* p = dynamic_cast<const Polygon*>(g);
-    return shell->compareToSameClass(p->shell.get());
+    int shellComp = shell->compareToSameClass(p->shell.get());
+    if (shellComp != 0) {
+        return shellComp;
+    }
+
+    int nHole1 = getNumInteriorRing();
+    int nHole2 = p->getNumInteriorRing();
+    if (nHole1 < nHole2) {
+        return -1;
+    }
+    if (nHole1 > nHole2) {
+        return 1;
+    }
+
+    const LinearRing *lr1, *lr2;
+    int holeComp = 0;
+    for (int i=0; i < nHole1; i++) {
+        lr1 = dynamic_cast<const LinearRing*>(getInteriorRingN(i));
+        lr2 = dynamic_cast<const LinearRing*>(p->getInteriorRingN(i));
+        holeComp = lr1->compareToSameClass(lr2);
+        if (holeComp != 0) {
+            return holeComp;
+        }
+    }
+
+    return 0;
 }
 
 /*

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -611,4 +611,39 @@ void object::test<42>
     ensure(!poly_->isDimensionStrict(geos::geom::Dimension::L));
 }
 
+
+// test compareToSameClass for polygons including holes
+template<>
+template<>
+void object::test<43>
+()
+{
+    auto geo = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))");
+    ensure(geo != nullptr);
+
+    PolygonPtr poly = dynamic_cast<PolygonPtr>(geo.get());
+    ensure(poly != nullptr);
+
+    auto geo2 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 2 3, 3 3, 3 2, 2 2))");
+    ensure(geo2 != nullptr);
+
+    PolygonPtr poly2 = dynamic_cast<PolygonPtr>(geo2.get());
+    ensure(poly2 != nullptr);
+
+    auto geo3 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
+    ensure(geo3 != nullptr);
+
+    PolygonPtr poly3 = dynamic_cast<PolygonPtr>(geo3.get());
+    ensure(poly3 != nullptr);
+
+    // polygon should equal self
+    ensure(poly->compareToSameClass(poly) == 0);
+
+    // polygons with different holes but same shell are not equal
+    ensure(poly->compareToSameClass(poly2) != 0);
+
+    // polygons with and without holes are not equal
+    ensure(poly->compareToSameClass(poly3) != 0);
+}
+
 } // namespace tut

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -619,31 +619,18 @@ void object::test<43>
 ()
 {
     auto geo = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))");
-    ensure(geo != nullptr);
-
     PolygonPtr poly = dynamic_cast<PolygonPtr>(geo.get());
-    ensure(poly != nullptr);
 
-    auto geo2 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 2 3, 3 3, 3 2, 2 2))");
-    ensure(geo2 != nullptr);
+    ensure("polygon should equal self",
+        poly->compareToSameClass(poly) == 0);
 
-    PolygonPtr poly2 = dynamic_cast<PolygonPtr>(geo2.get());
-    ensure(poly2 != nullptr);
+    auto poly2 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 2 3, 3 3, 3 2, 2 2))");
+    ensure("polygons with different holes but same shell are not equal",
+        poly->compareToSameClass(poly2.get()) != 0);
 
-    auto geo3 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
-    ensure(geo3 != nullptr);
-
-    PolygonPtr poly3 = dynamic_cast<PolygonPtr>(geo3.get());
-    ensure(poly3 != nullptr);
-
-    // polygon should equal self
-    ensure(poly->compareToSameClass(poly) == 0);
-
-    // polygons with different holes but same shell are not equal
-    ensure(poly->compareToSameClass(poly2) != 0);
-
-    // polygons with and without holes are not equal
-    ensure(poly->compareToSameClass(poly3) != 0);
+    auto poly3 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
+    ensure("polygons with and without holes are not equal",
+        poly->compareToSameClass(poly3.get()) != 0);
 }
 
 } // namespace tut

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -618,19 +618,18 @@ template<>
 void object::test<43>
 ()
 {
-    auto geo = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))");
-    PolygonPtr poly = dynamic_cast<PolygonPtr>(geo.get());
+    auto poly = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))");
 
     ensure("polygon should equal self",
-        poly->compareToSameClass(poly) == 0);
+        poly->compareTo(poly.get()) == 0);
 
     auto poly2 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 2 3, 3 3, 3 2, 2 2))");
     ensure("polygons with different holes but same shell are not equal",
-        poly->compareToSameClass(poly2.get()) != 0);
+        poly->compareTo(poly2.get()) != 0);
 
     auto poly3 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
     ensure("polygons with and without holes are not equal",
-        poly->compareToSameClass(poly3.get()) != 0);
+        poly->compareTo(poly3.get()) != 0);
 }
 
 } // namespace tut


### PR DESCRIPTION
This PR makes sure that `Polygon::compareToSameClass`` compares holes as well as outer shell and adds a 
 corresponding test.

Previously, the comparison was only based on comparing the outer shell.

Resolves [#1099](https://trac.osgeo.org/geos/ticket/1099)

This was adapted from [JTS](https://github.com/locationtech/jts/blob/jts-1.18.0/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java#L375-L396).  Note that the first variant of JTS `compareToSameClass` has the same issue as was present here.

I adapted another test in that unit test file to create the tests here; it was not obvious how to reduce the boilerplate in this case (i.e., simpler ways to instantiate from WKT here).