### PR TITLE
SegmentNodeList::getSplitCoordinates(): fix quadratic performance pattern

### DIFF
--- a/src/noding/SegmentNodeList.cpp
+++ b/src/noding/SegmentNodeList.cpp
@@ -301,6 +301,8 @@ SegmentNodeList::getSplitCoordinates()
         addEdgeCoordinates(eiPrev, ei, coordList);
         eiPrev = ei;
     }
+    // Remove duplicate Coordinates from coordList
+    coordList.erase(std::unique(coordList.begin(), coordList.end()), coordList.end());
     return coordList;
 }
 
@@ -311,8 +313,6 @@ SegmentNodeList::addEdgeCoordinates(const SegmentNode* ei0, const SegmentNode* e
     auto pts = createSplitEdgePts(ei0, ei1);
     // Append pts to coordList
     pts->toVector(coordList);
-    // Remove duplicate Coordinates from coordList
-    coordList.erase(std::unique(coordList.begin(), coordList.end()), coordList.end());
 }
 
 


### PR DESCRIPTION
getSplitCoordinates() calls addEdgeCoordinates() repeatdly, which itself
calls std::unique() on the whole coordList, thus iterating from the
start each time, which is a quadratic performance pattern. As
addEdgeCoordinates() is a private method only called by
getSplitCoordinates(), move the call to std::unique() to the end of
getSplitCoordinates() itself.

Issue was detected when observing long runtimes on safe-TestBufferJagged.xml

Before this PR:
$ /home/even/geos/build_cmake/bin/test_xmltester -v /home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test1: buffer(a, 0.35): ok. (11 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test2: buffer(a, 0.75): ok. (155 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test3: buffer(a, 1.01): ok. (209 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test4: buffer(a, 1.1): ok. (210 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test5: buffer(a, 1.5): ok. (310 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test6: buffer(a, 2): ok. (429 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test7: buffer(a, 5): ok. (1326 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test8: buffer(a, 10): ok. (2497 ms)

After:
$ /home/even/geos/build_cmake/bin/test_xmltester -v /home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test1: buffer(a, 0.35): ok. (11 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test2: buffer(a, 0.75): ok. (65 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test3: buffer(a, 1.01): ok. (79 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test4: buffer(a, 1.1): ok. (78 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test5: buffer(a, 1.5): ok. (105 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test6: buffer(a, 2): ok. (133 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test7: buffer(a, 5): ok. (302 ms)
/home/even/geos/tests/xmltester/tests/misc/safe-TestBufferJagged.xml: case1: test8: buffer(a, 10): ok. (464 ms)
Files: 1
Tests: 8
Failed: 0
Succeeded: 8