### PR TITLE
remove memory leak in BufferOp

### DIFF
--- a/include/geos/operation/buffer/BufferOp.h
+++ b/include/geos/operation/buffer/BufferOp.h
@@ -192,6 +192,8 @@ public:
     {
     }
 
+    ~BufferOp();
+
     /** \brief
      * Specifies the end cap style of the generated buffer.
      *

--- a/src/operation/buffer/BufferOp.cpp
+++ b/src/operation/buffer/BufferOp.cpp
@@ -78,6 +78,13 @@ OLDprecisionScaleFactor(const Geometry* g,
 }
 #endif
 
+BufferOp::~BufferOp(void)
+{
+    if (resultGeometry != nullptr) {
+        argGeom->getFactory()->destroyGeometry(resultGeometry);
+    }
+}
+
 /*private*/
 double
 BufferOp::precisionScaleFactor(const Geometry* g,


### PR DESCRIPTION
When instance variable resultGeometry was computed by a call to
getResultGeometry() it was never freed.

This change adds a destructor to BufferOp and destroys resultGeometry if
it was computed.