### PR TITLE
Fix GEOSSTRtree_query_r to be thread-safe on first call (lock TemplateSTRtreeImpl on build)

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,7 +13,9 @@ file(GLOB_RECURSE _sources ${CMAKE_CURRENT_LIST_DIR}/*.cpp CONFIGURE_DEPEND)
 add_executable(test_geos_unit ${_sources})
 unset(_sources)
 
-target_link_libraries(test_geos_unit PRIVATE geos geos_c)
+find_package(Threads)
+
+target_link_libraries(test_geos_unit PRIVATE geos geos_c Threads::Threads)
 target_include_directories(test_geos_unit
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)


### PR DESCRIPTION
This attempts to fix the problem that while querying the STRtree itself is thread-safe, building the tree is not, and building is only done on the first query, making the query also unsafe.

I ran into this while testing a parallel+partitioned spatial join (using the Dask, a python framework for parallel/distributed computing), where I end up querying the same tree from multiple threads at the same time. But I noticed occasional segfaults with this approach (https://github.com/pygeos/pygeos/issues/361). Doing a dummy query in advance to ensure the tree is already built before it's queried from multiple threads fixes it on the PyGEOS side, but adding a lock guard on the `build()` method also independently fixes the root problem in GEOS itself.

Note:

- I needed to add a custom copy constructor and copy assignment (because the `std::mutex lock_` is not copyable), but no idea if this is implemented properly.
- Not directly sure how to test this here



