### PR TITLE
Avoid out-of-memory for malformed WKB

### DIFF
--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -158,7 +158,7 @@ private:
 
     std::unique_ptr<geom::CoordinateSequence> readCoordinateSequence(unsigned int); // throws IOException
 
-    void minMemSize(int geomType, uint32_t size);
+    void minMemSize(int geomType, uint64_t size);
 
     void readCoordinate(); // throws IOException
 

--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -158,6 +158,8 @@ private:
 
     std::unique_ptr<geom::CoordinateSequence> readCoordinateSequence(unsigned int); // throws IOException
 
+    void minMemSize(int geomType, uint32_t size);
+
     void readCoordinate(); // throws IOException
 
     // Declare type as noncopyable

--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -171,36 +171,35 @@ WKBReader::readHEX(std::istream& is)
 }
 
 void
-WKBReader::minMemSize(int geomType, uint32_t size)
+WKBReader::minMemSize(int geomType, uint64_t size)
 {
-    uint64_t size64 = (std::size_t)size;
     uint64_t minMemSize = 0;
-    const uint64_t minCoordSize = 2 * sizeof(double);
-    const uint64_t minPtSize = (1+4) + minCoordSize;
-    const uint64_t minLineSize = (1+4+4); // empty line
-    const uint64_t minRingSize = 4; // empty ring
-    const uint64_t minPolySize = (1+4+4); // empty polygon
-    const uint64_t minGeomSize = minLineSize;
+    constexpr uint64_t minCoordSize = 2 * sizeof(double);
+    constexpr uint64_t minPtSize = (1+4) + minCoordSize;
+    constexpr uint64_t minLineSize = (1+4+4); // empty line
+    constexpr uint64_t minRingSize = 4; // empty ring
+    constexpr uint64_t minPolySize = (1+4+4); // empty polygon
+    constexpr uint64_t minGeomSize = minLineSize;
 
     switch(geomType) {
         case GEOS_LINESTRING:
         case GEOS_LINEARRING:
-            minMemSize = size64 * minCoordSize;
+            minMemSize = size * minCoordSize;
             break;
         case GEOS_POLYGON:
-            minMemSize = size64 * minRingSize;
+            minMemSize = size * minRingSize;
             break;
         case GEOS_MULTIPOINT:
-            minMemSize = size64 * minPtSize;
+            minMemSize = size * minPtSize;
             break;
         case GEOS_MULTILINESTRING:
-            minMemSize = size64 * minLineSize;
+            minMemSize = size * minLineSize;
             break;
         case GEOS_MULTIPOLYGON:
-            minMemSize = size64 * minPolySize;
+            minMemSize = size * minPolySize;
             break;
         case GEOS_GEOMETRYCOLLECTION:
-            minMemSize = size64 * minGeomSize;
+            minMemSize = size * minGeomSize;
             break;
     }
 

--- a/tests/unit/io/WKBReaderTest.cpp
+++ b/tests/unit/io/WKBReaderTest.cpp
@@ -59,7 +59,7 @@ struct test_wkbreader_data {
         std::stringstream hexin(hexwkb);
         try {
             GeomPtr g(wkbreader.readHEX(hexin));
-            ensure("Parse did not fail", !g);
+            fail();
         }
         catch(const geos::util::GEOSException& ex) {
             // std::cout << e.what() << std::endl;

--- a/tests/unit/io/WKBReaderTest.cpp
+++ b/tests/unit/io/WKBReaderTest.cpp
@@ -52,6 +52,23 @@ struct test_wkbreader_data {
         wktreader(gf.get())
     {}
 
+    void
+    testParseError(const std::string& hexwkb, const std::string& errstr)
+    {
+        std::string exstr;
+        std::stringstream hexin(hexwkb);
+        try {
+            GeomPtr g(wkbreader.readHEX(hexin));
+            ensure("Parse did not fail", !g);
+        }
+        catch(const geos::util::GEOSException& ex) {
+            // std::cout << e.what() << std::endl;
+            exstr = ex.what();
+            ensure("Missing expected error", !exstr.empty());
+            ensure_equals("Parse error incorrect", exstr, errstr);
+        }
+    }
+
     GeomPtr
     readHex(const std::string& hexwkb)
     {
@@ -572,6 +589,78 @@ void object::test<24>
 
 }
 
+// Malformed WKB wrong coordinate count
+template<>
+template<>
+void object::test<25>
+()
+{
+    testParseError(
+        "010200000003000000000000000000F03F000000000000004000000000000008400000000000001040",
+        "ParseException: Input buffer is smaller than requested object size"
+    );
+}
+
+// Malformed WKB with very large coordinate count
+template<>
+template<>
+void object::test<26>
+()
+{
+    testParseError(
+        "010200000000000080000000000000F03F000000000000004000000000000008400000000000001040",
+        "ParseException: Input buffer is smaller than requested object size"
+    );
+}
+
+
+// Malformed WKB polygon with very large ring count
+template<>
+template<>
+void object::test<27>
+()
+{
+    testParseError(
+        "01030000000000008001000000000000000000F03F000000000000004000000000000008400000000000001040",
+        "ParseException: Input buffer is smaller than requested object size"
+    );
+}
+
+// Malformed WKB polygon with slightly large ring count
+template<>
+template<>
+void object::test<28>
+()
+{
+    testParseError(
+        "01030000000200000000000000",
+        "ParseException: Input buffer is smaller than requested object size"
+    );
+}
+
+// Malformed WKB polygon with more buffer than data
+template<>
+template<>
+void object::test<29>
+()
+{
+    testInput(
+        "01030000000100000000000000000000000000F03F000000000000004000000000000008400000000000001040",
+        "010300000000000000"
+    );
+}
+
+// Malformed WKB collection with overly large geom count
+template<>
+template<>
+void object::test<30>
+()
+{
+    testParseError(
+        "010700000009000000010100000000000000000010400000000000001040",
+        "ParseException: Input buffer is smaller than requested object size"
+    );
+}
 
 } // namespace tut
 


### PR DESCRIPTION
By simply creating a WKB input with a vertex count/ring count/geometry count that is very very large, a user can get GEOS to allocate a very large vector in advance of actually parsing the WKB to fill in that vector.

Instead, we do a quick bounds check, comparing the number of objects requested and the minimum size those objects could be with the amount of space left in the input stream, and raising an exception if the minimum possible request size exceeds the amount of input data.