### PR TITLE
Use relative CMAKE_INSTALL_RPATH for geosop

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -12,6 +12,19 @@
 option(BUILD_GEOSOP "Build geosop command-line interface" ON)
 
 message(STATUS "GEOS: Build geosop ${BUILD_GEOSOP}")
+
 if(BUILD_GEOSOP)
+  if(BUILD_SHARED_LIBS)
+    if(NOT DEFINED CMAKE_INSTALL_RPATH)
+      # Use relative rpath
+      if(APPLE)
+        set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+      else()
+        set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+      endif()
+    endif()
+    message(STATUS "GEOS: install runtime path for util: ${CMAKE_INSTALL_RPATH}")
+  endif()
+
   add_subdirectory(geosop)
 endif()


### PR DESCRIPTION
This PR allows an installed `geosop` to be run without requiring `LD_LIBRARY_PATH`. E.g. see:
```
$ mkdir build && cd build
$ cmake -DCMAKE_INSTALL_PREFIX=/tmp/geos-main ..
...
$ make
...
$ make install
...
-- Installing: /tmp/geos-main/bin/geosop
-- Set runtime path of "/tmp/geos-master/bin/geosop" to "$ORIGIN/../lib"
...
$ readelf -d /tmp/geos-main/bin/geosop 

Dynamic section at offset 0x52810 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libgeos.so.3.11.0]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib]
...
$ ldd /tmp/geos-main/bin/geosop 
	linux-vdso.so.1 (0x00007ffe9b9fa000)
	libgeos.so.3.11.0 => /tmp/geos-main/bin/../lib/libgeos.so.3.11.0 (0x00007f5dd93db000)
$ /tmp/geos-main/bin/geosop
geosop - GEOS 3.11.0dev
Executes GEOS geometry operations
Usage:
  geosop [OPTION...] opName opArg
...
```