### PR TITLE
TST: Expand XML densify tests, reduce boilerplate in C API densify tests

### DIFF
--- a/tests/unit/capi/GEOSDensifyTest.cpp
+++ b/tests/unit/capi/GEOSDensifyTest.cpp
@@ -1,5 +1,5 @@
 //
-// Test Suite for C-API GEOSBuffer and GEOSBufferWithStyle
+// Test Suite for C-API GEOSDensify
 
 #include <tut/tut.hpp>
 // geos
@@ -7,38 +7,34 @@
 
 #include "capi_test_utils.h"
 
-
 namespace tut {
 //
 // Test Group
 //
 
-// Common data used in test cases.
-struct test_capigeosdensify_data : public capitest::utility {
-    GEOSGeometry* geom1_;
-    GEOSGeometry* geom2_;
-    GEOSWKTWriter* w_;
-    char* wkt_;
-
-    test_capigeosdensify_data()
-        : geom1_(nullptr), geom2_(nullptr), w_(nullptr)
+struct test_capigeosdensify_data : public capitest::utility
+{
+    void testDensify(const std::string &wkt_input,
+                            const std::string &wkt_output,
+                            double tolerance)
     {
-        initGEOS(notice, notice);
-        w_ = GEOSWKTWriter_create();
-        GEOSWKTWriter_setTrim(w_, 1);
-    }
+        int srid = 3857;
 
-    ~test_capigeosdensify_data()
-    {
-        GEOSGeom_destroy(geom1_);
-        GEOSGeom_destroy(geom2_);
-        GEOSWKTWriter_destroy(w_);
-        geom1_ = nullptr;
-        geom2_ = nullptr;
-        wkt_ = nullptr;
-        finishGEOS();
-    }
+        GEOSGeometry *input = GEOSGeomFromWKT(wkt_input.c_str());
+        GEOSSetSRID(input, srid);
 
+        GEOSGeometry *expected = GEOSGeomFromWKT(wkt_output.c_str());
+
+        GEOSGeometry *result = GEOSDensify(input, tolerance);
+        ensure("result not NULL", result != nullptr);
+
+        ensure_geometry_equals(result, expected);
+        ensure_equals("result SRID == expected SRID", GEOSGetSRID(result), srid);
+
+        GEOSGeom_destroy(input);
+        GEOSGeom_destroy(expected);
+        GEOSGeom_destroy(result);
+    }
 };
 
 typedef test_group<test_capigeosdensify_data> group;
@@ -50,165 +46,122 @@ group test_capigeosdensify_group("capi::GEOSDensify");
 // Test Cases
 //
 
-// Densify with a tolerance slightly larger than length of all edges.
+// Densify with a tolerance greater than or equal to length of all edges.
 // Result should match inputs.
-template<>
-template<>
+template <>
+template <>
 void object::test<1>()
 {
-    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 10.0);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(geom2_, geom1_);
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+        10.0
+    );
 }
 
-
 // Densify with a tolerance that evenly subdivides all outer and inner edges.
-template<>
-template<>
+template <>
+template <>
 void object::test<2>()
 {
-    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 7, 7 7, 7 1, 1 1))");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 5.0);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(
-        geom2_,
-        "POLYGON ((0 0, 5 0, 10 0, 10 5, 10 10, 5 10, 0 10, 0 5, 0 0), (1 1, 1 4, 1 7, 4 7, 7 7, 7 4, 7 1, 4 1, 1 1))");
-
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 7, 7 7, 7 1, 1 1))",
+        "POLYGON ((0 0, 5 0, 10 0, 10 5, 10 10, 5 10, 0 10, 0 5, 0 0), (1 1, 1 4, 1 7, 4 7, 7 7, 7 4, 7 1, 4 1, 1 1))",
+        5.0
+    );
 }
 
 // Densify a LINESTRING
-template<>
-template<>
+template <>
+template <>
 void object::test<3>()
 {
-    geom1_ = GEOSGeomFromWKT("LINESTRING (0 0, 0 6 )");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 3);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(
-        geom2_,
-        "LINESTRING (0 0, 0 3, 0 6)");
-
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "LINESTRING (0 0, 0 6 )",
+        "LINESTRING (0 0, 0 3, 0 6)",
+        3.0
+    );
 }
 
 // Ensure that tolerance results in the right number of subdivisions
 // ceil(6 / 2.9999999) = 3 new segments; 2 new vertices
-template<>
-template<>
+template <>
+template <>
 void object::test<4>()
 {
-    geom1_ = GEOSGeomFromWKT("LINESTRING (0 0, 0 6 )");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 2.9999999);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(
-        geom2_,
-        "LINESTRING (0 0, 0 2, 0 4, 0 6)");
-
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "LINESTRING (0 0, 0 6 )",
+        "LINESTRING (0 0, 0 2, 0 4, 0 6)",
+        2.9999999
+    );
 }
 
-
 // Densify a LINEARRING
-template<>
-template<>
+template <>
+template <>
 void object::test<5>()
 {
-    geom1_ = GEOSGeomFromWKT("LINEARRING (0 0, 0 6, 6 6, 0 0)");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 3.0);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(
-        geom2_,
-        "LINEARRING (0 0, 0 3, 0 6, 3 6, 6 6, 4 4, 2 2, 0 0)");
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "LINEARRING (0 0, 0 6, 6 6, 0 0)",
+        "LINEARRING (0 0, 0 3, 0 6, 3 6, 6 6, 4 4, 2 2, 0 0)",
+        3.0
+    );
 }
 
 // Densify a POINT
 // Results should match inputs
-template<>
-template<>
+template <>
+template <>
 void object::test<6>()
 {
-    geom1_ = GEOSGeomFromWKT("POINT (0 0)");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 3.0);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(geom2_, geom1_);
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "POINT (0 0)",
+        "POINT (0 0)",
+        3.0
+    );
 }
 
 // Densify a MULTIPOINT
 // Results should match inputs
-template<>
-template<>
+template <>
+template <>
 void object::test<7>()
 {
-    geom1_ = GEOSGeomFromWKT("MULTIPOINT ((0 0), (10 10))");
-    ensure(geom1_ != nullptr);
-    GEOSSetSRID(geom1_, 3857);
-
-    geom2_ = GEOSDensify(geom1_, 3.0);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(geom2_, geom1_);
-    ensure_equals("result SRID == expected SRID", GEOSGetSRID(geom2_), 3857);
+    testDensify(
+        "MULTIPOINT ((0 0), (10 10))",
+        "MULTIPOINT ((0 0), (10 10))",
+        3.0
+    );
 }
 
 // Densify an empty polygon
 // Results should match inputs
-template<>
-template<>
+template <>
+template <>
 void object::test<8>()
 {
-    geom1_ = GEOSGeomFromWKT("POLYGON EMPTY");
-    ensure(geom1_ != nullptr);
-
-    geom2_ = GEOSDensify(geom1_, 3.0);
-
-    ensure("result not null", geom2_ != nullptr);
-    ensure_geometry_equals(geom2_, geom1_);
+    testDensify(
+        "POLYGON EMPTY",
+        "POLYGON EMPTY",
+        3.0
+    );
 }
 
 // Densify with an invalid tolerances should fail
 // Note: this raises "IllegalArgumentException: Tolerance must be positive:
-template<>
-template<>
+template <>
+template <>
 void object::test<9>()
 {
-    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
-    ensure(geom1_ != nullptr);
+    GEOSGeometry *input = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
 
-    geom2_ = GEOSDensify(geom1_, 0.0);
-    ensure(geom2_ == nullptr);
+    GEOSGeometry *result = GEOSDensify(input, 0.0);
+    ensure("result expected to be NULL", result == nullptr);
 
-    geom2_ = GEOSDensify(geom1_, -1.0);
-    ensure(geom2_ == nullptr);
+    result = GEOSDensify(input, -1.0);
+    ensure("result expected to be NULL", result == nullptr);
+
+    GEOSGeom_destroy(input);
 }
 
 } // namespace tut
-

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -1305,7 +1305,6 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
 
             actual_result = printGeom(gRealRes.get());
             expected_result = printGeom(gRes.get());
-
         }
 
 

--- a/tests/xmltester/tests/general/TestDensify.xml
+++ b/tests/xmltester/tests/general/TestDensify.xml
@@ -1,65 +1,316 @@
 <run>
   <precisionModel type="FLOATING" />
 
-<case>
-  <desc>P - single point</desc>
-  <a>    POINT (10 10) </a>
-<test><op name="densify" arg1='A'  arg2='10.0'>  POINT (10 10)	</op></test>
-</case>
+  <case>
+    <desc>P - single point</desc>
+    <a>
+POINT (10 10)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+POINT (10 10)
+      </op>
+    </test>
+  </case>
 
-<case>
-  <desc>mP - multi point</desc>
-  <a>    MULTIPOINT ((10 10), (20 10)) </a>
-<test><op name="densify" arg1='A'  arg2='10.0'>  MULTIPOINT ((10 10), (20 10))	</op></test>
-</case>
+  <case>
+    <desc>P - empty point</desc>
+    <a>
+POINT EMPTY
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+POINT EMPTY
+      </op>
+    </test>
+  </case>
 
-<case>
-  <desc>L - single segment</desc>
-  <a>    LINESTRING(10 10, 100 10)  </a>
-<test><op name="densify" arg1='A'  arg2='10.0'>
+  <case>
+    <desc>mP - multi point</desc>
+    <a>
+MULTIPOINT ((10 10), (20 10))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+MULTIPOINT ((10 10), (20 10))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>L - empty line</desc>
+    <a>
+LINESTRING EMPTY
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+LINESTRING EMPTY
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>L - single segment with length equal to densify tolerance</desc>
+    <a>
+LINESTRING(10 10, 20 10)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+LINESTRING(10 10, 20 10)
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>L - single segment with length less than densify tolerance</desc>
+    <a>
+LINESTRING(10 10, 15 10)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+LINESTRING(10 10, 15 10)
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>L - single segment with length greater than densify tolerance</desc>
+    <a>LINESTRING(10 10, 100 10)</a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
 	LINESTRING (10 10, 20 10, 30 10, 40 10, 50 10, 60 10, 70 10, 80 10, 90 10, 100 10)
-	</op></test>
-</case>
+      </op>
+    </test>
+  </case>
 
-<case>
-  <desc>mL - multiple lines</desc>
-  <a>    MULTILINESTRING ((10 10, 30 30, 50 10, 70 30), (10 50, 40 50, 70 50))  </a>
-<test><op name="densify" arg1='A'  arg2='8.0'>
-	MULTILINESTRING ((10 10, 15 15, 20 20, 25 25, 30 30, 35 25, 40 20, 45 15, 50 10, 55 15, 60 20, 65 25, 70 30),
-  (10 50, 17.5 50, 25 50, 32.5 50, 40 50, 47.5 50, 55 50, 62.5 50, 70 50))
-	</op></test>
-</case>
+  <case>
+    <desc>L - single segment with non-integer tolerance, result is evenly subdivided</desc>
+    <a>LINESTRING (0 0, 0 6 )</a>
+    <test>
+      <op name="densify" arg1='A' arg2='2.999999'>
+LINESTRING (0 0, 0 2, 0 4, 0 6)
+      </op>
+    </test>
+  </case>
 
-<case>
-  <desc>A - simple polygon</desc>
-  <a>    POLYGON ((0 0, 0 20, 20 20, 20 0, 0 0))  </a>
-<test><op name="densify" arg1='A'  arg2='10.0'>
-  POLYGON ((0 0, 0 10, 0 20, 10 20, 20 20, 20 10, 20 0, 10 0, 0 0))
-  	</op></test>
-</case>
+  <case>
+    <desc>L - empty linear ring</desc>
+    <a>LINEARRING EMPTY</a>
+    <test>
+      <op name="densify" arg1='A' arg2='6'>
+LINEARRING EMPTY
+      </op>
+    </test>
+  </case>
 
-<case>
-  <desc>A - polygon with hole</desc>
-  <a>    POLYGON ((0 0, 0 70, 70 70, 70 0, 0 0), (10 10, 10 60, 60 60, 10 10))  </a>
-<test><op name="densify" arg1='A'  arg2='10.0'>
-  POLYGON ((0 0, 0 10, 0 20, 0 30, 0 40, 0 50, 0 60, 0 70, 10 70, 20 70, 30 70, 40 70, 50 70, 60 70, 70 70, 70 60, 70 50, 70 40, 70 30, 70 20, 70 10, 70 0, 60 0, 50 0, 40 0, 30 0, 20 0, 10 0, 0 0),
-  (10 10, 16.25 16.25, 22.5 22.5, 28.75 28.75, 35 35, 41.25 41.25, 47.5 47.5, 53.75 53.75, 60 60, 50 60, 40 60, 30 60, 20 60, 10 60, 10 50, 10 40, 10 30, 10 20, 10 10))
-  	</op></test>
-</case>
+  <case>
+    <desc>L - linear ring with segment lengths equal to densify tolerance</desc>
+    <a>
+LINEARRING (0 0, 0 6, 6 6, 6 0, 0 0)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='6'>
+LINEARRING (0 0, 0 6, 6 6, 6 0, 0 0)
+      </op>
+    </test>
+  </case>
 
-<case>
-  <desc>mA - multipolygon</desc>
-  <a>    MULTIPOLYGON (((0 0, 0 70, 70 70, 70 0, 0 0),
-  (10 10, 10 60, 60 60, 10 10)),
-  ((80 110, 80 70, 120 70, 120 110, 80 110)))  </a>
-<test><op name="densify" arg1='A'  arg2='10.0'>
-  MULTIPOLYGON (((80 70, 80 80, 80 90, 80 100, 80 110, 90 110, 100 110, 110 110, 120 110, 120 100, 120 90, 120 80, 120 70, 110 70, 100 70, 90 70, 80 70)),
-    ((0 0, 0 10, 0 20, 0 30, 0 40, 0 50, 0 60, 0 70, 10 70, 20 70, 30 70, 40 70, 50 70, 60 70, 70 70, 70 60, 70 50, 70 40, 70 30, 70 20, 70 10, 70 0, 60 0, 50 0, 40 0, 30 0, 20 0, 10 0, 0 0),
-    (10 10, 16.25 16.25, 22.5 22.5, 28.75 28.75, 35 35, 41.25 41.25, 47.5 47.5, 53.75 53.75, 60 60, 50 60, 40 60, 30 60, 20 60, 10 60, 10 50, 10 40, 10 30, 10 20, 10 10)))
-  </op></test>
-</case>
+  <case>
+    <desc>L - linear ring with segment lengths equal to densify tolerance</desc>
+    <a>
+LINEARRING (0 0, 0 6, 6 6, 6 0, 0 0)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='6'>
+LINEARRING (0 0, 0 6, 6 6, 6 0, 0 0)
+      </op>
+    </test>
+  </case>
 
+  <case>
+    <desc>L - linear ring with segment lengths greater than densify tolerance</desc>
+    <a>
+LINEARRING (0 0, 0 6, 6 6, 6 0, 0 0)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='3'>
+LINEARRING (0 0, 0 3, 0 6, 3 6, 6 6, 6 3, 6 0, 3 0, 0 0)
+      </op>
+    </test>
+  </case>
 
+  <case>
+    <desc>L - linear ring with non-integer tolerance, result is evenly subdivided</desc>
+    <a>
+LINEARRING (0 0, 0 6, 6 6, 6 0, 0 0)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='2.999999'>
+LINEARRING (0 0, 0 2, 0 4, 0 6, 2 6, 4 6, 6 6, 6 4, 6 2, 6 0, 4 0, 2 0, 0 0)
+      </op>
+    </test>
+  </case>
 
+  <case>
+    <desc>mL - multiple lines with segment lengths equal to densify tolerance</desc>
+    <a>
+MULTILINESTRING ((0 0, 10 0), (20 0, 20 10))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+MULTILINESTRING ((0 0, 10 0), (20 0, 20 10))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>mL - multiple lines with segment lengths greater than densify tolerance</desc>
+    <a>
+MULTILINESTRING ((0 0, 10 0), (20 0, 20 10))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='5.0'>
+MULTILINESTRING ((0 0, 5 0, 10 0), (20 0, 20 5, 20 10))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>mL - multiple lines with non-integer tolerance, result is evenly subdivided</desc>
+    <a>
+MULTILINESTRING ((0 0, 10 0), (20 0, 20 10))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='2.999999'>
+MULTILINESTRING ((20 0, 20 2.5, 20 5, 20 7.5, 20 10), (0 0, 2.5 0, 5 0, 7.5 0, 10 0))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>A - simple polygon with segment lengths equal to densify tolerance</desc>
+    <a>
+POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>A - simple polygon with segment lengths greater than densify tolerance</desc>
+    <a>
+POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='5.0'>
+POLYGON ((0 0, 0 5, 0 10, 5 10, 10 10, 10 5, 10 0, 5 0, 0 0))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>A - polygon with hole with segment lengths equal to densify tolerance</desc>
+    <a>
+POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 2, 2 8, 8 8, 8 2, 2 2))
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 2, 2 8, 8 8, 8 2, 2 2))
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>A - polygon with hole with segment lengths greater than densify tolerance</desc>
+    <a>
+POLYGON (
+  (0 0, 0 10, 10 10, 10 0, 0 0),
+  (2 2, 2 8, 8 8, 8 2, 2 2)
+)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='5.0'>
+POLYGON (
+  (0 0, 0 5, 0 10, 5 10, 10 10, 10 5, 10 0, 5 0, 0 0),
+  (2 2, 2 5, 2 8, 5 8, 8 8, 8 5, 8 2, 5 2, 2 2)
+)
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>A - polygon with hole with non-integer tolerance, result is evenly subdivided</desc>
+    <a>
+POLYGON (
+  (0 0, 0 10, 10 10, 10 0, 0 0),
+  (2 2, 2 8, 8 8, 8 2, 2 2)
+)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='2.999999'>
+POLYGON (
+  (0 0, 0 2.5, 0 5, 0 7.5, 0 10, 2.5 10, 5 10, 7.5 10, 10 10, 10 7.5, 10 5, 10 2.5, 10 0, 7.5 0, 5 0, 2.5 0, 0 0),
+  (2 2, 4 2, 6 2, 8 2, 8 4, 8 6, 8 8, 6 8, 4 8, 2 8, 2 6, 2 4, 2 2)
+)
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>mA - multipolygon with segment lengths equal to densify tolerance</desc>
+    <a>
+MULTIPOLYGON (
+  ((0 0, 0 10, 10 10, 10 0, 0 0)),
+  ((20 20, 20 30, 30 30, 30 20, 20 20))
+)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='10.0'>
+MULTIPOLYGON (
+  ((0 0, 0 10, 10 10, 10 0, 0 0)),
+  ((20 20, 20 30, 30 30, 30 20, 20 20))
+)
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>mA - multipolygon with segment lengths greater than densify tolerance</desc>
+    <a>
+MULTIPOLYGON (
+  ((0 0, 0 10, 10 10, 10 0, 0 0)),
+  ((20 20, 20 30, 30 30, 30 20, 20 20))
+)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='5.0'>
+MULTIPOLYGON (
+  ((20 20, 20 25, 20 30, 25 30, 30 30, 30 25, 30 20, 25 20, 20 20)),
+  ((0 0, 0 5, 0 10, 5 10, 10 10, 10 5, 10 0, 5 0, 0 0))
+)
+      </op>
+    </test>
+  </case>
+
+  <case>
+    <desc>mA - multipolygon with segment with non-integer tolerance, result is evenly subdivided</desc>
+    <a>
+MULTIPOLYGON (
+  ((20 20, 20 30, 30 30, 30 20, 20 20)),
+  ((0 0, 0 10, 10 10, 10 0, 0 0))
+)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='2.999999'>
+MULTIPOLYGON (
+  ((20 20, 20 22.5, 20 25, 20 27.5, 20 30, 22.5 30, 25 30, 27.5 30, 30 30, 30 27.5, 30 25, 30 22.5, 30 20, 27.5 20, 25 20, 22.5 20, 20 20)),
+  ((0 0, 0 2.5, 0 5, 0 7.5, 0 10, 2.5 10, 5 10, 7.5 10, 10 10, 10 7.5, 10 5, 10 2.5, 10 0, 7.5 0, 5 0, 2.5 0, 0 0))
+)
+      </op>
+    </test>
+  </case>
 
 </run>


### PR DESCRIPTION
This updates the Densify tests based on what I understood to be the direction in #391.

This uses a function in the C API tests to reduce the boilerplate, and since it is a function in the same file, my understanding was that it wouldn't contribute to a decrease in clarity / usability of the tests.  (Note: the last test checks nulls and needed to be a special case).

This also expands the XML tests used for `Densifier`.  I did a bit of cleanup there to make them easier to add and read:
1) used XML formatter; this makes them a bit longer, but removes all the mental overhead of formatting / alignment.
2) pulled all geometry WKT to left margin so that you can more easily see and compare inputs and outputs; this is arguably one of the most important things to see in these test files.