### PR TITLE
docs: update flags used in tar example

### DIFF
--- a/web/content/usage/download.md
+++ b/web/content/usage/download.md
@@ -28,7 +28,7 @@ Builds with CMake are done "outside the tree" either in a build directory in the
 
 ```bash
 # Unpack and setup build directory
-tar xvfz geos-{{<current_release>}}.tar.bz2
+tar xvfj geos-{{<current_release>}}.tar.bz2
 cd geos-{{<current_release>}}
 mkdir _build
 cd _build


### PR DESCRIPTION
The documentation suggests using the tar flag 'z', but it appears that downloads are bzipped instead of gzipped, so 'j' should be the recommended flag.