### PR TITLE
Remove always true check

### DIFF
--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -383,10 +383,7 @@ WKBReader::readPolygon()
         return factory.createPolygon(hasZ ? 3 : 2);
     }
 
-    std::unique_ptr<LinearRing> shell;
-    if(numRings > 0) {
-        shell = readLinearRing();
-    }
+    std::unique_ptr<LinearRing> shell(readLinearRing());
 
     if(numRings > 1) {
         std::vector<std::unique_ptr<LinearRing>> holes(numRings - 1);


### PR DESCRIPTION
numRings is unsigned, and we have tested just above if it was 0 and
returned if it was. Consequently at that point, it is > 0

Spotted by cppcheck