### PR TITLE
Add GEOSParams and util::Params for generic parameter handling

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -24,6 +24,7 @@
 #include <geos/io/GeoJSONReader.h>
 #include <geos/io/GeoJSONWriter.h>
 #include <geos/util/Interrupt.h>
+#include <geos/util/Params.h>
 
 #include <stdexcept>
 #include <new>
@@ -43,6 +44,7 @@
 #define GEOSWKBWriter geos::io::WKBWriter
 #define GEOSGeoJSONReader geos::io::GeoJSONReader
 #define GEOSGeoJSONWriter geos::io::GeoJSONWriter
+#define GEOSParams geos::util::Params
 typedef struct GEOSBufParams_t GEOSBufferParams;
 typedef struct GEOSMakeValidParams_t GEOSMakeValidParams;
 
@@ -77,6 +79,7 @@ using geos::io::WKBWriter;
 using geos::io::GeoJSONReader;
 using geos::io::GeoJSONWriter;
 
+using geos::util::Params;
 
 typedef std::unique_ptr<Geometry> GeomPtr;
 
@@ -838,6 +841,54 @@ extern "C" {
     GEOSBuildArea(const Geometry* g)
     {
         return GEOSBuildArea_r(handle, g);
+    }
+
+    GEOSParams*
+    GEOSParams_create()
+    {
+        return GEOSParams_create_r(handle);
+    }
+
+    void
+    GEOSParams_destroy(Params* p)
+    {
+        return GEOSParams_destroy_r(handle, p);
+    }
+
+    void
+    GEOSParams_setParamDouble(Params* p, const char* key, double d)
+    {
+        return GEOSParams_setParamDouble_r(handle, p, key, d);
+    }
+
+    void
+    GEOSParams_setParamInteger(Params* p, const char* key, int i)
+    {
+        return GEOSParams_setParamInteger_r(handle, p, key, i);
+    }
+
+    void
+    GEOSParams_setParamString(Params* p, const char* key, const char* str)
+    {
+        return GEOSParams_setParamString_r(handle, p, key, str);
+    }
+
+    int
+    GEOSParams_getParamDouble(Params* p, const char* key, double *d)
+    {
+        return GEOSParams_getParamDouble_r(handle, p, key, d);
+    }
+
+    int
+    GEOSParams_getParamInteger(Params* p, const char* key, int *i)
+    {
+        return GEOSParams_getParamInteger_r(handle, p, key, i);
+    }
+
+    int
+    GEOSParams_getParamString(Params* p, const char* key, const char** str)
+    {
+        return GEOSParams_getParamString_r(handle, p, key, str);
     }
 
     Geometry*

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -482,10 +482,10 @@ extern "C" {
 
     Geometry*
     GEOSPolygonHullSimplify(const Geometry* g,
-                            unsigned int isOuter,
-                            double vertexNumFraction)
+                            double ratio,
+                            const GEOSParams* params)
     {
-        return GEOSPolygonHullSimplify_r(handle, g, isOuter, vertexNumFraction);
+        return GEOSPolygonHullSimplify_r(handle, g, ratio, params);
     }
 
     Geometry*

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -222,6 +222,23 @@ enum GEOSGeomTypes {
 };
 
 /**
+* Algorithm behaviour codes for polygonal hull simplification.
+* consuming geometry types.
+*
+* \see GEOSPolygonHullSimplify
+*/
+enum GEOSPolygonHullSimplifyCodes {
+    /** Hull completely contained by input */
+    GEOS_POLYHULL_INSIDE,
+    /** Hull completely contains input */
+    GEOS_POLYHULL_OUTSIDE,
+    /** Ratio is relative to total area */
+    GEOS_POLYHULL_AREA_RATIO,
+    /** Ratio is relative to total vertices */
+    GEOS_POLYHULL_VERTEX_RATIO
+};
+
+/**
 * Well-known binary byte orders used when
 * writing to WKB.
 *
@@ -840,8 +857,8 @@ extern GEOSGeometry GEOS_DLL *GEOSConcaveHull_r(
 extern GEOSGeometry GEOS_DLL *GEOSPolygonHullSimplify_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g,
-    unsigned int isOuter,
-    double ratio);
+    double ratio,
+    const GEOSParams* params);
 
 /** \see GEOSConcaveHullOfPolygons */
 extern GEOSGeometry GEOS_DLL *GEOSConcaveHullOfPolygons_r(
@@ -2034,44 +2051,92 @@ extern void GEOS_DLL GEOSFree(void *buffer);
 */
 ///@{
 
-/**  GEOSParams_create */
+/**
+* Create a a new GEOSParams object for holding algorithm
+* configuration parameters. User is responsible for freeing
+* with GEOSParams_destroy()
+* \see GEOSParams_setParamDouble(), GEOSParams_setParamInteger(), GEOSParams_setParamString()
+*/
 extern GEOSParams GEOS_DLL *GEOSParams_create();
 
-/**  GEOSParams_destroy */
+/**
+* Free a GEOSParams object.
+* \param p The object to free.
+* \see GEOSParams_create()
+*/
 extern void GEOS_DLL GEOSParams_destroy(
-    GEOSParams* params);
+    GEOSParams* p);
 
-/**  GEOSParams_setParamDouble */
+/**
+* Store a double value with a key name.
+* \param p The object to set the value in.
+* \param key The name to store the value under.
+* \param d The double value.
+* \see GEOSParams_create(), GEOSParams_setParamInteger(), GEOSParams_setParamString()
+*/
 extern void GEOS_DLL GEOSParams_setParamDouble(
     GEOSParams* p,
     const char* key,
     double d);
 
-/** GEOSParams_setParamInteger */
+/**
+* Store a integer value with a key name.
+* \param p The object to set the value in.
+* \param key The name to store the value under.
+* \param i The integer value.
+* \see GEOSParams_create(), GEOSParams_setParamDouble(), GEOSParams_setParamString()
+*/
 extern void GEOS_DLL GEOSParams_setParamInteger(
     GEOSParams* p,
     const char* key,
     int i);
 
-/** GEOSParams_setParamString */
+/**
+* Store a string value with a key name.
+* \param p The object to set the value in.
+* \param key The name to store the value under.
+* \param str The string value.
+* \see GEOSParams_create(), GEOSParams_setParamDouble(), GEOSParams_setParamInteger()
+*/
 extern void GEOS_DLL GEOSParams_setParamString(
     GEOSParams* p,
     const char* key,
     const char* str);
 
-/** GEOSParams_getParamDouble */
+/**
+* Read a double value stored under a key name.
+* \param p The object to read the value from.
+* \param key The name to read from .
+* \param d A pointer to fill in with the value
+* \return 1 on success, 0 on error.
+* \see GEOSParams_setParamDouble()
+*/
 extern int GEOS_DLL GEOSParams_getParamDouble(
     GEOSParams* p,
     const char* key,
     double *d);
 
-/** GEOSParams_getParamInteger */
+/**
+* Read an integer value stored under a key name.
+* \param p The object to read the value from.
+* \param key The name to read from .
+* \param i A pointer to fill in with the value
+* \return 1 on success, 0 on error.
+* \see GEOSParams_setParamInteger()
+*/
 extern int GEOS_DLL GEOSParams_getParamInteger(
     GEOSParams* p,
     const char* key,
     int *i);
 
-/** GEOSParams_getParamString */
+/**
+* Read a string value stored under a key name.
+* \param p The object to read the value from.
+* \param key The name to read from .
+* \param str A pointer to fill in with the value
+* \return 1 on success, 0 on error.
+* \see GEOSParams_setParamString()
+*/
 extern int GEOS_DLL GEOSParams_getParamString(
     GEOSParams* p,
     const char* key,
@@ -3600,17 +3665,19 @@ extern GEOSGeometry GEOS_DLL *GEOSConcaveHull(
 * an inner hull is computed if it is negative.
 *
 * \param g the polygonal geometry to process
-* \param isOuter indicates whether to compute an outer or inner hull (1 for outer hull, 0 for inner)
-* \param vertexNumFraction the target fraction of the count of input vertices to retain in result
-* \return A newly allocated geometry of the concave hull. NULL on exception.
+* \param ratio the target fraction of the input to retail (1.0 to retain all, 0.0 to retain the minimum)
+* \param params parameters to control the algorithm. Null to use the defaults (vertex ratio, hull outside).
+*        Use "hull_location" and GEOS_POLYHULL_INSIDE, GEOS_POLYHULL_OUTSIDE.
+*        Use "hull_ratio" and GEOS_POLYHULL_AREA_RATIO, GEOS_POLYHULL_VERTEX_RATIO.
+* \return A newly allocated geometry of the concave hull. NULL on exception. Caller is responsible for freeing with GEOSGeom_destroy().
 *
-* Caller is responsible for freeing with GEOSGeom_destroy().
 * \see geos::simplify::PolygonHullSimplifier
+* \see GEOSParams_create()
 */
 extern GEOSGeometry GEOS_DLL *GEOSPolygonHullSimplify(
     const GEOSGeometry* g,
-    unsigned int isOuter,
-    double vertexNumFraction);
+    double ratio,
+    const GEOSParams* params);
 
 /**
 * Constructs a concave hull of a set of polygons, respecting

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -174,6 +174,14 @@ typedef struct GEOSBufParams_t GEOSBufferParams;
 */
 typedef struct GEOSMakeValidParams_t GEOSMakeValidParams;
 
+/**
+* Generic parameter object for functions with complex parameterizations.
+* \see GEOSParams_create()
+* \see GEOSParams_destroy()
+*/
+typedef struct GEOSParams_t GEOSParams;
+
+
 #endif
 
 /** \cond */
@@ -387,6 +395,60 @@ extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setErrorMessageHandler_r(
     GEOSContextHandle_t extHandle,
     GEOSMessageHandler_r ef,
     void *userData);
+
+
+/* ========== GEOS parameter functions ========== */
+
+/** \see GEOSParams_create */
+extern GEOSParams GEOS_DLL *GEOSParams_create_r(
+    GEOSContextHandle_t handle);
+
+/** \see GEOSParams_destroy */
+extern void GEOS_DLL GEOSParams_destroy_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* params);
+
+/** \see GEOSParams_setParamDouble */
+extern void GEOS_DLL GEOSParams_setParamDouble_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* p,
+    const char* key,
+    double d);
+
+/** \see GEOSParams_setParamInteger */
+extern void GEOS_DLL GEOSParams_setParamInteger_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* p,
+    const char* key,
+    int i);
+
+/** \see GEOSParams_setParamString */
+extern void GEOS_DLL GEOSParams_setParamString_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* p,
+    const char* key,
+    const char* str);
+
+/** \see GEOSParams_getParamDouble */
+extern int GEOS_DLL GEOSParams_getParamDouble_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* p,
+    const char* key,
+    double *d);
+
+/** \see GEOSParams_getParamInteger */
+extern int GEOS_DLL GEOSParams_getParamInteger_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* p,
+    const char* key,
+    int *i);
+
+/** \see GEOSParams_getParamString */
+extern int GEOS_DLL GEOSParams_getParamString_r(
+    GEOSContextHandle_t handle,
+    GEOSParams* p,
+    const char* key,
+    const char** str);
 
 /* ========== Coordinate Sequence functions ========== */
 
@@ -1962,6 +2024,58 @@ extern void GEOS_DLL finishGEOS(void);
 * \param buffer The memory to free
 */
 extern void GEOS_DLL GEOSFree(void *buffer);
+
+///@}
+
+/* ========== GEOS parameter functions ========== */
+/** @name Function Parameters
+* A GEOSParams is a map of string keys and
+* double, integer or string values.
+*/
+///@{
+
+/**  GEOSParams_create */
+extern GEOSParams GEOS_DLL *GEOSParams_create();
+
+/**  GEOSParams_destroy */
+extern void GEOS_DLL GEOSParams_destroy(
+    GEOSParams* params);
+
+/**  GEOSParams_setParamDouble */
+extern void GEOS_DLL GEOSParams_setParamDouble(
+    GEOSParams* p,
+    const char* key,
+    double d);
+
+/** GEOSParams_setParamInteger */
+extern void GEOS_DLL GEOSParams_setParamInteger(
+    GEOSParams* p,
+    const char* key,
+    int i);
+
+/** GEOSParams_setParamString */
+extern void GEOS_DLL GEOSParams_setParamString(
+    GEOSParams* p,
+    const char* key,
+    const char* str);
+
+/** GEOSParams_getParamDouble */
+extern int GEOS_DLL GEOSParams_getParamDouble(
+    GEOSParams* p,
+    const char* key,
+    double *d);
+
+/** GEOSParams_getParamInteger */
+extern int GEOS_DLL GEOSParams_getParamInteger(
+    GEOSParams* p,
+    const char* key,
+    int *i);
+
+/** GEOSParams_getParamString */
+extern int GEOS_DLL GEOSParams_getParamString(
+    GEOSParams* p,
+    const char* key,
+    const char** str);
 
 ///@}
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -1247,22 +1247,26 @@ extern "C" {
         const Params* params)
     {
         return execute(extHandle, [&]() {
+            // Read the optional parameter for inside/outside if it is there
             int isOuterParam;
             bool isOuter = true;
-            if (params->getParamInteger("hull_location", &isOuterParam) &&
+            if (params &&
+                params->getParamInteger("hull_location", &isOuterParam) &&
                 isOuterParam == GEOS_POLYHULL_INSIDE)
             {
                     isOuter = false;
             }
             std::unique_ptr<Geometry> g3;
+            // Read the optional parameter for area/vertex method, if it is there
             int methodParam = GEOS_POLYHULL_VERTEX_RATIO;
-            if (params->getParamInteger("hull_ratio", &methodParam) &&
+            if (params &&
+                params->getParamInteger("hull_ratio", &methodParam) &&
                 methodParam == GEOS_POLYHULL_AREA_RATIO)
             {
-                g3 = PolygonHullSimplifier::hull(g1, isOuter, ratio);
+                g3 = PolygonHullSimplifier::hullByAreaDelta(g1, isOuter, ratio);
             }
             else {
-                g3 = PolygonHullSimplifier::hullByAreaDelta(g1, isOuter, ratio);
+                g3 = PolygonHullSimplifier::hull(g1, isOuter, ratio);
             }
             g3->setSRID(g1->getSRID());
             return g3.release();

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -95,8 +95,9 @@
 #include <geos/util.h>
 #include <geos/util/IllegalArgumentException.h>
 #include <geos/util/Interrupt.h>
-#include <geos/util/UniqueCoordinateArrayFilter.h>
 #include <geos/util/Machine.h>
+#include <geos/util/Params.h>
+#include <geos/util/UniqueCoordinateArrayFilter.h>
 #include <geos/version.h>
 
 // This should go away
@@ -129,6 +130,7 @@
 #define GEOSWKBWriter geos::io::WKBWriter
 #define GEOSGeoJSONReader geos::io::GeoJSONReader
 #define GEOSGeoJSONWriter geos::io::GeoJSONWriter
+#define GEOSParams geos::util::Params
 
 // Implementation struct for the GEOSMakeValidParams object
 typedef struct {
@@ -192,6 +194,7 @@ using geos::precision::GeometryPrecisionReducer;
 using geos::simplify::PolygonHullSimplifier;
 
 using geos::util::IllegalArgumentException;
+using geos::util::Params;
 
 typedef std::unique_ptr<Geometry> GeomPtr;
 
@@ -2041,6 +2044,80 @@ extern "C" {
             return out.release();
         });
     }
+
+/* ========== GEOS parameter functions ========== */
+
+    Params*
+    GEOSParams_create_r(GEOSContextHandle_t handle)
+    {
+        return execute(handle, [&]() {
+            return new Params();
+        });
+    }
+
+    void
+    GEOSParams_destroy_r(GEOSContextHandle_t handle, Params* params)
+    {
+        return execute(handle, [&]() {
+            delete params;
+        });
+    }
+
+    void
+    GEOSParams_setParamDouble_r(GEOSContextHandle_t handle,
+        Params* p, const char* key, double d)
+    {
+        return execute(handle, [&]() {
+            return p->setParam(key, d);
+        });
+    }
+
+    void
+    GEOSParams_setParamInteger_r(GEOSContextHandle_t handle,
+        Params* p, const char* key, int i)
+    {
+        return execute(handle, [&]() {
+            return p->setParam(key, i);
+        });
+    }
+
+    void
+    GEOSParams_setParamString_r(GEOSContextHandle_t handle,
+        Params* p, const char* key, const char* str)
+    {
+        return execute(handle, [&]() {
+            return p->setParam(key, str);
+        });
+    }
+
+    int
+    GEOSParams_getParamDouble_r(GEOSContextHandle_t handle,
+        Params* p, const char* key, double *d)
+    {
+        return execute(handle, 0, [&]() {
+            return p->getParamDouble(key, d);
+        });
+    }
+
+    int
+    GEOSParams_getParamInteger_r(GEOSContextHandle_t handle,
+        Params* p, const char* key, int *i)
+    {
+        return execute(handle, 0, [&]() {
+            return p->getParamInteger(key, i);
+        });
+    }
+
+    int
+    GEOSParams_getParamString_r(GEOSContextHandle_t handle,
+        Params* p, const char* key, const char** str)
+    {
+        return execute(handle, 0, [&]() {
+            return p->getParamString(key, str);
+        });
+    }
+
+/* ========== Make Valid ========== */
 
     Geometry*
     GEOSMakeValid_r(GEOSContextHandle_t extHandle, const Geometry* g)

--- a/include/geos/util/Params.h
+++ b/include/geos/util/Params.h
@@ -10,13 +10,13 @@
  * by the Free Software Foundation.
  * See the COPYING file for more information.
  *
- **********************************************************************
  **********************************************************************/
 
 #pragma once
 
 #include <geos/export.h>
 #include <map>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -45,45 +45,46 @@ private:
 
     private:
 
-        union {
-            double d;
-            int i;
-            std::string s;
-        } m_val;
-
-        ParamType m_type;
+        double m_d = 0.0;
+        int m_i = 0;
+        std::string m_s;
+        ParamType m_type = ParamType::Double;
 
     public:
 
-        void setDouble(double d) {
-            m_val.d = d;
-            m_type = ParamType::Double;
-        };
+        ParamValue() {};
+        ParamValue(double d);
+        ParamValue(int i);
+        ParamValue(std::string& s);
+        ParamValue(const char* cstr);
 
-        void setInteger(int i) {
-            m_val.i = i;
-            m_type = ParamType::Integer;
-        };
-
-        void setString(std::string& s) {
-            m_val.s = s;
-            m_type = ParamType::String;
-        };
-
-        void setString(const char* cstr) {
-            std::string s(cstr);
-            m_val.s = s;
-            m_type = ParamType::String;
-        };
-
+        void setDouble(double d);
+        void setInteger(int i);
+        void setString(std::string& s);
+        void setCString(const char* cstr);
+        bool getDouble(double* d) const;
+        bool getInteger(int* i) const;
+        bool getCString(char** str) const;
 
     };
 
+    // where we actually store the parameters
+    std::map<std::string, ParamValue> m_params;
+
+    static void normalizeKey(std::string& str);
+    bool haveKey(std::string& str) const;
+    void clearEntry(std::string& key);
+    const ParamValue* getValue(std::string& key) const;
 
 
 public:
 
-    int get
+    void setParam(const char* key, double d);
+    void setParam(const char* key, int i);
+    void setParam(const char* key, const char* s);
+    bool getParamDouble(const char* key, double* d) const;
+    bool getParamInteger(const char* key, int* i) const;
+    bool getParamString(const char* key, char** str) const;
 
 };
 

--- a/include/geos/util/Params.h
+++ b/include/geos/util/Params.h
@@ -64,7 +64,7 @@ private:
         void setCString(const char* cstr);
         bool getDouble(double* d) const;
         bool getInteger(int* i) const;
-        bool getCString(char** str) const;
+        bool getCString(const char** str) const;
 
     };
 
@@ -79,12 +79,13 @@ private:
 
 public:
 
+    Params() {};
     void setParam(const char* key, double d);
     void setParam(const char* key, int i);
     void setParam(const char* key, const char* s);
     bool getParamDouble(const char* key, double* d) const;
     bool getParamInteger(const char* key, int* i) const;
-    bool getParamString(const char* key, char** str) const;
+    bool getParamString(const char* key, const char** str) const;
 
 };
 

--- a/include/geos/util/Params.h
+++ b/include/geos/util/Params.h
@@ -1,0 +1,96 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/export.h>
+#include <map>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251) // warning C4251: needs to have dll-interface to be used by clients of class
+#endif
+
+namespace geos {
+namespace util { // geos::util
+
+
+enum class ParamType {
+    Double, Integer, String
+};
+
+/** \brief
+ * Stores values that can be fed to the functions, for use in the
+ * CAPI primarily to expose functionality with a lot of parametric
+ * options.
+ *
+ */
+class GEOS_DLL Params {
+
+private:
+
+    class ParamValue {
+
+    private:
+
+        union {
+            double d;
+            int i;
+            std::string s;
+        } m_val;
+
+        ParamType m_type;
+
+    public:
+
+        void setDouble(double d) {
+            m_val.d = d;
+            m_type = ParamType::Double;
+        };
+
+        void setInteger(int i) {
+            m_val.i = i;
+            m_type = ParamType::Integer;
+        };
+
+        void setString(std::string& s) {
+            m_val.s = s;
+            m_type = ParamType::String;
+        };
+
+        void setString(const char* cstr) {
+            std::string s(cstr);
+            m_val.s = s;
+            m_type = ParamType::String;
+        };
+
+
+    };
+
+
+
+public:
+
+    int get
+
+};
+
+} // namespace geos::util
+} // namespace geos
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -1,0 +1,258 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ **********************************************************************/
+
+#include <vector>
+#include <memory>
+#include <map>
+
+namespace geos {
+namespace util { // geos.util
+
+Params::Params()
+    :
+    geomFact(factory),
+    precModel(factory->getPrecisionModel()),
+    nPts(100)
+{
+}
+
+void
+GeometricShapeFactory::setBase(const Coordinate& base)
+{
+    dim.setBase(base);
+}
+
+void
+GeometricShapeFactory::setCentre(const Coordinate& centre)
+{
+    dim.setCentre(centre);
+}
+
+void
+GeometricShapeFactory::setNumPoints(uint32_t nNPts)
+{
+    nPts = nNPts;
+}
+
+void
+GeometricShapeFactory::setSize(double size)
+{
+    dim.setSize(size);
+}
+
+void
+GeometricShapeFactory::setWidth(double width)
+{
+    dim.setWidth(width);
+}
+
+void
+GeometricShapeFactory::setHeight(double height)
+{
+    dim.setHeight(height);
+}
+
+std::unique_ptr<Polygon>
+GeometricShapeFactory::createRectangle()
+{
+    uint32_t i;
+    uint32_t ipt = 0;
+    uint32_t nSide = nPts / 4;
+    if(nSide < 1) {
+        nSide = 1;
+    }
+    std::unique_ptr<Envelope> env(dim.getEnvelope());
+    double XsegLen = env->getWidth() / nSide;
+    double YsegLen = env->getHeight() / nSide;
+
+    std::vector<Coordinate> vc(4 * nSide + 1);
+
+    for(i = 0; i < nSide; i++) {
+        double x = env->getMinX() + i * XsegLen;
+        double y = env->getMinY();
+        vc[ipt++] = coord(x, y);
+    }
+    for(i = 0; i < nSide; i++) {
+        double x = env->getMaxX();
+        double y = env->getMinY() + i * YsegLen;
+        vc[ipt++] = coord(x, y);
+    }
+    for(i = 0; i < nSide; i++) {
+        double x = env->getMaxX() - i * XsegLen;
+        double y = env->getMaxY();
+        vc[ipt++] = coord(x, y);
+    }
+    for(i = 0; i < nSide; i++) {
+        double x = env->getMinX();
+        double y = env->getMaxY() - i * YsegLen;
+        vc[ipt++] = coord(x, y);
+    }
+    vc[ipt++] = vc[0];
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(std::move(vc));
+    auto ring = geomFact->createLinearRing(std::move(cs));
+    auto poly = geomFact->createPolygon(std::move(ring));
+    return poly;
+}
+
+std::unique_ptr<Polygon>
+GeometricShapeFactory::createCircle()
+{
+    std::unique_ptr<Envelope> env(dim.getEnvelope());
+    double xRadius = env->getWidth() / 2.0;
+    double yRadius = env->getHeight() / 2.0;
+
+    double centreX = env->getMinX() + xRadius;
+    double centreY = env->getMinY() + yRadius;
+    env.reset();
+
+    std::vector<Coordinate> pts(nPts + 1);
+    uint32_t iPt = 0;
+    for(uint32_t i = 0; i < nPts; i++) {
+        double ang = i * (2 * 3.14159265358979 / nPts);
+        double x = xRadius * cos(ang) + centreX;
+        double y = yRadius * sin(ang) + centreY;
+        pts[iPt++] = coord(x, y);
+    }
+    pts[iPt++] = pts[0];
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(std::move(pts));
+    auto ring = geomFact->createLinearRing(std::move(cs));
+    auto poly = geomFact->createPolygon(std::move(ring));
+    return poly;
+}
+
+std::unique_ptr<LineString>
+GeometricShapeFactory::createArc(double startAng, double angExtent)
+{
+    std::unique_ptr<Envelope> env(dim.getEnvelope());
+    double xRadius = env->getWidth() / 2.0;
+    double yRadius = env->getHeight() / 2.0;
+
+    double centreX = env->getMinX() + xRadius;
+    double centreY = env->getMinY() + yRadius;
+    env.reset();
+
+    double angSize = angExtent;
+    if(angSize <= 0.0 || angSize > 2 * MATH_PI) {
+        angSize = 2 * MATH_PI;
+    }
+    double angInc = angSize / (nPts - 1);
+
+    std::vector<Coordinate> pts(nPts);
+    uint32_t iPt = 0;
+    for(uint32_t i = 0; i < nPts; i++) {
+        double ang = startAng + i * angInc;
+        double x = xRadius * cos(ang) + centreX;
+        double y = yRadius * sin(ang) + centreY;
+        pts[iPt++] = coord(x, y);
+    }
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(std::move(pts));
+    auto line = geomFact->createLineString(std::move(cs));
+    return line;
+}
+
+std::unique_ptr<Polygon>
+GeometricShapeFactory::createArcPolygon(double startAng, double angExtent)
+{
+    std::unique_ptr<Envelope> env(dim.getEnvelope());
+    double xRadius = env->getWidth() / 2.0;
+    double yRadius = env->getHeight() / 2.0;
+
+    double centreX = env->getMinX() + xRadius;
+    double centreY = env->getMinY() + yRadius;
+    env.reset();
+
+    double angSize = angExtent;
+    if(angSize <= 0.0 || angSize > 2 * MATH_PI) {
+        angSize = 2 * MATH_PI;
+    }
+    double angInc = angSize / (nPts - 1);
+
+    std::vector<Coordinate> pts(nPts + 2);
+    uint32_t iPt = 0;
+    pts[iPt++] = coord(centreX, centreY);
+    for(uint32_t i = 0; i < nPts; i++) {
+        double ang = startAng + i * angInc;
+        double x = xRadius * cos(ang) + centreX;
+        double y = yRadius * sin(ang) + centreY;
+        pts[iPt++] = coord(x, y);
+    }
+    pts[iPt++] = coord(centreX, centreY);
+
+    auto cs = geomFact->getCoordinateSequenceFactory()->create(std::move(pts));
+    auto ring = geomFact->createLinearRing(std::move(cs));
+
+    return geomFact->createPolygon(std::move(ring));
+}
+
+GeometricShapeFactory::Dimensions::Dimensions()
+    :
+    base(Coordinate::getNull()),
+    centre(Coordinate::getNull())
+{
+}
+
+void
+GeometricShapeFactory::Dimensions::setBase(const Coordinate& newBase)
+{
+    base = newBase;
+}
+
+void
+GeometricShapeFactory::Dimensions::setCentre(const Coordinate& newCentre)
+{
+    centre = newCentre;
+}
+
+void
+GeometricShapeFactory::Dimensions::setSize(double size)
+{
+    height = size;
+    width = size;
+}
+
+void
+GeometricShapeFactory::Dimensions::setWidth(double nWidth)
+{
+    width = nWidth;
+}
+
+void
+GeometricShapeFactory::Dimensions::setHeight(double nHeight)
+{
+    height = nHeight;
+}
+
+std::unique_ptr<Envelope>
+GeometricShapeFactory::Dimensions::getEnvelope() const
+{
+    if(!base.isNull()) {
+        return detail::make_unique<Envelope>(base.x, base.x + width, base.y, base.y + height);
+    }
+    if(!centre.isNull()) {
+        return detail::make_unique<Envelope>(centre.x - width / 2, centre.x + width / 2, centre.y - height / 2, centre.y + height / 2);
+    }
+    return detail::make_unique<Envelope>(0, width, 0, height);
+}
+
+/*protected*/
+Coordinate
+GeometricShapeFactory::coord(double x, double y) const
+{
+    Coordinate ret(x, y);
+    precModel->makePrecise(&ret);
+    return ret;
+}
+
+} // namespace geos.util
+} // namespace geos
+

--- a/src/util/Params.cpp
+++ b/src/util/Params.cpp
@@ -59,8 +59,7 @@ Params::ParamValue::setString(std::string& s)
 void
 Params::ParamValue::setCString(const char* cstr)
 {
-    std::string s(cstr);
-    m_s = s;
+    m_s.assign(cstr);
     m_type = ParamType::String;
 }
 
@@ -83,11 +82,11 @@ Params::ParamValue::getInteger(int* i) const
 }
 
 bool
-Params::ParamValue::getCString(char** str) const
+Params::ParamValue::getCString(const char** str) const
 {
     if (!str || m_type != ParamType::String)
         return false;
-    *str = strdup(m_s.c_str());
+    *str = m_s.c_str();
     return true;
 }
 
@@ -180,7 +179,7 @@ Params::getParamInteger(const char* key, int* i) const
 }
 
 bool
-Params::getParamString(const char* key, char** str) const
+Params::getParamString(const char* key, const char** str) const
 {
     std::string k(key);
     normalizeKey(k);

--- a/tests/unit/capi/GEOSPolygonHullSimplifyTest.cpp
+++ b/tests/unit/capi/GEOSPolygonHullSimplifyTest.cpp
@@ -18,6 +18,15 @@ namespace tut {
 
 // Common data used in test cases.
 struct test_capigeospolygonhull_data : public capitest::utility {
+    GEOSParams *params_;
+    test_capigeospolygonhull_data() {
+        params_ = GEOSParams_create();
+        GEOSParams_setParamInteger(params_, "hull_location", GEOS_POLYHULL_OUTSIDE);
+        GEOSParams_setParamInteger(params_, "hull_ratio", GEOS_POLYHULL_VERTEX_RATIO);
+    }
+    ~test_capigeospolygonhull_data() {
+        GEOSParams_destroy(params_);
+    }
 };
 
 typedef test_group<test_capigeospolygonhull_data> group;
@@ -35,7 +44,7 @@ void object::test<1>()
 {
     input_ = GEOSGeomFromWKT("POLYGON ((10 90, 40 60, 20 40, 40 20, 70 50, 40 30, 30 40, 60 70, 50 90, 90 90, 90 10, 10 10, 10 90))");
     ensure(nullptr != input_);
-    geom1_ = GEOSPolygonHullSimplify(input_, 1, 0.5);
+    geom1_ = GEOSPolygonHullSimplify(input_, 0.5, params_);
     ensure(nullptr != geom1_);
     expected_ = GEOSGeomFromWKT("POLYGON ((10 90, 50 90, 90 90, 90 10, 10 10, 10 90))");
     ensure_geometry_equals(geom1_, expected_);
@@ -48,7 +57,7 @@ void object::test<2>()
 {
     input_ = GEOSGeomFromWKT("POLYGON ((10 90, 40 60, 20 40, 40 20, 70 50, 40 30, 30 40, 60 70, 50 90, 90 90, 90 10, 10 10, 10 90))");
     ensure(nullptr != input_);
-    geom1_ = GEOSPolygonHullSimplify(input_, 1, 0.7);
+    geom1_ = GEOSPolygonHullSimplify(input_, 0.7, params_);
     ensure(nullptr != geom1_);
     expected_ = GEOSGeomFromWKT("POLYGON ((10 90, 40 60, 30 40, 60 70, 50 90, 90 90, 90 10, 10 10, 10 90))");
     ensure_geometry_equals(geom1_, expected_);
@@ -61,7 +70,7 @@ void object::test<3>()
 {
     input_ = GEOSGeomFromWKT("POLYGON EMPTY");
     ensure(nullptr != input_);
-    geom1_ = GEOSPolygonHullSimplify(input_, 1, 0.7);
+    geom1_ = GEOSPolygonHullSimplify(input_, 0.7, params_);
     ensure(nullptr != geom1_);
     expected_ = GEOSGeomFromWKT("POLYGON EMPTY");
     ensure_geometry_equals(geom1_, expected_);
@@ -73,7 +82,7 @@ void object::test<4>()
 {
     input_ = GEOSGeomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
     ensure(nullptr != input_);
-    geom1_ = GEOSPolygonHullSimplify(input_, 1, 0.7);
+    geom1_ = GEOSPolygonHullSimplify(input_, 0.7, params_);
     ensure(nullptr != geom1_);
     expected_ = GEOSGeomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
     ensure_geometry_equals(geom1_, expected_);

--- a/tests/unit/util/ParamsTest.cpp
+++ b/tests/unit/util/ParamsTest.cpp
@@ -99,26 +99,7 @@ void object::test<3> ()
     ensure_equals(std::strcmp(s3, s2), 0);
 }
 
-template<>
-template<>
-void object::test<4> ()
-{
-    Params prm;
-    double d1 = 11.1, d2;
-    prm.setParam("test_double", 3.4);
-    bool rv = prm.getParamDouble("test_double", &d2);
-    ensure_equals(rv, true);
-    ensure_equals(d1, d2);
-    // Wrong key should fail
-    rv = prm.getParamDouble("test_wrong", &d2);
-    ensure_equals(rv, false);
-    // Overwrite existing value
-    d1 = 5;
-    prm.setParam("test_double", d1);
-    rv = prm.getParamDouble("test_double", &d2);
-    ensure_equals(rv, true);
-    ensure_equals(d1, d2);
-}
+
 
 
 } // namespace tut

--- a/tests/unit/util/ParamsTest.cpp
+++ b/tests/unit/util/ParamsTest.cpp
@@ -38,7 +38,7 @@ void object::test<1> ()
 {
     Params prm;
     double d1 = 3.4, d2;
-    prm.setParam("test_double", 3.4);
+    prm.setParam("test_double", d1);
     bool rv = prm.getParamDouble("test_double", &d2);
     ensure_equals(rv, true);
     ensure_equals(d1, d2);
@@ -84,8 +84,8 @@ void object::test<3> ()
     prm.setParam("test_str", s1);
     bool rv = prm.getParamString("test_str", &s2);
     ensure_equals(rv, true);
-    ensure_equals(strlen(s1), strlen(s2));
-    ensure_equals(strcmp(s1, s2), 0);
+    ensure_equals(std::strlen(s1), std::strlen(s2));
+    ensure_equals(std::strcmp(s1, s2), 0);
     // Wrong key should fail
     rv = prm.getParamString("test_wrong", &s2);
     ensure_equals(rv, false);
@@ -94,8 +94,29 @@ void object::test<3> ()
     prm.setParam("test_str", s3);
     rv = prm.getParamString("test_str", &s2);
     ensure_equals(rv, true);
-    ensure_equals(strlen(s3), strlen(s2));
-    ensure_equals(strcmp(s3, s2), 0);
+    ensure_equals(std::strlen(s3), std::strlen(s2));
+    ensure_equals(std::strcmp(s3, s2), 0);
+}
+
+template<>
+template<>
+void object::test<4> ()
+{
+    Params prm;
+    double d1 = 11.1, d2;
+    prm.setParam("test_double", 3.4);
+    bool rv = prm.getParamDouble("test_double", &d2);
+    ensure_equals(rv, true);
+    ensure_equals(d1, d2);
+    // Wrong key should fail
+    rv = prm.getParamDouble("test_wrong", &d2);
+    ensure_equals(rv, false);
+    // Overwrite existing value
+    d1 = 5;
+    prm.setParam("test_double", d1);
+    rv = prm.getParamDouble("test_double", &d2);
+    ensure_equals(rv, true);
+    ensure_equals(d1, d2);
 }
 
 

--- a/tests/unit/util/ParamsTest.cpp
+++ b/tests/unit/util/ParamsTest.cpp
@@ -9,6 +9,7 @@
 
 // std
 #include <string>
+#include <cstring>
 
 namespace tut {
 //

--- a/tests/unit/util/ParamsTest.cpp
+++ b/tests/unit/util/ParamsTest.cpp
@@ -89,9 +89,14 @@ void object::test<3> ()
     // Wrong key should fail
     rv = prm.getParamString("test_wrong", &s2);
     ensure_equals(rv, false);
+    // Overwrite existing value
+    const char *s3 = "foobar";
+    prm.setParam("test_str", s3);
+    rv = prm.getParamString("test_str", &s2);
+    ensure_equals(rv, true);
+    ensure_equals(strlen(s3), strlen(s2));
+    ensure_equals(strcmp(s3, s2), 0);
 }
-
-
 
 
 } // namespace tut

--- a/tests/unit/util/ParamsTest.cpp
+++ b/tests/unit/util/ParamsTest.cpp
@@ -1,0 +1,98 @@
+//
+// Test Suite for geos::util::Params class.
+
+// tut
+#include <tut/tut.hpp>
+
+// geos
+#include <geos/util/Params.h>
+
+// std
+#include <string>
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_params_data {
+
+    test_params_data() {};
+};
+
+typedef test_group<test_params_data> group;
+typedef group::object object;
+
+group test_params_group("geos::util::Params");
+
+using geos::util::Params;
+
+//
+// Test Cases
+//
+
+template<>
+template<>
+void object::test<1> ()
+{
+    Params prm;
+    double d1 = 3.4, d2;
+    prm.setParam("test_double", 3.4);
+    bool rv = prm.getParamDouble("test_double", &d2);
+    ensure_equals(rv, true);
+    ensure_equals(d1, d2);
+    // Wrong key should fail
+    rv = prm.getParamDouble("test_wrong", &d2);
+    ensure_equals(rv, false);
+    // Overwrite existing value
+    d1 = 5;
+    prm.setParam("test_double", d1);
+    rv = prm.getParamDouble("test_double", &d2);
+    ensure_equals(rv, true);
+    ensure_equals(d1, d2);
+}
+
+template<>
+template<>
+void object::test<2> ()
+{
+    Params prm;
+    int i1 = 4, i2;
+    prm.setParam("test_int", i1);
+    bool rv = prm.getParamInteger("test_int", &i2);
+    ensure_equals(rv, true);
+    ensure_equals(i1, i2);
+    // Wrong key should fail
+    rv = prm.getParamInteger("test_wrong", &i2);
+    ensure_equals(rv, false);
+    // Overwrite existing value
+    i1 = 5;
+    prm.setParam("test_int", i1);
+    rv = prm.getParamInteger("test_int", &i2);
+    ensure_equals(rv, true);
+    ensure_equals(i1, i2);
+}
+
+template<>
+template<>
+void object::test<3> ()
+{
+    Params prm;
+    const char *s1 = "value";
+    const char *s2;
+    prm.setParam("test_str", s1);
+    bool rv = prm.getParamString("test_str", &s2);
+    ensure_equals(rv, true);
+    ensure_equals(strlen(s1), strlen(s2));
+    ensure_equals(strcmp(s1, s2), 0);
+    // Wrong key should fail
+    rv = prm.getParamString("test_wrong", &s2);
+    ensure_equals(rv, false);
+}
+
+
+
+
+} // namespace tut
+


### PR DESCRIPTION
References #627, can take over from GEOSMakeValidParams and even GEOSBufferParams if so desired. Can be used to exposed the modes behind the PolygonHull as well (area ratio vs vertex ratio) if we want.