### PR TITLE
SnapRoundingNoder fix

### DIFF
--- a/include/geos/noding/snapround/SnapRoundingIntersectionAdder.h
+++ b/include/geos/noding/snapround/SnapRoundingIntersectionAdder.h
@@ -65,11 +65,6 @@ namespace snapround { // geos::noding::snapround
 class GEOS_DLL SnapRoundingIntersectionAdder: public SegmentIntersector { // implements SegmentIntersector
 
 private:
-    /**
-    * The division factor used to determine
-    * nearness distance tolerance for interior intersection detection.
-    */
-    static constexpr int NEARNESS_FACTOR = 100;
 
     algorithm::LineIntersector li;
     std::unique_ptr<std::vector<geom::Coordinate>> intersections;
@@ -95,7 +90,11 @@ private:
 
 public:
 
-    SnapRoundingIntersectionAdder(const geom::PrecisionModel* newPm);
+    SnapRoundingIntersectionAdder(double p_nearnessTol)
+        : SegmentIntersector()
+        , intersections(new std::vector<geom::Coordinate>)
+        , nearnessTol(p_nearnessTol)
+    {}
 
     std::unique_ptr<std::vector<geom::Coordinate>> getIntersections() { return std::move(intersections); };
 

--- a/include/geos/noding/snapround/SnapRoundingNoder.h
+++ b/include/geos/noding/snapround/SnapRoundingNoder.h
@@ -71,6 +71,11 @@ namespace snapround { // geos::noding::snapround
 class GEOS_DLL SnapRoundingNoder : public Noder {
 
 private:
+    /**
+    * The division factor used to determine
+    * nearness distance tolerance for interior intersection detection.
+    */
+    static constexpr int INTERSECTION_NEARNESS_FACTOR = 100;
 
     // Members
     const geom::PrecisionModel* pm;

--- a/src/noding/snapround/SnapRoundingIntersectionAdder.cpp
+++ b/src/noding/snapround/SnapRoundingIntersectionAdder.cpp
@@ -38,15 +38,6 @@ namespace noding { // geos.noding
 namespace snapround { // geos.noding.snapround
 
 
-SnapRoundingIntersectionAdder::SnapRoundingIntersectionAdder(const geom::PrecisionModel* newPm)
-    : SegmentIntersector()
-    , intersections(new std::vector<geom::Coordinate>)
-    // , pm(newPm)
-{
-    double snapGridSize = 1.0 / newPm->getScale();
-    nearnessTol = snapGridSize / NEARNESS_FACTOR;
-}
-
 /*public*/
 void
 SnapRoundingIntersectionAdder::processIntersections(

--- a/src/noding/snapround/SnapRoundingNoder.cpp
+++ b/src/noding/snapround/SnapRoundingNoder.cpp
@@ -79,8 +79,7 @@ SnapRoundingNoder::addIntersectionPixels(std::vector<SegmentString*>& segStrings
 {
     double tolerance = 1.0 / pm->getScale() / INTERSECTION_NEARNESS_FACTOR;
     SnapRoundingIntersectionAdder intAdder(tolerance);
-    MCIndexNoder noder(nullptr, tolerance);
-    noder.setSegmentIntersector(&intAdder);
+    MCIndexNoder noder(&intAdder, tolerance);
     noder.computeNodes(&segStrings);
     std::unique_ptr<std::vector<Coordinate>> intPts = intAdder.getIntersections();
     pixelIndex.addNodes(*intPts);

--- a/src/noding/snapround/SnapRoundingNoder.cpp
+++ b/src/noding/snapround/SnapRoundingNoder.cpp
@@ -77,8 +77,9 @@ SnapRoundingNoder::snapRound(std::vector<SegmentString*>& inputSegStrings, std::
 void
 SnapRoundingNoder::addIntersectionPixels(std::vector<SegmentString*>& segStrings)
 {
-    SnapRoundingIntersectionAdder intAdder(pm);
-    MCIndexNoder noder;
+    double tolerance = 1.0 / pm->getScale() / INTERSECTION_NEARNESS_FACTOR;
+    SnapRoundingIntersectionAdder intAdder(tolerance);
+    MCIndexNoder noder(nullptr, tolerance);
     noder.setSegmentIntersector(&intAdder);
     noder.computeNodes(&segStrings);
     std::unique_ptr<std::vector<Coordinate>> intPts = intAdder.getIntersections();

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -169,5 +169,27 @@ void object::test<10> ()
     ensure_geometry_equals(geom2_, "LINEARRING EMPTY");
 }
 
+// Reduce polygon precision, corner case / Trac #1127
+template<>
+template<>
+void object::test<11> ()
+{
+    // POLYGON((
+    //   100 49.5, (1)
+    //   100 300,  (2)
+    //   320 60,   (3)
+    //   340 49.9, (4)
+    //   360 50.1, (5)
+    //   380 49.5, (6)
+    //   100 49.5  (7)
+    // ))
+    // * points 4 and 5 are close (less than 100.0/100) to segment (6, 7);
+    // * Y coordinates of points 4 and 5 are rounded to different values, 0 and 100 respectively;
+    // * point 4 belongs to monotone chain of size > 1 -- segments (2, 3) and (3, 4)
+    geom1_ = fromWKT("POLYGON((100 49.5, 100 300, 320 60, 340 49.9, 360 50.1, 380 49.5, 100 49.5))");
+    geom2_ = GEOSGeom_setPrecision(geom1_, 100.0, 0);
+    ensure(geom2_ != nullptr); // just check that valid geometry is constructed
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fix for "GEOSGeom_setPrecision returns error for valid geometry" https://trac.osgeo.org/geos/ticket/1127

`nearnessTol` calculation moved from SnapRoundingIntersectionAdder to SnapRoundingNoder; same tolerance value is passed to MCIndexNoder.  This allows to detect all cases of vertices positioned close enough to segments to be added as intersections by SnapRoundingIntersectionAdder::processNearVertex.  Currently closely positioned segments can be filtered out in `MonotoneChain::computeOverlaps()` by `MonotoneChain::overlaps()` called with zero `overlapTolerance`.