### PR TITLE
Add GeoJSON reader to C API

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -39,6 +39,7 @@
 #define GEOSWKTWriter geos::io::WKTWriter
 #define GEOSWKBReader geos::io::WKBReader
 #define GEOSWKBWriter geos::io::WKBWriter
+#define GEOSGeoJSONReader geos::io::GeoJSONReader
 typedef struct GEOSBufParams_t GEOSBufferParams;
 typedef struct GEOSMakeValidParams_t GEOSMakeValidParams;
 
@@ -70,6 +71,7 @@ using geos::io::WKTReader;
 using geos::io::WKTWriter;
 using geos::io::WKBReader;
 using geos::io::WKBWriter;
+using geos::io::GeoJSONReader;
 
 
 
@@ -1286,6 +1288,25 @@ extern "C" {
     GEOSWKBWriter_setIncludeSRID(GEOSWKBWriter* writer, const char newIncludeSRID)
     {
         GEOSWKBWriter_setIncludeSRID_r(handle, writer, newIncludeSRID);
+    }
+
+    /* GeoJSON Reader */
+    GeoJSONReader*
+    GEOSGeoJSONReader_create()
+    {
+        return GEOSGeoJSONReader_create_r(handle);
+    }
+
+    void
+    GEOSGeoJSONReader_destroy(GeoJSONReader* reader)
+    {
+        GEOSGeoJSONReader_destroy_r(handle, reader);
+    }
+
+    Geometry*
+    GEOSGeoJSONReader_read(GeoJSONReader* reader, const char* geojson)
+    {
+        return GEOSGeoJSONReader_read_r(handle, reader, geojson);
     }
 
 

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -21,6 +21,7 @@
 #include <geos/io/WKBReader.h>
 #include <geos/io/WKTWriter.h>
 #include <geos/io/WKBWriter.h>
+#include <geos/io/GeoJSONReader.h>
 #include <geos/util/Interrupt.h>
 
 #include <stdexcept>

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1585,6 +1585,13 @@ typedef struct GEOSWKBReader_t GEOSWKBReader;
 */
 typedef struct GEOSWKBWriter_t GEOSWKBWriter;
 
+/**
+* Reader object to read GeoJSON format and construct a GeometryCollection.
+* \see GEOSGeoJSONReader_create
+* \see GEOSGeoJSONReader_create_r
+*/
+typedef struct GEOSGeoJSONReader_t GEOSGeoJSONReader;
+
 #endif
 
 /* ========== WKT Reader ========== */
@@ -1729,6 +1736,22 @@ extern char GEOS_DLL GEOSWKBWriter_getIncludeSRID_r(
 extern void GEOS_DLL GEOSWKBWriter_setIncludeSRID_r(
     GEOSContextHandle_t handle,
     GEOSWKBWriter* writer, const char writeSRID);
+
+/* ========== GeoJSON Reader ========== */
+
+/** \see GEOSGeoJSONReader_create */
+extern GEOSGeoJSONReader GEOS_DLL *GEOSGeoJSONReader_create_r(
+    GEOSContextHandle_t handle);
+
+/** \see GEOSGeoJSONReader_destroy */
+extern void GEOS_DLL GEOSGeoJSONReader_destroy_r(GEOSContextHandle_t handle,
+    GEOSGeoJSONReader* reader);
+
+/** \see GEOSWKTReader_read */
+extern GEOSGeometry GEOS_DLL *GEOSGeoJSONReader_read_r(
+    GEOSContextHandle_t handle,
+    GEOSGeoJSONReader* reader,
+    const char *geojson);
 
 /** \see GEOSFree */
 extern void GEOS_DLL GEOSFree_r(
@@ -4241,6 +4264,31 @@ extern void GEOS_DLL GEOSWKBWriter_setIncludeSRID(
 * \param buffer The memory to free
 */
 extern void GEOS_DLL GEOSFree(void *buffer);
+
+/* ========= GeoJSON Reader ========= */
+
+/**
+* Allocate a new \ref GEOSGeoJSONReader.
+* \returns a new reader. Caller must free with GEOSGeoJSONReader_destroy()
+*/
+extern GEOSGeoJSONReader GEOS_DLL *GEOSGeoJSONReader_create(void);
+
+/**
+* Free the memory associated with a \ref GEOSGeoJSONReader.
+* \param reader The reader to destroy.
+*/
+extern void GEOS_DLL GEOSGeoJSONReader_destroy(GEOSGeoJSONReader* reader);
+
+/**
+* Use a reader to parse a GeoJSON containing a featurecollection,
+* and return geometrycollection. Feature properties are not read.
+* \param reader A GeoJSON reader object, caller retains ownership
+* \param geojson The json string to parse, caller retains ownership
+* \return A \ref GEOSGeometry, caller to free with GEOSGeometry_destroy())
+*/
+extern GEOSGeometry GEOS_DLL *GEOSGeoJSONReader_read(
+    GEOSGeoJSONReader* reader,
+    const char *geojson);
 
 #endif /* #ifndef GEOS_USE_ONLY_R_API */
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -3054,7 +3054,7 @@ extern "C" {
 
         return execute(extHandle, [&]() {
             GEOSContextHandleInternal_t *handle = reinterpret_cast<GEOSContextHandleInternal_t *>(extHandle);
-            return new GeoJSONReader((GeometryFactory *) handle->geomFactory);
+            return new GeoJSONReader(*(GeometryFactory *) handle->geomFactory);
         });
     }
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -120,6 +120,7 @@
 #define GEOSWKTWriter geos::io::WKTWriter
 #define GEOSWKBReader geos::io::WKBReader
 #define GEOSWKBWriter geos::io::WKBWriter
+#define GEOSGeoJSONReader geos::io::GeoJSONReader
 
 // Implementation struct for the GEOSMakeValidParams object
 typedef struct {
@@ -159,6 +160,7 @@ using geos::io::WKTReader;
 using geos::io::WKTWriter;
 using geos::io::WKBReader;
 using geos::io::WKBWriter;
+using geos::io::GeoJSONReader;
 
 using geos::algorithm::distance::DiscreteFrechetDistance;
 using geos::algorithm::distance::DiscreteHausdorffDistance;
@@ -3057,7 +3059,7 @@ extern "C" {
     }
 
     void
-    GeoJSONReader_destroy_r(GEOSContextHandle_t extHandle, GeoJSONReader* reader)
+    GEOSGeoJSONReader_destroy_r(GEOSContextHandle_t extHandle, GEOSGeoJSONReader* reader)
     {
         return execute(extHandle, [&]() {
             delete reader;
@@ -3065,11 +3067,11 @@ extern "C" {
     }
 
     Geometry*
-    GeoJSONReader_read_r(GEOSContextHandle_t extHandle, GeoJSONReader* reader, const char* geojson)
+    GEOSGeoJSONReader_read_r(GEOSContextHandle_t extHandle, GEOSGeoJSONReader* reader, const char* geojson)
     {
         return execute(extHandle, [&]() {
-            auto geojson_obj = geos_nlohmann::json::parse(geojson);
-            return reader->readFeatureCollectionForGeometry(geojson_obj).release();
+            const std::string geojsonstring(geojson);
+            return reader->read(geojsonstring).release();
         });
     }
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -3054,7 +3054,7 @@ extern "C" {
 
         return execute(extHandle, [&]() {
             GEOSContextHandleInternal_t *handle = reinterpret_cast<GEOSContextHandleInternal_t *>(extHandle);
-            return new GeoJSONReader(*(GeometryFactory *) handle->geomFactory);
+            return new GeoJSONReader(*(GeometryFactory*)handle->geomFactory);
         });
     }
 

--- a/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
+++ b/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
@@ -1,0 +1,55 @@
+//
+// Test Suite for C-API GEOSGeomFromWKB
+
+#include <tut/tut.hpp>
+#include <utility.h> // wkb_hex_decoder
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_capigeosgeomreadgeojson_data : public capitest::utility {
+    GEOSWKTReader* reader_;
+
+    test_capigeosgeomreadgeojson_data() : reader_(nullptr)
+    {
+        reader_ = GEOSGeoJSONReader_create();
+    }
+
+    ~test_capigeosgeomreadgeojson_data()
+    {
+        GEOSGeoJSONReader_destroy(reader_);
+        reader_ = nullptr;
+    }
+
+    void
+    test_geojson(std::string const& geojson, std::string const& wkt)
+    {
+        geom1_ = GEOSGeoJSONReader_read(&geojson[0]);
+        // TODO: Update test to compare with WKT-based geometry
+    }
+};
+
+typedef test_group<test_capigeosgeomreadgeojson_data> group;
+typedef group::object object;
+
+group test_capigeosgeomreadgeojson_group("capi::GEOSGeomReadGeoJSON");
+
+//
+// Test Cases
+//
+
+template<>
+template<>
+void object::test<1>
+()
+{
+    // POINT(1.234 5.678)
+    std::string geojson('{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[5.05,48.37]}}]');
+    std::string wkt("GEOMETRYCOLLECTION(POINT(5.05 48.37))");
+    test_geojson(geojson, wkt);
+}

--- a/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
+++ b/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
@@ -1,8 +1,7 @@
 //
-// Test Suite for C-API GEOSGeomFromWKB
+// Test Suite for C-API GEOSGeoJSONReader_read
 
 #include <tut/tut.hpp>
-#include <utility.h> // wkb_hex_decoder
 
 #include "capi_test_utils.h"
 

--- a/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
+++ b/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
@@ -13,24 +13,29 @@ namespace tut {
 
 // Common data used in test cases.
 struct test_capigeosgeomreadgeojson_data : public capitest::utility {
-    GEOSWKTReader* reader_;
+    GEOSGeoJSONReader* reader_;
+    GEOSWKTReader* wkt_reader_;
 
-    test_capigeosgeomreadgeojson_data() : reader_(nullptr)
+    test_capigeosgeomreadgeojson_data() : reader_(nullptr), wkt_reader_(nullptr)
     {
         reader_ = GEOSGeoJSONReader_create();
+        wkt_reader_ = GEOSWKTReader_create();
     }
 
     ~test_capigeosgeomreadgeojson_data()
     {
         GEOSGeoJSONReader_destroy(reader_);
+        GEOSWKTReader_destroy(wkt_reader_);
         reader_ = nullptr;
+        wkt_reader_ = nullptr;
     }
 
     void
     test_geojson(std::string const& geojson, std::string const& wkt)
     {
-        geom1_ = GEOSGeoJSONReader_read(&geojson[0]);
-        // TODO: Update test to compare with WKT-based geometry
+        geom1_ = GEOSGeoJSONReader_read(reader_, &geojson[0]);
+        expected_ = GEOSWKTReader_read(wkt_reader_, &wkt[0]);
+        ensure_geometry_equals(geom1_, expected_);
     }
 };
 
@@ -49,7 +54,8 @@ void object::test<1>
 ()
 {
     // POINT(1.234 5.678)
-    std::string geojson('{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[5.05,48.37]}}]');
-    std::string wkt("GEOMETRYCOLLECTION(POINT(5.05 48.37))");
+    std::string geojson(R"({"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[1.234,5.678]}}])");
+    std::string wkt("GEOMETRYCOLLECTION(POINT(1.234 5.678))");
     test_geojson(geojson, wkt);
+}
 }

--- a/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
+++ b/tests/unit/capi/GEOSGeomReadGeoJSONTest.cpp
@@ -14,28 +14,24 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosgeomreadgeojson_data : public capitest::utility {
     GEOSGeoJSONReader* reader_;
-    GEOSWKTReader* wkt_reader_;
 
-    test_capigeosgeomreadgeojson_data() : reader_(nullptr), wkt_reader_(nullptr)
+    test_capigeosgeomreadgeojson_data() : reader_(nullptr)
     {
         reader_ = GEOSGeoJSONReader_create();
-        wkt_reader_ = GEOSWKTReader_create();
     }
 
     ~test_capigeosgeomreadgeojson_data()
     {
         GEOSGeoJSONReader_destroy(reader_);
-        GEOSWKTReader_destroy(wkt_reader_);
         reader_ = nullptr;
-        wkt_reader_ = nullptr;
     }
 
     void
     test_geojson(std::string const& geojson, std::string const& wkt)
     {
         geom1_ = GEOSGeoJSONReader_read(reader_, &geojson[0]);
-        expected_ = GEOSWKTReader_read(wkt_reader_, &wkt[0]);
-        ensure_geometry_equals(geom1_, expected_);
+        ensure("GEOSGeoJSONReader_read failed to create geometry", nullptr != geom1_);
+        ensure_geometry_equals(geom1_, fromWKT(&wkt[0]));
     }
 };
 
@@ -53,9 +49,28 @@ template<>
 void object::test<1>
 ()
 {
-    // POINT(1.234 5.678)
-    std::string geojson(R"({"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[1.234,5.678]}}])");
-    std::string wkt("GEOMETRYCOLLECTION(POINT(1.234 5.678))");
+    std::string geojson("{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}");
+    std::string wkt("POINT(-117.0 33.0)");
     test_geojson(geojson, wkt);
+}
+
+template<>
+template<>
+void object::test<2>
+()
+{
+    std::string geojson("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-122.0,45.0]}}]}");
+    std::string wkt("GEOMETRYCOLLECTION (POINT (-117.000 33.000), POINT (-122.000 45.000))");
+    test_geojson(geojson, wkt);
+}
+
+template<>
+template<>
+void object::test<3>
+()
+{
+    std::string geojson("<gml>NOT_GEO_JSON</gml>");
+    geom1_ = GEOSGeoJSONReader_read(reader_, &geojson[0]);
+    ensure(geom1_ == nullptr);
 }
 }


### PR DESCRIPTION
Following up on the work done in #419 , I added basic read functionality to the C API. It follows the API of the WKB and WKT readers and reads GeoJSON into a single geometry. Features and properties are ignored.

@jorisvandenbossche 