### PR TITLE
Add assert and size check to FixedSizeCoordSeq.setPoints

### DIFF
--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -105,9 +105,11 @@ namespace geom {
         }
 
         void setPoints(const std::vector<Coordinate> & v) final override {
-            if (N > 0 && v.size() <= N) {
+            assert(v.size() == N);
+            if (N > 0) {
                 std::copy(v.begin(), v.end(), m_data.begin());
             }
+
         }
 
         void apply_ro(CoordinateFilter* filter) const final override {


### PR DESCRIPTION
Adds a size check and `assert` to `FixedSizeCoordSeq.setPoints`.  
Also prevents copying to zero-length sequence.