### PR TITLE
Add methods to release objects owned by some Geometry types 

### DIFF
--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -520,6 +520,8 @@ private:
 /// Checks if two Envelopes are equal (2D only check)
 GEOS_DLL bool operator==(const Envelope& a, const Envelope& b);
 
+GEOS_DLL bool operator!=(const Envelope& a, const Envelope& b);
+
 } // namespace geos::geom
 } // namespace geos
 

--- a/include/geos/geom/Envelope.inl
+++ b/include/geos/geom/Envelope.inl
@@ -344,6 +344,11 @@ Envelope::distanceSquaredToCoordinate(const Coordinate & c, const Coordinate & p
     return dx*dx + dy*dy;
 }
 
+INLINE
+bool operator!=(const Envelope& a, const Envelope& b) {
+    return !(a == b);
+}
+
 } // namespace geos::geom
 } // namespace geos
 

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -163,6 +163,15 @@ public:
     const Geometry* getGeometryN(std::size_t n) const override;
 
     /**
+     * \brief
+     * Take ownership of the sub-geometries managed by this GeometryCollection.
+     * After releasing the sub-geometries, the collection should be considered
+     * in a moved-from state and should not be accessed.
+     * @return vector of sub-geometries
+     */
+    std::vector<std::unique_ptr<Geometry>> releaseGeometries();
+
+    /**
      * Creates a GeometryCollection with
      * every component reversed.
      * The order of the components in the collection are not reversed.

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -92,6 +92,15 @@ public:
 
     virtual const Coordinate& getCoordinateN(std::size_t n) const;
 
+    /**
+     * \brief
+     * Take ownership of the CoordinateSequence managed by this geometry.
+     * After releasing the coordinates, the geometry should be considered
+     * in a moved-from state and should not be accessed.
+     * @return this Geometry's CoordinateSequence.
+     */
+    std::unique_ptr<CoordinateSequence> releaseCoordinates();
+
     /// Returns line dimension (1)
     Dimension::DimensionType getDimension() const override;
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -110,11 +110,31 @@ public:
     /// Returns the exterior ring (shell)
     const LinearRing* getExteriorRing() const;
 
+    /**
+     * \brief
+     * Take ownership of this Polygon's exterior ring.
+     * After releasing the exterior ring, the Polygon should be
+     * considered in a moved-from state and should not be accessed,
+     * except to release the interior rings (if desired.)
+     * @return exterior ring
+     */
+    std::unique_ptr<LinearRing> releaseExteriorRing();
+
     /// Returns number of interior rings (hole)
     std::size_t getNumInteriorRing() const;
 
     /// Get nth interior ring (hole)
     const LinearRing* getInteriorRingN(std::size_t n) const;
+
+    /**
+     * \brief
+     * Take ownership of this Polygon's interior rings.
+     * After releasing the rings, the Polygon should be
+     * considered in a moved-from state and should not be accessed,
+     * except to release the exterior ring (if desired.)
+     * @return vector of rings (may be empty)
+     */
+    std::vector<std::unique_ptr<LinearRing>> releaseInteriorRings();
 
     std::string getGeometryType() const override;
     GeometryTypeId getGeometryTypeId() const override;

--- a/include/geos/io/WKTReader.h
+++ b/include/geos/io/WKTReader.h
@@ -25,6 +25,7 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/Geometry.h>
+#include <geos/io/ParseException.h>
 #include <string>
 
 // Forward declarations
@@ -81,6 +82,17 @@ public:
     ~WKTReader();
 
     /// Parse a WKT string returning a Geometry
+    template<typename T>
+    std::unique_ptr<T> read(const std::string& wkt) const {
+        auto g = read(wkt);
+        auto gt = dynamic_cast<const T*>(g.get());
+        if (!gt) {
+            // Can improve this message once there's a good way to get a string repr of T
+            throw io::ParseException("Unexpected WKT type");
+        }
+        return std::unique_ptr<T>(static_cast<T*>(g.release()));
+    }
+
     std::unique_ptr<geom::Geometry> read(const std::string& wellKnownText) const;
 
 //	Geometry* read(Reader& reader);	//Not implemented yet

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -175,6 +175,14 @@ GeometryCollection::getGeometryN(std::size_t n) const
     return geometries[n].get();
 }
 
+std::vector<std::unique_ptr<Geometry>>
+GeometryCollection::releaseGeometries()
+{
+    auto ret = std::move(geometries);
+    geometryChanged();
+    return ret;
+}
+
 size_t
 GeometryCollection::getNumPoints() const
 {

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -122,6 +122,14 @@ LineString::getCoordinatesRO() const
     return points.get();
 }
 
+std::unique_ptr<CoordinateSequence>
+LineString::releaseCoordinates()
+{
+    auto ret = std::move(points);
+    geometryChanged();
+    return ret;
+}
+
 const Coordinate&
 LineString::getCoordinateN(std::size_t n) const
 {

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -191,6 +191,13 @@ Polygon::getExteriorRing() const
     return shell.get();
 }
 
+std::unique_ptr<LinearRing>
+Polygon::releaseExteriorRing()
+{
+    envelope.reset();
+    return std::move(shell);
+}
+
 size_t
 Polygon::getNumInteriorRing() const
 {
@@ -201,6 +208,12 @@ const LinearRing*
 Polygon::getInteriorRingN(std::size_t n) const
 {
     return holes[n].get();
+}
+
+std::vector<std::unique_ptr<LinearRing>>
+Polygon::releaseInteriorRings()
+{
+    return std::move(holes);
 }
 
 std::string
@@ -312,6 +325,7 @@ Polygon::convexHull() const
 {
     return getExteriorRing()->convexHull();
 }
+
 
 void
 Polygon::normalize()

--- a/tests/unit/geom/GeometryCollectionTest.cpp
+++ b/tests/unit/geom/GeometryCollectionTest.cpp
@@ -143,4 +143,15 @@ void object::test<6>
     ensure(!gc->isDimensionStrict(geos::geom::Dimension::A));
 }
 
+template<>
+template<>
+void object::test<7>()
+{
+    auto gc = geos::io::WKTReader().read<geos::geom::GeometryCollection>("GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (1 1, 2 2))");
+    ensure_equals(*gc->getEnvelopeInternal(), geos::geom::Envelope(1, 2, 1, 2));
+
+    auto components = gc->releaseGeometries();
+    ensure_equals(components.size(), 2u);
+}
+
 } // namespace tut

--- a/tests/unit/geom/LineStringTest.cpp
+++ b/tests/unit/geom/LineStringTest.cpp
@@ -527,5 +527,19 @@ void object::test<29>
     ensure(c != nullptr);
 }
 
+// releaseCoordinates
+template<>
+template<>
+void object::test<30>()
+{
+    auto ls = reader_.read<geos::geom::LineString>("LINESTRING (0 0, 10 10)");
+    auto env = ls->getEnvelopeInternal();
+    ensure_equals(*env, geos::geom::Envelope(0,10, 0, 10));
+
+    auto cs = ls->releaseCoordinates();
+    ensure_equals(cs->getSize(), 2u);
+}
+
+
 } // namespace tut
 

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -34,6 +34,10 @@ struct test_polygon_data {
     typedef std::unique_ptr<geos::geom::Polygon> PolygonAutoPtr;
     typedef geos::geom::GeometryFactory GeometryFactory;
 
+    using Geometry = geos::geom::Geometry;
+    using Envelope = geos::geom::Envelope;
+    using Polygon = geos::geom::Polygon;
+
     geos::geom::PrecisionModel pm_;
     GeometryFactory::Ptr factory_;
     geos::io::WKTReader reader_;
@@ -630,6 +634,21 @@ void object::test<43>
     auto poly3 = reader_.read("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
     ensure("polygons with and without holes are not equal",
         poly->compareTo(poly3.get()) != 0);
+}
+
+template<>
+template<>
+void object::test<44>()
+{
+    auto poly = reader_.read<Polygon>("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 2 3, 3 3, 3 2, 2 2))");
+    auto env = poly->getEnvelopeInternal();
+    ensure_equals(*env, Envelope(0,10, 0, 10));
+
+    auto shell = poly->releaseExteriorRing();
+    ensure_equals(*shell->getEnvelopeInternal(), Envelope(0, 10, 0, 10));
+
+    auto holes = poly->releaseInteriorRings();
+    ensure_equals(holes.size(), 1u);
 }
 
 } // namespace tut

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -9,7 +9,10 @@
 #include <geos/geom/PrecisionModel.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Geometry.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/Point.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/util/GEOSException.h>
 #include <geos/util/IllegalArgumentException.h>
 // std
 #include <sstream>
@@ -252,6 +255,33 @@ void object::test<10>
 
     geom = wktreader.read("POLYGON ((0 0, 1 0, 1 1 1, 0 1, 0 0))");
     ensure("dimension(POLYGON ((0 0, 1 0, 1 1 1, 0 1, 0 0)) == 2", geom->getCoordinateDimension() == 2);
+}
+
+template<>
+template<>
+void object::test<11>
+()
+{
+    // Correct type
+    auto ls = wktreader.read<geos::geom::LineString>("LINESTRING (5 8, 5 7)");
+    ensure(ls != nullptr);
+
+    // Exception thrown on incorrect type
+    try {
+        auto poly = wktreader.read<geos::geom::LineString>("POINT (2 8)");
+        fail();
+    } catch (geos::util::GEOSException & e) {
+        ensure_equals(std::string(e.what()), "ParseException: Unexpected WKT type");
+    }
+
+    // Malformed
+    try {
+        auto ps = wktreader.read<geos::geom::Point>("POINT (2, 8)");
+        fail();
+    } catch (geos::util::GEOSException & e) {
+        ensure_equals(std::string(e.what()), "ParseException: Expected number but encountered ','");
+    }
+
 }
 
 } // namespace tut


### PR DESCRIPTION
This can allow for more efficient implementation implementation of some
operations such as GeometryCombiner. Objects that release their
components are left in an undefined state. This approach is taken
because it is analogous to the state of moved-from objects, and because
reverting the objects to a defined state can be expensive. For example,
an empty Polygon must own an empty LinearRing, which must own an empty
CoordinateSequence.