### PR TITLE
do not use end() iterators

### DIFF
--- a/include/geos/index/strtree/TemplateSTRtree.h
+++ b/include/geos/index/strtree/TemplateSTRtree.h
@@ -359,12 +359,12 @@ public:
 
         // begin and end define a range of nodes needing parents
         auto begin = nodes.begin();
-        auto end = nodes.end();
+        auto number = static_cast<size_t>(std::distance(begin, nodes.end()));
 
-        while (std::distance(begin, end) > 1) {
-            createParentNodes(begin, end);
-            begin = end; // parents just added become children in the next round
-            end = nodes.end();
+        while (number > 1) {
+            createParentNodes(begin, number);
+            begin = begin + number; // parents just added become children in the next round
+            number = static_cast<size_t>(std::distance(begin, nodes.end()));
         }
 
         assert(finalSize == nodes.size());
@@ -421,23 +421,22 @@ protected:
         return nodesInTree;
     }
 
-    void createParentNodes(const NodeListIterator& begin, const NodeListIterator& end) {
+    void createParentNodes(const NodeListIterator& begin, size_t number) {
         // Arrange child nodes in two dimensions.
         // First, divide them into vertical slices of a given size (left-to-right)
         // Then create nodes within those slices (bottom-to-top)
-        auto numChildren = static_cast<std::size_t>(std::distance(begin, end));
-        auto numSlices = sliceCount(numChildren);
-        std::size_t nodesPerSlice = sliceCapacity(numChildren, numSlices);
+        auto numSlices = sliceCount(number);
+        std::size_t nodesPerSlice = sliceCapacity(number, numSlices);
 
         // We could sort all of the nodes here, but we don't actually need them to be
         // completely sorted. They need to be sorted enough for each node to end up
         // in the right vertical slice, but their relative position within the slice
         // doesn't matter. So we do a partial sort for each slice below instead.
-        sortNodesX(begin, end);
+        sortNodesX(begin, begin + number);
 
         auto startOfSlice = begin;
         for (decltype(numSlices) j = 0; j < numSlices; j++) {
-            auto nodesRemaining = static_cast<size_t>(std::distance(startOfSlice, end));
+            auto nodesRemaining = static_cast<size_t>(std::distance(startOfSlice, begin + number));
             auto nodesInSlice = std::min(nodesRemaining, nodesPerSlice);
             auto endOfSlice = std::next(startOfSlice, static_cast<long>(nodesInSlice));
 

--- a/include/geos/index/strtree/TemplateSTRtree.h
+++ b/include/geos/index/strtree/TemplateSTRtree.h
@@ -363,7 +363,7 @@ public:
 
         while (number > 1) {
             createParentNodes(begin, number);
-            begin = begin + number; // parents just added become children in the next round
+            std::advance(begin, static_cast<NodeListIterator::difference_type>(number)); // parents just added become children in the next round
             number = static_cast<size_t>(std::distance(begin, nodes.end()));
         }
 
@@ -432,11 +432,14 @@ protected:
         // completely sorted. They need to be sorted enough for each node to end up
         // in the right vertical slice, but their relative position within the slice
         // doesn't matter. So we do a partial sort for each slice below instead.
-        sortNodesX(begin, begin + number);
+        auto end = begin + static_cast<NodeListIterator::difference_type>(number);
+        sortNodesX(begin, end);
 
         auto startOfSlice = begin;
         for (decltype(numSlices) j = 0; j < numSlices; j++) {
-            auto nodesRemaining = static_cast<size_t>(std::distance(startOfSlice, begin + number));
+            // end iterator is being invalidated at each iteration
+            end = begin + static_cast<NodeListIterator::difference_type>(number);
+            auto nodesRemaining = static_cast<size_t>(std::distance(startOfSlice, end));
             auto nodesInSlice = std::min(nodesRemaining, nodesPerSlice);
             auto endOfSlice = std::next(startOfSlice, static_cast<long>(nodesInSlice));
 

--- a/include/geos/index/strtree/TemplateSTRtree.h
+++ b/include/geos/index/strtree/TemplateSTRtree.h
@@ -363,7 +363,7 @@ public:
 
         while (number > 1) {
             createParentNodes(begin, number);
-            std::advance(begin, static_cast<NodeListIterator::difference_type>(number)); // parents just added become children in the next round
+            std::advance(begin, static_cast<long>(number)); // parents just added become children in the next round
             number = static_cast<size_t>(std::distance(begin, nodes.end()));
         }
 
@@ -432,13 +432,13 @@ protected:
         // completely sorted. They need to be sorted enough for each node to end up
         // in the right vertical slice, but their relative position within the slice
         // doesn't matter. So we do a partial sort for each slice below instead.
-        auto end = begin + static_cast<NodeListIterator::difference_type>(number);
+        auto end = begin + static_cast<long>(number);
         sortNodesX(begin, end);
 
         auto startOfSlice = begin;
         for (decltype(numSlices) j = 0; j < numSlices; j++) {
             // end iterator is being invalidated at each iteration
-            end = begin + static_cast<NodeListIterator::difference_type>(number);
+            end = begin + static_cast<long>(number);
             auto nodesRemaining = static_cast<size_t>(std::distance(startOfSlice, end));
             auto nodesInSlice = std::min(nodesRemaining, nodesPerSlice);
             auto endOfSlice = std::next(startOfSlice, static_cast<long>(nodesInSlice));


### PR DESCRIPTION
Tentative fix for #490

It avoids using the `end()` iterator which, under a very strict interpretation of the C++ specifications, should be invalid after an `emplace_back`