### PR TITLE
Fix multiple docstring issues

### DIFF
--- a/include/geos/index/SpatialIndex.h
+++ b/include/geos/index/SpatialIndex.h
@@ -70,7 +70,6 @@ public:
      * intersect the query envelope.
      *
      * @param searchEnv the envelope to query for
-     * @return a list of the items found by the query in a newly allocated vector
      */
     //virtual std::vector<void*>* query(const geom::Envelope *searchEnv)=0;
     virtual void query(const geom::Envelope* searchEnv, std::vector<void*>&) = 0;

--- a/include/geos/index/VertexSequencePackedRtree.h
+++ b/include/geos/index/VertexSequencePackedRtree.h
@@ -136,7 +136,6 @@ public:
     *
     * @param queryEnv the query extent
     * @param result vector to fill with results
-    * @return
     */
     void query(const Envelope& queryEnv, std::vector<std::size_t>& result) const;
 

--- a/include/geos/noding/SegmentNodeList.h
+++ b/include/geos/noding/SegmentNodeList.h
@@ -155,9 +155,6 @@ public:
      * Adds an intersection into the list, if it isn't already there.
      * The input segmentIndex is expected to be normalized.
      *
-     * @return the SegmentIntersection found or added. It will be
-     *	   destroyed at SegmentNodeList destruction time.
-     *
      * @param intPt the intersection Coordinate, will be copied
      * @param segmentIndex
      */

--- a/include/geos/operation/buffer/OffsetCurve.h
+++ b/include/geos/operation/buffer/OffsetCurve.h
@@ -252,7 +252,6 @@ public:
     * @param dist the offset distance
     * @param bufParams the buffer parameters to use
     * @param lineList the vector to populate with the return value
-    * @return the raw offset line
     */
     static void rawOffset(const LineString& geom, double dist, BufferParameters& bufParams, std::vector<CoordinateSequence*>& lineList);
     static void rawOffset(const LineString& geom, double dist, std::vector<CoordinateSequence*>& lineList);

--- a/include/geos/precision/CommonBitsRemover.h
+++ b/include/geos/precision/CommonBitsRemover.h
@@ -74,7 +74,6 @@ public:
      *
      * @param geom the Geometry from which to remove the common
      *             coordinate bits
-     * @return the shifted Geometry
      */
     void removeCommonBits(geom::Geometry* geom);
 

--- a/include/geos/triangulate/polygon/PolygonEarClipper.h
+++ b/include/geos/triangulate/polygon/PolygonEarClipper.h
@@ -184,7 +184,6 @@ public:
     *
     * @param polyShell the vertices of the polygon
     * @param triListResult vector to fill in with the resultant Tri s
-    * @return a list of the Tris
     */
     static void triangulate(std::vector<Coordinate>& polyShell, TriList<Tri>& triListResult);
 


### PR DESCRIPTION
Remove invalid `@return`docstrings for void methods. Fixes currently failing `test_docs`.