### PR TITLE
Add GEOSPreparedContainsXY to C API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,10 @@
 xxxx-xx-xx
 
 - New things:
-  - Polygonal coverage operations: CoverageValidator, CoveragePolygonValidator, 
+  - Polygonal coverage operations: CoverageValidator, CoveragePolygonValidator,
     CoverageGapFinder, CoverageUnion (JTS-900, Martin Davis & Paul Ramsey)
+  - CAPI: GEOSPreparedContainsXY, GEOSPreparedContainsProperlyXY,
+    GEOSPreparedIntersectsXY (GH-677, Dan Baston)
 
 - Fixes/Improvements:
   -

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1450,9 +1450,21 @@ extern "C" {
     }
 
     char
+    GEOSPreparedContainsXY(const geos::geom::prep::PreparedGeometry* pg1, double x, double y)
+    {
+        return GEOSPreparedContainsXY_r(handle, pg1, x, y);
+    }
+
+    char
     GEOSPreparedContainsProperly(const geos::geom::prep::PreparedGeometry* pg1, const Geometry* g2)
     {
         return GEOSPreparedContainsProperly_r(handle, pg1, g2);
+    }
+
+    char
+    GEOSPreparedContainsProperlyXY(const geos::geom::prep::PreparedGeometry* pg1, double x, double y)
+    {
+        return GEOSPreparedContainsProperlyXY_r(handle, pg1, x, y);
     }
 
     char
@@ -1483,6 +1495,12 @@ extern "C" {
     GEOSPreparedIntersects(const geos::geom::prep::PreparedGeometry* pg1, const Geometry* g2)
     {
         return GEOSPreparedIntersects_r(handle, pg1, g2);
+    }
+
+    char
+    GEOSPreparedIntersectsXY(const geos::geom::prep::PreparedGeometry* pg1, double x, double y)
+    {
+        return GEOSPreparedIntersectsXY_r(handle, pg1, x, y);
     }
 
     char

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1111,11 +1111,25 @@ extern char GEOS_DLL GEOSPreparedContains_r(
     const GEOSPreparedGeometry* pg1,
     const GEOSGeometry* g2);
 
+/** \see GEOSPreparedContainsXY */
+extern char GEOS_DLL GEOSPreparedContainsXY_r(
+        GEOSContextHandle_t handle,
+        const GEOSPreparedGeometry* pg1,
+        double x,
+        double y);
+
 /** \see GEOSPreparedContainsProperly */
 extern char GEOS_DLL GEOSPreparedContainsProperly_r(
     GEOSContextHandle_t handle,
     const GEOSPreparedGeometry* pg1,
     const GEOSGeometry* g2);
+
+/** \see GEOSPreparedContainsProperlyXY */
+extern char GEOS_DLL GEOSPreparedContainsProperlyXY_r(
+        GEOSContextHandle_t handle,
+        const GEOSPreparedGeometry* pg1,
+        double x,
+        double y);
 
 /** \see GEOSPreparedCoveredBy */
 extern char GEOS_DLL GEOSPreparedCoveredBy_r(
@@ -1146,6 +1160,13 @@ extern char GEOS_DLL GEOSPreparedIntersects_r(
     GEOSContextHandle_t handle,
     const GEOSPreparedGeometry* pg1,
     const GEOSGeometry* g2);
+
+/** \see GEOSPreparedIntersectsXY */
+extern char GEOS_DLL GEOSPreparedIntersectsXY_r(
+        GEOSContextHandle_t handle,
+        const GEOSPreparedGeometry* pg1,
+        double x,
+        double y);
 
 /** \see GEOSPreparedOverlaps */
 extern char GEOS_DLL GEOSPreparedOverlaps_r(
@@ -4156,7 +4177,7 @@ extern char GEOS_DLL GEOSCovers(const GEOSGeometry* g1, const GEOSGeometry* g2);
 * \param g1 Input geometry
 * \param g2 Input geometry
 * \returns 1 on true, 0 on false, 2 on exception
-* \see geos::geom::Geometry::coveredby
+* \see geos::geom::Geometry::coveredBy
 */
 extern char GEOS_DLL GEOSCoveredBy(const GEOSGeometry* g1, const GEOSGeometry* g2);
 
@@ -4285,7 +4306,21 @@ extern char GEOS_DLL GEOSPreparedContains(
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedGeometry do a high performance
+* Use a \ref GEOSPreparedGeometry do a high performance
+* calculation of whether the provided point is contained.
+* \param pg1 The prepared geometry
+* \param x x coordinate of point to test
+* \param y y coordinate of point to test
+* \returns 1 on true, 0 on false, 2 on exception
+* \see GEOSContains
+*/
+extern char GEOS_DLL GEOSPreparedContainsXY(
+        const GEOSPreparedGeometry* pg1,
+        double x,
+        double y);
+
+/**
+* Use a \ref GEOSPreparedGeometry do a high performance
 * calculation of whether the provided geometry is contained properly.
 * \param pg1 The prepared geometry
 * \param g2 The geometry to test
@@ -4295,6 +4330,20 @@ extern char GEOS_DLL GEOSPreparedContains(
 extern char GEOS_DLL GEOSPreparedContainsProperly(
     const GEOSPreparedGeometry* pg1,
     const GEOSGeometry* g2);
+
+/**
+* Use a \ref GEOSPreparedGeometry do a high performance
+* calculation of whether the provided point is contained properly.
+* \param pg1 The prepared geometry
+* \param x x coordinate of point to test
+* \param y y coordinate of point to test
+* \returns 1 on true, 0 on false, 2 on exception
+* \see GEOSContainsProperly
+*/
+extern char GEOS_DLL GEOSPreparedContainsProperlyXY(
+        const GEOSPreparedGeometry* pg1,
+        double x,
+        double y);
 
 /**
 * Using a \ref GEOSPreparedGeometry do a high performance
@@ -4333,31 +4382,45 @@ extern char GEOS_DLL GEOSPreparedCrosses(
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedDisjoint do a high performance
+* Use a \ref GEOSPreparedGeometry do a high performance
 * calculation of whether the provided geometry is disjoint.
 * \param pg1 The prepared geometry
 * \param g2 The geometry to test
 * \returns 1 on true, 0 on false, 2 on exception
-* \see GEOSDisjoin
+* \see GEOSDisjoint
 */
 extern char GEOS_DLL GEOSPreparedDisjoint(
     const GEOSPreparedGeometry* pg1,
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedDisjoint do a high performance
-* calculation of whether the provided geometry is disjoint.
+* Use a \ref GEOSPreparedGeometry do a high performance
+* calculation of whether the provided geometry intersects.
 * \param pg1 The prepared geometry
 * \param g2 The geometry to test
 * \returns 1 on true, 0 on false, 2 on exception
-* \see GEOSDisjoin
+* \see GEOSIntersects
 */
 extern char GEOS_DLL GEOSPreparedIntersects(
     const GEOSPreparedGeometry* pg1,
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedDisjoint do a high performance
+* Use a \ref GEOSPreparedGeometry do a high performance
+* calculation of whether the provided point intersects.
+* \param pg1 The prepared geometry
+* \param x x coordinate of point to test
+* \param y y coordinate of point to test
+* \returns 1 on true, 0 on false, 2 on exception
+* \see GEOSIntersects
+*/
+extern char GEOS_DLL GEOSPreparedIntersectsXY(
+        const GEOSPreparedGeometry* pg1,
+        double x,
+        double y);
+
+/**
+* Use a \ref GEOSPreparedGeometry do a high performance
 * calculation of whether the provided geometry overlaps.
 * \param pg1 The prepared geometry
 * \param g2 The geometry to test
@@ -4369,7 +4432,7 @@ extern char GEOS_DLL GEOSPreparedOverlaps(
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedDisjoint do a high performance
+* Use a \ref GEOSPreparedGeometry do a high performance
 * calculation of whether the provided geometry touches.
 * \param pg1 The prepared geometry
 * \param g2 The geometry to test
@@ -4381,7 +4444,7 @@ extern char GEOS_DLL GEOSPreparedTouches(
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedDisjoint do a high performance
+* Use a \ref GEOSPreparedGeometry do a high performance
 * calculation of whether the provided geometry is within.
 * \param pg1 The prepared geometry
 * \param g2 The geometry to test
@@ -4393,7 +4456,7 @@ extern char GEOS_DLL GEOSPreparedWithin(
     const GEOSGeometry* g2);
 
 /**
-* Using a \ref GEOSPreparedDisjoint do a high performance
+* Use a \ref GEOSPreparedGeometry do a high performance
 * calculation to find the nearest points between the
 * prepared and provided geometry.
 * \param pg1 The prepared geometry

--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -597,7 +597,12 @@ public:
      * @param y the y-coordinate of the point which this Envelope is being checked for containing
      * @return `true` if `(x, y)` lies in the interior or on the boundary of this Envelope.
      */
-    bool covers(double x, double y) const;
+    bool covers(double x, double y) const {
+        return x >= minx &&
+               x <= maxx &&
+               y >= miny &&
+               y <= maxy;
+    }
 
     /** \brief
      * Tests if the given point lies in or on the envelope.

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -844,7 +844,9 @@ public:
      * Notifies this Geometry that its Coordinates have been changed
      * by an external party.
      */
-    void geometryChangedAction();
+    void geometryChangedAction() {
+        envelope.reset();
+    }
 
 protected:
 

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -109,6 +109,12 @@ public:
      */
     std::unique_ptr<Geometry> getBoundary() const override;
 
+    void setXY(double x, double y) {
+        empty3d = empty2d = false;
+        coordinates.setAt({x, y}, 0);
+        geometryChangedAction();
+    }
+
     double getX() const;
     double getY() const;
     double getZ() const;

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -115,10 +115,14 @@ public:
         geometryChangedAction();
     }
 
+    const Coordinate* getCoordinate() const override {
+        return isEmpty() ? nullptr : &coordinates[0];
+    }
+
     double getX() const;
     double getY() const;
     double getZ() const;
-    const Coordinate* getCoordinate() const override;
+
     std::string getGeometryType() const override;
     GeometryTypeId getGeometryTypeId() const override;
     void apply_ro(CoordinateFilter* filter) const override;

--- a/src/geom/Envelope.cpp
+++ b/src/geom/Envelope.cpp
@@ -100,18 +100,6 @@ Envelope::Envelope(const std::string& str)
          strtod(values[3].c_str(), nullptr));
 }
 
-
-/*public*/
-bool
-Envelope::covers(double x, double y) const
-{
-    return x >= minx &&
-           x <= maxx &&
-           y >= miny &&
-           y <= maxy;
-}
-
-
 /*public*/
 bool
 Envelope::covers(const Envelope& other) const

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -218,18 +218,6 @@ Geometry::geometryChanged()
     apply_rw(&geometryChangedFilter);
 }
 
-/**
- * Notifies this Geometry that its Coordinates have been changed by an external
- * party. When geometryChanged is called, this method will be called for
- * this Geometry and its component Geometries.
- * @see apply(GeometryComponentFilter *)
- */
-void
-Geometry::geometryChangedAction()
-{
-    envelope.reset(nullptr);
-}
-
 bool
 Geometry::isValid() const
 {

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -157,12 +157,6 @@ Point::getZ() const
     return getCoordinate()->z;
 }
 
-const Coordinate*
-Point::getCoordinate() const
-{
-    return isEmpty() ? nullptr : &coordinates[0];
-}
-
 std::string
 Point::getGeometryType() const
 {

--- a/tests/unit/capi/GEOSPreparedGeometryTest.cpp
+++ b/tests/unit/capi/GEOSPreparedGeometryTest.cpp
@@ -422,6 +422,29 @@ void object::test<14>
     ensure_equals(ret, 2);
 }
 
+// Test XY variants
+template<>
+template<>
+void object::test<15>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))")    ;
+    prepGeom1_ = GEOSPrepare(geom1_);
+
+    ensure_equals(GEOSPreparedContainsXY(prepGeom1_, 0.5, 0.5), 1);
+    ensure_equals(GEOSPreparedContainsXY(prepGeom1_, 1.5, 0.5), 0);
+    ensure_equals(GEOSPreparedContainsXY(prepGeom1_, 0.75, 0.5), 1);
+
+    ensure_equals(GEOSPreparedContainsProperlyXY(prepGeom1_, 0.5, 0.5), 1);
+    ensure_equals(GEOSPreparedContainsProperlyXY(prepGeom1_, 0, 0), 0);
+    ensure_equals(GEOSPreparedContainsProperlyXY(prepGeom1_, 1.5, 0.5), 0);
+    ensure_equals(GEOSPreparedContainsProperlyXY(prepGeom1_, 0.75, 0.5), 1);
+
+    ensure_equals(GEOSPreparedIntersectsXY(prepGeom1_, 0.5, 0.5), 1);
+    ensure_equals(GEOSPreparedIntersectsXY(prepGeom1_, 1.5, 0.5), 0);
+    ensure_equals(GEOSPreparedIntersectsXY(prepGeom1_, 0.75, 0.5), 1);
+}
+
 
 } // namespace tut
 

--- a/tests/unit/geom/PointTest.cpp
+++ b/tests/unit/geom/PointTest.cpp
@@ -600,5 +600,27 @@ void object::test<46>
     ensure("point->getCoordinateDimension() == 2", point->getCoordinateDimension() == 2);
 }
 
+// test Point::setXY
+template<>
+template<>
+void object::test<47>
+()
+{
+    auto pt = factory_->createPoint();
+
+    pt->setXY(2, 3);
+
+    ensure("!pt->isEmpty()", !pt->isEmpty());
+
+    ensure_equals(pt->getX(), 2);
+    ensure_equals(pt->getY(), 3.0);
+    ensure(pt->getEnvelopeInternal()->contains(2, 3));
+
+    pt->setXY(7, 9);
+    ensure_equals(pt->getX(), 7);
+    ensure_equals(pt->getY(), 9);
+    ensure(pt->getEnvelopeInternal()->contains(7, 9));
+}
+
 } // namespace tut
 


### PR DESCRIPTION
This PR adds a function `GEOSPreparedXY` to the C API to allow point-in-polygon tests without the overhead of point construction. The significance of this overhead depends on the data. When checking many points against a complex boundary, this PR makes almost no difference:

```
bin/perf_geospreparedcontains ~/data/australia.txt 100000

# Performing 100000 point-in-polygon tests.
# Reading shapes from /home/dan/data/australia.txt
# Read 1 geometries.
# GEOSPreparedContains: 32931 hits from 100000 points in 202,552
# GEOSPreparedContainsXY: 32931 hits from 100000 points in 196,158
```

With smaller polygons, it makes a measurable improvement (about 20%)

```
bin/perf_geospreparedcontains ~/data/wsa_individual.wkt 500

# Performing 500 point-in-polygon tests.
# Reading shapes from /home/dan/data/wsa_individual.wkt
# Read 2768 geometries.
# GEOSPreparedContains: 672198 hits from 500 points in 239,358
# GEOSPreparedContainsXY: 672198 hits from 500 points in 186,093
```

The C++ code surrounding prepared geometries is relatively complex, so rather than modify it to thread a `Coordinate` object through, I modified the C API `GEOSContextHandle` to hold a mutable `Point` object.

The existing API for modifying a `Point` is rather complex and slow. This is the best I could do:

```
struct SetCoordinateValue : public geos::geom::CoordinateFilter {
        SetCoordinateValue(double x, double y) : m_x(x), m_y(y) {}

        void filter_rw(Coordinate *c) const override {
            c->x = m_x;
            c->y = m_y;
        }

        double m_x;
        double m_y;
    };

    SetCoordinateValue filter(x, y);
    extHandle->point2d->apply_rw(&filter);
    extHandle->point2d->geometryChanged();
```

So I added a `Point::setXY` method to make this easier and faster.

If there is general support for this approach, I can document the new function and add `XY` variants in other cases where they would be useful (`GEOSPreparedIntersectsXY`, etc.)