### PR TITLE
Minor perf improvement to GEOSCoordSeq_copyToBuffer

### DIFF
--- a/benchmarks/capi/GEOSCoordSeqPerfTest.cpp
+++ b/benchmarks/capi/GEOSCoordSeqPerfTest.cpp
@@ -69,11 +69,60 @@ static void BM_CoordSeq_CreateByCoordinate(benchmark::State& state) {
             if (dim == 3) {
                 double z = *ptr++;
                 GEOSCoordSeq_setXYZ(seq, i, x, y, z);
+                benchmark::DoNotOptimize(z);
             }
+            benchmark::DoNotOptimize(x);
+            benchmark::DoNotOptimize(y);
         }
 
         GEOSCoordSeq_destroy(seq);
     }
+
+    finishGEOS();
+}
+
+template<size_t N, size_t dim>
+static void BM_CoordSeq_CopyByCoordinate(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    auto buf = create_buffer(N, dim);
+    auto seq = GEOSCoordSeq_copyFromBuffer(buf.data(), N, dim == 3, false);
+
+    for (auto _ : state) {
+        double x;
+        double y;
+        double z;
+        for (std::size_t i = 0; i < N; i++) {
+            if (dim == 2) {
+                GEOSCoordSeq_getXY(seq, i, &x, &y);
+            }
+            if (dim == 3) {
+                GEOSCoordSeq_getXYZ(seq, i, &x, &y, &z);
+                benchmark::DoNotOptimize(z);
+            }
+            benchmark::DoNotOptimize(x);
+            benchmark::DoNotOptimize(y);
+        }
+    }
+
+    GEOSCoordSeq_destroy(seq);
+
+    finishGEOS();
+}
+
+template<size_t N, size_t dim>
+static void BM_CoordSeq_CopyToBuffer(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    auto buf = create_buffer(N, dim);
+    auto seq = GEOSCoordSeq_copyFromBuffer(buf.data(), N, dim == 3, false);
+
+    for (auto _ : state) {
+        GEOSCoordSeq_copyToBuffer(seq, buf.data(), dim == 3, false);
+        benchmark::DoNotOptimize(buf);
+    }
+
+    GEOSCoordSeq_destroy(seq);
 
     finishGEOS();
 }
@@ -101,7 +150,13 @@ BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10, 3);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 10, 3);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10, 3);
 
-// N = 1,0000
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyByCoordinate, 10, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyToBuffer, 10, 2);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyByCoordinate, 10, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyToBuffer, 10, 3);
+
+// N = 1,000
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 1000, 2);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 1000, 2);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 1000, 2);
@@ -109,6 +164,12 @@ BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 1000, 2);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 1000, 3);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 1000, 3);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 1000, 3);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyByCoordinate, 1000, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyToBuffer, 1000, 2);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyByCoordinate, 1000, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyToBuffer, 1000, 3);
 
 // N = 10,000
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10000, 2);
@@ -118,6 +179,12 @@ BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10000, 2);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByOrdinate, 10000, 3);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CreateByCoordinate, 10000, 3);
 BENCHMARK_TEMPLATE(BM_CoordSeq_CopyFromBuffer, 10000, 3);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyByCoordinate, 10000, 2);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyToBuffer, 10000, 2);
+
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyByCoordinate, 10000, 3);
+BENCHMARK_TEMPLATE(BM_CoordSeq_CopyToBuffer, 10000, 3);
 
 BENCHMARK_MAIN();
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2388,11 +2388,18 @@ extern "C" {
 
             class CoordinateBufferCopier : public geos::geom::CoordinateFilter {
             public:
-                CoordinateBufferCopier(double* p_buf, bool p_hasZ, bool p_hasM) : buf(p_buf), m(p_hasM), dim(2 + p_hasZ) {}
+                CoordinateBufferCopier(double* p_buf, bool p_hasZ, bool p_hasM) : buf(p_buf), m(p_hasM), z(p_hasZ) {}
 
                 void filter_ro(const geos::geom::Coordinate* c) override {
-                    std::memcpy(buf, c, dim * sizeof(double));
-                    buf += dim;
+                    *buf = c->x;
+                    buf++;
+                    *buf = c->y;
+                    buf++;
+
+                    if (z) {
+                        *buf = c->z;
+                        buf++;
+                    }
 
                     if (m) {
                         *buf = std::numeric_limits<double>::quiet_NaN();
@@ -2402,8 +2409,8 @@ extern "C" {
 
             private:
                 double* buf;
-                bool m;
-                size_t dim;
+                const bool m;
+                const bool z;
             };
 
             CoordinateBufferCopier cop(buf, hasZ, hasM);

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -18,6 +18,7 @@
  ***********************************************************************/
 
 #include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/prep/PreparedGeometry.h>
 #include <geos/geom/prep/PreparedGeometryFactory.h>
@@ -2414,7 +2415,13 @@ extern "C" {
             };
 
             CoordinateBufferCopier cop(buf, hasZ, hasM);
-            cs->apply_ro(&cop);
+            // Speculatively check to see if our input is a CoordinateArraySequence.
+            // If so, gcc can inline the filter.
+            if (auto cas = dynamic_cast<const geos::geom::CoordinateArraySequence*>(cs)) {
+                cas->apply_ro(&cop);
+            } else {
+                cs->apply_ro(&cop);
+            }
 
             return 1;
         });

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -17,6 +17,7 @@
 #include <geos/export.h>
 #include <vector>
 
+#include <geos/geom/CoordinateFilter.h>
 #include <geos/geom/CoordinateSequence.h>
 
 // Forward declarations
@@ -126,7 +127,11 @@ public:
 
     void apply_rw(const CoordinateFilter* filter) override;
 
-    void apply_ro(CoordinateFilter* filter) const override;
+    void apply_ro(CoordinateFilter* filter) const override {
+        for(const auto& coord : vect) {
+            filter->filter_ro(&coord);
+        }
+    }
 
 private:
     std::vector<Coordinate> vect;

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -252,13 +252,5 @@ CoordinateArraySequence::apply_rw(const CoordinateFilter* filter)
     dimension = 0; // re-check (see http://trac.osgeo.org/geos/ticket/435)
 }
 
-void
-CoordinateArraySequence::apply_ro(CoordinateFilter* filter) const
-{
-    for(const auto& coord : vect) {
-        filter->filter_ro(&coord);
-    }
-}
-
 } // namespace geos::geom
 } //namespace geos


### PR DESCRIPTION
- Switch from std::memcpy to value copy
- Check for `CoordinateArraySequence` (likely) and so we can inline in that case

```
2022-02-06T12:43:43-05:00
Running bin/perf_capi_coordseq
Run on (8 X 3899.07 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 1.96, 2.98, 2.84
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------

BM_CoordSeq_CopyByCoordinate<10, 2>            30.0 ns         30.0 ns     23397094
BM_CoordSeq_CopyToBuffer<10, 2>                18.5 ns         18.5 ns     38914047
BM_CoordSeq_CopyByCoordinate<10, 3>            42.0 ns         42.0 ns     16709286
BM_CoordSeq_CopyToBuffer<10, 3>                16.6 ns         16.6 ns     41778813

BM_CoordSeq_CopyByCoordinate<1000, 2>          3121 ns         3121 ns       224390
BM_CoordSeq_CopyToBuffer<1000, 2>               540 ns          540 ns      1256236
BM_CoordSeq_CopyByCoordinate<1000, 3>          4148 ns         4147 ns       168217
BM_CoordSeq_CopyToBuffer<1000, 3>               777 ns          777 ns       885015

BM_CoordSeq_CopyByCoordinate<10000, 2>        31320 ns        31270 ns        22364
BM_CoordSeq_CopyToBuffer<10000, 2>             6652 ns         6643 ns       102111
BM_CoordSeq_CopyByCoordinate<10000, 3>        43295 ns        43293 ns        15862
BM_CoordSeq_CopyToBuffer<10000, 3>             8179 ns         8179 ns        84358
```