### PR TITLE
Skip github-action CI on push to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@
 # Based on AZP configuration by Mateusz Loskot <mateusz at loskot dot net>
 
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'master'
+  pull_request: ~
 
 jobs:
   linux:


### PR DESCRIPTION
It's just a duplicate check than the one in main branch