### PR TITLE
Catch nan/inf arguments to buffering sooner.

### DIFF
--- a/include/geos/operation/buffer/OffsetCurve.h
+++ b/include/geos/operation/buffer/OffsetCurve.h
@@ -196,12 +196,7 @@ public:
     *
     * \see BufferParameters
     */
-    OffsetCurve(const Geometry& geom, double dist)
-        : inputGeom(geom)
-        , distance(dist)
-        , matchDistance(std::abs(dist)/NEARNESS_FACTOR)
-        , geomFactory(geom.getFactory())
-        {};
+    OffsetCurve(const Geometry& geom, double dist);
 
     /**
     * Creates a new instance for computing an offset curve for a geometry at a given distance.
@@ -212,13 +207,7 @@ public:
     * @param dist
     * @param bp
     */
-    OffsetCurve(const Geometry& geom, double dist, BufferParameters& bp)
-        : inputGeom(geom)
-        , distance(dist)
-        , bufferParams(bp)
-        , matchDistance(std::abs(dist)/NEARNESS_FACTOR)
-        , geomFactory(geom.getFactory())
-        {};
+    OffsetCurve(const Geometry& geom, double dist, BufferParameters& bp);
 
     /**
     * Computes the offset curve of a geometry at a given distance,

--- a/include/geos/util/IllegalArgumentException.h
+++ b/include/geos/util/IllegalArgumentException.h
@@ -17,6 +17,7 @@
 
 #include <geos/export.h>
 #include <string>
+#include <cmath>
 
 #include <geos/util/GEOSException.h>
 
@@ -43,6 +44,7 @@ public:
     {}
 
     ~IllegalArgumentException() noexcept override {}
+
 };
 
 } // namespace geos::util

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -383,7 +383,7 @@ BufferBuilder::buffer(const Geometry* g, double distance)
 {
     // Thow error on nan/inf
     if (!std::isfinite(distance))
-        throw util::IllegalArgumentException("BufferBuilder distance must be a finite value");
+        throw util::IllegalArgumentException("BufferBuilder distance must be finite");
 
     const PrecisionModel* precisionModel = workingPrecisionModel;
     if(precisionModel == nullptr) {

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -138,6 +138,10 @@ BufferBuilder::bufferLineSingleSided(const Geometry* g, double distance,
         throw util::IllegalArgumentException("BufferBuilder::bufferLineSingleSided only accept linestrings");
     }
 
+    // Thow error on nan/inf
+    if (!std::isfinite(distance))
+        throw util::IllegalArgumentException("BufferBuilder distance must be a finite value");
+
     // Nothing to do for a distance of zero
     if(distance == 0) {
         return g->clone();
@@ -377,6 +381,10 @@ std::unique_ptr<Geometry>
 BufferBuilder::buffer(const Geometry* g, double distance)
 // throw(GEOSException *)
 {
+    // Thow error on nan/inf
+    if (!std::isfinite(distance))
+        throw util::IllegalArgumentException("BufferBuilder distance must be a finite value");
+
     const PrecisionModel* precisionModel = workingPrecisionModel;
     if(precisionModel == nullptr) {
         precisionModel = g->getPrecisionModel();

--- a/src/operation/buffer/BufferOp.cpp
+++ b/src/operation/buffer/BufferOp.cpp
@@ -41,6 +41,7 @@
 #include <geos/noding/MCIndexNoder.h>
 #include <geos/noding/IntersectionAdder.h>
 
+#include <geos/util/IllegalArgumentException.h>
 
 
 
@@ -111,6 +112,9 @@ BufferOp::bufferOp(const geom::Geometry* g, double dist,
 std::unique_ptr<Geometry>
 BufferOp::getResultGeometry(double nDistance)
 {
+    if (!std::isfinite(nDistance))
+        throw util::IllegalArgumentException("BufferOp distance must be finite");
+
     distance = nDistance;
     computeGeometry();
     return std::unique_ptr<Geometry>(resultGeometry.release());

--- a/src/operation/buffer/OffsetCurve.cpp
+++ b/src/operation/buffer/OffsetCurve.cpp
@@ -31,6 +31,7 @@
 #include <geos/geom/util/GeometryMapper.h>
 #include <geos/index/chain/MonotoneChain.h>
 #include <geos/index/chain/MonotoneChainSelectAction.h>
+#include <geos/util/IllegalArgumentException.h>
 
 #include <cassert>
 
@@ -41,6 +42,28 @@ using geos::geom::util::GeometryMapper;
 namespace geos {
 namespace operation {
 namespace buffer {
+
+
+OffsetCurve::OffsetCurve(const Geometry& geom, double dist)
+    : inputGeom(geom)
+    , distance(dist)
+    , matchDistance(std::abs(dist)/NEARNESS_FACTOR)
+    , geomFactory(geom.getFactory())
+{
+    if (!std::isfinite(dist))
+        throw util::IllegalArgumentException("OffsetCurve distance must be a finite value");
+};
+
+OffsetCurve::OffsetCurve(const Geometry& geom, double dist, BufferParameters& bp)
+    : inputGeom(geom)
+    , distance(dist)
+    , bufferParams(bp)
+    , matchDistance(std::abs(dist)/NEARNESS_FACTOR)
+    , geomFactory(geom.getFactory())
+{
+    if (!std::isfinite(dist))
+        throw util::IllegalArgumentException("OffsetCurve distance must be a finite value");
+};
 
 /* public static */
 std::unique_ptr<Geometry>

--- a/src/operation/buffer/OffsetCurve.cpp
+++ b/src/operation/buffer/OffsetCurve.cpp
@@ -52,7 +52,7 @@ OffsetCurve::OffsetCurve(const Geometry& geom, double dist)
 {
     if (!std::isfinite(dist))
         throw util::IllegalArgumentException("OffsetCurve distance must be a finite value");
-};
+}
 
 OffsetCurve::OffsetCurve(const Geometry& geom, double dist, BufferParameters& bp)
     : inputGeom(geom)
@@ -63,7 +63,7 @@ OffsetCurve::OffsetCurve(const Geometry& geom, double dist, BufferParameters& bp
 {
     if (!std::isfinite(dist))
         throw util::IllegalArgumentException("OffsetCurve distance must be a finite value");
-};
+}
 
 /* public static */
 std::unique_ptr<Geometry>

--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -348,7 +348,13 @@ void GeosOp::run() {
 
     //------------------------
 
-    execute();
+    try {
+        execute();
+    }
+    catch (std::exception &e) {
+        std::cerr << "Run-time exception: " << e.what() << std::endl;
+        exit(1);
+    }
 
     if (args.isShowTime || args.isVerbose) {
         std::cout


### PR DESCRIPTION
Report exceptions in geosop instead of dying
References #661.