### PR TITLE
Avoid undefined behavior in casts in Densify(), DiscreteHausdorffDistance and DiscreteFrechetDistance

### DIFF
--- a/include/geos/algorithm/distance/DiscreteFrechetDistance.h
+++ b/include/geos/algorithm/distance/DiscreteFrechetDistance.h
@@ -32,6 +32,7 @@
 #include <geos/geom/CoordinateSequence.h> // for inheritance
 
 #include <cstddef>
+#include <limits>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -132,7 +133,12 @@ public:
     void
     setDensifyFraction(double dFrac)
     {
-        if(dFrac > 1.0 || dFrac <= 0.0) {
+        // !(dFrac > 0) written that way to catch NaN
+        // and test on 1.0/dFrac to avoid a potential later undefined behaviour
+        // when casting to std::size_t
+        if(dFrac > 1.0 || !(dFrac > 0.0) ||
+           util::round(1.0 / dFrac) >
+               static_cast<double>(std::numeric_limits<std::size_t>::max())) {
             throw util::IllegalArgumentException(
                 "Fraction is not in range (0.0 - 1.0]");
         }

--- a/include/geos/algorithm/distance/DiscreteFrechetDistance.h
+++ b/include/geos/algorithm/distance/DiscreteFrechetDistance.h
@@ -32,7 +32,6 @@
 #include <geos/geom/CoordinateSequence.h> // for inheritance
 
 #include <cstddef>
-#include <limits>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -130,21 +129,7 @@ public:
      *
      * @param dFrac
      */
-    void
-    setDensifyFraction(double dFrac)
-    {
-        // !(dFrac > 0) written that way to catch NaN
-        // and test on 1.0/dFrac to avoid a potential later undefined behaviour
-        // when casting to std::size_t
-        if(dFrac > 1.0 || !(dFrac > 0.0) ||
-           util::round(1.0 / dFrac) >
-               static_cast<double>(std::numeric_limits<std::size_t>::max())) {
-            throw util::IllegalArgumentException(
-                "Fraction is not in range (0.0 - 1.0]");
-        }
-
-        densifyFrac = dFrac;
-    }
+    void setDensifyFraction(double dFrac);
 
     double
     distance()

--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -29,7 +29,6 @@
 #include <geos/geom/CoordinateSequenceFilter.h> // for inheritance
 
 #include <cstddef>
-#include <limits>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -124,21 +123,7 @@ public:
      *
      * @param dFrac
      */
-    void
-    setDensifyFraction(double dFrac)
-    {
-        // !(dFrac > 0) written that way to catch NaN
-        // and test on 1.0/dFrac to avoid a potential later undefined behaviour
-        // when casting to std::size_t
-        if(dFrac > 1.0 || !(dFrac > 0.0) ||
-           util::round(1.0 / dFrac) >
-               static_cast<double>(std::numeric_limits<std::size_t>::max())) {
-            throw util::IllegalArgumentException(
-                "Fraction is not in range (0.0 - 1.0]");
-        }
-
-        densifyFrac = dFrac;
-    }
+    void setDensifyFraction(double dFrac);
 
     double
     distance()

--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -29,6 +29,7 @@
 #include <geos/geom/CoordinateSequenceFilter.h> // for inheritance
 
 #include <cstddef>
+#include <limits>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -126,7 +127,12 @@ public:
     void
     setDensifyFraction(double dFrac)
     {
-        if(dFrac > 1.0 || dFrac <= 0.0) {
+        // !(dFrac > 0) written that way to catch NaN
+        // and test on 1.0/dFrac to avoid a potential later undefined behaviour
+        // when casting to std::size_t
+        if(dFrac > 1.0 || !(dFrac > 0.0) ||
+           util::round(1.0 / dFrac) >
+               static_cast<double>(std::numeric_limits<std::size_t>::max())) {
             throw util::IllegalArgumentException(
                 "Fraction is not in range (0.0 - 1.0]");
         }
@@ -195,6 +201,7 @@ public:
             const geom::Geometry& p_geom, double fraction)
             :
             geom(p_geom),
+            // Validity of the cast to size_t has been verified in setDensifyFraction()
             numSubSegs(std::size_t(util::round(1.0 / fraction)))
         {
         }

--- a/src/algorithm/distance/DiscreteFrechetDistance.cpp
+++ b/src/algorithm/distance/DiscreteFrechetDistance.cpp
@@ -59,6 +59,7 @@ geom::Coordinate
 DiscreteFrechetDistance::getSegementAt(const CoordinateSequence& seq, std::size_t index)
 {
     if(densifyFrac > 0.0) {
+        // Validity of the cast to size_t has been verified in setDensifyFraction()
         std::size_t numSubSegs =  std::size_t(util::round(1.0 / densifyFrac));
         std::size_t i = index / numSubSegs;
         std::size_t j = index % numSubSegs;

--- a/src/algorithm/distance/DiscreteFrechetDistance.cpp
+++ b/src/algorithm/distance/DiscreteFrechetDistance.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <vector>
 #include <algorithm>
+#include <limits>
 #include <iostream>
 using namespace geos::geom;
 
@@ -51,6 +52,22 @@ DiscreteFrechetDistance::distance(const geom::Geometry& g0,
     DiscreteFrechetDistance dist(g0, g1);
     dist.setDensifyFraction(densifyFrac);
     return dist.distance();
+}
+
+/* public */
+void DiscreteFrechetDistance::setDensifyFraction(double dFrac)
+{
+    // !(dFrac > 0) written that way to catch NaN
+    // and test on 1.0/dFrac to avoid a potential later undefined behaviour
+    // when casting to std::size_t
+    if(dFrac > 1.0 || !(dFrac > 0.0) ||
+       util::round(1.0 / dFrac) >
+           static_cast<double>(std::numeric_limits<std::size_t>::max())) {
+        throw util::IllegalArgumentException(
+            "Fraction is not in range (0.0 - 1.0]");
+    }
+
+    densifyFrac = dFrac;
 }
 
 /* private */

--- a/src/algorithm/distance/DiscreteHausdorffDistance.cpp
+++ b/src/algorithm/distance/DiscreteHausdorffDistance.cpp
@@ -21,6 +21,7 @@
 
 #include <typeinfo>
 #include <cassert>
+#include <limits>
 
 using namespace geos::geom;
 
@@ -74,6 +75,23 @@ DiscreteHausdorffDistance::distance(const geom::Geometry& g0,
     DiscreteHausdorffDistance dist(g0, g1);
     dist.setDensifyFraction(densifyFrac);
     return dist.distance();
+}
+
+/* public */
+
+void DiscreteHausdorffDistance::setDensifyFraction(double dFrac)
+{
+    // !(dFrac > 0) written that way to catch NaN
+    // and test on 1.0/dFrac to avoid a potential later undefined behaviour
+    // when casting to std::size_t
+    if(dFrac > 1.0 || !(dFrac > 0.0) ||
+       util::round(1.0 / dFrac) >
+           static_cast<double>(std::numeric_limits<std::size_t>::max())) {
+        throw util::IllegalArgumentException(
+            "Fraction is not in range (0.0 - 1.0]");
+    }
+
+    densifyFrac = dFrac;
 }
 
 /* private */

--- a/tests/unit/algorithm/distance/DiscreteFrechetDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteFrechetDistanceTest.cpp
@@ -97,6 +97,30 @@ void object::test<1>
 ()
 {
     runTest("LINESTRING (0 0, 2 1)", "LINESTRING (0 0, 2 0)", 1.0);
+
+    // zero densify factor
+    try {
+        runTest("LINESTRING (0 0, 2 1)", "LINESTRING EMPTY", 0.0, 0);
+    }
+    catch(const geos::util::IllegalArgumentException& ) {
+        // We do expect an exception
+    }
+
+    // too big densify factor
+    try {
+        runTest("LINESTRING (0 0, 2 1)", "LINESTRING EMPTY", 1 + 1e-10, 0);
+    }
+    catch(const geos::util::IllegalArgumentException& ) {
+        // We do expect an exception
+    }
+
+    // too small positive densify factor
+    try {
+        runTest("LINESTRING (0 0, 2 1)", "LINESTRING EMPTY", 1e-30, 0);
+    }
+    catch(const geos::util::IllegalArgumentException& ) {
+        // We do expect an exception
+    }
 }
 
 // 2 - testLineSegments2

--- a/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
@@ -98,6 +98,30 @@ void object::test<1>
 ()
 {
     runTest("LINESTRING (0 0, 2 1)", "LINESTRING (0 0, 2 0)", 1.0);
+
+    // zero densify factor
+    try {
+        runTest("LINESTRING (0 0, 2 1)", "LINESTRING EMPTY", 0.0, 0);
+    }
+    catch(const geos::util::IllegalArgumentException& ) {
+        // We do expect an exception
+    }
+
+    // too big densify factor
+    try {
+        runTest("LINESTRING (0 0, 2 1)", "LINESTRING EMPTY", 1 + 1e-10, 0);
+    }
+    catch(const geos::util::IllegalArgumentException& ) {
+        // We do expect an exception
+    }
+
+    // too small positive densify factor
+    try {
+        runTest("LINESTRING (0 0, 2 1)", "LINESTRING EMPTY", 1e-30, 0);
+    }
+    catch(const geos::util::IllegalArgumentException& ) {
+        // We do expect an exception
+    }
 }
 
 // 2 - testLineSegments2

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -1290,15 +1290,14 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
         else if(opName == "densify") {
             geom::Geometry* p_gT = gA;
 
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
             geom::util::Densifier den(p_gT);
             double distanceTolerance = std::atof(opArg2.c_str());
             den.setDistanceTolerance(distanceTolerance);
             GeomPtr gRealRes = den.getResultGeometry();
             gRealRes->normalize();
 
+            GeomPtr gRes(parseGeometry(opRes, "expected"));
+            gRes->normalize();
             if(gRes->compareTo(gRealRes.get()) == 0) {
                 success = 1;
             }
@@ -2216,10 +2215,16 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
 
     }
     catch(const std::exception& e) {
-        std::cerr << "EXCEPTION on case " << caseCount
-                  << " test " << testCount << ": " << e.what()
-                  << std::endl;
-        actual_result = e.what();
+        if (expected_result == "exception") {
+            success = true;
+            actual_result = "exception";
+        }
+        else {
+            std::cerr << "EXCEPTION on case " << caseCount
+                      << " test " << testCount << ": " << e.what()
+                      << std::endl;
+            actual_result = e.what();
+        }
     }
     catch(...) {
         std::cerr << "Unknown EXEPTION on case "

--- a/tests/xmltester/tests/general/TestDensify.xml
+++ b/tests/xmltester/tests/general/TestDensify.xml
@@ -313,4 +313,24 @@ MULTIPOLYGON (
     </test>
   </case>
 
+  <case>
+    <desc>L - zero tolerance: exception</desc>
+    <a>
+LINESTRING(10 10, 20 10)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='0'>exception</op>
+    </test>
+  </case>
+
+  <case>
+    <desc>L - too small positive tolerance: exception</desc>
+    <a>
+LINESTRING(10 10, 20 10)
+    </a>
+    <test>
+      <op name="densify" arg1='A' arg2='0.0000000000000001'>exception</op>
+    </test>
+  </case>
+
 </run>


### PR DESCRIPTION
Those pieces of code do things like (integer_type)potential_big_double_value,
which is undefined behavior if the potential_big_double_value is beyond
the validity range of integer_type. Catch that before the cast.