### PR TITLE
Represent empty envelope with NaN

### DIFF
--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -91,13 +91,13 @@ public:
      *
      * @param  p  the Coordinate
      */
-    Envelope(const Coordinate& p);
+    explicit Envelope(const Coordinate& p);
 
     /** \brief
      * Create an Envelope from an Envelope string representation produced
      * by Envelope::toString()
      */
-    Envelope(const std::string& str);
+    explicit Envelope(const std::string& str);
 
     /** \brief
      * Test the point `q` to see whether it intersects the Envelope
@@ -138,7 +138,7 @@ public:
     /** \brief
      *  Initialize to a null Envelope.
      */
-    void init(void);
+    void init();
 
     /** \brief
      * Initialize an Envelope for a region defined by maximum and minimum values.
@@ -172,7 +172,7 @@ public:
      * Makes this `Envelope` a "null" envelope, that is, the envelope
      * of the empty geometry.
      */
-    void setToNull(void);
+    void setToNull();
 
     /** \brief
      * Returns `true` if this Envelope is a "null" envelope.
@@ -180,21 +180,21 @@ public:
      * @return `true` if this Envelope is uninitialized or is the
      *                envelope of the empty geometry.
      */
-    bool isNull(void) const;
+    bool isNull() const;
 
     /** \brief
      * Returns the difference between the maximum and minimum x values.
      *
      * @return  `max x - min x`, or 0 if this is a null Envelope
      */
-    double getWidth(void) const;
+    double getWidth() const;
 
     /** \brief
      * Returns the difference between the maximum and minimum y values.
      *
      * @return `max y - min y`, or 0 if this is a null Envelope
      */
-    double getHeight(void) const;
+    double getHeight() const;
 
     /** \brief
      * Gets the area of this envelope.
@@ -449,7 +449,7 @@ public:
      *
      * @return a `string` of the form `Env[minx:maxx,miny:maxy]`
      */
-    std::string toString(void) const;
+    std::string toString() const;
 
     /** \brief
      * Computes the distance between this and another Envelope.
@@ -499,7 +499,7 @@ private:
      * This is a generic function that really belongs in a utility
      * file somewhere
      */
-    std::vector<std::string> split(const std::string& str,
+    static std::vector<std::string> split(const std::string& str,
                                    const std::string& delimiters = " ");
 
     static double distance(double x0, double y0, double x1, double y1);

--- a/include/geos/geom/Envelope.inl
+++ b/include/geos/geom/Envelope.inl
@@ -88,10 +88,10 @@ INLINE void
 Envelope::expandToInclude(const Envelope* other)
 {
     if(isNull()) {
-        minx = other->getMinX();
-        maxx = other->getMaxX();
-        miny = other->getMinY();
-        maxy = other->getMaxY();
+        minx = other->minx;
+        maxx = other->maxx;
+        miny = other->miny;
+        maxy = other->maxy;
     }
     else {
         if(other->minx < minx) {
@@ -139,6 +139,7 @@ Envelope::expandToInclude(double x, double y)
 INLINE double
 Envelope::getMaxY() const
 {
+    assert(!isNull());
     return maxy;
 }
 
@@ -146,6 +147,7 @@ Envelope::getMaxY() const
 INLINE double
 Envelope::getMaxX() const
 {
+    assert(!isNull());
     return maxx;
 }
 
@@ -153,6 +155,7 @@ Envelope::getMaxX() const
 INLINE double
 Envelope::getMinY() const
 {
+    assert(!isNull());
     return miny;
 }
 
@@ -160,6 +163,7 @@ Envelope::getMinY() const
 INLINE double
 Envelope::getMinX() const
 {
+    assert(!isNull());
     return minx;
 }
 

--- a/include/geos/geom/Envelope.inl
+++ b/include/geos/geom/Envelope.inl
@@ -34,10 +34,12 @@ namespace geom { // geos::geom
 
 /*public*/
 INLINE
-Envelope::Envelope()
-{
-    init();
-}
+Envelope::Envelope() :
+    minx(std::numeric_limits<double>::quiet_NaN()),
+    maxx(std::numeric_limits<double>::quiet_NaN()),
+    miny(std::numeric_limits<double>::quiet_NaN()),
+    maxy(std::numeric_limits<double>::quiet_NaN())
+{}
 
 /*public*/
 INLINE
@@ -85,9 +87,6 @@ Envelope::expandToInclude(const Envelope& other)
 INLINE void
 Envelope::expandToInclude(const Envelope* other)
 {
-    if(other->isNull()) {
-        return;
-    }
     if(isNull()) {
         minx = other->getMinX();
         maxx = other->getMaxX();
@@ -246,21 +245,17 @@ Envelope::intersects(const Envelope& other) const
 INLINE bool
 Envelope::isNull(void) const
 {
-    return maxx < minx;
+    return std::isnan(maxx);
 }
 
 /*public*/
 INLINE bool
 Envelope::intersects(const Envelope* other) const
 {
-    // Optimized to reduce function calls
-    if(isNull() || other->isNull()) {
-        return false;
-    }
-    return !(other->minx > maxx ||
-             other->maxx < minx ||
-             other->miny > maxy ||
-             other->maxy < miny);
+    return other->minx <= maxx &&
+           other->maxx >= minx &&
+           other->miny <= maxy &&
+           other->maxy >= miny;
 }
 
 /*public*/
@@ -281,13 +276,10 @@ Envelope::disjoint(const Envelope& other) const
 INLINE bool
 Envelope::disjoint(const Envelope* other) const
 {
-    if (isNull() || other->isNull()) {
-        return true;
-    }
-    return other->minx > maxx ||
-        other->maxx < minx ||
-        other->miny > maxy ||
-        other->maxy < miny;
+    return !(other->minx <= maxx ||
+             other->maxx >= minx ||
+             other->miny <= maxy ||
+             other->maxy >= miny);
 }
 
 
@@ -302,10 +294,7 @@ Envelope::covers(const Coordinate* p) const
 INLINE void
 Envelope::setToNull()
 {
-    minx = 0;
-    maxx = -1;
-    miny = 0;
-    maxy = -1;
+    minx = maxx = miny = maxy = std::numeric_limits<double>::quiet_NaN();
 }
 
 INLINE double

--- a/include/geos/operation/overlayng/RingClipper.h
+++ b/include/geos/operation/overlayng/RingClipper.h
@@ -74,11 +74,7 @@ private:
     static constexpr int BOX_BOTTOM = 0;
 
     // Members
-    // const Envelope* clipEnv;
-    double clipEnvMinY;
-    double clipEnvMaxY;
-    double clipEnvMinX;
-    double clipEnvMaxX;
+    const Envelope clipEnv;
 
     // Methods
 
@@ -101,10 +97,7 @@ private:
 public:
 
     RingClipper(const Envelope* env)
-        : clipEnvMinY(env->getMinY())
-        , clipEnvMaxY(env->getMaxY())
-        , clipEnvMinX(env->getMinX())
-        , clipEnvMaxX(env->getMaxX())
+        : clipEnv(*env)
         {};
 
     /**

--- a/include/geos/triangulate/quadedge/Vertex.h
+++ b/include/geos/triangulate/quadedge/Vertex.h
@@ -21,6 +21,7 @@
 
 #include <math.h>
 #include <memory>
+#include <cstring>
 
 #include <geos/geom/Coordinate.h>
 #include <geos/algorithm/HCoordinate.h>
@@ -112,10 +113,7 @@ public:
     inline bool
     equals(const Vertex& _x) const
     {
-        if(p.x == _x.getX() && p.y == _x.getY()) {
-            return true;
-        }
-        return false;
+        return p.equals2D(_x.p);
     }
 
     inline bool

--- a/src/geom/Envelope.cpp
+++ b/src/geom/Envelope.cpp
@@ -161,10 +161,10 @@ bool
 Envelope::covers(const Envelope& other) const
 {
     return
-        other.getMinX() >= minx &&
-        other.getMaxX() <= maxx &&
-        other.getMinY() >= miny &&
-        other.getMaxY() <= maxy;
+        other.minx >= minx &&
+        other.maxx <= maxx &&
+        other.miny >= miny &&
+        other.maxy <= maxy;
 }
 
 /*public*/
@@ -174,10 +174,10 @@ Envelope::equals(const Envelope* other) const
     if(isNull()) {
         return other->isNull();
     }
-    return  other->getMinX() == minx &&
-            other->getMaxX() == maxx &&
-            other->getMinY() == miny &&
-            other->getMaxY() == maxy;
+    return  other->minx == minx &&
+            other->maxx == maxx &&
+            other->miny == miny &&
+            other->maxy == maxy;
 }
 
 /* public */

--- a/src/operation/overlay/OverlayOp.cpp
+++ b/src/operation/overlay/OverlayOp.cpp
@@ -252,7 +252,7 @@ OverlayOp::copyPoints(uint8_t argIndex, const Envelope* env)
         assert(graphNode);
         const Coordinate& coord = graphNode->getCoordinate();
 
-        if(env && ! env->covers(coord)) {
+        if(env && ! env->covers(&coord)) {
             continue;
         }
 

--- a/src/operation/overlayng/OverlayNGRobust.cpp
+++ b/src/operation/overlayng/OverlayNGRobust.cpp
@@ -265,7 +265,7 @@ OverlayNGRobust::snapTolerance(const Geometry* geom)
 double
 OverlayNGRobust::ordinateMagnitude(const Geometry* geom)
 {
-    if (geom == nullptr) return 0;
+    if (geom == nullptr || geom->isEmpty()) return 0;
     const Envelope* env = geom->getEnvelopeInternal();
     double magMax = std::max(
         std::abs(env->getMaxX()),

--- a/src/operation/overlayng/RingClipper.cpp
+++ b/src/operation/overlayng/RingClipper.cpp
@@ -83,17 +83,17 @@ RingClipper::intersection(const Coordinate& a, const Coordinate& b, int edgeInde
 {
     switch (edgeIndex) {
     case BOX_BOTTOM:
-        rsltPt = Coordinate(intersectionLineY(a, b, clipEnvMinY), clipEnvMinY);
+        rsltPt = Coordinate(intersectionLineY(a, b, clipEnv.getMinY()), clipEnv.getMinY());
         break;
     case BOX_RIGHT:
-        rsltPt = Coordinate(clipEnvMaxX, intersectionLineX(a, b, clipEnvMaxX));
+        rsltPt = Coordinate(clipEnv.getMaxX(), intersectionLineX(a, b, clipEnv.getMaxX()));
         break;
     case BOX_TOP:
-        rsltPt = Coordinate(intersectionLineY(a, b, clipEnvMaxY), clipEnvMaxY);
+        rsltPt = Coordinate(intersectionLineY(a, b, clipEnv.getMaxY()), clipEnv.getMaxY());
         break;
     case BOX_LEFT:
     default:
-        rsltPt = Coordinate(clipEnvMinX, intersectionLineX(a, b, clipEnvMinX));
+        rsltPt = Coordinate(clipEnv.getMinX(), intersectionLineX(a, b, clipEnv.getMinX()));
     }
     return;
 }
@@ -120,20 +120,24 @@ RingClipper::intersectionLineX(const Coordinate& a, const Coordinate& b, double 
 bool
 RingClipper::isInsideEdge(const Coordinate& p, int edgeIndex) const
 {
+    if (clipEnv.isNull()) {
+        return false;
+    }
+
     bool isInside = false;
     switch (edgeIndex) {
     case BOX_BOTTOM: // bottom
-        isInside = p.y > clipEnvMinY;
+        isInside = p.y > clipEnv.getMinY();
         break;
     case BOX_RIGHT: // right
-        isInside = p.x < clipEnvMaxX;
+        isInside = p.x < clipEnv.getMaxX();
         break;
     case BOX_TOP: // top
-        isInside = p.y < clipEnvMaxY;
+        isInside = p.y < clipEnv.getMaxY();
         break;
     case BOX_LEFT:
     default: // left
-        isInside = p.x > clipEnvMinX;
+        isInside = p.x > clipEnv.getMinX();
     }
     return isInside;
 }

--- a/src/triangulate/DelaunayTriangulationBuilder.cpp
+++ b/src/triangulate/DelaunayTriangulationBuilder.cpp
@@ -101,10 +101,15 @@ DelaunayTriangulationBuilder::create()
         return;
     }
 
-    Envelope siteEnv;
-    siteCoords ->expandEnvelope(siteEnv);
+    if (siteCoords->isEmpty()) {
+        return;
+
+    }
+
+    Envelope siteEnv = siteCoords->getEnvelope();
     auto vertices = toVertices(*siteCoords);
-    std::sort(vertices.begin(), vertices.end()); // Best performance from locator when inserting points near each other
+    std::sort(vertices.begin(),
+              vertices.end()); // Best performance from locator when inserting points near each other
 
     subdiv.reset(new quadedge::QuadEdgeSubdivision(siteEnv, tolerance));
     IncrementalDelaunayTriangulator triangulator = IncrementalDelaunayTriangulator(subdiv.get());
@@ -123,6 +128,10 @@ DelaunayTriangulationBuilder::getEdges(
     const GeometryFactory& geomFact)
 {
     create();
+    if (!subdiv) {
+        return geomFact.createMultiLineString();
+    }
+
     return subdiv->getEdges(geomFact);
 }
 
@@ -131,15 +140,17 @@ DelaunayTriangulationBuilder::getTriangles(
     const geom::GeometryFactory& geomFact)
 {
     create();
+    if (!subdiv) {
+        return geomFact.createGeometryCollection();
+    }
+
     return subdiv->getTriangles(geomFact);
 }
 
 geom::Envelope
 DelaunayTriangulationBuilder::envelope(const geom::CoordinateSequence& coords)
 {
-    Envelope env;
-    coords.expandEnvelope(env);
-    return env;
+    return coords.getEnvelope();
 }
 
 

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -74,6 +74,10 @@ QuadEdgeSubdivision::QuadEdgeSubdivision(const geom::Envelope& env, double p_tol
 void
 QuadEdgeSubdivision::createFrame(const geom::Envelope& env)
 {
+    if (env.isNull()) {
+        throw util::IllegalArgumentException("Cannot create frame from empty Envelope.");
+    }
+
     double deltaX = env.getWidth();
     double deltaY = env.getHeight();
     double offset = 0.0;

--- a/tests/unit/capi/GEOSDelaunayTriangulationTest.cpp
+++ b/tests/unit/capi/GEOSDelaunayTriangulationTest.cpp
@@ -44,6 +44,7 @@ void object::test<1>
     ensure_equals(GEOSisEmpty(geom1_), 1);
 
     geom2_ = GEOSDelaunayTriangulation(geom1_, 0, 0);
+    ensure (geom2_ != nullptr);
     ensure_equals(GEOSisEmpty(geom2_), 1);
     ensure_equals(GEOSGeomTypeId(geom2_), GEOS_GEOMETRYCOLLECTION);
 


### PR DESCRIPTION
This allows explicit isNull() checks to be avoided in some of the
envelope operations, since NaN semantics make the affected comparisons
false for null envelopes.

Improves performance of watershed union operation by 1%.