### PR TITLE
Debug output fixes

### DIFF
--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -20,14 +20,11 @@
 #pragma once
 
 #include <geos/export.h>
-#include <geos/algorithm/LineIntersector.h>
 #include <geos/algorithm/Intersection.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/Envelope.h>
 
 #include <string>
-
-#include <geos/geom/Coordinate.h>
 
 // Forward declarations
 namespace geos {
@@ -86,6 +83,7 @@ public:
         :
         precisionModel(initialPrecisionModel),
         result(0),
+        inputLines(),
         isProperVar(false)
     {}
 

--- a/src/algorithm/HCoordinate.cpp
+++ b/src/algorithm/HCoordinate.cpp
@@ -45,7 +45,7 @@ HCoordinate::intersection(const Coordinate& p1, const Coordinate& p2,
 
 #if GEOS_DEBUG
     std::cerr << __FUNCTION__ << ":" << std::endl
-         << setprecision(20)
+         << std::setprecision(20)
          << " p1: " << p1 << std::endl
          << " p2: " << p2 << std::endl
          << " q1: " << q1 << std::endl

--- a/src/algorithm/InteriorPointLine.cpp
+++ b/src/algorithm/InteriorPointLine.cpp
@@ -29,7 +29,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -100,10 +100,13 @@ LineIntersector::computeIntersection(const Coordinate& p1, const Coordinate& p2,
 std::string
 LineIntersector::toString() const
 {
-    std::string str = inputLines[0][0]->toString() + "_"
-                 + inputLines[0][1]->toString() + " "
-                 + inputLines[1][0]->toString() + "_"
-                 + inputLines[1][1]->toString() + " : ";
+    auto getCoordString = [](const Coordinate* coord) -> std::string {
+        return coord ? coord->toString() : "<none>";
+    };
+    std::string str = getCoordString(inputLines[0][0]) + "_"
+        + getCoordString(inputLines[0][1]) + " "
+        + getCoordString(inputLines[1][0]) + "_"
+        + getCoordString(inputLines[1][1]) + " : ";
     if(isEndPoint()) {
         str += " endpoint";
     }

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -37,7 +37,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -83,7 +83,7 @@ GeometryFactory::GeometryFactory()
 {
 #if GEOS_DEBUG
     std::cerr << "GEOS_DEBUG: GeometryFactory[" << this << "]::GeometryFactory()" << std::endl;
-    std::cerr << "\tcreate PrecisionModel[" << precisionModel << "]" << std::endl;
+    std::cerr << "\tcreate PrecisionModel[" << &precisionModel << "]" << std::endl;
 #endif
 }
 

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -46,7 +46,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/geom/Position.cpp
+++ b/src/geom/Position.cpp
@@ -23,7 +23,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/geom/util/GeometryTransformer.cpp
+++ b/src/geom/util/GeometryTransformer.cpp
@@ -40,7 +40,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/geomgraph/EdgeRing.cpp
+++ b/src/geomgraph/EdgeRing.cpp
@@ -41,6 +41,10 @@
 #include <cassert>
 #include <iostream> // for operator<<
 
+#ifndef GEOS_DEBUG
+#define GEOS_DEBUG 0
+#endif
+
 using namespace geos::algorithm;
 using namespace geos::geom;
 
@@ -66,7 +70,7 @@ EdgeRing::EdgeRing(DirectedEdge* newStart,
      */
     //computePoints(start);
     //computeRing();
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
     std::cerr << "EdgeRing[" << this << "] ctor" << std::endl;
 #endif
     testInvariant();

--- a/src/index/quadtree/Key.cpp
+++ b/src/index/quadtree/Key.cpp
@@ -28,7 +28,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/index/quadtree/Root.cpp
+++ b/src/index/quadtree/Root.cpp
@@ -29,7 +29,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/index/quadtree/Root.cpp
+++ b/src/index/quadtree/Root.cpp
@@ -94,7 +94,7 @@ Root::insert(const Envelope* itemEnv, void* item)
     }
 
 #if GEOS_DEBUG
-    std::cerr << "(" << this << ") calling insertContained with subnode " << subnode[index] << std::endl;
+    std::cerr << "(" << this << ") calling insertContained with subnode " << subnodes[index] << std::endl;
 #endif
     /*
      * At this point we have a subquad which exists and must contain
@@ -103,7 +103,7 @@ Root::insert(const Envelope* itemEnv, void* item)
     insertContained(subnodes[static_cast<std::size_t>(index)], itemEnv, item);
 
 #if GEOS_DEBUG
-    std::cerr << "(" << this << ") done calling insertContained with subnode " << subnode[index] << std::endl;
+    std::cerr << "(" << this << ") done calling insertContained with subnode " << subnodes[index] << std::endl;
 #endif
 
     //System.out.println("depth = " + root.depth() + " size = " + root.size());

--- a/src/noding/ScaledNoder.cpp
+++ b/src/noding/ScaledNoder.cpp
@@ -35,7 +35,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #include <string>
 #endif

--- a/src/noding/SegmentNodeList.cpp
+++ b/src/noding/SegmentNodeList.cpp
@@ -36,7 +36,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 
@@ -199,7 +199,7 @@ SegmentNodeList::addSplitEdges(std::vector<SegmentString*>& edgeList)
         std::unique_ptr<SegmentString> newEdge = createSplitEdge(eiPrev, ei);
         edgeList.push_back(newEdge.release());
 #if GEOS_DEBUG
-        testingSplitEdges.push_back(newEdge);
+        testingSplitEdges.push_back(edgeList.back());
 #endif
         eiPrev = ei;
     }
@@ -213,6 +213,9 @@ SegmentNodeList::addSplitEdges(std::vector<SegmentString*>& edgeList)
 void
 SegmentNodeList::checkSplitEdgesCorrectness(const std::vector<SegmentString*>& splitEdges) const
 {
+    if (splitEdges.empty())
+        return;
+
     const CoordinateSequence* edgePts = edge.getCoordinates();
     assert(edgePts);
 

--- a/src/operation/buffer/BufferCurveSetBuilder.cpp
+++ b/src/operation/buffer/BufferCurveSetBuilder.cpp
@@ -22,6 +22,7 @@
 #include <geos/algorithm/Distance.h>
 #include <geos/algorithm/Orientation.h>
 #include <geos/algorithm/MinimumDiameter.h>
+#include <geos/util/IllegalArgumentException.h>
 #include <geos/util/UnsupportedOperationException.h>
 #include <geos/operation/buffer/BufferCurveSetBuilder.h>
 #include <geos/operation/buffer/OffsetCurveBuilder.h>
@@ -314,7 +315,14 @@ BufferCurveSetBuilder::addRingSide(const CoordinateSequence* coord,
     Location leftLoc = cwLeftLoc;
     Location rightLoc = cwRightLoc;
 #if GEOS_DEBUG
-    std::cerr << "BufferCurveSetBuilder::addPolygonRing: CCW: " << Orientation::isCCW(coord) << std::endl;
+    std::cerr << "BufferCurveSetBuilder::addPolygonRing: ";
+    try {
+        bool isCcw = Orientation::isCCW(coord);
+        std::cerr << (isCcw ? "CCW" : "CW");
+    } catch (const util::IllegalArgumentException& ex) {
+        std::cerr << "failed to determine orientation: " << ex.what();
+    }
+    std::cerr << std::endl;
 #endif
     bool isCCW = isRingCCW(coord);
     if (coord->size() >= LinearRing::MINIMUM_VALID_SIZE && isCCW)

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -147,9 +147,6 @@ DistanceOp::updateMinDistance(std::array<std::unique_ptr<GeometryLocation>, 2> &
 {
     // if not set then don't update
     if(locGeom[0] == nullptr) {
-#if GEOS_DEBUG
-        std::cerr << "updateMinDistance called with loc[0] == null and loc[1] == " << locGeom[1] << std::endl;
-#endif
         assert(locGeom[1] == nullptr);
         return;
     }

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -148,6 +148,9 @@ DistanceOp::updateMinDistance(std::array<std::unique_ptr<GeometryLocation>, 2> &
     // if not set then don't update
     if(locGeom[0] == nullptr) {
         assert(locGeom[1] == nullptr);
+#if GEOS_DEBUG
+        std::cerr << "updateMinDistance called with loc[0] == null and loc[1] == null" << std::endl;
+#endif
         return;
     }
 

--- a/src/operation/linemerge/LineMergeGraph.cpp
+++ b/src/operation/linemerge/LineMergeGraph.cpp
@@ -34,7 +34,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/operation/linemerge/LineMerger.cpp
+++ b/src/operation/linemerge/LineMerger.cpp
@@ -40,6 +40,10 @@ using namespace geos::geom;
 #define GEOS_DEBUG 0
 #endif
 
+#if GEOS_DEBUG
+#include <iostream>
+#endif
+
 namespace geos {
 namespace operation { // geos.operation
 namespace linemerge { // geos.operation.linemerge

--- a/src/operation/overlay/PolygonBuilder.cpp
+++ b/src/operation/overlay/PolygonBuilder.cpp
@@ -42,6 +42,9 @@
 #define GEOS_DEBUG 0
 #endif
 
+#if GEOS_DEBUG
+#include <iostream>
+#endif
 
 using namespace geos::geomgraph;
 using namespace geos::algorithm;
@@ -290,22 +293,19 @@ PolygonBuilder::placeFreeHoles(std::vector<FastPIPRing>& newShellList,
             EdgeRing* shell = findEdgeRingContaining(hole, newShellList);
             if(shell == nullptr) {
 #if GEOS_DEBUG
-                Geometry* geom;
                 std::cerr << "CREATE TABLE shells (g geometry);" << std::endl;
                 std::cerr << "CREATE TABLE hole (g geometry);" << std::endl;
-                for(std::vector<EdgeRing*>::iterator rIt = newShellList.begin(),
+                for(std::vector<FastPIPRing>::iterator rIt = newShellList.begin(),
                         rEnd = newShellList.end(); rIt != rEnd; rIt++) {
-                    geom = (*rIt)->toPolygon(geometryFactory);
+                    std::unique_ptr<Geometry> geom = (*rIt).edgeRing->toPolygon(geometryFactory);
                     std::cerr << "INSERT INTO shells VALUES ('"
                               << *geom
                               << "');" << std::endl;
-                    delete geom;
                 }
-                geom = hole->toPolygon(geometryFactory);
+                std::unique_ptr<Geometry> geom = hole->toPolygon(geometryFactory);
                 std::cerr << "INSERT INTO hole VALUES ('"
                           << *geom
                           << "');" << std::endl;
-                delete geom;
 #endif
                 //assert(shell!=NULL); // unable to assign hole to a shell
                 throw util::TopologyException("unable to assign hole to a shell");

--- a/src/operation/overlay/validate/OverlayResultValidator.cpp
+++ b/src/operation/overlay/validate/OverlayResultValidator.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #if GEOS_DEBUG
+#include <iostream>
 #include <iomanip> // for setprecision
 #endif
 
@@ -180,7 +181,7 @@ OverlayResultValidator::testValid(OverlayOp::OpCode overlayOp,
     location[2] = fplres.getLocation(pt);
 
 #if GEOS_DEBUG
-    std::cerr << setprecision(10) << "Point " << pt << std::endl
+    std::cerr << std::setprecision(10) << "Point " << pt << std::endl
          << "Loc0: " << location[0] << std::endl
          << "Loc1: " << location[1] << std::endl
          << "Locr: " << location[2] << std::endl;

--- a/src/operation/overlayng/ElevationModel.cpp
+++ b/src/operation/overlayng/ElevationModel.cpp
@@ -118,7 +118,7 @@ ElevationModel::add(const Geometry& geom)
             }
             const Coordinate& c = seq.getAt(i);
 #if GEOS_DEBUG
-            std::cout << "Coordinate " << i << " of added geom is: "
+            std::cerr << "Coordinate " << i << " of added geom is: "
 << c << std::endl;
 #endif
             model.add(c.x, c.y, c.z);
@@ -167,7 +167,7 @@ ElevationModel::init()
         if (!cell.isNull()) {
           cell.compute();
 #if GEOS_DEBUG
-          std::cout << "init: cell" << offset
+          std::cerr << "init: cell" << offset
                     << " getZ: " << cell.getZ()
                     << std::endl;
 #endif
@@ -183,7 +183,7 @@ ElevationModel::init()
       averageZ = sumZ / numCells;
     }
 #if GEOS_DEBUG
-    std::cout << "init: numCells: " << numCells
+    std::cerr << "init: numCells: " << numCells
               << " averageZ: " << averageZ << std::endl;
 #endif
 }
@@ -223,12 +223,12 @@ ElevationModel::populateZ(Geometry& geom)
         void filter_rw(geom::Coordinate* c) const override
         {
 #if GEOS_DEBUG
-            std::cout << "Input coord:  " << *c << std::endl;
+            std::cerr << "Input coord:  " << *c << std::endl;
 #endif
             if (std::isnan( c->z )) {
                 c->z = model.getZ(c->x, c->y);
 #if GEOS_DEBUG
-                std::cout << "New coord: " << *c << std::endl;
+                std::cerr << "New coord: " << *c << std::endl;
 #endif
             }
         }
@@ -237,7 +237,7 @@ ElevationModel::populateZ(Geometry& geom)
 
     Filter filter(*this);
 #if GEOS_DEBUG
-    std::cout << "ElevationModel::poplateZ calling apply_rw(CoordinateSequenceFilter&) against" <<
+    std::cerr << "ElevationModel::poplateZ calling apply_rw(CoordinateSequenceFilter&) against" <<
               //std::type_name<decltype(ci)>()
               typeid(geom).name()
               << std::endl;
@@ -261,7 +261,7 @@ ElevationModel::getCell(double x, double y) //, bool isCreateIfMissing
     }
     int cellOffset = getCellOffset(ix, iy);
 #if GEOS_DEBUG
-    std::cout << "Cell of coordinate " << x << "," << y
+    std::cerr << "Cell of coordinate " << x << "," << y
               << " is " << ix << "," << iy
               << " offset " << cellOffset << std::endl;
 #endif

--- a/src/operation/overlayng/OverlayNG.cpp
+++ b/src/operation/overlayng/OverlayNG.cpp
@@ -186,7 +186,7 @@ OverlayNG::getResult()
     w.setOutputDimension(3);
     w.setTrim(true);
 
-    std::cout << "Before populatingZ: " << w.write(result.get()) << std::endl;
+    std::cerr << "Before populatingZ: " << w.write(result.get()) << std::endl;
 #endif
 
     /**
@@ -196,7 +196,7 @@ OverlayNG::getResult()
     elevModel->populateZ(*result);
 
 #if GEOS_DEBUG
-    std::cout << " After populatingZ: " << w.write(result.get()) << std::endl;
+    std::cerr << " After populatingZ: " << w.write(result.get()) << std::endl;
 #endif
 
     return result;

--- a/src/operation/overlayng/OverlayNGRobust.cpp
+++ b/src/operation/overlayng/OverlayNGRobust.cpp
@@ -92,7 +92,7 @@ OverlayNGRobust::Overlay(const Geometry* geom0, const Geometry* geom1, int opCod
     */
     if (!geom0->getPrecisionModel()->isFloating()) {
 #if GEOS_DEBUG
-        std::cout << "Using fixed precision overlay." << std::endl;
+        std::cerr << "Using fixed precision overlay." << std::endl;
 #endif
         return OverlayNG::overlay(geom0, geom1, opCode, geom0->getPrecisionModel());
     }
@@ -106,14 +106,14 @@ OverlayNGRobust::Overlay(const Geometry* geom0, const Geometry* geom1, int opCod
      */
     try {
         geom::PrecisionModel PM_FLOAT;
-        // std::cout << "Using floating point overlay." << std::endl;
+        // std::cerr << "Using floating point overlay." << std::endl;
         result = OverlayNG::overlay(geom0, geom1, opCode, &PM_FLOAT);
 
         // Simple noding with no validation
         // There are cases where this succeeds with invalid noding (e.g. STMLF 1608).
         // So currently it is NOT safe to run overlay without noding validation
         //result = OverlayNG.overlay(geom0, geom1, opCode, createFloatingNoValidNoder());
-        // std::cout << "Floating point overlay success." << std::endl;
+        // std::cerr << "Floating point overlay success." << std::endl;
         return result;
     }
     catch (const std::runtime_error &ex) {
@@ -123,7 +123,7 @@ OverlayNGRobust::Overlay(const Geometry* geom0, const Geometry* geom1, int opCod
         */
         exOriginal = ex;
 #if GEOS_DEBUG
-        std::cout << "Floating point overlay FAILURE: " << ex.what() << std::endl;
+        std::cerr << "Floating point overlay FAILURE: " << ex.what() << std::endl;
 #endif
     }
 
@@ -160,7 +160,7 @@ OverlayNGRobust::overlaySnapTries(const Geometry* geom0, const Geometry* geom1, 
     for (std::size_t i = 0; i < NUM_SNAP_TRIES; i++) {
 
 #if GEOS_DEBUG
-        std::cout << "Trying overlaySnapping(tol " << snapTol << ")." << std::endl;
+        std::cerr << "Trying overlaySnapping(tol " << snapTol << ")." << std::endl;
 #endif
 
         result = overlaySnapping(geom0, geom1, opCode, snapTol);
@@ -192,7 +192,7 @@ OverlayNGRobust::overlaySnapping(const Geometry* geom0, const Geometry* geom1, i
         ::geos::ignore_unused_variable_warning(ex);
         //---- ignore exception, return null result to indicate failure
 #if GEOS_DEBUG
-        std::cout << "overlaySnapping(tol " << snapTol << ") FAILURE: " << ex.what() << std::endl;
+        std::cerr << "overlaySnapping(tol " << snapTol << ") FAILURE: " << ex.what() << std::endl;
 #endif
     }
     return nullptr;
@@ -212,7 +212,7 @@ OverlayNGRobust::overlaySnapBoth(const Geometry* geom0, const Geometry* geom1, i
         ::geos::ignore_unused_variable_warning(ex);
         //---- ignore this exception, just return a nullptr result to indicate failure
 #if GEOS_DEBUG
-        std::cout << "overlaySnapBoth(tol " << snapTol << ") FAILURE: " << ex.what() << std::endl;
+        std::cerr << "overlaySnapBoth(tol " << snapTol << ") FAILURE: " << ex.what() << std::endl;
 #endif
     }
     return nullptr;
@@ -295,7 +295,7 @@ OverlayNGRobust::overlaySR(const Geometry* geom0, const Geometry* geom1, int opC
         ::geos::ignore_unused_variable_warning(ex);
         // ignore this exception, since the operation will be rerun
 #if GEOS_DEBUG
-        std::cout << "OverlayNGRobust::overlaySR FAILURE: " << ex.what() << std::endl;
+        std::cerr << "OverlayNGRobust::overlaySR FAILURE: " << ex.what() << std::endl;
 #endif
     }
     return nullptr;

--- a/src/precision/CommonBitsOp.cpp
+++ b/src/precision/CommonBitsOp.cpp
@@ -26,7 +26,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/precision/CommonBitsRemover.cpp
+++ b/src/precision/CommonBitsRemover.cpp
@@ -27,7 +27,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/precision/EnhancedPrecisionOp.cpp
+++ b/src/precision/EnhancedPrecisionOp.cpp
@@ -27,7 +27,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/DouglasPeuckerSimplifier.cpp
+++ b/src/simplify/DouglasPeuckerSimplifier.cpp
@@ -35,7 +35,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/LineSegmentIndex.cpp
+++ b/src/simplify/LineSegmentIndex.cpp
@@ -32,7 +32,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/TaggedLineSegment.cpp
+++ b/src/simplify/TaggedLineSegment.cpp
@@ -24,7 +24,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/TaggedLineString.cpp
+++ b/src/simplify/TaggedLineString.cpp
@@ -32,7 +32,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/TaggedLineStringSimplifier.cpp
+++ b/src/simplify/TaggedLineStringSimplifier.cpp
@@ -35,7 +35,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/TaggedLinesSimplifier.cpp
+++ b/src/simplify/TaggedLinesSimplifier.cpp
@@ -29,7 +29,7 @@
 #define GEOS_DEBUG 0
 #endif
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
 #include <iostream>
 #endif
 

--- a/src/simplify/TopologyPreservingSimplifier.cpp
+++ b/src/simplify/TopologyPreservingSimplifier.cpp
@@ -34,7 +34,14 @@
 #include <memory> // for unique_ptr
 #include <unordered_map>
 #include <cassert>
+
+#ifndef GEOS_DEBUG
+#define GEOS_DEBUG 0
+#endif
+
+#if GEOS_DEBUG
 #include <iostream>
+#endif
 
 using namespace geos::geom;
 
@@ -137,7 +144,7 @@ LineStringTransformer::transformCoordinates(
     const CoordinateSequence* coords,
     const Geometry* parent)
 {
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
     std::cerr << __FUNCTION__ << ": parent: " << parent
               << std::endl;
 #endif
@@ -146,7 +153,7 @@ LineStringTransformer::transformCoordinates(
         assert(it != linestringMap.end());
 
         TaggedLineString* taggedLine = it->second;
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
         std::cerr << "LineStringTransformer[" << this << "] "
                   << " getting result Coordinates from "
                   << " TaggedLineString[" << taggedLine << "]"
@@ -292,7 +299,7 @@ TopologyPreservingSimplifier::getResultGeometry()
         LineStringMapBuilderFilter lsmbf(linestringMap);
         inputGeom->apply_ro(&lsmbf);
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
         std::cerr << "LineStringMapBuilderFilter applied, "
                   << " lineStringMap contains "
                   << linestringMap.size() << " elements\n";
@@ -303,14 +310,14 @@ TopologyPreservingSimplifier::getResultGeometry()
         lineSimplifier->simplify(begin, end);
 
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
         std::cerr << "all TaggedLineString simplified\n";
 #endif
 
         LineStringTransformer trans(linestringMap);
         result = trans.transform(inputGeom);
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
         std::cerr << "inputGeom transformed\n";
 #endif
 
@@ -335,7 +342,7 @@ TopologyPreservingSimplifier::getResultGeometry()
         delete it->second;
     }
 
-#ifdef GEOS_DEBUG
+#if GEOS_DEBUG
     std::cerr << "returning result\n";
 #endif
 


### PR DESCRIPTION
* Compilation and runtime error fixes for GEOS_DEBUG=1;
* `#ifdef GEOS_DEBUG` replaced with `#if GEOS_DEBUG` (since GEOS_DEBUG is always defined in .cpp);
* few other minor fixes related to GEOS_DEBUG