### PR TITLE
Fix memory-handling bugs found by GCC 12

### DIFF
--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -105,7 +105,9 @@ namespace geom {
         }
 
         void setPoints(const std::vector<Coordinate> & v) final override {
-            std::copy(v.begin(), v.end(), m_data.begin());
+            if (N > 0 && v.size() <= N) {
+                std::copy(v.begin(), v.end(), m_data.begin());
+            }
         }
 
         void apply_ro(CoordinateFilter* filter) const final override {
@@ -126,4 +128,3 @@ namespace geom {
 
 }
 }
-

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -556,11 +556,13 @@ QuadEdgeSubdivision::getVoronoiCellPolygon(const QuadEdge* qe, const geom::Geome
     auto seq = geomFact.getCoordinateSequenceFactory()->create(std::move(cellPts));
     std::unique_ptr<Geometry> cellPoly = geomFact.createPolygon(geomFact.createLinearRing(std::move(seq)));
 
-    // FIXME why is this returning a pointer to a local variable?
+    /*
+    //-- attach cell centroid coordinate
+    // MD - disable this since memory handling is problematic
     Vertex v = startQE->orig();
-    Coordinate c(0, 0);
     c = v.getCoordinate();
     cellPoly->setUserData(reinterpret_cast<void*>(&c));
+    */
     return cellPoly;
 }
 


### PR DESCRIPTION
* Avoid potential buffer overrun by copy in FixedSizeCoordinateSequence
* Disable Voronoi Diagram use of userData to avoid returning pointer to stack mem
