### PR TITLE
CMake: improvements so GEOS works as a subproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,3 +253,31 @@ jobs:
        cd build
        ctest --output-on-failure -C Release
 
+  cmake-subproject:
+    name: 'CMake Subproject'
+    runs-on: ubuntu-18.04
+    steps:
+    - name: 'Install'
+      run: |
+        set -e
+        uname -a
+        sudo -E apt-get update
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends install make python3-pip g++
+        python3 -m pip install --disable-pip-version-check --user cmake==3.13.*
+        echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+
+    - name: 'Check Out'
+      uses: actions/checkout@v2
+      with:
+        path: geos
+
+    - name: 'CMake Superbuild'
+      run: |
+        set -e
+        cp geos/tests/superbuild.CMakeLists.txt ./CMakeLists.txt
+        cp geos/examples/capi_read.c .
+        cmake --version
+        cmake -S . -B build
+        cmake --build build -j 2
+        build/capi_read
+        test ! -f build/geos/bin/test_geos_unit || { echo "Error: GEOS tests were built" 1>&2 ; exit 1; }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,11 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
   cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # TODO: Follow CMake detection of git and version tagging
 #       https://gitlab.kitware.com/cmake/cmake/blob/master/Source/CMakeVersionSource.cmake
-if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   set(GEOS_BUILD_FROM_GIT ON)
 endif()
 
@@ -66,9 +66,9 @@ endif()
 # Place executables and shared libraries in the same location for
 # convenience of direct execution from common spot and for
 # convenience in environments without RPATH support.
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 message(STATUS "GEOS: Run-time output: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 message(STATUS "GEOS: Archives output: ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
@@ -400,12 +400,12 @@ add_subdirectory(tools)
 # Uninstall
 #-----------------------------------------------------------------------------
 
-configure_file("${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-  "${PROJECT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
 add_custom_target(uninstall
-  "${CMAKE_COMMAND}" -P "${PROJECT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
+  "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
 
 #-----------------------------------------------------------------------------
 # "make dist" workalike
@@ -437,7 +437,7 @@ if(NOT _is_multi_config_generator)
     "/tools/geos-config\$"
     "/tools/geos\\\\.pc\$"
     "/bin/"
-    ${PROJECT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
     )
 
   # message(STATUS "GEOS: CPACK_SOURCE_PACKAGE_FILE_NAME: ${CPACK_SOURCE_PACKAGE_FILE_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,14 @@ message(STATUS "GEOS: Version ${GEOS_VERSION}")
 message(STATUS "GEOS: C API Version ${CAPI_VERSION}")
 message(STATUS "GEOS: JTS port ${JTS_PORT}")
 
+if(CMAKE_VERSION VERSION_LESS 3.21)
+  if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(PROJECT_IS_TOP_LEVEL ON)
+  else()
+    set(PROJECT_IS_TOP_LEVEL OFF)
+  endif()
+endif()
+
 #-----------------------------------------------------------------------------
 # Setup
 #-----------------------------------------------------------------------------
@@ -125,7 +133,7 @@ set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 
 option(BUILD_BENCHMARKS "Build GEOS benchmarks" OFF)
 cmake_dependent_option(GEOS_BUILD_DEVELOPER
   "Build with compilation flags useful for development" ON
-  "GEOS_BUILD_FROM_GIT" OFF)
+  "GEOS_BUILD_FROM_GIT;PROJECT_IS_TOP_LEVEL" OFF)
 mark_as_advanced(GEOS_BUILD_DEVELOPER)
 
 if (POLICY CMP0092)
@@ -313,32 +321,40 @@ add_subdirectory(capi)
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
-include(CTest)
-if(BUILD_TESTING)
-  add_subdirectory(tests)
+if(PROJECT_IS_TOP_LEVEL)
+  include(CTest)
+  if(BUILD_TESTING)
+    add_subdirectory(tests)
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------
 # Benchmarks
 #-----------------------------------------------------------------------------
-if(BUILD_BENCHMARKS)
+if(PROJECT_IS_TOP_LEVEL AND BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif()
 
 #-----------------------------------------------------------------------------
 # Utils
 #-----------------------------------------------------------------------------
-add_subdirectory(util)
+if(PROJECT_IS_TOP_LEVEL)
+  add_subdirectory(util)
+endif()
 
 #-----------------------------------------------------------------------------
 # Documentation/Examples
 #-----------------------------------------------------------------------------
-add_subdirectory(doxygen)
+if(PROJECT_IS_TOP_LEVEL)
+  add_subdirectory(doxygen)
+endif()
 
 #-----------------------------------------------------------------------------
 # Web Site
 #-----------------------------------------------------------------------------
-add_subdirectory(web)
+if(PROJECT_IS_TOP_LEVEL)
+  add_subdirectory(web)
+endif()
 
 #-----------------------------------------------------------------------------
 # Install and export targets - support 'make install' or equivalent
@@ -403,69 +419,76 @@ add_subdirectory(tools)
 #-----------------------------------------------------------------------------
 # Uninstall
 #-----------------------------------------------------------------------------
+if(PROJECT_IS_TOP_LEVEL)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
 
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
-  IMMEDIATE @ONLY)
-
-add_custom_target(uninstall
-  "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
+  add_custom_target(uninstall
+    "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
+endif()  # PROJECT_IS_TOP_LEVEL
 
 #-----------------------------------------------------------------------------
 # "make dist" workalike
 #-----------------------------------------------------------------------------
-get_property(_is_multi_config_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(NOT _is_multi_config_generator)
-  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GEOS Computational Geometry Library")
-  set(CPACK_PACKAGE_VENDOR "OSGeo")
-  set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
-  set(CPACK_SOURCE_GENERATOR "TBZ2")
-  set(CPACK_PACKAGE_VERSION_MAJOR ${GEOS_VERSION_MAJOR})
-  set(CPACK_PACKAGE_VERSION_MINOR ${GEOS_VERSION_MINOR})
-  set(CPACK_PACKAGE_VERSION_PATCH ${GEOS_VERSION_PATCH})
-  set(CPACK_SOURCE_PACKAGE_FILE_NAME "geos-${GEOS_VERSION}")
+if(PROJECT_IS_TOP_LEVEL)
+  get_property(_is_multi_config_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(NOT _is_multi_config_generator)
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GEOS Computational Geometry Library")
+    set(CPACK_PACKAGE_VENDOR "OSGeo")
+    set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+    set(CPACK_SOURCE_GENERATOR "TBZ2")
+    set(CPACK_PACKAGE_VERSION_MAJOR ${GEOS_VERSION_MAJOR})
+    set(CPACK_PACKAGE_VERSION_MINOR ${GEOS_VERSION_MINOR})
+    set(CPACK_PACKAGE_VERSION_PATCH ${GEOS_VERSION_PATCH})
+    set(CPACK_SOURCE_PACKAGE_FILE_NAME "geos-${GEOS_VERSION}")
 
-  set(CPACK_SOURCE_IGNORE_FILES
-    "/\\\\.git"
-    "/autogen\\\\.sh"
-    "/tools/ci"
-    "/HOWTO_RELEASE"
-    "/autom4te\\\\.cache"
-    "\\\\.yml\$"
-    "\\\\.deps"
-    "/debian/"
-    "/php/"
-    "/.*build-.*/"
-    "cmake_install\\\\.cmake\$"
-    "/include/geos/version\\\\.h\$"
-    "/tools/geos-config\$"
-    "/tools/geos\\\\.pc\$"
-    "/bin/"
-    ${CMAKE_CURRENT_BINARY_DIR}
-    )
+    set(CPACK_SOURCE_IGNORE_FILES
+      "/\\\\.git"
+      "/autogen\\\\.sh"
+      "/tools/ci"
+      "/HOWTO_RELEASE"
+      "/autom4te\\\\.cache"
+      "\\\\.yml\$"
+      "\\\\.deps"
+      "/debian/"
+      "/php/"
+      "/.*build-.*/"
+      "cmake_install\\\\.cmake\$"
+      "/include/geos/version\\\\.h\$"
+      "/tools/geos-config\$"
+      "/tools/geos\\\\.pc\$"
+      "/bin/"
+      ${CMAKE_CURRENT_BINARY_DIR}
+      )
 
-  # message(STATUS "GEOS: CPACK_SOURCE_PACKAGE_FILE_NAME: ${CPACK_SOURCE_PACKAGE_FILE_NAME}")
-  # message(STATUS "GEOS: CPACK_SOURCE_IGNORE_FILES: ${CPACK_SOURCE_IGNORE_FILES}")
-  # message(STATUS "GEOS: CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
-  include(CPack)
-  add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
+    # message(STATUS "GEOS: CPACK_SOURCE_PACKAGE_FILE_NAME: ${CPACK_SOURCE_PACKAGE_FILE_NAME}")
+    # message(STATUS "GEOS: CPACK_SOURCE_IGNORE_FILES: ${CPACK_SOURCE_IGNORE_FILES}")
+    # message(STATUS "GEOS: CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
+    include(CPack)
+    add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 
-  message(STATUS "GEOS: Configured 'dist' target")
-endif()
+    message(STATUS "GEOS: Configured 'dist' target")
+  endif()
+endif()  # PROJECT_IS_TOP_LEVEL
 
 #-----------------------------------------------------------------------------
 # "make check" workalike
 #-----------------------------------------------------------------------------
 
-add_custom_target(check COMMAND ${CMAKE_BUILD_TOOL} test)
+if(PROJECT_IS_TOP_LEVEL)
+  add_custom_target(check COMMAND ${CMAKE_BUILD_TOOL} test)
+endif()
 
 #-----------------------------------------------------------------------------
 # "make distcheck" workalike
 #-----------------------------------------------------------------------------
-if(NOT _is_multi_config_generator)
-  find_package(MakeDistCheck)
-  AddMakeDistCheck()
-  message(STATUS "GEOS: Configured 'distcheck' target")
-endif()
+if(PROJECT_IS_TOP_LEVEL)
+  if(NOT _is_multi_config_generator)
+    find_package(MakeDistCheck)
+    AddMakeDistCheck()
+    message(STATUS "GEOS: Configured 'distcheck' target")
+  endif()
 
-unset(_is_multi_config_generator)
+  unset(_is_multi_config_generator)
+endif()  # PROJECT_IS_TOP_LEVEL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,65 +13,6 @@
 # modes for specific C/C++ language standard levels, and object libraries.
 cmake_minimum_required(VERSION 3.13)
 
-# Default to release build so packagers don't release debug builds
-set(DEFAULT_BUILD_TYPE Release)
-
-# Require CMake 3.13+ with VS generator for complete support of VS versions
-# and support by AppVeyor.
-if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
-  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-endif()
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
-# TODO: Follow CMake detection of git and version tagging
-#       https://gitlab.kitware.com/cmake/cmake/blob/master/Source/CMakeVersionSource.cmake
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
-  set(GEOS_BUILD_FROM_GIT ON)
-endif()
-
-# Make sure we know our build type
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE})
-  message(STATUS "GEOS: Using default build type: ${CMAKE_BUILD_TYPE}")
-else()
-  message(STATUS "GEOS: Build type: ${CMAKE_BUILD_TYPE}")
-endif()
-
-#-----------------------------------------------------------------------------
-# Options
-#-----------------------------------------------------------------------------
-include(CMakeDependentOption)
-
-## CMake global variables
-option(BUILD_SHARED_LIBS "Build GEOS with shared libraries" ON)
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 11)")
-
-## GEOS custom variables
-option(BUILD_BENCHMARKS "Build GEOS benchmarks" OFF)
-cmake_dependent_option(GEOS_BUILD_DEVELOPER
-  "Build with compilation flags useful for development" ON
-  "GEOS_BUILD_FROM_GIT" OFF)
-mark_as_advanced(GEOS_BUILD_DEVELOPER)
-
-if (POLICY CMP0092)
-  # dont set /W3 warning flags by default, we already
-  # set /W4 anyway
-  cmake_policy(SET CMP0092 NEW)
-endif()
-
-#-----------------------------------------------------------------------------
-# Setup build directories
-#-----------------------------------------------------------------------------
-# Place executables and shared libraries in the same location for
-# convenience of direct execution from common spot and for
-# convenience in environments without RPATH support.
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-message(STATUS "GEOS: Run-time output: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-message(STATUS "GEOS: Archives output: ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
-
 #-----------------------------------------------------------------------------
 # Version
 #-----------------------------------------------------------------------------
@@ -141,6 +82,69 @@ unset(_version_patch_word)
 message(STATUS "GEOS: Version ${GEOS_VERSION}")
 message(STATUS "GEOS: C API Version ${CAPI_VERSION}")
 message(STATUS "GEOS: JTS port ${JTS_PORT}")
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+# Default to release build so packagers don't release debug builds
+set(DEFAULT_BUILD_TYPE Release)
+
+# Require CMake 3.13+ with VS generator for complete support of VS versions
+# and support by AppVeyor.
+if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
+  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# TODO: Follow CMake detection of git and version tagging
+#       https://gitlab.kitware.com/cmake/cmake/blob/master/Source/CMakeVersionSource.cmake
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+  set(GEOS_BUILD_FROM_GIT ON)
+endif()
+
+# Make sure we know our build type
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE})
+  message(STATUS "GEOS: Using default build type: ${CMAKE_BUILD_TYPE}")
+else()
+  message(STATUS "GEOS: Build type: ${CMAKE_BUILD_TYPE}")
+endif()
+
+#-----------------------------------------------------------------------------
+# Options
+#-----------------------------------------------------------------------------
+include(CMakeDependentOption)
+
+## CMake global variables
+option(BUILD_SHARED_LIBS "Build GEOS with shared libraries" ON)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 11)")
+
+## GEOS custom variables
+option(BUILD_BENCHMARKS "Build GEOS benchmarks" OFF)
+cmake_dependent_option(GEOS_BUILD_DEVELOPER
+  "Build with compilation flags useful for development" ON
+  "GEOS_BUILD_FROM_GIT" OFF)
+mark_as_advanced(GEOS_BUILD_DEVELOPER)
+
+if (POLICY CMP0092)
+  # dont set /W3 warning flags by default, we already
+  # set /W4 anyway
+  cmake_policy(SET CMP0092 NEW)
+endif()
+
+#-----------------------------------------------------------------------------
+# Setup build directories
+#-----------------------------------------------------------------------------
+# Place executables and shared libraries in the same location for
+# convenience of direct execution from common spot and for
+# convenience in environments without RPATH support.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+message(STATUS "GEOS: Run-time output: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+message(STATUS "GEOS: Archives output: ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 #-----------------------------------------------------------------------------
 # Install directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ check_library_exists(m pow "" HAVE_LIBM)
 # Target geos: C++ API library
 #-----------------------------------------------------------------------------
 add_library(geos "")
+add_library(GEOS::geos ALIAS geos)
 target_link_libraries(geos PUBLIC geos_cxx_flags PRIVATE $<BUILD_INTERFACE:ryu>)
 # ryu is an object library, nothing is actually being linked here. The BUILD_INTERFACE
 # switch was necessary to build on AppVeyor (CMake 3.16.2) but not locally (CMake 3.16.3)
@@ -301,6 +302,7 @@ endif()
 # Target geos_c: C API library
 #-----------------------------------------------------------------------------
 add_library(geos_c "")
+add_library(GEOS::geos_c ALIAS geos_c)
 target_link_libraries(geos_c PRIVATE geos)
 
 if(BUILD_SHARED_LIBS)

--- a/benchmarks/algorithm/CMakeLists.txt
+++ b/benchmarks/algorithm/CMakeLists.txt
@@ -21,18 +21,18 @@ target_link_libraries(perf_unaryunion_segments geos)
 
 if (benchmark_FOUND)
     add_executable(perf_orientation OrientationIndexPerfTest.cpp
-            ${CMAKE_SOURCE_DIR}/src/algorithm/CGAlgorithmsDD.cpp
-            ${CMAKE_SOURCE_DIR}/src/math/DD.cpp)
+            ${PROJECT_SOURCE_DIR}/src/algorithm/CGAlgorithmsDD.cpp
+            ${PROJECT_SOURCE_DIR}/src/math/DD.cpp)
     target_include_directories(perf_orientation PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_orientation PRIVATE
             benchmark::benchmark geos_cxx_flags)
 
     add_executable(perf_line_intersector LineIntersectorPerfTest.cpp)
     target_include_directories(perf_line_intersector PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_line_intersector PRIVATE
             benchmark::benchmark geos)
 endif()

--- a/benchmarks/algorithm/locate/CMakeLists.txt
+++ b/benchmarks/algorithm/locate/CMakeLists.txt
@@ -14,8 +14,8 @@
 if (benchmark_FOUND)
     add_executable(perf_indexed_point_in_area_locator IndexedPointInAreaLocatorPerfTest.cpp)
     target_include_directories(perf_indexed_point_in_area_locator PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_indexed_point_in_area_locator PRIVATE
             benchmark::benchmark geos)
 endif()

--- a/benchmarks/capi/CMakeLists.txt
+++ b/benchmarks/capi/CMakeLists.txt
@@ -13,8 +13,8 @@ add_executable(perf_memleak_mp_prep memleak_mp_prep.c)
 # but geos_c only, so need explicit include directories.
 target_include_directories(perf_memleak_mp_prep
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 target_link_libraries(perf_memleak_mp_prep PRIVATE geos_c)
 
 add_executable(perf_geospreparedcontains GEOSPreparedContainsPerfTest.cpp)
@@ -29,8 +29,8 @@ target_link_libraries(perf_unary PRIVATE geos geos_c)
 if(benchmark_FOUND)
     add_executable(perf_capi_coordseq GEOSCoordSeqPerfTest.cpp)
     target_include_directories(perf_capi_coordseq PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_capi_coordseq PRIVATE
             benchmark::benchmark geos_c)
 endif()

--- a/benchmarks/geom/CMakeLists.txt
+++ b/benchmarks/geom/CMakeLists.txt
@@ -12,10 +12,10 @@
 IF(benchmark_FOUND)
     add_executable(perf_envelope
             EnvelopePerfTest.cpp
-            ${CMAKE_SOURCE_DIR}/src/geom/Envelope.cpp)
+            ${PROJECT_SOURCE_DIR}/src/geom/Envelope.cpp)
     target_include_directories(perf_envelope PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_envelope PRIVATE
             benchmark::benchmark geos_cxx_flags)
 endif()

--- a/benchmarks/index/CMakeLists.txt
+++ b/benchmarks/index/CMakeLists.txt
@@ -14,8 +14,8 @@ add_subdirectory(chain)
 IF(benchmark_FOUND)
     add_executable(perf_spatial_index SpatialIndexPerfTest.cpp)
     target_include_directories(perf_spatial_index PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_spatial_index PRIVATE
             benchmark::benchmark geos)
 endif()

--- a/benchmarks/index/chain/CMakeLists.txt
+++ b/benchmarks/index/chain/CMakeLists.txt
@@ -12,15 +12,15 @@
 IF(benchmark_FOUND)
     add_executable(perf_monotone_chain MonotoneChainPerfTest.cpp)
     target_include_directories(perf_monotone_chain PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_monotone_chain PRIVATE
             benchmark::benchmark geos)
 
     add_executable(perf_monotone_chain_builder MonotoneChainBuilderPerfTest.cpp)
     target_include_directories(perf_monotone_chain_builder PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_monotone_chain_builder PRIVATE
             benchmark::benchmark geos)
 endif()

--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -18,6 +18,12 @@ target_include_directories(geos_c
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:include/geos>)
 
+target_include_directories(geos_c
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/geos>)
+
 # Copy these over so they match the @VARIABLES@ used by autoconf
 # in geos_c.h.in
 set(VERSION ${GEOS_VERSION})

--- a/tests/superbuild.CMakeLists.txt
+++ b/tests/superbuild.CMakeLists.txt
@@ -1,0 +1,11 @@
+# This is used in CI as a simple test of GEOS building as a subproject
+# within a CMake super-build context.
+
+cmake_minimum_required(VERSION 3.13)
+
+project(superbuild_example)
+
+add_subdirectory("geos")
+
+add_executable(capi_read capi_read.c)
+target_link_libraries(capi_read PRIVATE GEOS::geos_c)


### PR DESCRIPTION
Currently GEOS doesn't work as a subproject in CMake via `add_subdirectory()` or FetchContent. 

[Example hello-world super-project](https://gist.github.com/rcoup/2bb5a8b6f0f9d7c26d83f285a7dd314a) & current output.

This is a series of fixes that move GEOS from erroring during generation to building & linking as a CMake subproject:

1. stops using `CMAKE_SOURCE_DIR`/`CMAKE_BINARY_DIR` since they're relative to the top-level project which may not be GEOS.
2. expose `GEOS::geos_c` and `GEOS::geos` alias targets, which is what `find_package(GEOS CONFIG)` has already
3. don't setup testing, packaging, developer-mode, etc when GEOS is a subproject. Moves the `project()` call as early as possible to use [`PROJECT_IS_TOP_LEVEL`](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) for this.
4. fix `geos_c` headers needing `geos` headers when using GEOS from the build tree

I'm not a CMake guru, but 1-3 are recommended practises from [Professional CMake](https://crascit.com/professional-cmake/). I haven't looked at any subproject install issues yet.