### PR TITLE
Remove support/use of Ubuntu 16.04 (xenial)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
         sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
         if test -n "${LLVM_REPO}" ; then
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo -E apt-add-repository "deb http://apt.llvm.org/xenial/ ${LLVM_REPO} main"
+          sudo -E apt-add-repository "deb http://apt.llvm.org/bionic/ ${LLVM_REPO} main"
         fi
         sudo -E apt-get update
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install cmake ${PACKAGES}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,6 @@ jobs:
         - {
           compiler: clang++,
           build_type: Release,
-          cxxstd: 11,
-          arch: 64,
-          packages: 'clang',
-          cmake: 3.8.*,
-          os: ubuntu-16.04
-        }
-        - {
-          compiler: clang++,
-          build_type: Release,
           cxxstd: 14,
           arch: 64,
           packages: 'clang',

--- a/tools/cppcheck.sh
+++ b/tools/cppcheck.sh
@@ -50,14 +50,7 @@ for category in "style" "performance" "portability"; do
     fi
 done
 
-# unusedPrivateFunction not reliable enough in cppcheck 1.72 of Ubuntu 16.04
-if test "$(cppcheck --version)" = "Cppcheck 1.72"; then
-    UNUSED_PRIVATE_FUNCTION=""
-else
-    UNUSED_PRIVATE_FUNCTION="unusedPrivateFunction"
-fi
-
-for category in "error" "warning" "clarifyCalculation" "duplicateExpressionTernary" "redundantCondition" "postfixOperator" "${UNUSED_PRIVATE_FUNCTION}"; do
+for category in "error" "warning" "clarifyCalculation" "duplicateExpressionTernary" "redundantCondition" "postfixOperator" "unusedPrivateFunction"; do
     if test "${category}" != ""; then
         if grep "${category}," ${LOG_FILE}  >/dev/null; then
             echo "ERROR: Issues in '${category}' category found:"


### PR DESCRIPTION
It seems there were a few remaining reliance on Ubuntu 16.04 (xenial), which is long out of support.

This PR fixes the azp ubuntu-18.04 vmImage to use bionic instead of xenial, which is one of the recent CI failures.

It also drops a job from `.github/workflows/ci.yml` that uses ubuntu-16.04 with clang.

Further, it simplifies `tools/cppcheck.sh` by removing a workaround for cppcheck-1.72 distributed with ubuntu-16.04.