### PR TITLE
WIP: Add forEach and forEachSegment methods to CoordinateSequence

### DIFF
--- a/benchmarks/geom/CMakeLists.txt
+++ b/benchmarks/geom/CMakeLists.txt
@@ -18,4 +18,16 @@ IF(benchmark_FOUND)
             $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
     target_link_libraries(perf_envelope PRIVATE
             benchmark::benchmark geos_cxx_flags)
+
+    add_executable(perf_coordseq
+            CoordinateSequencePerfTest.cpp
+            ${CMAKE_SOURCE_DIR}/src/geom/Coordinate.cpp
+            ${CMAKE_SOURCE_DIR}/src/geom/CoordinateArraySequence.cpp
+            ${CMAKE_SOURCE_DIR}/src/geom/CoordinateArraySequenceFactory.cpp
+            ${CMAKE_SOURCE_DIR}/src/geom/CoordinateSequence.cpp)
+    target_include_directories(perf_coordseq PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+    target_link_libraries(perf_coordseq PRIVATE
+            benchmark::benchmark geos_cxx_flags)
 endif()

--- a/benchmarks/geom/CoordinateSequencePerfTest.cpp
+++ b/benchmarks/geom/CoordinateSequencePerfTest.cpp
@@ -1,0 +1,137 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2021 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <benchmark/benchmark.h>
+
+#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateFilter.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <geos/geom/CoordinateArraySequenceFactory.h>
+#include <geos/geom/SegmentInspector.h>
+
+using geos::geom::Coordinate;
+using geos::geom::CoordinateArraySequence;
+using geos::geom::CoordinateSequence;
+using geos::geom::CoordinateFilter;
+using geos::geom::SegmentInspector;
+
+constexpr size_t N = 10000;
+
+std::unique_ptr<CoordinateSequence> getSeq(std::size_t n) {
+    // prevent devirtualization by constructing this outside the benchmark function itself
+    geos::geom::CoordinateArraySequenceFactory casf;
+    return casf.create(n);
+}
+
+static void BM_CoordinateSequenceForLoopCacheSize(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    for (auto _ : state) {
+        const Coordinate* q;
+        auto sz = seq->size();
+        for (size_t i = 0; i < sz; i++) {
+            benchmark::DoNotOptimize(q = &seq->getAt(i));
+        }
+    }
+}
+
+static void BM_CoordinateSequenceSegmentForLoopCacheSize(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    for (auto _ : state) {
+        const Coordinate* q;
+        auto sz = seq->size();
+        for (size_t i = 1; i < sz; i++) {
+            benchmark::DoNotOptimize(q = &seq->getAt(i - 1));
+            benchmark::DoNotOptimize(q = &seq->getAt(i));
+        }
+    }
+}
+
+static void BM_CoordinateSequenceForLoop(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    for (auto _ : state) {
+        const Coordinate* q;
+        for (size_t i = 0; i < seq->size(); i++) {
+            benchmark::DoNotOptimize(q = &seq->getAt(i));
+        }
+    }
+}
+
+static void BM_CoordinateSequenceFilter(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    class Filter : public CoordinateFilter {
+        void filter_ro(const Coordinate* c) override {
+            benchmark::DoNotOptimize(c);
+        }
+    };
+    Filter f;
+
+    for (auto _ : state) {
+        seq->apply_ro(&f);
+    }
+}
+
+static void BM_CoordinateSequenceSegmentInspector(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    class Inspector : public SegmentInspector {
+        void inspect(const Coordinate& c1, const Coordinate& c2) override {
+            benchmark::DoNotOptimize(c1);
+            benchmark::DoNotOptimize(c2);
+        }
+    };
+    Inspector f;
+
+    for (auto _ : state) {
+        seq->apply_ro(&f);
+    }
+}
+
+static void BM_CoordinateSequenceForEach(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    for (auto _ : state) {
+        const Coordinate* q;
+        seq->forEach([&q](const Coordinate* c) {
+            benchmark::DoNotOptimize(q = c);
+        });
+    }
+}
+
+static void BM_CoordinateSequenceSegmentForEach(benchmark::State& state) {
+    auto seq = getSeq(N);
+
+    for (auto _ : state) {
+        const Coordinate* q;
+        seq->forEachSegment([&q](const Coordinate& c1, const Coordinate& c2) {
+            (void) c2;
+            benchmark::DoNotOptimize(q = &c1);
+        });
+    }
+}
+
+BENCHMARK(BM_CoordinateSequenceForLoop);
+BENCHMARK(BM_CoordinateSequenceForLoopCacheSize);
+BENCHMARK(BM_CoordinateSequenceFilter);
+BENCHMARK(BM_CoordinateSequenceForEach);
+
+BENCHMARK(BM_CoordinateSequenceSegmentForLoopCacheSize);
+BENCHMARK(BM_CoordinateSequenceSegmentInspector);
+BENCHMARK(BM_CoordinateSequenceSegmentForEach);
+
+BENCHMARK_MAIN();
+

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -131,6 +131,8 @@ public:
 
     void apply_ro(CoordinateFilter* filter) const override;
 
+    void apply_ro(SegmentInspector* inspector) const override;
+
 private:
     std::vector<Coordinate> vect;
     mutable std::size_t dimension;

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -18,6 +18,7 @@
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateFilter.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/SegmentInspector.h>
 #include <geos/util.h>
 
 #include <algorithm>
@@ -117,6 +118,12 @@ namespace geom {
             std::for_each(m_data.begin(), m_data.end(),
                     [&filter](Coordinate &c) { filter->filter_rw(&c); });
             dimension = 0; // re-check (see http://trac.osgeo.org/geos/ticket/435)
+        }
+
+        void apply_ro(SegmentInspector* inspector) const final override {
+            for (std::size_t i = 1; i < m_data.size(); i++) {
+                inspector->inspect(m_data[i-1], m_data[i]);
+            }
         }
 
     private:

--- a/include/geos/geom/SegmentInspector.h
+++ b/include/geos/geom/SegmentInspector.h
@@ -1,0 +1,30 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2021 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#pragma once
+
+namespace geos {
+namespace geom {
+
+class Coordinate;
+
+class SegmentInspector {
+
+public:
+    virtual void inspect(const Coordinate& p0, const Coordinate& p1) = 0;
+
+};
+
+}
+}

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -17,6 +17,7 @@
 #include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateFilter.h>
+#include <geos/geom/SegmentInspector.h>
 #include <geos/util.h>
 
 #include <sstream>
@@ -257,6 +258,14 @@ CoordinateArraySequence::apply_ro(CoordinateFilter* filter) const
 {
     for(const auto& coord : vect) {
         filter->filter_ro(&coord);
+    }
+}
+
+void
+CoordinateArraySequence::apply_ro(SegmentInspector* inspector) const
+{
+    for (size_t i = 1; i < vect.size(); i++) {
+        inspector->inspect(vect[i-1], vect[i]);
     }
 }
 


### PR DESCRIPTION
This PR adds `forEach` and `forEachSegment` methods to `CoordinateSequence`.

Iterating over a `CoordinateSequence` in GEOS is slow because `size`, `getAt` and `operator[]` are all virtual methods that cannot be inlined. To improve performance, a `CoordinateFilter` can be used but this is tedious to write and arguably comes with a readability penalty.

This implementation would allow you to write code like

```
double minX = std::numeric_limits<double>::positive_infinity();
seq.forEach([&minX](const Coordinate* c) {
  minX = std::min(minX, c.x);
});
```

or 

```
seq.forEachSegment[&index](const Coordinate& c1, const Coordinate& c2) {
  index.add(c1, c2);
})
```

Performance is roughly double that of a for loop. Whether that is important depends on the application, but sometimes it is. I suspect that still better performance would be obtained by ditching `CoordinateSequence` in favor of `std::vector<Coordinate>`.

```
2021-12-06T20:00:59-05:00
Running bin/perf_coordseq
Run on (8 X 4200 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 1.27, 0.55, 0.38
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
BM_CoordinateSequenceForLoop                      41666 ns        41383 ns        16913
BM_CoordinateSequenceForLoopCacheSize             22494 ns        22265 ns        35950
BM_CoordinateSequenceFilter                       17066 ns        17065 ns        46334
BM_CoordinateSequenceForEach                      16230 ns        16228 ns        42949
BM_CoordinateSequenceSegmentForLoopCacheSize      49302 ns        49154 ns        14228
BM_CoordinateSequenceSegmentInspector             29130 ns        28899 ns        25200
BM_CoordinateSequenceSegmentForEach               28161 ns        27407 ns        23331
```

If this seems like a good approach I will add tests and apply the method where applicable through the code base.
