### PR TITLE
Correctly round-trip collections of EMPTY

### DIFF
--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -514,10 +514,7 @@ WKTWriter::appendGeometryCollectionText(
     int p_level,
     Writer* writer)
 {
-    if(geometryCollection->isEmpty()) {
-        writer->write("EMPTY");
-    }
-    else {
+    if(geometryCollection->getNumGeometries() > 0) {
         int level2 = p_level;
         writer->write("(");
         for(std::size_t i = 0, n = geometryCollection->getNumGeometries();
@@ -529,6 +526,9 @@ WKTWriter::appendGeometryCollectionText(
             appendGeometryTaggedText(geometryCollection->getGeometryN(i), level2, writer);
         }
         writer->write(")");
+    }
+    else {
+        writer->write("EMPTY");
     }
 }
 

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -220,5 +220,23 @@ void object::test<7>
 }
 
 
+// 5 - Test negative number of digits in precision model
+template<>
+template<>
+void object::test<8>
+()
+{
+    const char* gctxt = "GEOMETRYCOLLECTION (LINESTRING EMPTY, POLYGON EMPTY)";
+    PrecisionModel pm;
+    GeometryFactory::Ptr gf(GeometryFactory::create(&pm));
+    WKTReader wktreader(gf.get());
+    GeomPtr geom(wktreader.read(gctxt));
+    std::string result = wktwriter.write(geom.get());
+    ensure_equals(result, std::string(gctxt));
+}
+
+
+
+
 } // namespace tut
 

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -227,11 +227,11 @@ void object::test<8>
 ()
 {
     const char* gctxt = "GEOMETRYCOLLECTION (LINESTRING EMPTY, POLYGON EMPTY)";
-    PrecisionModel pm;
-    GeometryFactory::Ptr gf(GeometryFactory::create(&pm));
-    WKTReader wktreader(gf.get());
-    GeomPtr geom(wktreader.read(gctxt));
-    std::string result = wktwriter.write(geom.get());
+    PrecisionModel gcpm;
+    GeometryFactory::Ptr gcgf(GeometryFactory::create(&gcpm));
+    WKTReader wktreader(gcgf.get());
+    GeomPtr gcgeom(wktreader.read(gctxt));
+    std::string result = wktwriter.write(gcgeom.get());
     ensure_equals(result, std::string(gctxt));
 }
 

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -230,8 +230,8 @@ void object::test<8>
     PrecisionModel gcpm;
     GeometryFactory::Ptr gcgf(GeometryFactory::create(&gcpm));
     WKTReader gcwktreader(gcgf.get());
-    GeomPtr gcgeom(wktreader.read(gctxt));
-    std::string result = gcwktwriter.write(gcgeom.get());
+    GeomPtr gcgeom(gcwktreader.read(gctxt));
+    std::string result = wktwriter.write(gcgeom.get());
     ensure_equals(result, std::string(gctxt));
 }
 

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -229,9 +229,9 @@ void object::test<8>
     const char* gctxt = "GEOMETRYCOLLECTION (LINESTRING EMPTY, POLYGON EMPTY)";
     PrecisionModel gcpm;
     GeometryFactory::Ptr gcgf(GeometryFactory::create(&gcpm));
-    WKTReader wktreader(gcgf.get());
+    WKTReader gcwktreader(gcgf.get());
     GeomPtr gcgeom(wktreader.read(gctxt));
-    std::string result = wktwriter.write(gcgeom.get());
+    std::string result = gcwktwriter.write(gcgeom.get());
     ensure_equals(result, std::string(gctxt));
 }
 


### PR DESCRIPTION
As described in https://trac.osgeo.org/geos/ticket/1040