### PR TITLE
CI: use different versions of CMake in GitHub Actions matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
           build_type: Coverage,
           cxxstd: 11,
           arch: 64,
-          packages: 'g++ cmake doxygen',
+          packages: 'g++',
+          cmake: 3.15.*,
           os: ubuntu-18.04
         }
         - {
@@ -25,7 +26,8 @@ jobs:
           build_type: Release,
           cxxstd: 11,
           arch: 32,
-          packages: 'g++-4.8-multilib gcc-4.8-multilib g++-multilib gcc-multilib cmake doxygen',
+          packages: 'g++-4.8-multilib gcc-4.8-multilib g++-multilib gcc-multilib',
+          cmake: 3.12.*,
           os: ubuntu-18.04
         }
         - {
@@ -33,7 +35,8 @@ jobs:
           build_type: Release,
           cxxstd: 11,
           arch: 64,
-          packages: 'clang cmake doxygen',
+          packages: 'clang',
+          cmake: 3.10.*,
           os: ubuntu-18.04
         }
         - {
@@ -41,7 +44,8 @@ jobs:
           build_type: Debug,
           cxxstd: 11,
           arch: 64,
-          packages: 'g++ cmake doxygen',
+          packages: 'g++',
+          cmake: 3.15.*,
           os: ubuntu-20.04
         }
         - {
@@ -49,7 +53,8 @@ jobs:
           build_type: Release,
           cxxstd: 11,
           arch: 64,
-          packages: 'clang cmake doxygen',
+          packages: 'clang',
+          cmake: 3.8.*,
           os: ubuntu-16.04
         }
         - {
@@ -57,7 +62,8 @@ jobs:
           build_type: Release,
           cxxstd: 14,
           arch: 64,
-          packages: 'clang cmake doxygen',
+          packages: 'clang',
+          cmake: 3.17.*,
           os: ubuntu-20.04
         }
 
@@ -70,7 +76,8 @@ jobs:
         set -e
         uname -a
         sudo -E apt-get update
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends install make ${{ matrix.ci.packages }}
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends install make doxygen python3-pip ${{ matrix.ci.packages }}
+        python3 -m pip install --disable-pip-version-check --user cmake==${{ matrix.ci.cmake }}
 
     - name: 'Check Out'
       uses: actions/checkout@v2


### PR DESCRIPTION
The minimum version of CMake is set at 3.8, but testing often uses much newer versions of CMake that are not installed on (e.g.) Ubuntu 18.04 with cmake 3.10.2.

This PR uses a few different versions of CMake in the CI test matrix on GitHub actions. These were picked more-or-less at random, but [this is a good reference](https://cliutils.gitlab.io/modern-cmake/chapters/intro/newcmake.html) for anyone that thinks other versions should be specified.

PyPi is used to quickly install the specified version; see https://pypi.org/project/cmake/#history