### PR TITLE
GEOS_DEBUG: missing header fix

### DIFF
--- a/include/geos/util.h
+++ b/include/geos/util.h
@@ -21,7 +21,7 @@
 #ifndef GEOS_UTIL_H
 #define GEOS_UTIL_H
 
-
+#include <cassert>
 #include <memory>
 #include <type_traits>
 


### PR DESCRIPTION
Should `#if GEOS_DEBUG  ... #endif` be removed around `assert(...)`?