### PR TITLE
Use HTTPS for download.osgeo.org links

### DIFF
--- a/web/content/usage/download.md
+++ b/web/content/usage/download.md
@@ -9,15 +9,15 @@ draft: false
 
 | Release Date | Release | Download Link | Changes |
 | ------------ | ------- | ------------- | ------- |
-|  2022/06/20 | **3.11.0beta2** |  [geos-3.11.0beta2.tar.bz2](http://download.osgeo.org/geos/geos-3.11.0beta2.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.11.0beta2/NEWS.md) |
-|  2022/06/03 | **{{<current_release>}}** | [geos-{{<current_release>}}.tar.bz2](http://download.osgeo.org/geos/geos-{{<current_release>}}.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/{{<current_release>}}/NEWS)
-|  2022/06/02 | **3.9.3** |  [geos-3.9.3.tar.bz2](http://download.osgeo.org/geos/geos-3.9.3.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.9.3/NEWS) |
-|  2022/06/02 | **3.8.3** |  [geos-3.8.3.tar.bz2](http://download.osgeo.org/geos/geos-3.8.3.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.8.3/NEWS) |
-|  2022/06/08 | **3.7.5** |  [geos-3.7.5.tar.bz2](http://download.osgeo.org/geos/geos-3.7.5.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.7.5/NEWS) |
-|  2020/12/11 | **3.6.5** |  [geos-3.6.5.tar.bz2](http://download.osgeo.org/geos/geos-3.6.5.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.6.5/NEWS) |
-|  2019/10/04 | **3.5.2** |  [geos-3.5.2.tar.bz2](http://download.osgeo.org/geos/geos-3.5.2.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.5.2/NEWS) |
+|  2022/06/20 | **3.11.0beta2** |  [geos-3.11.0beta2.tar.bz2](https://download.osgeo.org/geos/geos-3.11.0beta2.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.11.0beta2/NEWS.md) |
+|  2022/06/03 | **{{<current_release>}}** | [geos-{{<current_release>}}.tar.bz2](https://download.osgeo.org/geos/geos-{{<current_release>}}.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/{{<current_release>}}/NEWS)
+|  2022/06/02 | **3.9.3** |  [geos-3.9.3.tar.bz2](https://download.osgeo.org/geos/geos-3.9.3.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.9.3/NEWS) |
+|  2022/06/02 | **3.8.3** |  [geos-3.8.3.tar.bz2](https://download.osgeo.org/geos/geos-3.8.3.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.8.3/NEWS) |
+|  2022/06/08 | **3.7.5** |  [geos-3.7.5.tar.bz2](https://download.osgeo.org/geos/geos-3.7.5.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.7.5/NEWS) |
+|  2020/12/11 | **3.6.5** |  [geos-3.6.5.tar.bz2](https://download.osgeo.org/geos/geos-3.6.5.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.6.5/NEWS) |
+|  2019/10/04 | **3.5.2** |  [geos-3.5.2.tar.bz2](https://download.osgeo.org/geos/geos-3.5.2.tar.bz2) | [Changes](https://github.com/libgeos/geos/blob/3.5.2/NEWS) |
 
-Old releases can be downloaded from http://download.osgeo.org/geos/
+Old releases can be downloaded from https://download.osgeo.org/geos/
 
 
 ## Build From Source


### PR DESCRIPTION
You may find that modern browsers (e.g. Chrome) don't always download non-secure HTTP links. Note that the OSGeo Download server does support HTTPS and has a valid certificate, so HTTPS should be promoted instead.

Related: https://trac.osgeo.org/osgeo/ticket/2775