### PR TITLE
GEOSExtent function to get overall bounding box of set of geometries

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -414,6 +414,12 @@ extern "C" {
     }
 
     Geometry*
+    GEOSExtent(Geometry** geoms, unsigned int ngeoms)
+    {
+        return GEOSExtent_r(handle, geoms, ngeoms);
+    }
+
+    Geometry*
     GEOSIntersection(const Geometry* g1, const Geometry* g2)
     {
         return GEOSIntersection_r(handle, g1, g2);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -723,6 +723,12 @@ extern GEOSGeometry GEOS_DLL *GEOSEnvelope_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g);
 
+/** \see GEOSExtent */
+extern GEOSGeometry GEOS_DLL *GEOSExtent_r(
+    GEOSContextHandle_t handle,
+    GEOSGeometry** geoms,
+    unsigned int ngeoms);
+
 /** \see GEOSIntersection */
 extern GEOSGeometry GEOS_DLL *GEOSIntersection_r(
     GEOSContextHandle_t handle,
@@ -2409,6 +2415,9 @@ extern void GEOS_DLL GEOSGeom_destroy(GEOSGeometry* g);
 * Caller is responsible for freeing with GEOSGeom_destroy().
 */
 extern GEOSGeometry GEOS_DLL *GEOSEnvelope(const GEOSGeometry* g);
+
+/** \see GEOSExtent */
+extern GEOSGeometry GEOS_DLL *GEOSExtent(GEOSGeometry** geoms,unsigned int ngeoms);
 
 /**
 * Returns the intersection of two geometries: the set of points


### PR DESCRIPTION
Would there be interest in adding such a function? It calculates the aggregated envelope of a set of geometries. 

This goes a bit beyond the typical scope of the current C API functions, as it works on an array of geometries (although you could compare it to `GEOSGeom_createCollection` which also creates a single geometry for an array input, although here we also perform some calculation on the input). 

I should maybe have first opened an issue, but I coded this up anyway to check if it would be beneficial and whether I would propose it. But so if this seems interesting/acceptable, I can further update this PR (docs, tests, etc).

When exposed in python through pygeos/shapely, I compared this with our current "total_bounds" implementation (which gets the bounds of each geometry with `GEOSEnvelope`, get the bbox from that, and then calculates the overall min/max of those bboxes). And this dedicated GEOS function gives around 10x speedup for a simple benchmark case.

I took the "GEOSExtent" naming following PostGIS, which also has a [`ST_Extent`](https://postgis.net/docs/ST_Extent.html) as an aggregation version of [`ST_Envelope`](https://postgis.net/docs/ST_Envelope.html)