### PR TITLE
clone(), reverse() and dynamic_cast<> improvements

### DIFF
--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -201,7 +201,7 @@ public:
     using Ptr = std::unique_ptr<Geometry> ;
 
     /// Make a deep-copy of this Geometry
-    virtual std::unique_ptr<Geometry> clone() const = 0;
+    std::unique_ptr<Geometry> clone() const { return std::unique_ptr<Geometry>(cloneImpl()); }
 
     /// Destroy Geometry and all components
     virtual ~Geometry();
@@ -855,6 +855,9 @@ protected:
 
     /// The bounding box of this Geometry
     mutable std::unique_ptr<Envelope> envelope;
+
+    /// Make a deep-copy of this Geometry
+    virtual Geometry* cloneImpl() const = 0;
 
     /// Returns true if the array contains any non-empty Geometrys.
     template<typename T>

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -654,7 +654,7 @@ public:
      *
      * @return a reversed geometry
      */
-    virtual std::unique_ptr<Geometry> reverse() const = 0;
+    std::unique_ptr<Geometry> reverse() const { return std::unique_ptr<Geometry>(reverseImpl()); }
 
     /** \brief
      * Returns a Geometry representing the points shared by
@@ -858,6 +858,9 @@ protected:
 
     /// Make a deep-copy of this Geometry
     virtual Geometry* cloneImpl() const = 0;
+
+    /// Make a geometry with coordinates in reverse order
+    virtual Geometry* reverseImpl() const = 0;
 
     /// Returns true if the array contains any non-empty Geometrys.
     template<typename T>

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -71,10 +71,9 @@ public:
      *
      * @return a clone of this instance
      */
-    std::unique_ptr<Geometry>
-    clone() const override
+    std::unique_ptr<GeometryCollection> clone() const
     {
-        return std::unique_ptr<Geometry>(new GeometryCollection(*this));
+        return std::unique_ptr<GeometryCollection>(cloneImpl());
     }
 
     ~GeometryCollection() override = default;
@@ -216,6 +215,8 @@ protected:
     template<typename T>
     GeometryCollection(std::vector<std::unique_ptr<T>> && newGeoms, const GeometryFactory& newFactory) :
         GeometryCollection(toGeometryArray(std::move(newGeoms)), newFactory) {}
+
+    GeometryCollection* cloneImpl() const override { return new GeometryCollection(*this); }
 
     int
     getSortIndex() const override

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -177,7 +177,7 @@ public:
      *
      * @return a GeometryCollection in the reverse order
      */
-    std::unique_ptr<Geometry> reverse() const override;
+    std::unique_ptr<GeometryCollection> reverse() const { return std::unique_ptr<GeometryCollection>(reverseImpl()); }
 
 protected:
 
@@ -217,6 +217,8 @@ protected:
         GeometryCollection(toGeometryArray(std::move(newGeoms)), newFactory) {}
 
     GeometryCollection* cloneImpl() const override { return new GeometryCollection(*this); }
+
+    GeometryCollection* reverseImpl() const override;
 
     int
     getSortIndex() const override

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -193,7 +193,7 @@ public:
      *
      * @return a LineString with coordinates in the reverse order
      */
-    std::unique_ptr<Geometry> reverse() const override;
+    std::unique_ptr<LineString> reverse() const { return std::unique_ptr<LineString>(reverseImpl()); }
 
 protected:
 
@@ -209,6 +209,8 @@ protected:
                const GeometryFactory& newFactory);
 
     LineString* cloneImpl() const override { return new LineString(*this); }
+
+    LineString* reverseImpl() const override;
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -83,7 +83,10 @@ public:
      *
      * @return A clone of this instance
      */
-    std::unique_ptr<Geometry> clone() const override;
+    std::unique_ptr<LineString> clone() const
+    {
+        return std::unique_ptr<LineString>(cloneImpl());
+    }
 
     std::unique_ptr<CoordinateSequence> getCoordinates() const override;
 
@@ -205,6 +208,8 @@ protected:
     LineString(CoordinateSequence::Ptr && pts,
                const GeometryFactory& newFactory);
 
+    LineString* cloneImpl() const override { return new LineString(*this); }
+
     Envelope::Ptr computeEnvelopeInternal() const override;
 
     CoordinateSequence::Ptr points;
@@ -230,13 +235,6 @@ struct GEOS_DLL  LineStringLT {
         return ls1->compareTo(ls2) < 0;
     }
 };
-
-
-inline std::unique_ptr<Geometry>
-LineString::clone() const
-{
-    return std::unique_ptr<Geometry>(new LineString(*this));
-}
 
 } // namespace geos::geom
 } // namespace geos

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -82,10 +82,9 @@ public:
     LinearRing(CoordinateSequence::Ptr && points,
             const GeometryFactory& newFactory);
 
-    std::unique_ptr<Geometry>
-    clone() const override
+    std::unique_ptr<LinearRing> clone() const
     {
-        return std::unique_ptr<Geometry>(new LinearRing(*this));
+        return std::unique_ptr<LinearRing>(cloneImpl());
     }
 
     ~LinearRing() override = default;
@@ -116,6 +115,7 @@ protected:
         return SORTINDEX_LINEARRING;
     };
 
+    LinearRing* cloneImpl() const override { return new LinearRing(*this); }
 
 private:
 

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -105,7 +105,7 @@ public:
 
     void setPoints(const CoordinateSequence* cl);
 
-    std::unique_ptr<Geometry> reverse() const override;
+    std::unique_ptr<LinearRing> reverse() const { return std::unique_ptr<LinearRing>(reverseImpl()); }
 
 protected:
 
@@ -116,6 +116,8 @@ protected:
     };
 
     LinearRing* cloneImpl() const override { return new LinearRing(*this); }
+
+    LinearRing* reverseImpl() const override;
 
 private:
 

--- a/include/geos/geom/MultiLineString.h
+++ b/include/geos/geom/MultiLineString.h
@@ -83,7 +83,7 @@ public:
 
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
 
-    std::unique_ptr<Geometry> clone() const override;
+    std::unique_ptr<MultiLineString> clone() const;
 
     /**
      * Creates a MultiLineString in the reverse
@@ -125,6 +125,8 @@ protected:
                     const GeometryFactory& newFactory);
 
     MultiLineString(const MultiLineString& mp);
+
+    MultiLineString* cloneImpl() const override { return new MultiLineString(*this); }
 
     int
     getSortIndex() const override

--- a/include/geos/geom/MultiLineString.h
+++ b/include/geos/geom/MultiLineString.h
@@ -92,7 +92,7 @@ public:
      *
      * @return a MultiLineString in the reverse order
      */
-    std::unique_ptr<Geometry> reverse() const override;
+    std::unique_ptr<MultiLineString> reverse() const { return std::unique_ptr<MultiLineString>(reverseImpl()); }
 
 protected:
 
@@ -125,6 +125,8 @@ protected:
     MultiLineString(const MultiLineString& mp);
 
     MultiLineString* cloneImpl() const override { return new MultiLineString(*this); }
+
+    MultiLineString* reverseImpl() const override;
 
     int
     getSortIndex() const override

--- a/include/geos/geom/MultiLineString.h
+++ b/include/geos/geom/MultiLineString.h
@@ -81,8 +81,6 @@ public:
 
     bool isClosed() const;
 
-    bool equalsExact(const Geometry* other, double tolerance = 0) const override;
-
     std::unique_ptr<MultiLineString> clone() const;
 
     /**

--- a/include/geos/geom/MultiLineString.inl
+++ b/include/geos/geom/MultiLineString.inl
@@ -35,10 +35,10 @@ MultiLineString::MultiLineString(const MultiLineString& mp)
 {
 }
 
-INLINE std::unique_ptr<Geometry>
+INLINE std::unique_ptr<MultiLineString>
 MultiLineString::clone() const
 {
-    return std::unique_ptr<Geometry>(new MultiLineString(*this));
+    return std::unique_ptr<MultiLineString>(cloneImpl());
 }
 
 } // namespace geos::geom

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -88,10 +88,9 @@ public:
 
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
 
-    std::unique_ptr<Geometry>
-    clone() const override
+    std::unique_ptr<MultiPoint> clone() const
     {
-        return std::unique_ptr<Geometry>(new MultiPoint(*this));
+        return std::unique_ptr<MultiPoint>(cloneImpl());
     }
 
     std::unique_ptr<Geometry>
@@ -127,6 +126,8 @@ protected:
     MultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints, const GeometryFactory& newFactory);
 
     MultiPoint(const MultiPoint& mp): GeometryCollection(mp) {}
+
+    MultiPoint* cloneImpl() const override { return new MultiPoint(*this); }
 
     const Coordinate* getCoordinateN(std::size_t n) const;
 

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -86,8 +86,6 @@ public:
 
     GeometryTypeId getGeometryTypeId() const override;
 
-    bool equalsExact(const Geometry* other, double tolerance = 0) const override;
-
     std::unique_ptr<MultiPoint> clone() const
     {
         return std::unique_ptr<MultiPoint>(cloneImpl());

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -91,10 +91,9 @@ public:
         return std::unique_ptr<MultiPoint>(cloneImpl());
     }
 
-    std::unique_ptr<Geometry>
-    reverse() const override
+    std::unique_ptr<MultiPoint> reverse() const
     {
-        return clone();
+        return std::unique_ptr<MultiPoint>(reverseImpl());
     }
 
 protected:
@@ -126,6 +125,8 @@ protected:
     MultiPoint(const MultiPoint& mp): GeometryCollection(mp) {}
 
     MultiPoint* cloneImpl() const override { return new MultiPoint(*this); }
+
+    MultiPoint* reverseImpl() const override { return new MultiPoint(*this); }
 
     const Coordinate* getCoordinateN(std::size_t n) const;
 

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -89,7 +89,7 @@ public:
 
     std::unique_ptr<MultiPolygon> clone() const;
 
-    std::unique_ptr<Geometry> reverse() const override;
+    std::unique_ptr<MultiPolygon> reverse() const { return std::unique_ptr<MultiPolygon>(reverseImpl()); }
 
 protected:
 
@@ -125,6 +125,8 @@ protected:
     MultiPolygon(const MultiPolygon& mp);
 
     MultiPolygon* cloneImpl() const override { return new MultiPolygon(*this); }
+
+    MultiPolygon* reverseImpl() const override;
 
     int
     getSortIndex() const override

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -89,7 +89,7 @@ public:
 
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
 
-    std::unique_ptr<Geometry> clone() const override;
+    std::unique_ptr<MultiPolygon> clone() const;
 
     std::unique_ptr<Geometry> reverse() const override;
 
@@ -125,6 +125,8 @@ protected:
                  const GeometryFactory& newFactory);
 
     MultiPolygon(const MultiPolygon& mp);
+
+    MultiPolygon* cloneImpl() const override { return new MultiPolygon(*this); }
 
     int
     getSortIndex() const override

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -87,8 +87,6 @@ public:
 
     GeometryTypeId getGeometryTypeId() const override;
 
-    bool equalsExact(const Geometry* other, double tolerance = 0) const override;
-
     std::unique_ptr<MultiPolygon> clone() const;
 
     std::unique_ptr<Geometry> reverse() const override;

--- a/include/geos/geom/MultiPolygon.inl
+++ b/include/geos/geom/MultiPolygon.inl
@@ -32,10 +32,10 @@ MultiPolygon::MultiPolygon(const MultiPolygon& mp)
 {
 }
 
-INLINE std::unique_ptr<Geometry>
+INLINE std::unique_ptr<MultiPolygon>
 MultiPolygon::clone() const
 {
-    return std::unique_ptr<Geometry>(new MultiPolygon(*this));
+    return std::unique_ptr<MultiPolygon>(cloneImpl());
 }
 
 } // namespace geos::geom

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -135,10 +135,9 @@ public:
         // a Point is always in normalized form
     }
 
-    std::unique_ptr<Geometry>
-    reverse() const override
+    std::unique_ptr<Point> reverse() const
     {
-        return clone();
+        return std::unique_ptr<Point>(reverseImpl());
     }
 
 protected:
@@ -162,6 +161,8 @@ protected:
     Point(const Point& p);
 
     Point* cloneImpl() const override { return new Point(*this); }
+
+    Point* reverseImpl() const override { return new Point(*this); }
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -80,10 +80,9 @@ public:
      *
      * @return a clone of this instance
      */
-    std::unique_ptr<Geometry>
-    clone() const override
+    std::unique_ptr<Point> clone() const
     {
-        return std::unique_ptr<Geometry>(new Point(*this));
+        return std::unique_ptr<Point>(cloneImpl());
     }
 
     std::unique_ptr<CoordinateSequence> getCoordinates(void) const override;
@@ -161,6 +160,8 @@ protected:
     Point(const Coordinate& c, const GeometryFactory* newFactory);
 
     Point(const Point& p);
+
+    Point* cloneImpl() const override { return new Point(*this); }
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -78,10 +78,9 @@ public:
      *
      * @return a clone of this instance
      */
-    std::unique_ptr<Geometry>
-    clone() const override
+    std::unique_ptr<Polygon> clone() const
     {
-        return std::unique_ptr<Geometry>(new Polygon(*this));
+        return std::unique_ptr<Polygon>(cloneImpl());
     }
 
     std::unique_ptr<CoordinateSequence> getCoordinates() const override;
@@ -197,6 +196,8 @@ protected:
     Polygon(std::unique_ptr<LinearRing> && newShell,
             std::vector<std::unique_ptr<LinearRing>> && newHoles,
             const GeometryFactory& newFactory);
+
+    Polygon* cloneImpl() const override { return new Polygon(*this); }
 
     std::unique_ptr<LinearRing> shell;
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -151,7 +151,7 @@ public:
 
     void normalize() override;
 
-    std::unique_ptr<Geometry> reverse() const override;
+    std::unique_ptr<Polygon> reverse() const { return std::unique_ptr<Polygon>(reverseImpl()); }
 
     const Coordinate* getCoordinate() const override;
 
@@ -198,6 +198,8 @@ protected:
             const GeometryFactory& newFactory);
 
     Polygon* cloneImpl() const override { return new Polygon(*this); }
+
+    Polygon* reverseImpl() const override;
 
     std::unique_ptr<LinearRing> shell;
 

--- a/include/geos/operation/linemerge/LineSequencer.h
+++ b/include/geos/operation/linemerge/LineSequencer.h
@@ -110,9 +110,6 @@ private:
 
     void delAll(Sequences&);
 
-    /// return a newly allocated LineString
-    static geom::LineString* reverse(const geom::LineString* line);
-
     /**
      * Builds a geometry ({@link LineString} or {@link MultiLineString} )
      * representing the sequence.

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -321,11 +321,11 @@ Geometry::intersects(const Geometry* g) const
 
     // optimization for rectangle arguments
     if(isRectangle()) {
-        const Polygon* p = dynamic_cast<const Polygon*>(this);
+        const Polygon* p = detail::down_cast<const Polygon*>(this);
         return predicate::RectangleIntersects::intersects(*p, *g);
     }
     if(g->isRectangle()) {
-        const Polygon* p = dynamic_cast<const Polygon*>(g);
+        const Polygon* p = detail::down_cast<const Polygon*>(g);
         return predicate::RectangleIntersects::intersects(*p, *this);
     }
 
@@ -412,7 +412,7 @@ Geometry::contains(const Geometry* g) const
 
     // optimization for rectangle arguments
     if(isRectangle()) {
-        const Polygon* p = dynamic_cast<const Polygon*>(this);
+        const Polygon* p = detail::down_cast<const Polygon*>(this);
         return predicate::RectangleContains::contains(*p, *g);
     }
     // Incorrect: contains is not commutative

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -212,11 +212,7 @@ GeometryCollection::equalsExact(const Geometry* other, double tolerance) const
         return false;
     }
 
-    const GeometryCollection* otherCollection = dynamic_cast<const GeometryCollection*>(other);
-    if(! otherCollection) {
-        return false;
-    }
-
+    const GeometryCollection* otherCollection = detail::down_cast<const GeometryCollection*>(other);
     if(geometries.size() != otherCollection->geometries.size()) {
         return false;
     }
@@ -287,7 +283,7 @@ GeometryCollection::computeEnvelopeInternal() const
 int
 GeometryCollection::compareToSameClass(const Geometry* g) const
 {
-    const GeometryCollection* gc = dynamic_cast<const GeometryCollection*>(g);
+    const GeometryCollection* gc = detail::down_cast<const GeometryCollection*>(g);
     return compare(geometries, gc->geometries);
 }
 

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -382,11 +382,11 @@ GeometryCollection::getGeometryTypeId() const
     return GEOS_GEOMETRYCOLLECTION;
 }
 
-std::unique_ptr<Geometry>
-GeometryCollection::reverse() const
+GeometryCollection*
+GeometryCollection::reverseImpl() const
 {
     if(isEmpty()) {
-        return clone();
+        return clone().release();
     }
 
     std::vector<std::unique_ptr<Geometry>> reversed(geometries.size());
@@ -398,7 +398,7 @@ GeometryCollection::reverse() const
         return g->reverse();
     });
 
-    return getFactory()->createGeometryCollection(std::move(reversed));
+    return getFactory()->createGeometryCollection(std::move(reversed)).release();
 }
 
 } // namespace geos::geom

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -57,18 +57,18 @@ LineString::LineString(const LineString& ls)
     //points=ls.points->clone();
 }
 
-std::unique_ptr<Geometry>
-LineString::reverse() const
+LineString*
+LineString::reverseImpl() const
 {
     if(isEmpty()) {
-        return clone();
+        return clone().release();
     }
 
     assert(points.get());
     auto seq = points->clone();
     CoordinateSequence::reverse(seq.get());
     assert(getFactory());
-    return std::unique_ptr<Geometry>(getFactory()->createLineString(seq.release()));
+    return getFactory()->createLineString(seq.release());
 }
 
 

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -274,8 +274,7 @@ LineString::equalsExact(const Geometry* other, double tolerance) const
         return false;
     }
 
-    const LineString* otherLineString = dynamic_cast<const LineString*>(other);
-    assert(otherLineString);
+    const LineString* otherLineString = detail::down_cast<const LineString*>(other);
     std::size_t npts = points->getSize();
     if(npts != otherLineString->points->getSize()) {
         return false;
@@ -364,8 +363,8 @@ LineString::normalize()
 int
 LineString::compareToSameClass(const Geometry* ls) const
 {
-    const LineString* line = dynamic_cast<const LineString*>(ls);
-    assert(line);
+    const LineString* line = detail::down_cast<const LineString*>(ls);
+
     // MD - optimized implementation
     std::size_t mynpts = points->getSize();
     std::size_t othnpts = line->points->getSize();

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -108,18 +108,18 @@ LinearRing::getGeometryTypeId() const
     return GEOS_LINEARRING;
 }
 
-std::unique_ptr<Geometry>
-LinearRing::reverse() const
+LinearRing*
+LinearRing::reverseImpl() const
 {
     if(isEmpty()) {
-        return clone();
+        return clone().release();
     }
 
     assert(points.get());
     auto seq = points->clone();
     CoordinateSequence::reverse(seq.get());
     assert(getFactory());
-    return getFactory()->createLinearRing(std::move(seq));
+    return getFactory()->createLinearRing(std::move(seq)).release();
 }
 
 } // namespace geos::geom

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -84,7 +84,7 @@ MultiLineString::isClosed() const
         return false;
     }
     for(const auto& g : geometries) {
-        LineString* ls = dynamic_cast<LineString*>(g.get());
+        const LineString* ls = detail::down_cast<const LineString*>(g.get());
         if(! ls->isClosed()) {
             return false;
         }

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -110,11 +110,11 @@ MultiLineString::getGeometryTypeId() const
     return GEOS_MULTILINESTRING;
 }
 
-std::unique_ptr<Geometry>
-MultiLineString::reverse() const
+MultiLineString*
+MultiLineString::reverseImpl() const
 {
     if(isEmpty()) {
-        return clone();
+        return clone().release();
     }
 
     std::vector<std::unique_ptr<Geometry>> reversed(geometries.size());
@@ -126,7 +126,7 @@ MultiLineString::reverse() const
                        return g->reverse();
                    });
 
-    return getFactory()->createMultiLineString(std::move(reversed));
+    return getFactory()->createMultiLineString(std::move(reversed)).release();
 }
 
 const LineString*

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -104,14 +104,6 @@ MultiLineString::getBoundary() const
     return std::unique_ptr<Geometry>(getFactory()->createMultiPoint(*pts));
 }
 
-bool
-MultiLineString::equalsExact(const Geometry* other, double tolerance) const
-{
-    if(!isEquivalentClass(other)) {
-        return false;
-    }
-    return GeometryCollection::equalsExact(other, tolerance);
-}
 GeometryTypeId
 MultiLineString::getGeometryTypeId() const
 {

--- a/src/geom/MultiPoint.cpp
+++ b/src/geom/MultiPoint.cpp
@@ -73,15 +73,6 @@ MultiPoint::getBoundary() const
     return std::unique_ptr<Geometry>(getFactory()->createGeometryCollection());
 }
 
-bool
-MultiPoint::equalsExact(const Geometry* other, double tolerance) const
-{
-    if(!isEquivalentClass(other)) {
-        return false;
-    }
-    return GeometryCollection::equalsExact(other, tolerance);
-}
-
 const Coordinate*
 MultiPoint::getCoordinateN(std::size_t n) const
 {

--- a/src/geom/MultiPolygon.cpp
+++ b/src/geom/MultiPolygon.cpp
@@ -100,11 +100,11 @@ MultiPolygon::getGeometryTypeId() const
     return GEOS_MULTIPOLYGON;
 }
 
-std::unique_ptr<Geometry>
-MultiPolygon::reverse() const
+MultiPolygon*
+MultiPolygon::reverseImpl() const
 {
     if(isEmpty()) {
-        return clone();
+        return clone().release();
     }
 
     std::vector<std::unique_ptr<Geometry>> reversed(geometries.size());
@@ -116,7 +116,7 @@ MultiPolygon::reverse() const
         return g->reverse();
     });
 
-    return getFactory()->createMultiPolygon(std::move(reversed));
+    return getFactory()->createMultiPolygon(std::move(reversed)).release();
 }
 
 const Polygon*

--- a/src/geom/MultiPolygon.cpp
+++ b/src/geom/MultiPolygon.cpp
@@ -94,14 +94,6 @@ MultiPolygon::getBoundary() const
     return getFactory()->createMultiLineString(std::move(allRings));
 }
 
-bool
-MultiPolygon::equalsExact(const Geometry* other, double tolerance) const
-{
-    if(!isEquivalentClass(other)) {
-        return false;
-    }
-    return GeometryCollection::equalsExact(other, tolerance);
-}
 GeometryTypeId
 MultiPolygon::getGeometryTypeId() const
 {

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -281,7 +281,7 @@ Point::equalsExact(const Geometry* other, double tolerance) const
 int
 Point::compareToSameClass(const Geometry* g) const
 {
-    const Point* p = dynamic_cast<const Point*>(g);
+    const Point* p = detail::down_cast<const Point*>(g);
     return getCoordinate()->compareTo(*(p->getCoordinate()));
 }
 

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -541,24 +541,23 @@ Polygon::isRectangle() const
     return true;
 }
 
-std::unique_ptr<Geometry>
-Polygon::reverse() const
+Polygon*
+Polygon::reverseImpl() const
 {
     if(isEmpty()) {
-        return clone();
+        return clone().release();
     }
 
-    std::unique_ptr<LinearRing> exteriorRingReversed(static_cast<LinearRing*>(shell->reverse().release()));
     std::vector<std::unique_ptr<LinearRing>> interiorRingsReversed(holes.size());
 
     std::transform(holes.begin(),
                    holes.end(),
                    interiorRingsReversed.begin(),
     [](const std::unique_ptr<LinearRing> & g) {
-        return std::unique_ptr<LinearRing>(static_cast<LinearRing*>(g->reverse().release()));
+        return g->reverse();
     });
 
-    return getFactory()->createPolygon(std::move(exteriorRingReversed), std::move(interiorRingsReversed));
+    return getFactory()->createPolygon(shell->reverse(), std::move(interiorRingsReversed)).release();
 }
 
 } // namespace geos::geom

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -264,7 +264,11 @@ Polygon::computeEnvelopeInternal() const
 bool
 Polygon::equalsExact(const Geometry* other, double tolerance) const
 {
-    const Polygon* otherPolygon = dynamic_cast<const Polygon*>(other);
+    if(!isEquivalentClass(other)) {
+        return false;
+    }
+
+    const Polygon* otherPolygon = detail::down_cast<const Polygon*>(other);
     if(! otherPolygon) {
         return false;
     }
@@ -342,7 +346,7 @@ Polygon::normalize()
 int
 Polygon::compareToSameClass(const Geometry* g) const
 {
-    const Polygon* p = dynamic_cast<const Polygon*>(g);
+    const Polygon* p = detail::down_cast<const Polygon*>(g);
     int shellComp = shell->compareToSameClass(p->shell.get());
     if (shellComp != 0) {
         return shellComp;

--- a/src/geom/prep/AbstractPreparedPolygonContains.cpp
+++ b/src/geom/prep/AbstractPreparedPolygonContains.cpp
@@ -70,8 +70,7 @@ AbstractPreparedPolygonContains::isSingleShell(const geom::Geometry& geom)
     }
 
     const geom::Geometry* g = geom.getGeometryN(0);
-    const geom::Polygon* poly = dynamic_cast<const Polygon*>(g);
-    assert(poly);
+    const geom::Polygon* poly = detail::down_cast<const Polygon*>(g);
 
     std::size_t numHoles = poly->getNumInteriorRing();
     return (0 == numHoles);

--- a/src/geom/prep/PreparedPolygon.cpp
+++ b/src/geom/prep/PreparedPolygon.cpp
@@ -87,7 +87,7 @@ contains(const geom::Geometry* g) const
     // optimization for rectangles
     if(isRectangle) {
         geom::Geometry const& geom = getGeometry();
-        geom::Polygon const& poly = dynamic_cast<geom::Polygon const&>(geom);
+        geom::Polygon const& poly = *detail::down_cast<geom::Polygon const*>(&geom);
 
         return operation::predicate::RectangleContains::contains(poly, *g);
     }

--- a/src/geom/util/GeometryEditor.cpp
+++ b/src/geom/util/GeometryEditor.cpp
@@ -104,7 +104,7 @@ GeometryEditor::edit(const Geometry* geometry, GeometryEditorOperation* operatio
 std::unique_ptr<Polygon>
 GeometryEditor::editPolygon(const Polygon* polygon, GeometryEditorOperation* operation)
 {
-    std::unique_ptr<Polygon> newPolygon(dynamic_cast<Polygon*>(
+    std::unique_ptr<Polygon> newPolygon(detail::down_cast<Polygon*>(
                                                 operation->edit(polygon, factory).release()
                                         ));
     if(newPolygon->isEmpty()) {
@@ -118,7 +118,7 @@ GeometryEditor::editPolygon(const Polygon* polygon, GeometryEditorOperation* ope
         }
     }
 
-    std::unique_ptr<LinearRing> shell(dynamic_cast<LinearRing*>(
+    std::unique_ptr<LinearRing> shell(detail::down_cast<LinearRing*>(
             edit(newPolygon->getExteriorRing(), operation).release()));
 
     if(shell->isEmpty()) {
@@ -129,10 +129,8 @@ GeometryEditor::editPolygon(const Polygon* polygon, GeometryEditorOperation* ope
     auto holes = detail::make_unique<std::vector<LinearRing*>>();
     for(std::size_t i = 0, n = newPolygon->getNumInteriorRing(); i < n; ++i) {
 
-        std::unique_ptr<LinearRing> hole(dynamic_cast<LinearRing*>(
+        std::unique_ptr<LinearRing> hole(detail::down_cast<LinearRing*>(
                 edit(newPolygon->getInteriorRingN(i), operation).release()));
-
-        assert(hole);
 
         if(hole->isEmpty()) {
             continue;

--- a/src/geom/util/GeometryTransformer.cpp
+++ b/src/geom/util/GeometryTransformer.cpp
@@ -272,8 +272,7 @@ GeometryTransformer::transformPolygon(
 
     bool isAllValidLinearRings = true;
 
-    const LinearRing* lr = dynamic_cast<const LinearRing*>(
-                               geom->getExteriorRing());
+    const LinearRing* lr = geom->getExteriorRing();
     assert(lr);
 
     Geometry::Ptr shell = transformLinearRing(lr, geom);

--- a/src/linearref/LinearLocation.cpp
+++ b/src/linearref/LinearLocation.cpp
@@ -107,6 +107,9 @@ LinearLocation::clamp(const Geometry* linear)
     }
     if(segmentIndex >= linear->getNumPoints()) {
         const LineString* line = dynamic_cast<const LineString*>(linear->getGeometryN(componentIndex));
+        if(! line) {
+            throw util::IllegalArgumentException("LinearLocation::clamp only works with LineString geometries");
+        }
         segmentIndex = line->getNumPoints() - 1;
         segmentFraction = 1.0;
     }
@@ -135,7 +138,9 @@ double
 LinearLocation::getSegmentLength(const Geometry* linearGeom) const
 {
     const LineString* lineComp = dynamic_cast<const LineString*>(linearGeom->getGeometryN(componentIndex));
-
+    if(! lineComp) {
+        throw util::IllegalArgumentException("LinearLocation::getSegmentLength only works with LineString geometries");
+    }
     // ensure segment index is valid
     std::size_t segIndex = segmentIndex;
     if(segmentIndex >= lineComp->getNumPoints() - 1) {
@@ -160,6 +165,9 @@ LinearLocation::setToEnd(const Geometry* linear)
     }
     componentIndex--;
     const LineString* lastLine = dynamic_cast<const LineString*>(linear->getGeometryN(componentIndex));
+    if(! lastLine) {
+        throw util::IllegalArgumentException("LinearLocation::setToEnd only works with LineString geometries");
+    }
     segmentIndex = lastLine->getNumPoints() - 1;
     segmentFraction = 1.0;
 }
@@ -216,6 +224,9 @@ std::unique_ptr<LineSegment>
 LinearLocation::getSegment(const Geometry* linearGeom) const
 {
     const LineString* lineComp = dynamic_cast<const LineString*>(linearGeom->getGeometryN(componentIndex));
+    if(! lineComp) {
+        throw util::IllegalArgumentException("LinearLocation::getSegment only works with LineString geometries");
+    }
     Coordinate p0 = lineComp->getCoordinateN(segmentIndex);
     // check for endpoint - return last segment of the line if so
     if(segmentIndex >= lineComp->getNumPoints() - 1) {
@@ -235,6 +246,9 @@ LinearLocation::isValid(const Geometry* linearGeom) const
     }
 
     const LineString* lineComp = dynamic_cast<const LineString*>(linearGeom->getGeometryN(componentIndex));
+    if(! lineComp) {
+        throw util::IllegalArgumentException("LinearLocation::isValid only works with LineString geometries");
+    }
     if(segmentIndex > lineComp->getNumPoints()) {
         return false;
     }
@@ -367,10 +381,13 @@ LinearLocation::isOnSameSegment(const LinearLocation& loc) const
 bool
 LinearLocation::isEndpoint(const Geometry& linearGeom) const
 {
-    const LineString& lineComp = dynamic_cast<const LineString&>(
-                                     *(linearGeom.getGeometryN(componentIndex)));
+    const LineString* lineComp = dynamic_cast<const LineString*>(
+                                     linearGeom.getGeometryN(componentIndex));
+    if(! lineComp) {
+        throw util::IllegalArgumentException("LinearLocation::isEndpoint only works with LineString geometries");
+    }
     // check for endpoint
-    auto nseg = lineComp.getNumPoints() - 1;
+    auto nseg = lineComp->getNumPoints() - 1;
     return segmentIndex >= nseg
            || (segmentIndex == nseg && segmentFraction >= 1.0);
 

--- a/src/linearref/LocationIndexOfLine.cpp
+++ b/src/linearref/LocationIndexOfLine.cpp
@@ -22,6 +22,7 @@
 #include <geos/linearref/LinearLocation.h>
 #include <geos/linearref/LocationIndexOfLine.h>
 #include <geos/linearref/LocationIndexOfPoint.h>
+#include <geos/util/IllegalArgumentException.h>
 
 
 
@@ -46,8 +47,12 @@ LocationIndexOfLine::LocationIndexOfLine(const Geometry* p_linearGeom) :
 LinearLocation*
 LocationIndexOfLine::indicesOf(const Geometry* subLine) const
 {
-    Coordinate startPt = dynamic_cast<const LineString*>(subLine->getGeometryN(0))->getCoordinateN(0);
+    const LineString* firstLine = dynamic_cast<const LineString*>(subLine->getGeometryN(0));
     const LineString* lastLine = dynamic_cast<const LineString*>(subLine->getGeometryN(subLine->getNumGeometries() - 1));
+    if(! firstLine || !lastLine) {
+        throw util::IllegalArgumentException("LocationIndexOfLine::indicesOf only works with geometry collections of LineString");
+    }
+    Coordinate startPt = firstLine->getCoordinateN(0);
     Coordinate endPt = lastLine->getCoordinateN(lastLine->getNumPoints() - 1);
 
     LocationIndexOfPoint locPt(linearGeom);

--- a/src/operation/intersection/RectangleIntersection.cpp
+++ b/src/operation/intersection/RectangleIntersection.cpp
@@ -125,7 +125,7 @@ RectangleIntersection::clip_point(const geom::Point* g,
     double y = g->getY();
 
     if(rect.position(x, y) == Rectangle::Inside) {
-        parts.add(dynamic_cast<geom::Point*>(g->clone().release()));
+        parts.add(g->clone().release());
     }
 }
 
@@ -391,7 +391,7 @@ RectangleIntersection::clip_polygon_to_linestrings(const geom::Polygon* g,
     // If everything was in, just clone the original
 
     if(clip_linestring_parts(g->getExteriorRing(), parts, rect)) {
-        toParts.add(dynamic_cast<geom::Polygon*>(g->clone().release()));
+        toParts.add(g->clone().release());
         return;
     }
 
@@ -457,7 +457,7 @@ RectangleIntersection::clip_polygon_to_polygons(const geom::Polygon* g,
 
     const LineString* shell = g->getExteriorRing();
     if(clip_linestring_parts(shell, parts, rect)) {
-        toParts.add(dynamic_cast<geom::Polygon*>(g->clone().release()));
+        toParts.add(g->clone().release());
         return;
     }
 
@@ -562,7 +562,7 @@ RectangleIntersection::clip_linestring(const geom::LineString* g,
     // If everything was in, just clone the original
 
     if(clip_linestring_parts(g, parts, rect)) {
-        parts.add(dynamic_cast<geom::LineString*>(g->clone().release()));
+        parts.add(g->clone().release());
     }
 
 }

--- a/src/operation/intersection/RectangleIntersectionBuilder.cpp
+++ b/src/operation/intersection/RectangleIntersectionBuilder.cpp
@@ -521,7 +521,7 @@ RectangleIntersectionBuilder::reverseLines()
     std::list<geom::LineString*> new_lines;
     for(std::list<geom::LineString*>::reverse_iterator i = lines.rbegin(), e = lines.rend(); i != e; ++i) {
         LineString* ol = *i;
-        new_lines.push_back(dynamic_cast<LineString*>(ol->reverse().release()));
+        new_lines.push_back(detail::down_cast<LineString*>(ol->reverse().release()));
         delete ol;
     }
     lines = new_lines;

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -228,9 +228,7 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
         return nullptr;
     }
     else {
-        Geometry::NonConstVect* l = lines.get();
-        lines.release();
-        return factory->buildGeometry(l);
+        return factory->buildGeometry(lines.release());
     }
 }
 

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -214,7 +214,7 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
             LineString* lineToAdd;
 
             if(! de->getEdgeDirection() && ! line->isClosed()) {
-                lineToAdd = reverse(line);
+                lineToAdd = line->reverse().release();
             }
             else {
                 lineToAdd = line->clone().release();
@@ -232,15 +232,6 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
         lines.release();
         return factory->buildGeometry(l);
     }
-}
-
-/*static private*/
-LineString*
-LineSequencer::reverse(const LineString* line)
-{
-    auto cs = line->getCoordinates();
-    CoordinateSequence::reverse(cs.get());
-    return line->getFactory()->createLineString(cs.release());
 }
 
 /*private static*/

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -217,8 +217,7 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
                 lineToAdd = reverse(line);
             }
             else {
-                Geometry* lineClone = line->clone().release();
-                lineToAdd = detail::down_cast<LineString*>(lineClone);
+                lineToAdd = line->clone().release();
             }
 
             lines->push_back(lineToAdd);

--- a/src/operation/overlayng/OverlayMixedPoints.cpp
+++ b/src/operation/overlayng/OverlayMixedPoints.cpp
@@ -255,8 +255,7 @@ OverlayMixedPoints::extractPolygons(const Geometry* geom) const
     for (std::size_t i = 0; i < geom->getNumGeometries(); i++) {
         const Polygon* poly = static_cast<const Polygon*>(geom->getGeometryN(i));
         if(!poly->isEmpty()) {
-            Polygon* p = static_cast<Polygon*>(poly->clone().release());
-            list.emplace_back(p);
+            list.emplace_back(poly->clone());
         }
     }
     return list;
@@ -270,8 +269,7 @@ OverlayMixedPoints::extractLines(const Geometry* geom) const
     for (std::size_t i = 0; i < geom->getNumGeometries(); i++) {
         const LineString* line = static_cast<const LineString*>(geom->getGeometryN(i));
         if (! line->isEmpty()) {
-            LineString* l = static_cast<LineString*>(line->clone().release());
-            list.emplace_back(l);
+            list.emplace_back(line->clone());
         }
     }
     return list;

--- a/src/operation/union/PointGeometryUnion.cpp
+++ b/src/operation/union/PointGeometryUnion.cpp
@@ -57,7 +57,7 @@ PointGeometryUnion::Union() const
 
     // if no points are in exterior, return the other geom
     if(exteriorCoords.empty()) {
-        return std::unique_ptr<Geometry>(otherGeom.clone());
+        return otherGeom.clone();
     }
 
     // make a puntal geometry of appropriate size

--- a/src/operation/valid/MakeValid.cpp
+++ b/src/operation/valid/MakeValid.cpp
@@ -96,12 +96,10 @@ nodeLineWithFirstCoordinate(const geom::Geometry* geom)
 
   std::unique_ptr<geom::Geometry> point;
   if( geomType == GEOS_LINESTRING ) {
-      auto line = dynamic_cast<const geom::LineString*>(geom);
-      assert(line);
+      auto line = detail::down_cast<const geom::LineString*>(geom);
       point = line->getPointN(0);
   } else {
-      auto mls = dynamic_cast<const geom::MultiLineString*>(geom);
-      assert(mls);
+      auto mls = detail::down_cast<const geom::MultiLineString*>(geom);
       auto line = mls->getGeometryN(0);
       assert(line);
       point = line->getPointN(0);
@@ -122,8 +120,7 @@ static std::unique_ptr<geom::Geometry> MakeValidMultiLine(const geom::MultiLineS
     std::vector<std::unique_ptr<geom::Geometry>> lines;
 
     for(const auto& subgeom: *mls) {
-        auto line = dynamic_cast<const geom::LineString*>(subgeom.get());
-        assert(line);
+        auto line = detail::down_cast<const geom::LineString*>(subgeom.get());
         auto validSubGeom = MakeValidLine(line);
         if( !validSubGeom || validSubGeom->isEmpty() ) {
             continue;
@@ -135,7 +132,7 @@ static std::unique_ptr<geom::Geometry> MakeValidMultiLine(const geom::MultiLineS
         else if( validLineType == GEOS_LINESTRING ) {
             lines.emplace_back(std::move(validSubGeom));
         } else if( validLineType == GEOS_MULTILINESTRING ) {
-            auto mlsValid = dynamic_cast<const geom::MultiLineString*>(validSubGeom.get());
+            auto mlsValid = detail::down_cast<const geom::MultiLineString*>(validSubGeom.get());
             for(const auto& subgeomMlsValid: *mlsValid) {
                 lines.emplace_back(subgeomMlsValid->clone());
             }
@@ -316,11 +313,11 @@ std::unique_ptr<geom::Geometry> MakeValid::build(const geom::Geometry* geom)
 
     auto typeId = geom->getGeometryTypeId();
     if( typeId == GEOS_LINESTRING ) {
-        auto lineString = dynamic_cast<const LineString*>(geom);
+        auto lineString = detail::down_cast<const LineString*>(geom);
         return MakeValidLine(lineString);
     }
     if( typeId == GEOS_MULTILINESTRING ) {
-        auto mls = dynamic_cast<const MultiLineString*>(geom);
+        auto mls = detail::down_cast<const MultiLineString*>(geom);
         return MakeValidMultiLine(mls);
     }
     if( typeId == GEOS_POLYGON ||
@@ -328,7 +325,7 @@ std::unique_ptr<geom::Geometry> MakeValid::build(const geom::Geometry* geom)
         return MakeValidPoly(geom);
     }
     if( typeId == GEOS_GEOMETRYCOLLECTION ) {
-        auto coll = dynamic_cast<const GeometryCollection*>(geom);
+        auto coll = detail::down_cast<const GeometryCollection*>(geom);
         return MakeValidCollection(coll);
     }
 


### PR DESCRIPTION
- make clone() and reverse() return a std::unique_ptr<ActualGeometryType> instead of a std::unique_ptr<Geometry>
- replace uses of dynamic_cast<> with detail::down_cast<> when the cast is bound to succeed
-  remove useless override of equalsExact() in MultiXXXX classes GeometryCollection::equalsExact() already does the isEquivalentClass() check
- other tiny improvements





