### PR TITLE
[3.9] Fix MonotoneChainBuilder::getChain with empty CoordinateString

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Changes in 3.9.3
 2022-xx-xx
 
 - Bug fixes / improvements:
+  - Fix crash in MonotoneChain with empty CoordinateSequence (GH-539, Sandro Santilli)
   - Improve BuildArea performance (#1122, Sandro Santilli)
   - Memory leak on exception in prepared geometry (GH-506, Dan Baston)
   - Infinite loop on collapsed input in MaximumInscribedCircle (Paul Ramsey)

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -55,6 +55,7 @@ void
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
                                 std::vector<std::unique_ptr<MonotoneChain>>& mcList)
 {
+    if ( pts->isEmpty() ) return;
     std::size_t chainStart = 0;
     do {
         std::size_t chainEnd = findChainEnd(*pts, chainStart);

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -141,6 +141,7 @@ geos_unit_SOURCES = \
 	geom/Geometry/equalsTest.cpp \
 	geom/GeometryFactoryTest.cpp \
 	geom/GeometryFilterTest.cpp \
+	geom/Geometry/differenceTest.cpp \
 	geom/Geometry/isRectangleTest.cpp \
 	geom/Geometry/normalizeTest.cpp \
 	geom/Geometry/touchesTest.cpp \
@@ -159,6 +160,7 @@ geos_unit_SOURCES = \
 	geom/prep/PreparedGeometry/touchesTest.cpp \
 	geom/TriangleTest.cpp \
 	geom/util/GeometryExtracterTest.cpp \
+	index/chain/MonotoneChainBuilderTest.cpp \
 	index/strtree/SIRtreeTest.cpp \
 	index/strtree/SimpleSTRtreeTest.cpp \
 	index/kdtree/KdTreeTest.cpp \

--- a/tests/unit/geom/Geometry/differenceTest.cpp
+++ b/tests/unit/geom/Geometry/differenceTest.cpp
@@ -1,0 +1,60 @@
+//
+// Test Suite for geos::geom::Geometry::difference() method.
+
+#include <tut/tut.hpp>
+#include <utility.h>
+// geos
+#include <geos/io/WKTReader.h>
+#include <geos/io/WKTWriter.h>
+#include <geos/geom/PrecisionModel.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/Point.h>
+#include <geos/geom/LineString.h>
+#include <geos/util.h>
+
+namespace tut {
+// dummy data, not used
+struct test_geometry_difference_data {
+    geos::io::WKTReader wktreader;
+    geos::io::WKTWriter wktwriter;
+
+    test_geometry_difference_data()
+        :
+        wktreader()
+    {}
+};
+
+typedef test_group<test_geometry_difference_data> group;
+typedef group::object object;
+
+group test_geometry_difference_group("geos::geom::Geometry::difference");
+
+//
+// Test Cases
+
+
+// This issue exercised a bug in MonotoneChainBuilder
+// https://github.com/libgeos/geos/issues/290
+template<>
+template<>
+void object::test<1>
+()
+{
+    std::string wkt1("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))");
+    std::unique_ptr<geos::geom::Geometry> g1(wktreader.read(wkt1));
+
+    std::string wkt2("POLYGON((0.1 0.1, 4.0 0.1, 4.0 1.9, 0.1 1.9, 0.1 0.1))");
+    std::unique_ptr<geos::geom::Geometry> g2(wktreader.read(wkt2));
+
+    auto result = g2->difference(g1.get());
+    result->normalize();
+
+    std::string wktExpected("POLYGON ((2 0.1, 2 1.9, 4 1.9, 4 0.1, 2 0.1))");
+    std::unique_ptr<geos::geom::Geometry> expected(wktreader.read(wktExpected));
+
+    ensure_equals_geometry(expected.get(), result.get());
+}
+
+
+} // namespace tut

--- a/tests/unit/index/chain/MonotoneChainBuilderTest.cpp
+++ b/tests/unit/index/chain/MonotoneChainBuilderTest.cpp
@@ -4,14 +4,12 @@
 #include <tut/tut.hpp>
 #include <utility.h>
 // geos
-#include <geos/io/WKTReader.h>
-#include <geos/io/WKTWriter.h>
-#include <geos/geom/PrecisionModel.h>
-#include <geos/geom/GeometryFactory.h>
-#include <geos/geom/Geometry.h>
-#include <geos/geom/Point.h>
-#include <geos/geom/LineString.h>
-#include <geos/util.h>
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <geos/index/chain/MonotoneChain.h>
+#include <geos/index/chain/MonotoneChainBuilder.h>
+
 
 namespace tut {
 // dummy data, not used
@@ -33,28 +31,19 @@ group test_monotonechain_group("geos::index::chain::MonotoneChainBuilder");
 //
 // Test Cases
 
-
 // This issue exercised a bug in MonotoneChainBuilder
-// https://github.com/libgeos/geos/issues/290
+// https://github.com/libgeos/geos/issues/539
 template<>
 template<>
 void object::test<1>
 ()
 {
-    std::string wkt1("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))");
-    std::unique_ptr<geos::geom::Geometry> g1(wktreader.read(wkt1));
+    std::vector< std::unique_ptr<geos::index::chain::MonotoneChain> > chain;
+    geos::geom::CoordinateArraySequence pts;
 
-    std::string wkt2("POLYGON((0.1 0.1, 4.0 0.1, 4.0 1.9, 0.1 1.9, 0.1 0.1))");
-    std::unique_ptr<geos::geom::Geometry> g2(wktreader.read(wkt2));
+    geos::index::chain::MonotoneChainBuilder::getChains(&pts, 0, chain);
 
-    auto result = g2->difference(g1.get());
-    result->normalize();
-
-    std::string wktExpected("POLYGON ((2 0.1, 2 1.9, 4 1.9, 4 0.1, 2 0.1))");
-    std::unique_ptr<geos::geom::Geometry> expected(wktreader.read(wktExpected));
-
-    ensure_equals_geometry(expected.get(), result.get());
+    ensure_equals(chain.size(), 0u);
 }
-
 
 } // namespace tut


### PR DESCRIPTION
See https://github.com/libgeos/geos/issues/539

Also enable previously disabled Geometry::difference test