### PR TITLE
ENH: add GEOSGeom_transformXY to C API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   - ConcaveHull (GH-549, Paul Ramsey/Martin Davis)
   - CAPI: GEOSHilbertCode (GH-556, Brendan Ward)
   - CAPI: GEOSGeom_createRectangle (GH-558, Brendan Ward)
+  - CAPI: GEOSGeom_transformXY (GH-563, Dan Baston/Brendan Ward)
 
 - Fixes/Improvements:
   - Fix unaryUnion to avoid segfault with empty polygon (GH-501, Mike Taves)

--- a/benchmarks/capi/CMakeLists.txt
+++ b/benchmarks/capi/CMakeLists.txt
@@ -35,3 +35,10 @@ if(benchmark_FOUND)
             benchmark::benchmark geos_c)
 endif()
 
+if(benchmark_FOUND)
+    add_executable(perf_capi_transformxy GEOSGeom_transformXYPerfTest.cpp)
+    target_include_directories(perf_capi_transformxy PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+    target_link_libraries(perf_capi_transformxy PRIVATE benchmark::benchmark geos_c)
+endif()

--- a/benchmarks/capi/GEOSGeom_transformXYPerfTest.cpp
+++ b/benchmarks/capi/GEOSGeom_transformXYPerfTest.cpp
@@ -1,0 +1,42 @@
+#include <geos_c.h>
+
+#include <benchmark/benchmark.h>
+
+static int SCALE_USER_DATA(double* x, double* y, void* userdata) {
+    double scale = *(double *)(userdata);
+    (*x) *= scale;
+    (*y) *= scale;
+    return 1;
+}
+
+template<size_t N>
+static void BM_GEOSGeom_transformXY(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    // create a linestring N coords long
+    std::vector<double> buf(2 * N);
+        for(auto& di : buf) {
+        di = d;
+        d += 1.0;
+    }
+    auto seq = GEOSCoordSeq_copyFromBuffer(buf.data(), N, false, false);
+    auto geom = GEOSGeom_createLineString(seq);
+
+    for (auto _ : state) {
+        GEOSGeom_transformXY(geom, SCALE_USER_DATA, 2.0);
+    }
+
+    GEOSGeom_destroy(geom)
+    finishGEOS();
+}
+
+// N = 10
+BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 10, 2);
+
+// N = 1,000
+BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 1000, 2);
+
+// N = 10,000
+BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 10000, 2);
+
+BENCHMARK_MAIN();

--- a/benchmarks/capi/GEOSGeom_transformXYPerfTest.cpp
+++ b/benchmarks/capi/GEOSGeom_transformXYPerfTest.cpp
@@ -1,42 +1,100 @@
-#include <geos_c.h>
+#include <iostream>
 
 #include <benchmark/benchmark.h>
+#include <geos_c.h>
 
 static int SCALE_USER_DATA(double* x, double* y, void* userdata) {
-    double scale = *(double *)(userdata);
+    double scale = *(double*)(userdata);
     (*x) *= scale;
     (*y) *= scale;
     return 1;
 }
 
-template<size_t N>
-static void BM_GEOSGeom_transformXY(benchmark::State& state) {
-    initGEOS(nullptr, nullptr);
-
-    // create a linestring N coords long
-    std::vector<double> buf(2 * N);
-        for(auto& di : buf) {
+GEOSGeometry* create_polygon(size_t N) {
+    // create a linearring N coords long
+    std::vector<double> buf(2 * (N + 1));
+    double d = 0.0;
+    for (auto& di : buf) {
         di = d;
         d += 1.0;
     }
-    auto seq = GEOSCoordSeq_copyFromBuffer(buf.data(), N, false, false);
-    auto geom = GEOSGeom_createLineString(seq);
+
+    // close the ring
+    buf[N * 2] = buf[0];
+    buf[(N * 2) + 1] = buf[1];
+
+    auto seq = GEOSCoordSeq_copyFromBuffer(buf.data(), N + 1, false, false);
+    assert(seq != nullptr);
+    auto ring = GEOSGeom_createLinearRing(seq);
+    return GEOSGeom_createPolygon(ring, nullptr, 0);
+}
+
+template <size_t N>
+static void BM_GEOSGeom_transformXY(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    auto geom = create_polygon(N);
+    GEOSGeometry *out_geom;
+
+    double scale = 2.0;
 
     for (auto _ : state) {
-        GEOSGeom_transformXY(geom, SCALE_USER_DATA, 2.0);
+        out_geom = GEOSGeom_transformXY(geom, SCALE_USER_DATA, (void*)(&scale));
+
+        // not really part of benchmark but need to cleanup geom
+        GEOSGeom_destroy(out_geom);
     }
 
-    GEOSGeom_destroy(geom)
+    GEOSGeom_destroy(geom);
+    finishGEOS();
+}
+
+template <size_t N>
+static void BM_Geom_from_transformed_coords(benchmark::State& state) {
+    initGEOS(nullptr, nullptr);
+
+    const GEOSCoordSequence *seq;
+    GEOSCoordSequence *out_seq;
+    unsigned int i, size;
+    double x, y, scale=2.0;
+    const GEOSGeometry *ring;
+    GEOSGeometry *out_ring, *out_geom;
+
+    auto geom = create_polygon(N);
+
+    for (auto _ : state) {
+        ring = GEOSGetExteriorRing(geom);
+        seq = GEOSGeom_getCoordSeq(ring);
+        GEOSCoordSeq_getSize(seq, &size);
+        out_seq = GEOSCoordSeq_create(size, 2);
+
+        for (i = 0; i < size; i++) {
+            GEOSCoordSeq_getXY(seq, i, &x, &y);
+            SCALE_USER_DATA(&x, &y, (void *)(&scale));
+            GEOSCoordSeq_setXY(out_seq, i, x, y);
+        }
+
+        out_ring = GEOSGeom_createLinearRing(out_seq);
+        out_geom = GEOSGeom_createPolygon(out_ring, nullptr, 0);
+
+        // not really part of benchmark but need to cleanup geom
+        GEOSGeom_destroy(out_geom);
+    }
+
+    GEOSGeom_destroy(geom);
     finishGEOS();
 }
 
 // N = 10
-BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 10, 2);
+BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 10);
+BENCHMARK_TEMPLATE(BM_Geom_from_transformed_coords, 10);
 
 // N = 1,000
-BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 1000, 2);
+BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 1000);
+BENCHMARK_TEMPLATE(BM_Geom_from_transformed_coords, 1000);
 
 // N = 10,000
-BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 10000, 2);
+BENCHMARK_TEMPLATE(BM_GEOSGeom_transformXY, 10000);
+BENCHMARK_TEMPLATE(BM_Geom_from_transformed_coords, 10000);
 
 BENCHMARK_MAIN();

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -599,6 +599,11 @@ extern "C" {
     }
 
 
+    Geometry*
+    GEOSGeom_transformXY(const GEOSGeometry* g, GEOSTransformXYCallback callback, void* userdata) {
+        return GEOSGeom_transformXY_r(handle, g, callback, userdata);
+    }
+
 
 //-------------------------------------------------------------------
 // memory management functions

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -4256,15 +4256,15 @@ extern GEOSCoordSequence GEOS_DLL *GEOSNearestPoints(
     const GEOSGeometry* g2);
 
 /**
-* Apply XY coordinate transform callback to all coordinates in geometry.
-* If the callback returns an error, returned geometry will be NULL.  Z values,
-* if present, are not modified by this function.
+* Apply XY coordinate transform callback to all coordinates in a copy of
+* input geometry.  If the callback returns an error, returned geometry will be
+* NULL.  Z values, if present, are not modified by this function.
 * \param[in] g Input geometry
 * \param[in] callback a function to be executed for each coordinate in the
                 geometry.  The callback takes 3 parameters: x and y coordinate
                 values to be updated and a void userdata pointer.
 * \param userdata an optional pointer to pe passed to 'callback' as an argument
-* \return The geometry with transformed coordinates.
+* \return a copy of the input geometry with transformed coordinates.
 * Caller must free with GEOSGeom_destroy().
 */
 extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXY(

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -273,6 +273,25 @@ typedef int (*GEOSDistanceCallback)(
     double* distance,
     void* userdata);
 
+
+/**
+* Callback function for use in GEOSGeom_transformXY.
+* Allows custom function to be applied to x and y values for each coordinate
+* in a geometry.
+* Extra data for the calculation can be passed via the userdata.
+*
+* \param x coordinate value to be updated
+* \param y coordinate value to be updated
+* \param userdata extra data for the calculation
+*
+* \return 1 if calculation succeeded, 0 on failure
+*/
+typedef int (*GEOSTransformXYCallback)(
+    double* x,
+    double* y,
+    void* userdata);
+
+
 /* ========== Interruption ========== */
 
 /**
@@ -1610,6 +1629,12 @@ extern GEOSCoordSequence GEOS_DLL *GEOSNearestPoints_r(
     const GEOSGeometry* g1,
     const GEOSGeometry* g2);
 
+/** \see GEOSGeom_transformXY */
+extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXY_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g,
+    GEOSTransformXYCallback callback,
+    void* userdata);
 
 /* ========= Algorithms ========= */
 
@@ -4230,6 +4255,21 @@ extern GEOSCoordSequence GEOS_DLL *GEOSNearestPoints(
     const GEOSGeometry* g1,
     const GEOSGeometry* g2);
 
+/**
+* Apply XY coordinate transform callback to all coordinates in geometry.
+* If the callback returns an error, returned geometry will be NULL;
+* \param[in] g Input geometry
+* \param[in] callback a function to be executed for each coordinate in the
+                geometry.  The callback takes 3 parameters: x and y coordinate
+                values to be updated and a void userdata pointer.
+* \param userdata an optional pointer to pe passed to 'callback' as an argument
+* \return The geometry with transformed coordinates.
+* Caller must free with GEOSGeom_destroy().
+*/
+extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXY(
+    const GEOSGeometry* g,
+    GEOSTransformXYCallback callback,
+    void* userdata);
 
 /* ========== Algorithms ========== */
 

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -277,7 +277,7 @@ typedef int (*GEOSDistanceCallback)(
 /**
 * Callback function for use in GEOSGeom_transformXY.
 * Allows custom function to be applied to x and y values for each coordinate
-* in a geometry.
+* in a geometry.  Z values are unchanged by this function.
 * Extra data for the calculation can be passed via the userdata.
 *
 * \param x coordinate value to be updated
@@ -4257,7 +4257,8 @@ extern GEOSCoordSequence GEOS_DLL *GEOSNearestPoints(
 
 /**
 * Apply XY coordinate transform callback to all coordinates in geometry.
-* If the callback returns an error, returned geometry will be NULL;
+* If the callback returns an error, returned geometry will be NULL.  Z values,
+* if present, are not modified by this function.
 * \param[in] g Input geometry
 * \param[in] callback a function to be executed for each coordinate in the
                 geometry.  The callback takes 3 parameters: x and y coordinate

--- a/tests/unit/capi/GEOSGeom_transformXYTest.cpp
+++ b/tests/unit/capi/GEOSGeom_transformXYTest.cpp
@@ -19,23 +19,28 @@ typedef group::object object;
 
 group test_capi_geosgeom_transformxy_group("capi::GEOSGeom_transformXY");
 
+static int SCALE_2_3(double* x, double* y, void* userdata) {
+    (*x) *= 2;
+    (*y) *= 3;
+    (void)(userdata);  // make unused parameter warning go away
+    return 1;
+}
 
 // callback that doesn't update coordinates should return original values
-template<>
-template<>
-void object::test<1>
-()
-{
+template <>
+template <>
+void object::test<1>() {
     GEOSGeometry* geom = GEOSGeomFromWKT("POINT (1 1)");
 
     GEOSGeometry* out = GEOSGeom_transformXY(
-        geom, [](double* x, double *y, void* userdata) {
-            (void)(x); // make unused parameter warning go away
-            (void)(y);  // make unused parameter warning go away
-            (void)(userdata); // make unused parameter warning go away
+        geom,
+        [](double* x, double* y, void* userdata) {
+            (void)(x);         // make unused parameter warning go away
+            (void)(y);         // make unused parameter warning go away
+            (void)(userdata);  // make unused parameter warning go away
             return 1;
-        }, nullptr
-    );
+        },
+        nullptr);
 
     ensure(out != nullptr);
     ensure_equals(GEOSEquals(out, geom), 1);
@@ -45,21 +50,20 @@ void object::test<1>
 }
 
 // failed callback should return NULL
-template<>
-template<>
-void object::test<2>
-()
-{
+template <>
+template <>
+void object::test<2>() {
     GEOSGeometry* geom = GEOSGeomFromWKT("POINT (1 1)");
 
     GEOSGeometry* out = GEOSGeom_transformXY(
-        geom, [](double* x, double *y, void* userdata) {
-            (void)(x); // make unused parameter warning go away
-            (void)(y);  // make unused parameter warning go away
-            (void)(userdata); // make unused parameter warning go away
-            return 0; // indicates error
-        }, nullptr
-    );
+        geom,
+        [](double* x, double* y, void* userdata) {
+            (void)(x);         // make unused parameter warning go away
+            (void)(y);         // make unused parameter warning go away
+            (void)(userdata);  // make unused parameter warning go away
+            return 0;          // indicates error
+        },
+        nullptr);
 
     ensure(out == nullptr);
 
@@ -67,88 +71,212 @@ void object::test<2>
 }
 
 // callback should modify point coordinates
-template<>
-template<>
-void object::test<3>
-()
-{
+template <>
+template <>
+void object::test<3>() {
     GEOSGeometry* geom = GEOSGeomFromWKT("POINT (1 1)");
-    GEOSGeometry* expected = GEOSGeomFromWKT("POINT (2 3)");
 
-    GEOSGeometry* out = GEOSGeom_transformXY(
-        geom, [](double* x, double *y, void* userdata) {
-            (*x) *= 2;
-            (*y) *= 3;
-            (void)(userdata); // make unused parameter warning go away
-            return 1;
-        }, nullptr
-    );
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
 
     ensure(out != nullptr);
-    ensure_equals(GEOSEquals(out, expected), 1);
+    ensure_geometry_equals(out, "POINT (2 3)");
+
+    double xmin, ymin, xmax, ymax;
+    GEOSGeom_getExtent(out, &xmin, &ymin, &xmax, &ymax);
+    ensure_equals(xmin, 2);
+    ensure_equals(ymin, 3);
+    ensure_equals(xmax, 2);
+    ensure_equals(ymax, 3);
 
     GEOSGeom_destroy(geom);
-    GEOSGeom_destroy(expected);
     GEOSGeom_destroy(out);
 }
 
 // callback should modify linestring coordinates
-template<>
-template<>
-void object::test<4>
-()
-{
+template <>
+template <>
+void object::test<4>() {
     GEOSGeometry* geom = GEOSGeomFromWKT("LINESTRING (1 1, 2 2)");
-    GEOSGeometry* expected = GEOSGeomFromWKT("LINESTRING (2 3, 4 6)");
 
-    GEOSGeometry* out = GEOSGeom_transformXY(
-        geom, [](double* x, double *y, void* userdata) {
-            (*x) *= 2;
-            (*y) *= 3;
-            (void)(userdata); // make unused parameter warning go away
-            return 1;
-        }, nullptr
-    );
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
 
     ensure(out != nullptr);
-    ensure_equals(GEOSEquals(out, expected), 1);
+    ensure_geometry_equals(out, "LINESTRING (2 3, 4 6)");
+
+    double xmin, ymin, xmax, ymax;
+    GEOSGeom_getExtent(out, &xmin, &ymin, &xmax, &ymax);
+    ensure_equals(xmin, 2);
+    ensure_equals(ymin, 3);
+    ensure_equals(xmax, 4);
+    ensure_equals(ymax, 6);
 
     GEOSGeom_destroy(geom);
-    GEOSGeom_destroy(expected);
     GEOSGeom_destroy(out);
 }
 
 // callback should modify polygon coordinates
-template<>
-template<>
-void object::test<5>
-()
-{
-    GEOSGeometry* geom = GEOSGeomFromWKT("POLYGON ((1 1, 1 10, 10 10, 10 1, 1 1),  (2 2, 2 4, 4 4, 4 2, 2 2))");
-    GEOSGeometry* expected = GEOSGeomFromWKT("POLYGON ((2 3, 2 30, 20 30, 20 3, 2 3), (4 6, 4 12, 8 12, 8 6, 4 6))");
+template <>
+template <>
+void object::test<5>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT(
+        "POLYGON ((1 1, 1 10, 10 10, 10 1, 1 1),  (2 2, 2 4, 4 4, 4 2, 2 2))");
 
-    GEOSGeometry* out = GEOSGeom_transformXY(
-        geom, [](double* x, double *y, void* userdata) {
-            (*x) *= 2;
-            (*y) *= 3;
-            (void)(userdata); // make unused parameter warning go away
-            return 1;
-        }, nullptr
-    );
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
 
     ensure(out != nullptr);
-    ensure_equals(GEOSEquals(out, expected), 1);
+    ensure_geometry_equals(out,
+        "POLYGON ((2 3, 2 30, 20 30, 20 3, 2 3), (4 6, 4 12, 8 12, 8 6, 4 6))");
+
+    double xmin, ymin, xmax, ymax;
+    GEOSGeom_getExtent(out, &xmin, &ymin, &xmax, &ymax);
+    ensure_equals(xmin, 2);
+    ensure_equals(ymin, 3);
+    ensure_equals(xmax, 20);
+    ensure_equals(ymax, 30);
 
     GEOSGeom_destroy(geom);
-    GEOSGeom_destroy(expected);
     GEOSGeom_destroy(out);
 }
 
+// callback should modify multi point coordinates
+template <>
+template <>
+void object::test<6>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT(
+        "MULTIPOINT ((1 1), (2 2))");
 
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
 
+    ensure(out != nullptr);
+    ensure_geometry_equals(out,
+        "MULTIPOINT ((2 3), (4 6))");
 
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
 
+// callback should modify multi linestring coordinates
+template <>
+template <>
+void object::test<7>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT(
+        "MULTILINESTRING ((1 1, 2 2), (3 3, 4 4))");
 
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
 
-} // namespace tut
+    ensure(out != nullptr);
+    ensure_geometry_equals(out,
+        "MULTILINESTRING ((2 3, 4 6), (6 9, 8 12 ))");
 
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+// callback should modify multi polygon coordinates
+template <>
+template <>
+void object::test<8>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT(
+        "MULTIPOLYGON (((1 1, 1 10, 10 10, 10 1, 1 1),  (2 2, 2 4, 4 4, 4 2, 2 2)), ((0 0, 0 100, 100 100, 100 0, 0 0)))");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
+
+    ensure(out != nullptr);
+    ensure_geometry_equals(out,
+        "MULTIPOLYGON (((2 3, 2 30, 20 30, 20 3, 2 3), (4 6, 4 12, 8 12, 8 6, 4 6)), ((0 0, 0 300, 200 300, 200 0, 0 0)))");
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+// callback should modify geometry collection coordinates
+template <>
+template <>
+void object::test<9>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT(
+        "GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (1 1, 2 2), POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)))");
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
+
+    ensure(out != nullptr);
+    ensure_geometry_equals(out, "GEOMETRYCOLLECTION (POINT (2 3), LINESTRING (2 3, 4 6), POLYGON ((2 3, 2 6, 4 6, 4 3, 2 3)))");
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+// should not fail for empty geometry
+template <>
+template <>
+void object::test<10>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT("POINT EMPTY");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
+
+    ensure(out != nullptr);
+    ensure_geometry_equals(out, "POINT EMPTY");
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+// should retain original coords even if they collapse to same coordinate
+template <>
+template <>
+void object::test<11>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT("LINESTRING (1 1, 2 2)");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom,
+        [](double* x, double* y, void* userdata) {
+            *x = 0;
+            *y = 0;
+            (void)(userdata);  // make unused parameter warning go away
+            return 1;
+        },
+        nullptr);
+
+    ensure(out != nullptr);
+    ensure_equals(GEOSGetNumCoordinates(out), 2);
+
+    // Cannot construct WKT for this case, must test coords directly
+    const GEOSCoordSequence* seq = GEOSGeom_getCoordSeq(out);
+
+    double x, y;
+    GEOSCoordSeq_getXY(seq, 0, &x, &y);
+    ensure_equals(x, 0);
+    ensure_equals(y, 0);
+
+    GEOSCoordSeq_getXY(seq, 1, &x, &y);
+    ensure_equals(x, 0);
+    ensure_equals(y, 0);
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+// should pass through userdata
+template <>
+template <>
+void object::test<12>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT("LINESTRING (1 1, 2 2)");
+
+    double userdata_scale = 5.0;
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom,
+        [](double* x, double* y, void* userdata) {
+            double scale = *(double *)(userdata);
+            *x = (*x) * scale;
+            *y = (*y) * scale;
+            return 1;
+        },
+        (void *)(&userdata_scale));
+
+    ensure(out != nullptr);
+    ensure_geometry_equals(out, "LINESTRING (5 5, 10 10)");
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+}  // namespace tut

--- a/tests/unit/capi/GEOSGeom_transformXYTest.cpp
+++ b/tests/unit/capi/GEOSGeom_transformXYTest.cpp
@@ -279,4 +279,19 @@ void object::test<12>() {
     GEOSGeom_destroy(out);
 }
 
+// transform should preserve existing Z coordinate values
+template <>
+template <>
+void object::test<13>() {
+    GEOSGeometry* geom = GEOSGeomFromWKT("POINT Z (1 1 4)");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(geom, SCALE_2_3, nullptr);
+
+    ensure(out != nullptr);
+    ensure_geometry_equals(out, "POINT Z (2 3 4)");
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
 }  // namespace tut

--- a/tests/unit/capi/GEOSGeom_transformXYTest.cpp
+++ b/tests/unit/capi/GEOSGeom_transformXYTest.cpp
@@ -266,8 +266,8 @@ void object::test<12>() {
         geom,
         [](double* x, double* y, void* userdata) {
             double scale = *(double *)(userdata);
-            *x = (*x) * scale;
-            *y = (*y) * scale;
+            (*x) *= scale;
+            (*y) *= scale;
             return 1;
         },
         (void *)(&userdata_scale));

--- a/tests/unit/capi/GEOSGeom_transformXYTest.cpp
+++ b/tests/unit/capi/GEOSGeom_transformXYTest.cpp
@@ -1,0 +1,154 @@
+//
+// Test Suite for C-API GEOSGeom_transformXY
+
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+// std
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+struct test_capi_geosgeom_transformxy : public capitest::utility {};
+
+typedef test_group<test_capi_geosgeom_transformxy> group;
+typedef group::object object;
+
+group test_capi_geosgeom_transformxy_group("capi::GEOSGeom_transformXY");
+
+
+// callback that doesn't update coordinates should return original values
+template<>
+template<>
+void object::test<1>
+()
+{
+    GEOSGeometry* geom = GEOSGeomFromWKT("POINT (1 1)");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom, [](double* x, double *y, void* userdata) {
+            (void)(x); // make unused parameter warning go away
+            (void)(y);  // make unused parameter warning go away
+            (void)(userdata); // make unused parameter warning go away
+            return 1;
+        }, nullptr
+    );
+
+    ensure(out != nullptr);
+    ensure_equals(GEOSEquals(out, geom), 1);
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(out);
+}
+
+// failed callback should return NULL
+template<>
+template<>
+void object::test<2>
+()
+{
+    GEOSGeometry* geom = GEOSGeomFromWKT("POINT (1 1)");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom, [](double* x, double *y, void* userdata) {
+            (void)(x); // make unused parameter warning go away
+            (void)(y);  // make unused parameter warning go away
+            (void)(userdata); // make unused parameter warning go away
+            return 0; // indicates error
+        }, nullptr
+    );
+
+    ensure(out == nullptr);
+
+    GEOSGeom_destroy(geom);
+}
+
+// callback should modify point coordinates
+template<>
+template<>
+void object::test<3>
+()
+{
+    GEOSGeometry* geom = GEOSGeomFromWKT("POINT (1 1)");
+    GEOSGeometry* expected = GEOSGeomFromWKT("POINT (2 3)");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom, [](double* x, double *y, void* userdata) {
+            (*x) *= 2;
+            (*y) *= 3;
+            (void)(userdata); // make unused parameter warning go away
+            return 1;
+        }, nullptr
+    );
+
+    ensure(out != nullptr);
+    ensure_equals(GEOSEquals(out, expected), 1);
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(expected);
+    GEOSGeom_destroy(out);
+}
+
+// callback should modify linestring coordinates
+template<>
+template<>
+void object::test<4>
+()
+{
+    GEOSGeometry* geom = GEOSGeomFromWKT("LINESTRING (1 1, 2 2)");
+    GEOSGeometry* expected = GEOSGeomFromWKT("LINESTRING (2 3, 4 6)");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom, [](double* x, double *y, void* userdata) {
+            (*x) *= 2;
+            (*y) *= 3;
+            (void)(userdata); // make unused parameter warning go away
+            return 1;
+        }, nullptr
+    );
+
+    ensure(out != nullptr);
+    ensure_equals(GEOSEquals(out, expected), 1);
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(expected);
+    GEOSGeom_destroy(out);
+}
+
+// callback should modify polygon coordinates
+template<>
+template<>
+void object::test<5>
+()
+{
+    GEOSGeometry* geom = GEOSGeomFromWKT("POLYGON ((1 1, 1 10, 10 10, 10 1, 1 1),  (2 2, 2 4, 4 4, 4 2, 2 2))");
+    GEOSGeometry* expected = GEOSGeomFromWKT("POLYGON ((2 3, 2 30, 20 30, 20 3, 2 3), (4 6, 4 12, 8 12, 8 6, 4 6))");
+
+    GEOSGeometry* out = GEOSGeom_transformXY(
+        geom, [](double* x, double *y, void* userdata) {
+            (*x) *= 2;
+            (*y) *= 3;
+            (void)(userdata); // make unused parameter warning go away
+            return 1;
+        }, nullptr
+    );
+
+    ensure(out != nullptr);
+    ensure_equals(GEOSEquals(out, expected), 1);
+
+    GEOSGeom_destroy(geom);
+    GEOSGeom_destroy(expected);
+    GEOSGeom_destroy(out);
+}
+
+
+
+
+
+
+
+} // namespace tut
+


### PR DESCRIPTION
Resolves #560

Allows caller to provide a callback function to transform x,y values of all cordinates in a geometry and return a new geometry; z values are unchanged.

Many thanks to @dbaston for providing >95% of the implementation in #560; I mostly tweaked a few things and added tests / benchmarks.

I diverged a bit from the direction suggested in #560, specifically:
* I retained the `XY` suffix on the function names (`GEOSGeom_transformXY`, `GEOSTransformXYCallback`); I think this provides a very clear signal to the user that these apply only to x,y coordinates and helps avoid future ambiguity if an XYZ form is ever added.  This follows the precedent for some of the other XY coordinate sequence getters / setters.  As a user of the library, the `XY` suffix has been helpful and appreciated.
* I switched the order of inputs to be geometry, callback.  This is consistent with `GEOSSTRtree_query`, etc
* I made the `GEOSTransformXYCallback` return 1 on success, 0 on failure like several other functions in the C API.  Notably, it diverges from `GEOSQueryCallback` which is `void` and `GEOSDistanceCallback` which is 0 on success and nonzero otherwise (which I found a bit confusing).  We need a clear way to signal from this callback in case of error.  If appropriate, we can make this match the precedent of `GEOSDistanceCallback`.

