### PR TITLE
Fix `IsSimpleOp` for closed lines with repeated endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
   - Add SnappingNoder seeding (Martin Davis)
   - Fix RelateOp (and intersects predicate) for lines with intersections very near boundary (GH-570, Martin Davis)
   - Fix IsValidOp to handle repeated node points (JTS-845, Martin Davis)
+  - Fix IsSimpleOp to handle closed LineStrings with repeated endpoints (JTS-851, Martin Davis)
 
 - Changes:
 

--- a/include/geos/operation/valid/IsSimpleOp.h
+++ b/include/geos/operation/valid/IsSimpleOp.h
@@ -21,8 +21,8 @@
 
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/algorithm/BoundaryNodeRule.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/noding/SegmentIntersector.h>
-
 
 // Forward declarations
 namespace geos {
@@ -130,9 +130,11 @@ private:
 
     bool isSimpleLinearGeometry(const geom::Geometry& geom);
 
-    static std::vector<std::unique_ptr<noding::SegmentString>>
-        extractSegmentStrings(const geom::Geometry& geom);
+    static std::vector<std::unique_ptr<geos::geom::CoordinateArraySequence>>
+        removeRepeatedPts(const geom::Geometry& geom);
 
+    static std::vector<std::unique_ptr<noding::SegmentString>>
+        createSegmentStrings(std::vector<std::unique_ptr<geos::geom::CoordinateArraySequence>>& seqs);
 
     class NonSimpleIntersectionFinder : public noding::SegmentIntersector
     {

--- a/tests/unit/operation/valid/IsSimpleOpTest.cpp
+++ b/tests/unit/operation/valid/IsSimpleOpTest.cpp
@@ -40,7 +40,7 @@ struct test_issimpleop_data {
     double tolerance_;
 
     test_issimpleop_data()
-        : pm_(1)
+        : pm_()
         , factory_(GeometryFactory::create(&pm_, 0))
         , reader_(factory_.get())
         , tolerance_(0.00005)

--- a/tests/xmltester/tests/general/TestSimple.xml
+++ b/tests/xmltester/tests/general/TestSimple.xml
@@ -1,4 +1,3 @@
-
 <run>
   <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
@@ -54,6 +53,90 @@
   <desc>L - simple line</desc>
   <a>
     LINESTRING(10 10, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - repeated start point</desc>
+  <a>
+    LINESTRING(10 10, 10 10, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - repeated end point</desc>
+  <a>
+    LINESTRING(10 10, 20 20, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - repeated points at both ends</desc>
+  <a>
+    LINESTRING(10 10, 10 10, 20 20, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - zerolength</desc>
+  <a>
+    LINESTRING(10 10, 10 10, 10 10)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple ring - repeated start point</desc>
+  <a>
+    LINESTRING (10 10, 2 2, 20 2, 10 10, 10 10)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple ring - repeated end point</desc>
+  <a>
+    LINESTRING (10 10, 10 10, 10 10, 2 2, 20 2, 10 10, 10 10)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple ring - repeated all points</desc>
+  <a>
+    LINESTRING (10 10, 10 10, 10 10)
   </a>
 <test>
   <op name="isSimple" arg1="A">
@@ -163,7 +246,7 @@
   <desc>mL - intersection between elements at non-vertex</desc>
   <a>
     MULTILINESTRING(
-  (40 140, 160 40), 
+  (40 140, 160 40),
   (160 140, 40 40))
   </a>
 <test>
@@ -177,7 +260,7 @@
   <desc>mL - no intersection between elements</desc>
   <a>
     MULTILINESTRING(
-  (20 160, 20 20), 
+  (20 160, 20 20),
   (100 160, 100 20))
   </a>
 <test>
@@ -190,7 +273,7 @@
 <case>
   <desc>mL - mutual intersection at endpoints only</desc>
   <a>
-    MULTILINESTRING ((60 140, 20 80, 60 40), 
+    MULTILINESTRING ((60 140, 20 80, 60 40),
   (60 40, 100 80, 60 140))
   </a>
 <test>
@@ -203,7 +286,7 @@
 <case>
   <desc>mL - one element is non-simple</desc>
   <a>
-    MULTILINESTRING ((60 40, 140 40, 100 120, 100 0), 
+    MULTILINESTRING ((60 40, 140 40, 100 120, 100 0),
   (100 200, 200 120))
   </a>
 <test>
@@ -216,8 +299,8 @@
 <case>
   <desc>mL - proper intersection between elements at vertex</desc>
   <a>
-    MULTILINESTRING ((40 120, 100 60), 
-  (160 120, 100 60), 
+    MULTILINESTRING ((40 120, 100 60),
+  (160 120, 100 60),
   (40 60, 160 60))
   </a>
 <test>
@@ -230,7 +313,7 @@
 <case>
   <desc>mL - intersection between closed lines</desc>
   <a>
-    MULTILINESTRING ((80 160, 40 220, 40 100, 80 160), 
+    MULTILINESTRING ((80 160, 40 220, 40 100, 80 160),
   (80 160, 120 220, 120 100, 80 160))
   </a>
 <test>
@@ -243,8 +326,8 @@
 <case>
   <desc>mL - intersection between closed and open lines</desc>
   <a>
-    MULTILINESTRING ((80 160, 40 220), 
-  (80 160, 120 220, 120 100, 80 160), 
+    MULTILINESTRING ((80 160, 40 220),
+  (80 160, 120 220, 120 100, 80 160),
   (40 100, 80 160))
   </a>
 <test>
@@ -311,6 +394,14 @@
 </case>
 
 <case>
+   <desc>A - polygon with too few points </desc>
+   <a>POLYGON ((0 0, 10 10, 0 0))</a>
+   <test>
+      <op name="isSimple" arg1="A"> false </op>
+   </test>
+</case>
+
+<case>
    <desc>A - polygon with equal segments </desc>
    <a>POLYGON ((50 90, 90 90, 90 50, 50 50, 10 10, 50 50, 50 90))</a>
    <test>
@@ -331,8 +422,8 @@
 <case>
   <desc>mA - valid polygon</desc>
   <a>
-    MULTIPOLYGON (((240 160, 140 220, 80 60, 220 40, 240 160)), 
-  ((160 380, 100 240, 20 380, 160 380), 
+    MULTIPOLYGON (((240 160, 140 220, 80 60, 220 40, 240 160)),
+  ((160 380, 100 240, 20 380, 160 380),
     (120 340, 60 360, 80 320, 120 340)))
   </a>
 <test>
@@ -343,8 +434,8 @@
 <case>
   <desc>mA - with touching elements</desc>
   <a>
-    MULTIPOLYGON (((240 160, 100 240, 80 60, 220 40, 240 160)), 
-  ((160 380, 100 240, 20 380, 160 380), 
+    MULTIPOLYGON (((240 160, 100 240, 80 60, 220 40, 240 160)),
+  ((160 380, 100 240, 20 380, 160 380),
     (120 340, 60 360, 80 320, 120 340)))
   </a>
 <test>
@@ -365,9 +456,9 @@ MULTIPOLYGON (((100 100, 100 200, 200 100, 200 200, 100 100)), ((100 400, 200 40
 <case>
   <desc>GC - all components simple</desc>
   <a>
-GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)), 
-  LINESTRING (100 300, 200 250), 
-  POINT (250 250), 
+GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)),
+  LINESTRING (100 300, 200 250),
+  POINT (250 250),
   POINT (250 150))</a>
 <test>
   <op name="isSimple" arg1="A"> true </op>
@@ -377,9 +468,9 @@ GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)),
 <case>
   <desc>GC - one non-simple component</desc>
   <a>
-GEOMETRYCOLLECTION (POLYGON ((100 100, 100 200, 200 100, 200 200, 100 100)), 
-  LINESTRING (100 300, 200 250), 
-  POINT (250 250), 
+GEOMETRYCOLLECTION (POLYGON ((100 100, 100 200, 200 100, 200 200, 100 100)),
+  LINESTRING (100 300, 200 250),
+  POINT (250 250),
   POINT (250 150))</a>
 <test>
   <op name="isSimple" arg1="A"> false </op>


### PR DESCRIPTION
Fix `IsSimpleOp` for closed lines with repeated endpoints

Port of [JTS-851](https://github.com/locationtech/jts/pull/851)

To fix [Shapely-1343](https://github.com/shapely/shapely/issues/1343).