### PR TITLE
Handle buffers with M in GEOSCoordSeq_copyFromBuffer, GEOSCoordSeq_copyToBuffer

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -868,15 +868,15 @@ extern "C" {
     }
 
     CoordinateSequence*
-    GEOSCoordSeq_copyFromBuffer(const double* buf, unsigned int size, unsigned int dims)
+    GEOSCoordSeq_copyFromBuffer(const double* buf, unsigned int size, int hasZ, int hasM)
     {
-        return GEOSCoordSeq_copyFromBuffer_r(handle, buf, size, dims);
+        return GEOSCoordSeq_copyFromBuffer_r(handle, buf, size, hasZ, hasM);
     }
 
     int
-    GEOSCoordSeq_copyToBuffer(const CoordinateSequence* s, double* buf, unsigned int dims)
+    GEOSCoordSeq_copyToBuffer(const CoordinateSequence* s, double* buf, int hasZ, int hasM)
     {
-        return GEOSCoordSeq_copyToBuffer_r(handle, s, buf, dims);
+        return GEOSCoordSeq_copyToBuffer_r(handle, s, buf, hasZ, hasM);
     }
 
     CoordinateSequence*

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -358,7 +358,8 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromBuffer_r(
         GEOSContextHandle_t handle,
         const double* buf,
         unsigned int size,
-        unsigned int dims);
+        int hasZ,
+        int hasM);
 
 /** \see GEOSCoordSeq_copyFromArrays */
 extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays_r(
@@ -374,7 +375,8 @@ extern int GEOS_DLL GEOSCoordSeq_copyToBuffer_r(
         GEOSContextHandle_t handle,
         const GEOSCoordSequence* s,
         double* buf,
-        unsigned int dims);
+        int hasZ,
+        int hasM);
 
 /** \see GEOSCoordSeq_copyToArrays */
 extern int GEOS_DLL GEOSCoordSeq_copyToArrays_r(
@@ -1731,10 +1733,11 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_create(unsigned int size, unsign
 * Create a coordinate sequence by copying from a buffer of doubles (XYXY or XYZXYZ)
 * \param buf pointer to buffer
 * \param size number of coordinates in the sequence
-* \param dims dimensionality of the coordinates (2 or 3)
+* \param hasZ does buffer have Z values?
+* \param hasM does buffer have M values? (they will be ignored)
 * \return the sequence or NULL on exception
 */
-extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromBuffer(const double* buf, unsigned int size, unsigned int dims);
+extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromBuffer(const double* buf, unsigned int size, int hasZ, int hasM);
 
 /**
 * Create a coordinate sequence by copying from arrays of doubles
@@ -1751,10 +1754,11 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_copyFromArrays(const double* x, 
 * Copy the contents of a coordinate sequence to a buffer of doubles (XYXY or XYZXYZ)
 * \param s sequence to copy
 * \param buf buffer to which coordinates should be copied
-* \param dims dimensionality of the coordinates to be constructed in the buffer (2 or 3)
+* \param hasZ copy Z values to buffer?
+* \param hasM copy M values to buffer? (will be NaN)
 * \return 1 on success, 0 on error
 */
-extern int GEOS_DLL GEOSCoordSeq_copyToBuffer(const GEOSCoordSequence* s, double* buf, unsigned int dims);
+extern int GEOS_DLL GEOSCoordSeq_copyToBuffer(const GEOSCoordSequence* s, double* buf, int hasZ, int hasM);
 
 /**
 * Copy the contents of a coordinate sequence to a buffer of doubles (XYZY or XYZXYZ)

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -389,7 +389,7 @@ void object::test<12>()
         values[i] = static_cast<double>(i);
     }
 
-    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, dim);
+    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, false, false);
 
     double x, y;
     ensure(GEOSCoordSeq_getXY(cs_, 0, &x, &y));
@@ -405,57 +405,57 @@ void object::test<12>()
     ensure_equals(dim_out, dim);
 
     std::vector<double> out3(N * 3);
-    ensure(GEOSCoordSeq_copyToBuffer(cs_, out3.data(), 3));
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out3.data(), true, false));
     ensure_equals(out3[0], values[0]); // X1
     ensure_equals(out3[1], values[1]); // Y1
     ensure(std::isnan(out3[2])); // Z1
     ensure_equals(out3[3], values[2]); // X2
 
     std::vector<double> out2(N * 2);
-    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), 2));
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), false, false));
     ensure(out2 == values);
 }
 
 // test 3D from/to buffer
-template<>
-template<>
-void object::test<13>()
-{
-    unsigned int N = 10;
-    unsigned int dim = 3;
-    std::vector<double> values(N * dim);
-    for (size_t i = 0; i < values.size(); i++) {
-        values[i] = static_cast<double>(i);
+    template<>
+    template<>
+    void object::test<13>()
+    {
+        unsigned int N = 10;
+        unsigned int dim = 3;
+        std::vector<double> values(N * dim);
+        for (size_t i = 0; i < values.size(); i++) {
+            values[i] = static_cast<double>(i);
+        }
+
+        cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, true, false);
+
+        double x, y, z;
+        ensure(GEOSCoordSeq_getXYZ(cs_, 0, &x, &y, &z));
+        ensure_equals(x, 0.0);
+        ensure_equals(y, 1.0);
+        ensure_equals(z, 2.0);
+
+        ensure(GEOSCoordSeq_getXYZ(cs_, N - 1, &x, &y, &z));
+        ensure_equals(x, static_cast<double>(N-1)*3);
+        ensure_equals(y, static_cast<double>(N-1)*3 + 1);
+        ensure_equals(z, static_cast<double>(N-1)*3 + 2);
+
+        unsigned int dim_out;
+        ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+        ensure_equals(dim_out, dim);
+
+        std::vector<double> out3(N * 3);
+        ensure(GEOSCoordSeq_copyToBuffer(cs_, out3.data(), true, false));
+        ensure(out3 == values);
+
+        std::vector<double> out2(N * 2);
+        ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), false, false));
+        ensure_equals(out2[0], values[0]); // X1
+        ensure_equals(out2[1], values[1]); // Y1
+        ensure_equals(out2[2], values[3]); // X2
+        ensure_equals(out2[3], values[4]); // Y2
     }
-
-    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, dim);
-
-    double x, y, z;
-    ensure(GEOSCoordSeq_getXYZ(cs_, 0, &x, &y, &z));
-    ensure_equals(x, 0.0);
-    ensure_equals(y, 1.0);
-    ensure_equals(z, 2.0);
-
-    ensure(GEOSCoordSeq_getXYZ(cs_, N - 1, &x, &y, &z));
-    ensure_equals(x, static_cast<double>(N-1)*3);
-    ensure_equals(y, static_cast<double>(N-1)*3 + 1);
-    ensure_equals(z, static_cast<double>(N-1)*3 + 2);
-
-    unsigned int dim_out;
-    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
-    ensure_equals(dim_out, dim);
-
-    std::vector<double> out3(N * 3);
-    ensure(GEOSCoordSeq_copyToBuffer(cs_, out3.data(), 3));
-    ensure(out3 == values);
-
-    std::vector<double> out2(N * 2);
-    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), 2));
-    ensure_equals(out2[0], values[0]); // X1
-    ensure_equals(out2[1], values[1]); // Y1
-    ensure_equals(out2[2], values[3]); // X2
-    ensure_equals(out2[3], values[4]); // Y2
-}
 
 // test 2D from/to arrays
 template<>
@@ -548,6 +548,91 @@ void object::test<15>()
     ensure(y == yout);
     ensure(z == zout);
     ensure(std::all_of(mout.begin(), mout.end(), [](double mval) { return std::isnan(mval); }));
+}
+
+// test 3DM from/to buffer
+template<>
+template<>
+void object::test<16>()
+{
+    unsigned int N = 10;
+    unsigned int dim = 3;
+    std::vector<double> values(N * dim);
+    for (size_t i = 0; i < values.size(); i++) {
+        values[i] = static_cast<double>(i);
+    }
+
+    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, false, true);
+
+    // XYM buffer produces 2D coordinate sequence
+    unsigned int dim_out;
+    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+    ensure_equals(dim_out, 2u);
+
+    // Check first coordinate
+    double x, y, z;
+    ensure(GEOSCoordSeq_getXYZ(cs_, 0, &x, &y, &z));
+    ensure_equals(x, 0.0);
+    ensure_equals(y, 1.0);
+    ensure(std::isnan(z));
+
+    // Check last coordinate
+    ensure(GEOSCoordSeq_getXYZ(cs_, N - 1, &x, &y, &z));
+    ensure_equals(x, static_cast<double>(N-1)*3);
+    ensure_equals(y, static_cast<double>(N-1)*3 + 1);
+    ensure(std::isnan(z));
+
+    // Copy to 2D buffer
+    std::vector<double> out2(N * 2);
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), false, false));
+    ensure_equals(out2[0], values[0]); // X1
+    ensure_equals(out2[1], values[1]); // Y1
+    ensure_equals(out2[2], values[3]); // X2
+    ensure_equals(out2[3], values[4]); // Y2
+}
+
+// test 3DZM from/to buffer
+template<>
+template<>
+void object::test<17>()
+{
+    unsigned int N = 10;
+    unsigned int dim = 4;
+    std::vector<double> values(N * dim);
+    for (size_t i = 0; i < values.size(); i++) {
+        values[i] = static_cast<double>(i);
+    }
+
+    cs_ = GEOSCoordSeq_copyFromBuffer(values.data(), N, true, true);
+
+    // XYZM buffer creates a 3D coordinate sequence
+    unsigned int dim_out;
+    ensure(GEOSCoordSeq_getDimensions(cs_, &dim_out));
+    ensure_equals(dim_out, 3u);
+
+    // Check first coordinate
+    double x, y, z;
+    ensure(GEOSCoordSeq_getXYZ(cs_, 0, &x, &y, &z));
+    ensure_equals(x, 0.0);
+    ensure_equals(y, 1.0);
+    ensure_equals(z, 2.0);
+
+    // Check last coordinate
+    ensure(GEOSCoordSeq_getXYZ(cs_, N - 1, &x, &y, &z));
+    ensure_equals(x, static_cast<double>(N-1)*4);
+    ensure_equals(y, static_cast<double>(N-1)*4 + 1);
+    ensure_equals(z, static_cast<double>(N-1)*4 + 2);
+
+    // Copy to 4D buffer
+    std::vector<double> out2(N * 4);
+    ensure(GEOSCoordSeq_copyToBuffer(cs_, out2.data(), true, true));
+    ensure_equals(out2[0], values[0]); // X1
+    ensure_equals(out2[1], values[1]); // Y1
+    ensure_equals(out2[2], values[2]); // Z1
+    ensure(std::isnan(out2[3]));
+    ensure_equals(out2[4], values[4]); // X2
+    ensure_equals(out2[5], values[5]); // Y2
+    ensure_equals(out2[6], values[6]); // Z2
 }
 
 } // namespace tut


### PR DESCRIPTION
Results in cleaner usage for PostGIS (https://github.com/dbaston/postgis/commit/1c4aead9c5b8c166d243f5397b7237cc3087ebc7), avoids future ambiguity about what `dims == 3` means.