### PR TITLE
geos-config: remove reference to geos-3 library

### DIFF
--- a/tools/geos-config.in
+++ b/tools/geos-config.in
@@ -44,7 +44,7 @@ while test $# -gt 0; do
     --libs)
       # TODO: make an alias for --clibs
       # see http://trac.osgeo.org/geos/ticket/497
-      echo -L${libdir} -lgeos-@VERSION_RELEASE@
+      echo -L${libdir} -lgeos
       ;;
     --clibs)
       echo -L${libdir} -lgeos_c


### PR DESCRIPTION
Now that autotools is gone, the library never has the version number appended, but `geos-config` was still referencing the name with the version suffix.