### PR TITLE
inline: ensure inline.h is included in all .inl includers

### DIFF
--- a/include/geos/algorithm/ConvexHull.h
+++ b/include/geos/algorithm/ConvexHull.h
@@ -21,6 +21,7 @@
 #ifndef GEOS_ALGORITHM_CONVEXHULL_H
 #define GEOS_ALGORITHM_CONVEXHULL_H
 
+#include <geos/inline.h>
 #include <geos/export.h>
 #include <memory>
 #include <vector>

--- a/include/geos/geomgraph/index/SegmentIntersector.h
+++ b/include/geos/geomgraph/index/SegmentIntersector.h
@@ -16,6 +16,7 @@
 #ifndef GEOS_GEOMGRAPH_INDEX_SEGMENTINTERSECTOR_H
 #define GEOS_GEOMGRAPH_INDEX_SEGMENTINTERSECTOR_H
 
+#include <geos/inline.h>
 #include <geos/export.h>
 #include <array>
 #include <vector>

--- a/include/geos/operation/overlayng/EdgeKey.h
+++ b/include/geos/operation/overlayng/EdgeKey.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <geos/inline.h>
 #include <geos/operation/overlayng/OverlayLabel.h>
 #include <geos/export.h>
 


### PR DESCRIPTION
This commit adds inline.h includes in all remaining files that were including an .inl file conditionally based on `GEOS_INLINE`.

Fixes #524 