### PR TITLE
Fix crash with GEOSPreparedIntersects/Covers on a POINT EMPTY

### DIFF
--- a/src/geom/prep/BasicPreparedGeometry.cpp
+++ b/src/geom/prep/BasicPreparedGeometry.cpp
@@ -42,7 +42,11 @@ bool
 BasicPreparedGeometry::envelopesIntersect(const geom::Geometry* g) const
 {
     if (g->getGeometryTypeId() == GEOS_POINT) {
-        return baseGeom->getEnvelopeInternal()->intersects(*(g->getCoordinate()));
+        auto pt = g->getCoordinate();
+        if (pt == nullptr) {
+            return false;
+        }
+        return baseGeom->getEnvelopeInternal()->intersects(*pt);
     }
 
     return baseGeom->getEnvelopeInternal()->intersects(g->getEnvelopeInternal());
@@ -52,7 +56,11 @@ bool
 BasicPreparedGeometry::envelopeCovers(const geom::Geometry* g) const
 {
     if (g->getGeometryTypeId() == GEOS_POINT) {
-        return baseGeom->getEnvelopeInternal()->covers(g->getCoordinate());
+        auto pt = g->getCoordinate();
+        if (pt == nullptr) {
+            return false;
+        }
+        return baseGeom->getEnvelopeInternal()->covers(pt);
     }
 
     return baseGeom->getEnvelopeInternal()->covers(g->getEnvelopeInternal());

--- a/tests/unit/capi/GEOSPreparedGeometryTest.cpp
+++ b/tests/unit/capi/GEOSPreparedGeometryTest.cpp
@@ -370,5 +370,40 @@ void object::test<11>
         ensure_equals(ret, 0);
     }
 }
+
+// Test PreparedIntersects with Point EMPTY
+template<>
+template<>
+void object::test<12>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))");
+    geom2_ = GEOSGeomFromWKT("POINT EMPTY");
+    prepGeom1_ = GEOSPrepare(geom1_);
+
+    ensure(nullptr != prepGeom1_);
+    ensure(nullptr != geom2_);
+
+    int ret = GEOSPreparedIntersects(prepGeom1_, geom2_);
+    ensure_equals(ret, 0);
+}
+
+// Test PreparedCovers with Point EMPTY
+template<>
+template<>
+void object::test<13>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))");
+    geom2_ = GEOSGeomFromWKT("POINT EMPTY");
+    prepGeom1_ = GEOSPrepare(geom1_);
+
+    ensure(nullptr != prepGeom1_);
+    ensure(nullptr != geom2_);
+
+    int ret = GEOSPreparedCovers(prepGeom1_, geom2_);
+    ensure_equals(ret, 0);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fixes use case spotted by https://github.com/OSGeo/gdal/issues/3542#issuecomment-792659437