### PR TITLE
Enable GeometryCombiner to consume its inputs

### DIFF
--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -353,7 +353,7 @@ public:
     //
     /// Will clone the geometries accessible trough the iterator.
     ///
-    /// @tparam T an iterator yelding something which casts to const Geometry*
+    /// @tparam T an iterator yielding something which casts to const Geometry*
     /// @param from start iterator
     /// @param toofar end iterator
     ///

--- a/include/geos/geom/util/GeometryCombiner.h
+++ b/include/geos/geom/util/GeometryCombiner.h
@@ -49,16 +49,23 @@ namespace util { // geos.geom.util
 class GeometryCombiner {
 public:
     /** \brief
-     * Combines a collection of geometries.
+     * Copies a collection of geometries and combines the result.
      *
      * @param geoms the geometries to combine (ownership left to caller)
      * @return the combined geometry
      */
     static std::unique_ptr<Geometry> combine(std::vector<const Geometry*> const& geoms);
-    static std::unique_ptr<Geometry> combine(std::vector<std::unique_ptr<Geometry>> const& geoms);
 
     /** \brief
-     * Combines two geometries.
+     * Combines a collection of geometries.
+     *
+     * @param geoms the geometries to combine (ownership transferred to combined geometry)
+     * @return the combined geometry
+     */
+    static std::unique_ptr<Geometry> combine(std::vector<std::unique_ptr<Geometry>> && geoms);
+
+    /** \brief
+     * Copies two geometries and combines the result.
      *
      * @param g0 a geometry to combine (ownership left to caller)
      * @param g1 a geometry to combine (ownership left to caller)
@@ -67,7 +74,17 @@ public:
     static std::unique_ptr<Geometry> combine(const Geometry* g0, const Geometry* g1);
 
     /** \brief
-     * Combines three geometries.
+     * Combines two geometries.
+     *
+     * @param g0 a geometry to combine (ownership transferred to combined geometry)
+     * @param g1 a geometry to combine (ownership transferred to combined geometry)
+     * @return the combined geometry
+     */
+    static std::unique_ptr<Geometry> combine(std::unique_ptr<Geometry> && g0,
+                                             std::unique_ptr<Geometry> && g1);
+
+    /** \brief
+     * Copies three geometries and combines the result.
      *
      * @param g0 a geometry to combine (ownership left to caller)
      * @param g1 a geometry to combine (ownership left to caller)
@@ -76,10 +93,21 @@ public:
      */
     static std::unique_ptr<Geometry> combine(const Geometry* g0, const Geometry* g1, const Geometry* g2);
 
+    /** \brief
+     * Combines three geometries.
+     *
+     * @param g0 a geometry to combine (ownership transferred to combined geometry)
+     * @param g1 a geometry to combine (ownership transferred to combined geometry)
+     * @param g2 a geometry to combine (ownership transferred to combined geometry)
+     * @return the combined geometry
+     */
+    static std::unique_ptr<Geometry> combine(std::unique_ptr<Geometry> && g0,
+                                             std::unique_ptr<Geometry> && g1,
+                                             std::unique_ptr<Geometry> && g2);
+
 private:
-    GeometryFactory const* geomFactory;
+    std::vector<std::unique_ptr<Geometry>> inputGeoms;
     bool skipEmpty;
-    std::vector<const Geometry*> const& inputGeoms;
 
 public:
     /** \brief
@@ -87,15 +115,16 @@ public:
      *
      * @param geoms the geometries to combine
      */
-    GeometryCombiner(std::vector<const Geometry*> const& geoms);
+    explicit GeometryCombiner(std::vector<const Geometry*> const& geoms);
+
+    explicit GeometryCombiner(std::vector<std::unique_ptr<Geometry>> && geoms);
 
     /** \brief
      * Extracts the GeometryFactory used by the geometries in a collection.
      *
-     * @param geoms
      * @return a GeometryFactory
      */
-    static GeometryFactory const* extractFactory(std::vector<const Geometry*> const& geoms);
+    GeometryFactory const* extractFactory() const;
 
     /** \brief
      * Computes the combination of the input geometries
@@ -105,8 +134,10 @@ public:
      */
     std::unique_ptr<Geometry> combine();
 
-private:
-    void extractElements(const Geometry* geom, std::vector<const Geometry*>& elems);
+    /** \brief
+     * Set a flag indicating that empty geometries should be omitted from the result.
+     */
+    void setSkipEmpty(bool);
 
     // Declare type as noncopyable
     GeometryCombiner(const GeometryCombiner& other) = delete;

--- a/include/geos/geom/util/GeometryCombiner.h
+++ b/include/geos/geom/util/GeometryCombiner.h
@@ -22,6 +22,8 @@
 #include <memory>
 #include <vector>
 
+#include <geos/export.h>
+
 // Forward declarations
 namespace geos {
 namespace geom {
@@ -46,7 +48,7 @@ namespace util { // geos.geom.util
  *
  * @see GeometryFactory#buildGeometry
  */
-class GeometryCombiner {
+class GEOS_DLL GeometryCombiner {
 public:
     /** \brief
      * Copies a collection of geometries and combines the result.

--- a/src/operation/union/OverlapUnion.cpp
+++ b/src/operation/union/OverlapUnion.cpp
@@ -84,7 +84,7 @@ OverlapUnion::combine(std::unique_ptr<Geometry>& unionGeom, std::vector<std::uni
         return std::move(unionGeom);
 
     disjointPolys.push_back(std::move(unionGeom));
-    return GeometryCombiner::combine(disjointPolys);
+    return GeometryCombiner::combine(std::move(disjointPolys));
 }
 
 /* private */

--- a/tests/unit/geom/util/GeometryCombinerTest.cpp
+++ b/tests/unit/geom/util/GeometryCombinerTest.cpp
@@ -1,0 +1,125 @@
+//
+// Test Suite for geos::geom::util::GeometryCombiner class.
+
+// tut
+#include <tut/tut.hpp>
+// geos
+#include <geos/io/WKTReader.h>
+#include <geos/geom/util/GeometryCombiner.h>
+
+#include <utility.h>
+// std
+#include <vector>
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used by tests
+struct test_geometrycombiner_data {
+    using GeometryCombiner = geos::geom::util::GeometryCombiner;
+
+    geos::io::WKTReader wktreader_;
+};
+
+typedef test_group<test_geometrycombiner_data> group;
+typedef group::object object;
+
+group test_geometrycombiner_group("geos::geom::util::GeometryCombiner");
+
+// Two-argument version
+template<>
+template<>
+void object::test<1>(){
+    auto g1 = wktreader_.read("POINT (1 1)");
+    auto g2 = wktreader_.read("POINT (2 2)");
+
+    auto result_via_copy = GeometryCombiner::combine(g1.get(), g2.get());
+    ensure_equals_geometry(result_via_copy.get(), "MULTIPOINT ((1 1), (2 2))");
+
+    auto result_via_move = GeometryCombiner::combine(std::move(g1), std::move(g2));
+    ensure_equals_geometry(result_via_move.get(), result_via_copy.get());
+}
+
+// Three-argument version
+template<>
+template<>
+void object::test<2>(){
+    auto g1 = wktreader_.read("POINT (1 1)");
+    auto g2 = wktreader_.read("POINT (2 2)");
+    auto g3 = wktreader_.read("LINESTRING (3 3, 4 4)");
+
+    auto result_via_copy = GeometryCombiner::combine(g1.get(), g2.get(), g3.get());
+    ensure_equals_geometry(result_via_copy.get(), "GEOMETRYCOLLECTION (POINT (1 1), POINT (2 2), LINESTRING (3 3, 4 4))");
+
+    auto result_via_move = GeometryCombiner::combine(std::move(g1), std::move(g2), std::move(g3));
+    ensure_equals_geometry(result_via_move.get(), result_via_copy.get());
+}
+
+// Vector version
+template<>
+template<>
+void object::test<3>() {
+    std::vector<std::unique_ptr<geos::geom::Geometry>> geoms;
+    geoms.push_back(wktreader_.read("POINT (1 1)"));
+    geoms.push_back(wktreader_.read("POLYGON EMPTY"));
+    geoms.push_back(wktreader_.read("POINT (2 2)"));
+
+    GeometryCombiner gc(std::move(geoms));
+    gc.setSkipEmpty(true);
+
+    auto result = gc.combine();
+
+    ensure_equals_geometry(result.get(), "MULTIPOINT ((1 1), (2 2))");
+}
+
+// Outermost level of GeometryCollection is collapsed
+template<>
+template<>
+void object::test<4>() {
+    auto g1 = wktreader_.read("MULTIPOINT ((1 1), (2 2))");
+    auto g2 = wktreader_.read("MULTILINESTRING ((3 3, 4 4), (5 5, 6 6))");
+
+    auto result_via_copy = GeometryCombiner::combine(g1->clone(), g2->clone());
+    ensure_equals_geometry(result_via_copy.get(), "GEOMETRYCOLLECTION("
+                                                  "POINT (1 1),"
+                                                  "POINT (2 2),"
+                                                  "LINESTRING (3 3, 4 4),"
+                                                  "LINESTRING (5 5, 6 6))");
+
+    auto result_via_move = GeometryCombiner::combine(std::move(g1), std::move(g2));
+    ensure_equals_geometry(result_via_move.get(), result_via_copy.get());
+}
+
+// Test behavior when only empty inputs provided
+template<>
+template<>
+void object::test<5>()
+{
+    std::vector<std::unique_ptr<geos::geom::Geometry>> geoms;
+    geoms.emplace_back(wktreader_.read("POINT EMPTY"));
+
+    GeometryCombiner gc(std::move(geoms));
+    gc.setSkipEmpty(true);
+
+    auto result = gc.combine();
+
+    ensure_equals_geometry(result.get(), "GEOMETRYCOLLECTION EMPTY");
+}
+
+// Test behavior when no inputs provided
+template<>
+template<>
+void object::test<6>()
+{
+    std::vector<const geos::geom::Geometry*> geoms;
+    GeometryCombiner gc(geoms);
+
+    auto result = gc.combine();
+
+    ensure_equals_geometry(result.get(), "GEOMETRYCOLLECTION EMPTY");
+}
+
+
+} // namespace tut

--- a/tests/unit/utility.h
+++ b/tests/unit/utility.h
@@ -125,6 +125,7 @@ ensure_equals_geometry(T1 const* lhs, T2 const* rhs)
     ensure(lhs != 0 && rhs != 0 && lhs != rhs);
 }
 
+
 template <typename T>
 inline void
 ensure_equals_geometry(T const* lhs_in, T const* rhs_in, double tolerance = 0.0)
@@ -189,7 +190,21 @@ ensure_equals_geometry(T const* lhs_in, T const* rhs_in, double tolerance = 0.0)
     // }
 }
 
+template<typename T>
+inline void
+ensure_equals_geometry(const T& lhs, const char* rhs, double tolerance = 0.0) {
+    geos::io::WKTReader reader(lhs->getFactory());
+    auto rhs_geom = reader.read(rhs);
+    ensure_equals_geometry(lhs, rhs_geom.get(), tolerance);
+}
 
+template<typename T>
+inline void
+ensure_equals_geometry(const T& lhs, const std::string& rhs, double tolerance = 0.0) {
+    geos::io::WKTReader reader(lhs->getFactory());
+    auto rhs_geom = reader.read(rhs);
+    ensure_equals_geometry(lhs, rhs_geom.get(), tolerance);
+}
 
 template <>
 inline void


### PR DESCRIPTION
Add test cases and make "skipEmpty" flag settable. Potentially can be used to avoid copies in cascaded union, but that's a frightening place to go.