### PR TITLE
Add GEOSCoordSeq_copyFromBuffer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ Changes in 3.10.0
   - geosop CLI for GEOS (Martin Davis)
   - Full doxygen of the C-API (Paul Ramsey)
   - CAPI: GEOSDensify (Brendan Ward)
+  - CAPI: GEOSCoordSeq_copyFromArrays, GEOSCoordSeq_copyFromBuffer,
+          GEOSCoordSeq_copyToArrays, GEOSCoordSeq_copyToBuffer (Daniel Baston)
 
 - Fixes/Improvements:
   - Preserve ordering of lines in overlay results (Martin Davis)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -8,6 +8,9 @@
 # by the Free Software Foundation.
 # See the COPYING file for more information.
 ################################################################################
+
+find_package(benchmark QUIET)
+
 add_executable(perf_class_sizes ClassSizes.cpp)
 target_link_libraries(perf_class_sizes PRIVATE geos)
 

--- a/benchmarks/algorithm/CMakeLists.txt
+++ b/benchmarks/algorithm/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(perf_voronoi geos)
 add_executable(perf_unaryunion_segments UnaryUnionSegmentsPerfTest.cpp)
 target_link_libraries(perf_unaryunion_segments geos)
 
-find_package(benchmark QUIET)
 if (benchmark_FOUND)
     add_executable(perf_orientation OrientationIndexPerfTest.cpp
             ${CMAKE_SOURCE_DIR}/src/algorithm/CGAlgorithmsDD.cpp

--- a/benchmarks/algorithm/locate/CMakeLists.txt
+++ b/benchmarks/algorithm/locate/CMakeLists.txt
@@ -11,7 +11,6 @@
 #
 #################################################################################
 
-find_package(benchmark QUIET)
 if (benchmark_FOUND)
     add_executable(perf_indexed_point_in_area_locator IndexedPointInAreaLocatorPerfTest.cpp)
     target_include_directories(perf_indexed_point_in_area_locator PUBLIC

--- a/benchmarks/capi/CMakeLists.txt
+++ b/benchmarks/capi/CMakeLists.txt
@@ -25,3 +25,13 @@ target_link_libraries(perf_intersection PRIVATE geos geos_c)
 
 add_executable(perf_unary UnaryOpPerfTest.cpp)
 target_link_libraries(perf_unary PRIVATE geos geos_c)
+
+if(benchmark_FOUND)
+    add_executable(perf_capi_coordseq GEOSCoordSeqPerfTest.cpp)
+    target_include_directories(perf_capi_coordseq PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+    target_link_libraries(perf_capi_coordseq PRIVATE
+            benchmark::benchmark geos_c)
+endif()
+

--- a/benchmarks/capi/GEOSCoordSeqPerfTest.cpp
+++ b/benchmarks/capi/GEOSCoordSeqPerfTest.cpp
@@ -1,0 +1,124 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2021 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos_c.h>
+
+#include <benchmark/benchmark.h>
+
+static std::vector<double> create_buffer(std::size_t N, unsigned int dim) {
+    std::vector<double> buf(2 * N);
+    double d = 0.0;
+    for(auto& di : buf) {
+        di = d;
+        d += 1.0;
+    }
+
+    return buf;
+}
+
+template<size_t N, size_t dim>
+static void BM_CoordSeq_CreateByOrdinate(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+    auto buf = create_buffer(N, dim);
+
+    for (auto _ : state) {
+        double* ptr = buf.data();
+        auto seq = GEOSCoordSeq_create(N, dim);
+
+        for (std::size_t i = 0; i < N; i++) {
+            GEOSCoordSeq_setX(seq, i, *ptr++);
+            GEOSCoordSeq_setY(seq, i, *ptr++);
+            if (dim == 3) {
+                GEOSCoordSeq_setZ(seq, i, *ptr++);
+            }
+        }
+
+        GEOSCoordSeq_destroy(seq);
+    }
+
+    finishGEOS();
+}
+
+template<size_t N, size_t dim>
+static void BM_CoordSeq_CreateByCoordinate(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    auto buf = create_buffer(N, dim);
+
+    for (auto _ : state) {
+        double* ptr = buf.data();
+        auto seq = GEOSCoordSeq_create(N, dim);
+
+        for (std::size_t i = 0; i < N; i++) {
+            double x = *ptr++;
+            double y = *ptr++;
+            if (dim == 2) {
+                GEOSCoordSeq_setXY(seq, i, x, y);
+            }
+            if (dim == 3) {
+                double z = *ptr++;
+                GEOSCoordSeq_setXYZ(seq, i, x, y, z);
+            }
+        }
+
+        GEOSCoordSeq_destroy(seq);
+    }
+
+    finishGEOS();
+}
+
+template<size_t N, size_t dim>
+static void BM_CoordSeq_CopyFromBuffer(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    auto buf = create_buffer(N, dim);
+
+    for (auto _ : state) {
+        auto seq = GEOSCoordSeq_copyFromBuffer(buf.data(), N, dim);
+        GEOSCoordSeq_destroy(seq);
+    }
+
+    finishGEOS();
+}
+
+// N = 10
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 10, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10, 2);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 10, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10, 3);
+
+// N = 1,0000
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 1000, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 1000, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 1000, 2);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 1000, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 1000, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 1000, 3);
+
+// N = 10,000
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10000, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 10000, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10000, 2);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10000, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 10000, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10000, 3);
+
+BENCHMARK_MAIN();
+
+

--- a/benchmarks/geom/CMakeLists.txt
+++ b/benchmarks/geom/CMakeLists.txt
@@ -9,8 +9,6 @@
 # See the COPYING file for more information.
 ################################################################################
 
-find_package(benchmark QUIET)
-
 IF(benchmark_FOUND)
     add_executable(perf_envelope
             EnvelopePerfTest.cpp

--- a/benchmarks/index/CMakeLists.txt
+++ b/benchmarks/index/CMakeLists.txt
@@ -11,8 +11,6 @@
 
 add_subdirectory(chain)
 
-find_package(benchmark QUIET)
-
 IF(benchmark_FOUND)
     add_executable(perf_spatial_index SpatialIndexPerfTest.cpp)
     target_include_directories(perf_spatial_index PUBLIC

--- a/benchmarks/index/chain/CMakeLists.txt
+++ b/benchmarks/index/chain/CMakeLists.txt
@@ -9,8 +9,6 @@
 # See the COPYING file for more information.
 ################################################################################
 
-find_package(benchmark QUIET)
-
 IF(benchmark_FOUND)
     add_executable(perf_monotone_chain MonotoneChainPerfTest.cpp)
     target_include_directories(perf_monotone_chain PUBLIC

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -861,11 +861,34 @@ extern "C" {
         return GEOS_setWKBByteOrder_r(handle, byteOrder);
     }
 
-
     CoordinateSequence*
     GEOSCoordSeq_create(unsigned int size, unsigned int dims)
     {
         return GEOSCoordSeq_create_r(handle, size, dims);
+    }
+
+    CoordinateSequence*
+    GEOSCoordSeq_copyFromBuffer(const double* buf, unsigned int size, unsigned int dims)
+    {
+        return GEOSCoordSeq_copyFromBuffer_r(handle, buf, size, dims);
+    }
+
+    int
+    GEOSCoordSeq_copyToBuffer(const CoordinateSequence* s, double* buf, unsigned int dims)
+    {
+        return GEOSCoordSeq_copyToBuffer_r(handle, s, buf, dims);
+    }
+
+    CoordinateSequence*
+    GEOSCoordSeq_copyFromArrays(const double* x, const double* y, const double* z, unsigned int size)
+    {
+        return GEOSCoordSeq_copyFromArrays_r(handle, x, y, z, size);
+    }
+
+    int
+    GEOSCoordSeq_copyToArrays(const CoordinateSequence* s, double* x, double* y, double* z)
+    {
+        return GEOSCoordSeq_copyToArrays_r(handle, s, x, y, z);
     }
 
     int

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -880,15 +880,15 @@ extern "C" {
     }
 
     CoordinateSequence*
-    GEOSCoordSeq_copyFromArrays(const double* x, const double* y, const double* z, unsigned int size)
+    GEOSCoordSeq_copyFromArrays(const double* x, const double* y, const double* z, const double* m, unsigned int size)
     {
-        return GEOSCoordSeq_copyFromArrays_r(handle, x, y, z, size);
+        return GEOSCoordSeq_copyFromArrays_r(handle, x, y, z, m, size);
     }
 
     int
-    GEOSCoordSeq_copyToArrays(const CoordinateSequence* s, double* x, double* y, double* z)
+    GEOSCoordSeq_copyToArrays(const CoordinateSequence* s, double* x, double* y, double* z, double* m)
     {
-        return GEOSCoordSeq_copyToArrays_r(handle, s, x, y, z);
+        return GEOSCoordSeq_copyToArrays_r(handle, s, x, y, z, m);
     }
 
     int

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -353,6 +353,36 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_create_r(
     unsigned int size,
     unsigned int dims);
 
+/** \see GEOSCoordSeq_copyFromBuffer */
+extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromBuffer_r(
+        GEOSContextHandle_t handle,
+        const double* buf,
+        unsigned int size,
+        unsigned int dims);
+
+/** \see GEOSCoordSeq_copyFromArrays */
+extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays_r(
+        GEOSContextHandle_t handle,
+        const double* x,
+        const double* y,
+        const double* z,
+        unsigned int size);
+
+/** \see GEOSCoordSeq_copyToBuffer */
+extern int GEOS_DLL GEOSCoordSeq_copyToBuffer_r(
+        GEOSContextHandle_t handle,
+        const GEOSCoordSequence* s,
+        double* buf,
+        unsigned int dims);
+
+/** \see GEOSCoordSeq_copyToArrays */
+extern int GEOS_DLL GEOSCoordSeq_copyToArrays_r(
+        GEOSContextHandle_t handle,
+        const GEOSCoordSequence* s,
+        double* x,
+        double* y,
+        double* z);
+
 /** \see GEOSCoordSeq_clone */
 extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_clone_r(
     GEOSContextHandle_t handle,
@@ -1692,6 +1722,44 @@ extern const char GEOS_DLL *GEOSversion(void);
 * \return the sequence or NULL on exception
 */
 extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_create(unsigned int size, unsigned int dims);
+
+/**
+* Create a coordinate sequence by copying from a buffer of doubles (XYXY or XYZXYZ)
+* \param buf pointer to buffer
+* \param size number of coordinates in the sequence
+* \param dims dimensionality of the coordinates (2 or 3)
+* \return the sequence or NULL on exception
+*/
+extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromBuffer(const double* buf, unsigned int size, unsigned int dims);
+
+/**
+* Create a coordinate sequence by copying from arrays of doubles
+* \param x array of x coordinates
+* \param y array of y coordinates
+* \param z array of z coordinates, or NULL
+* \param size length of each array
+* \return the sequence or NULL on exception
+*/
+extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays(const double* x, const double* y, const double* z, unsigned int size);
+
+/**
+* Copy the contents of a coordinate sequence to a buffer of doubles (XYZY or XYZXYZ)
+* \param s sequence to copy
+* \param buf buffer to which coordinates should be copied
+* \param dims dimensionality of the coordinates to be constructed in the buffer (2 or 3)
+* \return 1 on success, 0 on error
+*/
+extern int GEOS_DLL GEOSCoordSeq_copyToBuffer(const GEOSCoordSequence* s, double* buf, unsigned int dims);
+
+/**
+* Copy the contents of a coordinate sequence to a buffer of doubles (XYZY or XYZXYZ)
+* \param s sequence to copy
+* \param x array to which x values should be copied
+* \param y array to which y values should be copied
+* \param z array to which z values should be copied, or NULL
+* \return 1 on success, 0 on error
+*/
+extern int GEOS_DLL GEOSCoordSeq_copyToArrays(const GEOSCoordSequence* s, double* x, double* y, double* z);
 
 /**
 * Clone a coordinate sequence.

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -366,6 +366,7 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays_r(
         const double* x,
         const double* y,
         const double* z,
+        const double* m,
         unsigned int size);
 
 /** \see GEOSCoordSeq_copyToBuffer */
@@ -381,7 +382,8 @@ extern int GEOS_DLL GEOSCoordSeq_copyToArrays_r(
         const GEOSCoordSequence* s,
         double* x,
         double* y,
-        double* z);
+        double* z,
+        double* m);
 
 /** \see GEOSCoordSeq_clone */
 extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_clone_r(
@@ -1737,13 +1739,14 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromBuffer(const double* buf
 * \param x array of x coordinates
 * \param y array of y coordinates
 * \param z array of z coordinates, or NULL
+* \param m array of m coordinates, (must be NULL)
 * \param size length of each array
 * \return the sequence or NULL on exception
 */
-extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays(const double* x, const double* y, const double* z, unsigned int size);
+extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays(const double* x, const double* y, const double* z, const double* m, unsigned int size);
 
 /**
-* Copy the contents of a coordinate sequence to a buffer of doubles (XYZY or XYZXYZ)
+* Copy the contents of a coordinate sequence to a buffer of doubles (XYXY or XYZXYZ)
 * \param s sequence to copy
 * \param buf buffer to which coordinates should be copied
 * \param dims dimensionality of the coordinates to be constructed in the buffer (2 or 3)
@@ -1757,9 +1760,10 @@ extern int GEOS_DLL GEOSCoordSeq_copyToBuffer(const GEOSCoordSequence* s, double
 * \param x array to which x values should be copied
 * \param y array to which y values should be copied
 * \param z array to which z values should be copied, or NULL
+* \param m array to which m values should be copied (will all be NAN)
 * \return 1 on success, 0 on error
 */
-extern int GEOS_DLL GEOSCoordSeq_copyToArrays(const GEOSCoordSequence* s, double* x, double* y, double* z);
+extern int GEOS_DLL GEOSCoordSeq_copyToArrays(const GEOSCoordSequence* s, double* x, double* y, double* z, double* m);
 
 /**
 * Clone a coordinate sequence.

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2200,8 +2200,10 @@ extern "C" {
     }
 
     CoordinateSequence*
-    GEOSCoordSeq_copyFromArrays_r(GEOSContextHandle_t extHandle, const double* x, const double* y, const double* z, unsigned int size)
+    GEOSCoordSeq_copyFromArrays_r(GEOSContextHandle_t extHandle, const double* x, const double* y, const double* z, const double* m, unsigned int size)
     {
+        (void) m;
+
         return execute(extHandle, [&]() {
             GEOSContextHandleInternal_t *handle = reinterpret_cast<GEOSContextHandleInternal_t *>(extHandle);
             const GeometryFactory *gf = handle->geomFactory;
@@ -2221,7 +2223,7 @@ extern "C" {
 
     int
     GEOSCoordSeq_copyToArrays_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs,
-                                double* x, double* y, double* z)
+                                double* x, double* y, double* z, double* m)
     {
         return execute(extHandle, 0, [&]() {
 
@@ -2247,6 +2249,10 @@ extern "C" {
 
             CoordinateArrayCopier cop(x, y, z);
             cs->apply_ro(&cop);
+
+            if (m) {
+                std::fill(m, m + cs->getSize(), std::numeric_limits<double>::quiet_NaN());
+            }
 
             return 1;
         });

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2005-2006 Refractions Research Inc.
  * Copyright (C) 2010-2012 Sandro Santilli <strk@kbt.io>
- * Copyright (C) 2016-2019 Daniel Baston <dbaston@gmail.com>
+ * Copyright (C) 2016-2021 Daniel Baston <dbaston@gmail.com>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU Lesser General Public Licence as published
@@ -2172,6 +2172,119 @@ extern "C" {
                     return gf->getCoordinateSequenceFactory()->create(size, dims).release();
                 }
             }
+        });
+    }
+
+    CoordinateSequence*
+    GEOSCoordSeq_copyFromBuffer_r(GEOSContextHandle_t extHandle, const double* buf, unsigned int size, unsigned int dims)
+    {
+        return execute(extHandle, [&]() {
+            GEOSContextHandleInternal_t *handle = reinterpret_cast<GEOSContextHandleInternal_t *>(extHandle);
+            const GeometryFactory *gf = handle->geomFactory;
+
+            std::vector<geos::geom::Coordinate> coords(size);
+            if (dims == 2) {
+                for (std::size_t i = 0; i < size; i++) {
+                    coords[i] = { *buf, *(buf + 1) };
+                    buf += 2;
+                }
+            } else if (dims == 3) {
+                static_assert(sizeof(geos::geom::Coordinate) == 3 * sizeof(double), "Coordinate is 3D");
+                std::memcpy((double*) coords.data(), buf, size * sizeof(geos::geom::Coordinate));
+            } else {
+                throw geos::util::IllegalArgumentException("Unsupported CoordinateSequence dimension.");
+            }
+
+            return gf->getCoordinateSequenceFactory()->create(std::move(coords)).release();
+        });
+    }
+
+    CoordinateSequence*
+    GEOSCoordSeq_copyFromArrays_r(GEOSContextHandle_t extHandle, const double* x, const double* y, const double* z, unsigned int size)
+    {
+        return execute(extHandle, [&]() {
+            GEOSContextHandleInternal_t *handle = reinterpret_cast<GEOSContextHandleInternal_t *>(extHandle);
+            const GeometryFactory *gf = handle->geomFactory;
+
+            std::vector<geos::geom::Coordinate> coords(size);
+            for (std::size_t i = 0; i < size; i++) {
+                if (z) {
+                    coords[i] = { x[i], y[i], z[i] };
+                } else {
+                    coords[i] = { x[i], y[i] };
+                }
+            }
+
+            return gf->getCoordinateSequenceFactory()->create(std::move(coords)).release();
+        });
+    }
+
+    int
+    GEOSCoordSeq_copyToArrays_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs,
+                                double* x, double* y, double* z)
+    {
+        return execute(extHandle, 0, [&]() {
+
+            class CoordinateArrayCopier : public geos::geom::CoordinateFilter {
+            public:
+                CoordinateArrayCopier(double* p_x, double* p_y, double* p_z) : i(0), x(p_x), y(p_y), z(p_z) {}
+
+                void filter_ro(const geos::geom::Coordinate* c) override {
+                    x[i] = c->x;
+                    y[i] = c->y;
+                    if (z) {
+                        z[i] = c->z;
+                    }
+                    i++;
+                }
+
+            private:
+                size_t i;
+                double* x;
+                double* y;
+                double* z;
+            };
+
+            CoordinateArrayCopier cop(x, y, z);
+            cs->apply_ro(&cop);
+
+            return 1;
+        });
+    }
+
+    int
+    GEOSCoordSeq_copyToBuffer_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs,
+                                double* buf, unsigned int dim)
+    {
+        return execute(extHandle, 0, [&]() {
+
+            class CoordinateBufferCopier : public geos::geom::CoordinateFilter {
+            public:
+                CoordinateBufferCopier(double* p_buf, bool hasZ) : buf(p_buf), dim(hasZ ? 3 : 2) {}
+
+                void filter_ro(const geos::geom::Coordinate* c) override {
+                    std::memcpy(buf, c, dim * sizeof(double));
+                    buf += dim;
+                }
+
+            private:
+                double* buf;
+                size_t dim;
+            };
+
+            bool hasZ;
+            if (dim == 2) {
+                hasZ = false;
+            } else if (dim == 3) {
+                hasZ = true;
+            } else {
+                throw geos::util::IllegalArgumentException("Invalid dimension.");
+            }
+
+            CoordinateBufferCopier cop(buf, hasZ);
+            cs->apply_ro(&cop);
+
+            return 1;
         });
     }
 

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -471,7 +471,7 @@ void object::test<14>()
         y[i] = static_cast<double>(2 * i);
     }
 
-    cs_ = GEOSCoordSeq_copyFromArrays(x.data(), y.data(), nullptr, N);
+    cs_ = GEOSCoordSeq_copyFromArrays(x.data(), y.data(), nullptr, nullptr, N);
     unsigned int dim_out;
     ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
     ensure_equals(dim_out, dim);
@@ -490,12 +490,12 @@ void object::test<14>()
     ensure_equals(cy, 4.0);
 
     std::vector<double> xout(N), yout(N), zout(N);
-    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), nullptr));
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), nullptr, nullptr));
     ensure(x == xout);
     ensure(y == yout);
 
     // providing z vector to 2D coordinate sequence populates it with NaN
-    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), zout.data()));
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), zout.data(), nullptr));
     ensure(std::all_of(zout.begin(), zout.end(), [](double z) {
         return std::isnan(z);
     }));
@@ -517,7 +517,7 @@ void object::test<15>()
         z[i] = static_cast<double>(3 * i);
     }
 
-    cs_ = GEOSCoordSeq_copyFromArrays(x.data(), y.data(), z.data(), N);
+    cs_ = GEOSCoordSeq_copyFromArrays(x.data(), y.data(), z.data(), nullptr, N);
     unsigned int dim_out;
     ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
     ensure_equals(dim_out, dim);
@@ -538,15 +538,16 @@ void object::test<15>()
     ensure_equals(cy, 4.0);
     ensure_equals(cz, 6.0);
 
-    std::vector<double> xout(N), yout(N), zout(N);
-    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), nullptr));
+    std::vector<double> xout(N), yout(N), zout(N), mout(N);
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), nullptr, nullptr));
     ensure(x == xout);
     ensure(y == yout);
 
-    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), zout.data()));
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), zout.data(), mout.data()));
     ensure(x == xout);
     ensure(y == yout);
     ensure(z == zout);
+    ensure(std::all_of(mout.begin(), mout.end(), [](double mval) { return std::isnan(mval); }));
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -377,5 +377,177 @@ void object::test<11>
     ensure_equals(zcheck, z);
 }
 
+// test 2D from/to buffer
+template<>
+template<>
+void object::test<12>()
+{
+    unsigned int N = 10;
+    unsigned int dim = 2;
+    std::vector<double> values(N * dim);
+    for (size_t i = 0; i < values.size(); i++) {
+        values[i] = static_cast<double>(i);
+    }
+
+    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, dim);
+
+    double x, y;
+    ensure(GEOSCoordSeq_getXY(cs_, 0, &x, &y));
+    ensure_equals(x, 0.0);
+    ensure_equals(y, 1.0);
+
+    ensure(GEOSCoordSeq_getXY(cs_, N - 1, &x, &y));
+    ensure_equals(x, static_cast<double>(N-1)*2);
+    ensure_equals(y, static_cast<double>(N-1)*2 + 1);
+
+    unsigned int dim_out;
+    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+    ensure_equals(dim_out, dim);
+
+    std::vector<double> out3(N * 3);
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out3.data(), 3));
+    ensure_equals(out3[0], values[0]); // X1
+    ensure_equals(out3[1], values[1]); // Y1
+    ensure(std::isnan(out3[2])); // Z1
+    ensure_equals(out3[3], values[2]); // X2
+
+    std::vector<double> out2(N * 2);
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), 2));
+    ensure(out2 == values);
+}
+
+// test 3D from/to buffer
+template<>
+template<>
+void object::test<13>()
+{
+    unsigned int N = 10;
+    unsigned int dim = 3;
+    std::vector<double> values(N * dim);
+    for (size_t i = 0; i < values.size(); i++) {
+        values[i] = static_cast<double>(i);
+    }
+
+    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, dim);
+
+    double x, y, z;
+    ensure(GEOSCoordSeq_getXYZ(cs_, 0, &x, &y, &z));
+    ensure_equals(x, 0.0);
+    ensure_equals(y, 1.0);
+    ensure_equals(z, 2.0);
+
+    ensure(GEOSCoordSeq_getXYZ(cs_, N - 1, &x, &y, &z));
+    ensure_equals(x, static_cast<double>(N-1)*3);
+    ensure_equals(y, static_cast<double>(N-1)*3 + 1);
+    ensure_equals(z, static_cast<double>(N-1)*3 + 2);
+
+    unsigned int dim_out;
+    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+    ensure_equals(dim_out, dim);
+
+    std::vector<double> out3(N * 3);
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out3.data(), 3));
+    ensure(out3 == values);
+
+    std::vector<double> out2(N * 2);
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), 2));
+    ensure_equals(out2[0], values[0]); // X1
+    ensure_equals(out2[1], values[1]); // Y1
+    ensure_equals(out2[2], values[3]); // X2
+    ensure_equals(out2[3], values[4]); // Y2
+}
+
+// test 2D from/to arrays
+template<>
+template<>
+void object::test<14>()
+{
+    unsigned int N = 10;
+    unsigned int dim = 2;
+    std::vector<double> x(N);
+    std::vector<double> y(N);
+    for (size_t i = 0; i < N; i++) {
+        x[i] = static_cast<double>(i);
+        y[i] = static_cast<double>(2 * i);
+    }
+
+    cs_ = GEOSCoordSeq_copyFromArrays(x.data(), y.data(), nullptr, N);
+    unsigned int dim_out;
+    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+    ensure_equals(dim_out, dim);
+
+    double cx, cy;
+    ensure(GEOSCoordSeq_getXY(cs_, 0, &cx, &cy));
+    ensure_equals(cx, 0.0);
+    ensure_equals(cy, 0.0);
+
+    ensure(GEOSCoordSeq_getXY(cs_, 1, &cx, &cy));
+    ensure_equals(cx, 1.0);
+    ensure_equals(cy, 2.0);
+
+    ensure(GEOSCoordSeq_getXY(cs_, 2, &cx, &cy));
+    ensure_equals(cx, 2.0);
+    ensure_equals(cy, 4.0);
+
+    std::vector<double> xout(N), yout(N), zout(N);
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), nullptr));
+    ensure(x == xout);
+    ensure(y == yout);
+
+    // providing z vector to 2D coordinate sequence populates it with NaN
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), zout.data()));
+    ensure(std::all_of(zout.begin(), zout.end(), [](double z) {
+        return std::isnan(z);
+    }));
+}
+
+// test 3D from/to arrays
+template<>
+template<>
+void object::test<15>()
+{
+    unsigned int N = 10;
+    unsigned int dim = 3;
+    std::vector<double> x(N);
+    std::vector<double> y(N);
+    std::vector<double> z(N);
+    for (size_t i = 0; i < N; i++) {
+        x[i] = static_cast<double>(i);
+        y[i] = static_cast<double>(2 * i);
+        z[i] = static_cast<double>(3 * i);
+    }
+
+    cs_ = GEOSCoordSeq_copyFromArrays(x.data(), y.data(), z.data(), N);
+    unsigned int dim_out;
+    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+    ensure_equals(dim_out, dim);
+
+    double cx, cy, cz;
+    ensure(GEOSCoordSeq_getXYZ(cs_, 0, &cx, &cy, &cz));
+    ensure_equals(cx, 0.0);
+    ensure_equals(cy, 0.0);
+    ensure_equals(cz, 0.0);
+
+    ensure(GEOSCoordSeq_getXYZ(cs_, 1, &cx, &cy, &cz));
+    ensure_equals(cx, 1.0);
+    ensure_equals(cy, 2.0);
+    ensure_equals(cz, 3.0);
+
+    ensure(GEOSCoordSeq_getXYZ(cs_, 2, &cx, &cy, &cz));
+    ensure_equals(cx, 2.0);
+    ensure_equals(cy, 4.0);
+    ensure_equals(cz, 6.0);
+
+    std::vector<double> xout(N), yout(N), zout(N);
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), nullptr));
+    ensure(x == xout);
+    ensure(y == yout);
+
+    ensure(GEOSCoordSeq_copyToArrays(cs_, xout.data(), yout.data(), zout.data()));
+    ensure(x == xout);
+    ensure(y == yout);
+    ensure(z == zout);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Add a method to copy coordinates into a GEOS structure from a contiguous chunk of memory. While this is not as good as using that chunk of memory directly, it greatly simplifies and improves the performance of bringing coordinates into GEOS.

Results of included benchmark show the performance on coordinate sequences of size 10, 1000, and 10 000 relative to existing methods (createByOrdinate: setX/setY and createByCoordinate: setXY)

```
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_CoordSeq_CreateByOrdinate<10, 2>             167 ns          167 ns      4181695
BM_CoordSeq_CreateByCoordinate<10, 2>          78.7 ns         78.7 ns      8633210
BM_CoordSeq_CopyFromBuffer<10, 2>              41.3 ns         41.3 ns     17085606
BM_CoordSeq_CreateByOrdinate<10, 3>             224 ns          224 ns      3109464
BM_CoordSeq_CreateByCoordinate<10, 3>          84.6 ns         84.6 ns      8025830
BM_CoordSeq_CopyFromBuffer<10, 3>              39.0 ns         39.0 ns     17938309
BM_CoordSeq_CreateByOrdinate<1000, 2>         12733 ns        12731 ns        54801
BM_CoordSeq_CreateByCoordinate<1000, 2>        4640 ns         4639 ns       151689
BM_CoordSeq_CopyFromBuffer<1000, 2>            1319 ns         1319 ns       517824
BM_CoordSeq_CreateByOrdinate<1000, 3>         19150 ns        19146 ns        36583
BM_CoordSeq_CreateByCoordinate<1000, 3>        5288 ns         5287 ns       127731
BM_CoordSeq_CopyFromBuffer<1000, 3>             926 ns          926 ns       740152
BM_CoordSeq_CreateByOrdinate<10000, 2>       121681 ns       121665 ns         5632
BM_CoordSeq_CreateByCoordinate<10000, 2>      50718 ns        50708 ns        12875
BM_CoordSeq_CopyFromBuffer<10000, 2>          13983 ns        13981 ns        48776
BM_CoordSeq_CreateByOrdinate<10000, 3>       178439 ns       178433 ns         3901
BM_CoordSeq_CreateByCoordinate<10000, 3>      53240 ns        53238 ns        12754
BM_CoordSeq_CopyFromBuffer<10000, 3>          11894 ns        11893 ns        57954
``` 