### PR TITLE
Bufferop::getResultGeometry() documentation

### DIFF
--- a/include/geos/operation/buffer/BufferOp.h
+++ b/include/geos/operation/buffer/BufferOp.h
@@ -236,7 +236,8 @@ public:
      * distance.
      *
      * @param nDistance the buffer distance
-     * @return the buffer of the input geometry
+     * @return the buffer of the input geometry.
+     *         Ownership of the returned object is transferred to caller.
      */
     geom::Geometry* getResultGeometry(double nDistance);
 


### PR DESCRIPTION
When instance variable resultGeometry is computed by a call to
getResultGeometry() it is never freed by the BufferOf instance.
It is the responisibilty of the caller to free this object.

This change documents the ownership transfer intent.