### PR TITLE
Fix conditional inlining in WKTReader

### DIFF
--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -49,7 +49,7 @@
 #include <iostream>
 #endif
 
-#ifndef GEOS_INLINE
+#ifdef GEOS_INLINE
 #include <geos/io/WKTReader.inl>
 #endif
 


### PR DESCRIPTION
This looks like a typo — every other conditional include of an `inl` file is inside of an `#ifdef GEOS_INLINE`, but the one in WKTReader.cpp was within an `#ifndef GEOS_INLINE`.