### PR TITLE
Reduce heap allocs in SegmentNodeList

### DIFF
--- a/include/geos/noding/SegmentNodeList.h
+++ b/include/geos/noding/SegmentNodeList.h
@@ -95,7 +95,7 @@ private:
     * @param ei1 the end node of the split edge
     * @return the points for the split edge
     */
-    void createSplitEdgePts(const SegmentNode* ei0, const SegmentNode* ei1, std::vector<geom::Coordinate>& pts) const;
+    std::unique_ptr<geom::CoordinateSequence> createSplitEdgePts(const SegmentNode* ei0, const SegmentNode* ei1) const;
 
     /**
      * Adds nodes for any collapsed edge pairs.


### PR DESCRIPTION
createSplitPts is usually returning a vector of length 2, so switch to a FixedCoordinateSequence instead.