### PR TITLE
geosop: GeosOp.cpp: catch ParseException

### DIFF
--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -337,7 +337,13 @@ void GeosOp::run() {
     // ensure at least one op processed
     if (args.repeatNum < 1) args.repeatNum = 1;
 
-    auto geomsLoadA = loadInput("A", args.srcA, args.limitA);
+   std::vector<std::unique_ptr<Geometry>> geomsLoadA;
+    try {
+      geomsLoadA = loadInput("A", args.srcA, args.limitA);
+    } catch (geos::util::GEOSException & e) {
+      std::cout << e.what() << std::endl;
+      exit(1);
+    }
 
     //--- collect input into single geometry collection if required
     bool doCollect = args.isCollect || fun->isAggregate();
@@ -348,7 +354,12 @@ void GeosOp::run() {
         geomA = std::move(geomsLoadA);
     }
 
-    geomB = loadInput("B", args.srcB, -1);
+    try {
+      geomB = loadInput("B", args.srcB, -1);
+    } catch (geos::util::GEOSException & e) {
+      std::cout << e.what() << std::endl;
+      exit(1);
+    }
 
     //------------------------
 


### PR DESCRIPTION
geosop crashes when the WKT type is an unknown type.
Catching the exception solves this issue.

before:
```shell
$ ./build/bin/geosop intersection -a "LINESTRINGZ(1 1 -1, 1 1 1)" -b "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))" -f wkt
ABRT
$ ./build/bin/geosop intersection -a "LINESTRING(1 1 -1, 1 1 1)" -b "POLYGONZ((0 0, 0 2, 2 2, 2 0, 0 0))" -f wkt
ABRT
```

after:

```shell
$ ./build/bin/geosop intersection -a "LINESTRINGZ(1 1 -1, 1 1 1)" -b "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))" -f wkt
ParseException: Unknown type: 'LINESTRINGZ'
$ ./build/bin/geosop intersection -a "LINESTRING(1 1 -1, 1 1 1)" -b "POLYGONZ((0 0, 0 2, 2 2, 2 0, 0 0))" -f wkt
ParseException: Unknown type: 'POLYGONZ'
```


linestringz/polygonz could/must be accepted, but there is an issue for that.