### PR TITLE
Directed line merge fix

### DIFF
--- a/src/operation/linemerge/LineMerger.cpp
+++ b/src/operation/linemerge/LineMerger.cpp
@@ -189,7 +189,17 @@ LineMerger::buildEdgeStringsForNonDegree2Nodes()
 #if GEOS_DEBUG
         std::cerr << "Node " << i << ": " << *node << std::endl;
 #endif
-        if(node->getDegree() != 2) {
+        bool isStartNode = (node->getDegree() != 2);
+
+        // For directed merge a node also has to be processed
+        // if both edges are incoming or outgoing
+        if (!isStartNode && isDirected) {
+            const auto& edges = node->getOutEdges()->getEdges();
+            assert(edges.size() == 2);
+            isStartNode = (edges[0]->getEdgeDirection() == edges[1]->getEdgeDirection());
+        }
+
+        if (isStartNode) {
             buildEdgeStringsStartingAt(node);
             node->setMarked(true);
 #if GEOS_DEBUG

--- a/tests/unit/operation/linemerge/LineMergerTest.cpp
+++ b/tests/unit/operation/linemerge/LineMergerTest.cpp
@@ -267,7 +267,7 @@ template<> template<>
 void object::test<8>()
 {
     const char* inpWKT[] = {
-        "MULTILINESTRING ((-29 -27, 1 2), (-29 -27, -45 -33, -46 -32))",
+        "MULTILINESTRING((-29 -27,1 2),(-29 -27,-45 -33),(-45 -33,-46 -32))",
         nullptr
     };
     const char* expWKT[] = {


### PR DESCRIPTION
A fix for directed line merging.
* In the first step, 2nd degree nodes can be start nodes in directed case, because both directed edges can be incoming or outgoing.
* Test case had wrong input WKT (but consistent with result).

`(1) <- (2) <- (3) -> (4)`
In this case, `(3)` is clearly a start node but has degree 2. If is is skipped in `buildEdgeStringsForNonDegree2Nodes`, then `buildEdgeStringsForUnprocessedNodes` creates a `LineString` starting from `(2) -> (1)`, since this edge is not marked yet.