### PR TITLE
Fix RelateOp intersects for points near boundary

### DIFF
--- a/src/geomgraph/index/SegmentIntersector.cpp
+++ b/src/geomgraph/index/SegmentIntersector.cpp
@@ -118,7 +118,9 @@ SegmentIntersector::addIntersections(Edge* e0, std::size_t segIndex0, Edge* e1, 
             std::cerr << "SegmentIntersector::addIntersections(): has !TrivialIntersection" << std::endl;
 #endif
             hasIntersectionVar = true;
-            if(includeProper || !li->isProper()) {
+            bool isBdyPt = isBoundaryPoint(li, bdyNodes);
+            bool isNonProper = isBdyPt || !li->isProper();
+            if(includeProper || isNonProper) {
                 //Debug.println(li);
                 e0->addIntersections(li, segIndex0, 0);
                 e1->addIntersections(li, segIndex1, 1);
@@ -136,7 +138,7 @@ SegmentIntersector::addIntersections(Edge* e0, std::size_t segIndex0, Edge* e1, 
                 if(isDoneWhenProperInt) {
                     isDone = true;
                 }
-                if(!isBoundaryPoint(li, bdyNodes)) {
+                if (! isBdyPt) {
                     hasProperInterior = true;
                 }
             }

--- a/tests/unit/operation/relate/RelateOpTest.cpp
+++ b/tests/unit/operation/relate/RelateOpTest.cpp
@@ -1,0 +1,79 @@
+//
+// Test Suite for geos::operation::relate::RelateOp class
+
+#include <tut/tut.hpp>
+// geos
+#include <geos/constants.h> // for std::isnan
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <geos/geom/Dimension.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/PrecisionModel.h>
+#include <geos/io/WKTReader.h>
+#include <geos/operation/relate/RelateOp.h>
+
+// std
+#include <cmath>
+#include <string>
+#include <memory>
+
+using namespace geos::geom;
+using namespace geos::operation::relate;
+
+namespace tut {
+//
+// Test Group
+//
+
+struct test_relateop_data {
+    geos::io::WKTReader wktreader;
+    typedef std::unique_ptr<Geometry> GeomPtr;
+    typedef geos::geom::GeometryFactory GeometryFactory;
+
+    geos::geom::PrecisionModel pm_;
+    GeometryFactory::Ptr factory_;
+
+    test_relateop_data()
+        : pm_(1), factory_(GeometryFactory::create(&pm_, 0))
+    {}
+
+    void checkRelate(const char* wkta, const char* wktb, const char* imExpected)
+    {
+        std::string wktstra(wkta);
+        std::string wktstrb(wktb);
+        auto ga = wktreader.read(wktstra);
+        auto gb = wktreader.read(wktstrb);
+
+        std::unique_ptr<IntersectionMatrix> im(ga->relate( gb.get() ));
+        auto imActual = im->toString();
+        ensure_equals(imExpected, imActual);
+    }
+
+};
+
+
+typedef test_group<test_relateop_data> group;
+typedef group::object object;
+
+group test_relateop_group("geos::operation::relate::RelateOp");
+
+//
+// Test Cases
+//
+
+// 1 - testInvalidCoordinate
+template<>
+template<>
+void object::test<1> ()
+{
+    checkRelate(
+"LINESTRING (-57.2681216 49.4063466, -57.267725199999994 49.406617499999996, -57.26747895046037 49.406750916517765)",
+"LINESTRING (-57.267475399999995 49.4067465, -57.2675701 49.406864299999995, -57.267989 49.407135399999994)",
+"FF10F0102"
+    );
+
+}
+
+} // namespace tut

--- a/tests/unit/operation/relate/RelateOpTest.cpp
+++ b/tests/unit/operation/relate/RelateOpTest.cpp
@@ -38,12 +38,10 @@ struct test_relateop_data {
     test_relateop_data()
     {}
 
-    void checkRelate(const char* wkta, const char* wktb, const char* imExpected)
+    void checkRelate(const std::string& wkta, const std::string& wktb, const std::string& imExpected)
     {
-        std::string wktstra(wkta);
-        std::string wktstrb(wktb);
-        auto ga = wktreader.read(wktstra);
-        auto gb = wktreader.read(wktstrb);
+        auto ga = wktreader.read(wkta);
+        auto gb = wktreader.read(wktb);
 
         std::unique_ptr<IntersectionMatrix> im(ga->relate( gb.get() ));
         auto imActual = im->toString();

--- a/tests/unit/operation/relate/RelateOpTest.cpp
+++ b/tests/unit/operation/relate/RelateOpTest.cpp
@@ -1,19 +1,24 @@
-//
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 Martin Davis
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
 // Test Suite for geos::operation::relate::RelateOp class
 
 #include <tut/tut.hpp>
 // geos
-#include <geos/constants.h> // for std::isnan
-#include <geos/geom/Coordinate.h>
-#include <geos/geom/CoordinateArraySequence.h>
-#include <geos/geom/Dimension.h>
 #include <geos/geom/Geometry.h>
-#include <geos/geom/LineString.h>
-#include <geos/geom/GeometryFactory.h>
-#include <geos/geom/PrecisionModel.h>
 #include <geos/io/WKTReader.h>
 #include <geos/operation/relate/RelateOp.h>
-
 // std
 #include <cmath>
 #include <string>
@@ -23,20 +28,14 @@ using namespace geos::geom;
 using namespace geos::operation::relate;
 
 namespace tut {
-//
+//----------------------------------------------
 // Test Group
-//
+//----------------------------------------------
 
 struct test_relateop_data {
     geos::io::WKTReader wktreader;
-    typedef std::unique_ptr<Geometry> GeomPtr;
-    typedef geos::geom::GeometryFactory GeometryFactory;
-
-    geos::geom::PrecisionModel pm_;
-    GeometryFactory::Ptr factory_;
 
     test_relateop_data()
-        : pm_(1), factory_(GeometryFactory::create(&pm_, 0))
     {}
 
     void checkRelate(const char* wkta, const char* wktb, const char* imExpected)
@@ -50,30 +49,41 @@ struct test_relateop_data {
         auto imActual = im->toString();
         ensure_equals(imExpected, imActual);
     }
-
 };
-
 
 typedef test_group<test_relateop_data> group;
 typedef group::object object;
 
 group test_relateop_group("geos::operation::relate::RelateOp");
 
-//
+//----------------------------------------------
 // Test Cases
-//
+//----------------------------------------------
 
-// 1 - testInvalidCoordinate
+// 1 - test intersection of lines very close to a boundary endpoint
+// See https://lists.osgeo.org/pipermail/postgis-users/2022-February/045266.html
+//      https://github.com/locationtech/jts/pull/839
 template<>
 template<>
 void object::test<1> ()
 {
     checkRelate(
+"LINESTRING (-29796.696826656284 138522.76848210802, -29804.3911369969 138519.3504205817)",
+"LINESTRING (-29802.795222153436 138520.05937757515, -29802.23305474065 138518.7938969792)""FF10F0102",
+    "F01FF0102"    );
+}
+
+// 2 - test intersection of lines very close to a boundary endpoint
+// See https://lists.osgeo.org/pipermail/postgis-users/2022-February/045277.html
+//      https://github.com/locationtech/jts/pull/839
+template<>
+template<>
+void object::test<2> ()
+{
+    checkRelate(
 "LINESTRING (-57.2681216 49.4063466, -57.267725199999994 49.406617499999996, -57.26747895046037 49.406750916517765)",
 "LINESTRING (-57.267475399999995 49.4067465, -57.2675701 49.406864299999995, -57.267989 49.407135399999994)",
-"FF10F0102"
-    );
-
+    "FF10F0102"    );
 }
 
 } // namespace tut


### PR DESCRIPTION
A port of the fix for `SegmentIntersector` in [JTS-839](https://github.com/locationtech/jts/pull/839).

Fixes #565