### PR TITLE
Buffer operation: use fallback to lower precision when result geometry is invalid

### DIFF
--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -36,6 +36,7 @@
 #include <geos/operation/overlay/snap/SnapOverlayOp.h>
 #include <geos/operation/overlay/PolygonBuilder.h>
 #include <geos/operation/overlay/OverlayNodeFactory.h>
+#include <geos/operation/valid/IsValidOp.h>
 #include <geos/operation/valid/RepeatedPointRemover.h>
 #include <geos/operation/linemerge/LineMerger.h>
 #include <geos/algorithm/LineIntersector.h>
@@ -49,6 +50,7 @@
 #include <geos/geomgraph/Node.h>
 #include <geos/geomgraph/Edge.h>
 #include <geos/util/GEOSException.h>
+#include <geos/util/TopologyException.h>
 #include <geos/io/WKTWriter.h> // for debugging
 #include <geos/util/IllegalArgumentException.h>
 #include <geos/profiler.h>
@@ -476,6 +478,11 @@ BufferBuilder::buffer(const Geometry* g, double distance)
         // resultPolyList ownership transferred here
         resultGeom.reset(geomFact->buildGeometry(resultPolyList.release()));
 
+        // Validate result
+        valid::IsValidOp validator(resultGeom.get());
+        if (!validator.isValid()) {
+            throw util::TopologyException(validator.getValidationError()->toString());
+        }
     }
     catch(const util::GEOSException& /* exc */) {
 

--- a/tests/unit/capi/GEOSBufferTest.cpp
+++ b/tests/unit/capi/GEOSBufferTest.cpp
@@ -543,5 +543,25 @@ void object::test<20>
 
 }
 
+// Invalid result polygon with full precision, fall back on lower precision
+// https://trac.osgeo.org/geos/ticket/1131
+template<>
+template<>
+void object::test<21>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON((-6503873.862740669 -3656747.43316935, -6481859.9985945 -3656747.43316935, -6481859.9985945 -3688545.2369360398, -6506319.8476458 -3688545.2369360398, -6506319.8476458 -3664085.38788474, -6501427.87783554 -3664085.38788474, -6501427.87783554 -3661639.40297961, -6498981.89293041 -3661639.40297961, -6498981.89293041 -3659193.41807448, -6503873.862740669 -3659193.41807448, -6503873.862740669 -3656747.43316935))");
+
+    ensure(nullptr != geom1_);
+
+    bp_ = GEOSBufferParams_create();
+
+    GEOSBufferParams_setQuadrantSegments(bp_, 0);
+    geom2_ = GEOSBufferWithParams(geom1_, bp_, 2445.98490513);
+
+    ensure(nullptr != geom2_);
+    ensure("Buffer result polygon is not valid", GEOSisValid(geom2_));
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fix for "GEOSBufferWithStyle produce invalid geometry when quadsegs = 0" https://trac.osgeo.org/geos/ticket/1131

The issue can be solved by falling back on lower precision in `BufferOp::computeGeometry()`, but currently the result of `BufferBuilder::buffer()` is assumed to always be valid.  I suggest adding validity check to `BufferBuilder::buffer()` and throwing when it fails, so the caller can retry with lower precision.

