### PR TITLE
LineSegment: tiny improvement in project(const LineSegment&, ...) and  closestPoint()

### DIFF
--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -369,6 +369,10 @@ public:
             return h ^ (std::hash<double>{}(s.p1.y) << 1);
         }
     };
+
+private:
+    void project(double factor, Coordinate& ret) const;
+
 };
 
 std::ostream& operator<< (std::ostream& o, const LineSegment& l);

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -105,6 +105,16 @@ LineSegment::project(const Coordinate& p, Coordinate& ret) const
     ret = Coordinate(p0.x + r * (p1.x - p0.x), p0.y + r * (p1.y - p0.y));
 }
 
+/*private*/
+void
+LineSegment::project(double factor, Coordinate& ret) const
+{
+    if( factor == 1.0 )
+        ret = p1;
+    else
+        ret = Coordinate(p0.x + factor * (p1.x - p0.x), p0.y + factor * (p1.y - p0.y));
+}
+
 bool
 LineSegment::project(const LineSegment& seg, LineSegment& ret) const
 {
@@ -121,9 +131,9 @@ LineSegment::project(const LineSegment& seg, LineSegment& ret) const
     }
 
     Coordinate newp0;
-    project(seg.p0, newp0);
+    project(pf0, newp0);
     Coordinate newp1;
-    project(seg.p1, newp1);
+    project(pf1, newp1);
 
     ret.setCoordinates(newp0, newp1);
 
@@ -136,7 +146,7 @@ LineSegment::closestPoint(const Coordinate& p, Coordinate& ret) const
 {
     double factor = projectionFactor(p);
     if(factor > 0 && factor < 1) {
-        project(p, ret);
+        project(factor, ret);
         return;
     }
     double dist0 = p0.distance(p);


### PR DESCRIPTION
Those methods already compute the projection factor, but then call
project() which recomputes it again. Avoid that duplicated computation.

Didn't identify this as a hotspot, but should save a few CPU cycles.