### PR TITLE
DOC: add missing entry to NEWS (empty points change)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ xxxx-xx-xx
   - CAPI: GEOSPolygonHullSimplify (GH-603, Paul Ramsey)
   - CAPI: GEOSPolygonHullSimplifyByArea (GH-633, Paul Ramsey)
   - CAPI: GEOSLineMergeDirected (GH-597, Sergei Sh)
+  - CAPI: GEOSGeom_getExtent (GH-555, Joris Van den Bossche)
   - CAPI: setFixStructure for WKB/WKT readers to automatically repair
     structural errors in the input (GH-639, Paul Ramsey)
 
@@ -128,6 +129,7 @@ xxxx-xx-xx
   - Remove undefined behaviour in CAPI (#1021, Greg Troxel)
   - Fix buffering issue (#1022, JTS-525, Paul Ramsey)
   - MinimumBoundingCircle.getMaximumDiameter fix (JTS-533, Paul Ramsey)
+  - Output POINT EMPTY in WKB as POINT (NaN NaN) (#1005, Paul Ramsey)
 
 - Changes:
   - Drop SWIG bindings, including for Ruby and Python (#1076, Mike Taves)


### PR DESCRIPTION
I was wondering in which version the WKB serialization of POINT EMPTY was changed, and didn't find that in the changelog, only in a commit https://github.com/libgeos/geos/commit/466cff135c8e504632ae38b79a1348dbadb390f1. So thought to add it to the NEWS in case someone else would also look for that in the future. 
And also noticed that another CAPI addition was missing for 3.11