### PR TITLE
Fix docs, add tests for GEOSEnvelope edge cases

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -3428,9 +3428,10 @@ extern GEOSGeometry GEOS_DLL *GEOSOffsetCurve(const GEOSGeometry* g,
 ///@{
 
 /**
-* Returns minimum rectangular polygon that contains the geometry.
+* Returns minimum rectangular polygon or point that contains the geometry,
+* or an empty point for empty inputs.
 * \param g The geometry to calculate an envelope for
-* \return A newly allocated polygonal envelope. NULL on exception.
+* \return A newly allocated polygonal envelope or point. NULL on exception.
 * Caller is responsible for freeing with GEOSGeom_destroy().
 */
 extern GEOSGeometry GEOS_DLL *GEOSEnvelope(const GEOSGeometry* g);

--- a/tests/unit/capi/GEOSEnvelopeTest.cpp
+++ b/tests/unit/capi/GEOSEnvelopeTest.cpp
@@ -16,6 +16,7 @@ typedef group::object object;
 
 group test_geosenvelope("capi::GEOSEnvelope");
 
+// non-degenerate input
 template<>
 template<>
 void object::test<1>
@@ -26,6 +27,60 @@ void object::test<1>
     GEOSGeometry* expected = GEOSGeomFromWKT("POLYGON ((1 -2, 9 -2, 9 5, 1 5, 1 -2))");
 
     ensure_equals(GEOSEqualsExact(result, expected, 0), 1);
+
+    GEOSGeom_destroy(input);
+    GEOSGeom_destroy(result);
+    GEOSGeom_destroy(expected);
+}
+
+// point input
+template<>
+template<>
+void object::test<2>
+()
+{
+    GEOSGeometry* input = GEOSGeomFromWKT("POINT (3 8)");
+    GEOSGeometry* result = GEOSEnvelope(input);
+
+    GEOSGeometry* expected = GEOSGeomFromWKT("POINT (3 8)");
+
+    ensure_geometry_equals(result, expected);
+
+    GEOSGeom_destroy(input);
+    GEOSGeom_destroy(result);
+    GEOSGeom_destroy(expected);
+}
+
+// empty point input
+template<>
+template<>
+void object::test<3>
+()
+{
+    GEOSGeometry* input = GEOSGeomFromWKT("POINT EMPTY");
+    GEOSGeometry* result = GEOSEnvelope(input);
+
+    GEOSGeometry* expected = GEOSGeomFromWKT("POINT EMPTY");
+
+    ensure_geometry_equals(result, expected);
+
+    GEOSGeom_destroy(input);
+    GEOSGeom_destroy(result);
+    GEOSGeom_destroy(expected);
+}
+
+// empty polygon input
+template<>
+template<>
+void object::test<4>
+()
+{
+    GEOSGeometry* input = GEOSGeomFromWKT("POLYGON EMPTY");
+    GEOSGeometry* result = GEOSEnvelope(input);
+
+    GEOSGeometry* expected = GEOSGeomFromWKT("POINT EMPTY");
+
+    ensure_geometry_equals(result, expected);
 
     GEOSGeom_destroy(input);
     GEOSGeom_destroy(result);


### PR DESCRIPTION
Added tests for point/empty inputs. I think it would have been preferable to return a degenerate polygon, but probably not worth changing longstanding behavior.