### PR TITLE
Add link to Go bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ classes, e.g. `#include <geos/algorithm/distance/DiscreteHausdorffDistance.h>`.
 C++ usage examples can be found in [examples](examples/).
 
 
-### Scripting Language Bindings
+### Language Bindings
+
+#### Go
+
+Go bindings are available via [go-geos](https://github.com/twpayne/go-geos).
 
 #### Ruby
 


### PR DESCRIPTION
[`github.com/twpayne/go-geos`](https://github.com/twpayne/go-geos) provides a mature set of bindings to use GEOS from Go.