### PR TITLE
Fix PreparedGeometry for EMPTY elements

### DIFF
--- a/src/geom/prep/PreparedPolygonPredicate.cpp
+++ b/src/geom/prep/PreparedPolygonPredicate.cpp
@@ -47,6 +47,8 @@ struct LocationMatchingFilter : public GeometryComponentFilter {
     bool found;
 
     void filter_ro(const Geometry* g) override {
+        if (g->isEmpty())
+            return;
         const Coordinate* pt = g->getCoordinate();
         const auto loc = pt_locator->locate(pt);
 
@@ -69,6 +71,8 @@ struct LocationNotMatchingFilter : public GeometryComponentFilter {
     bool found;
 
     void filter_ro(const Geometry* g) override {
+        if (g->isEmpty())
+            return;
         const Coordinate* pt = g->getCoordinate();
         const auto loc = pt_locator->locate(pt);
 
@@ -93,6 +97,8 @@ struct OutermostLocationFilter : public GeometryComponentFilter {
     bool done;
 
     void filter_ro(const Geometry* g) override {
+        if (g->isEmpty())
+            return;
         const Coordinate* pt = g->getCoordinate();
         auto loc = pt_locator->locate(pt);
 

--- a/src/geom/util/ComponentCoordinateExtracter.cpp
+++ b/src/geom/util/ComponentCoordinateExtracter.cpp
@@ -28,6 +28,8 @@ ComponentCoordinateExtracter::ComponentCoordinateExtracter(std::vector<const Coo
 void
 ComponentCoordinateExtracter::filter_rw(Geometry* geom)
 {
+    if (geom->isEmpty())
+        return;
     if(geom->getGeometryTypeId() == geos::geom::GEOS_LINEARRING
             ||	geom->getGeometryTypeId() == geos::geom::GEOS_LINESTRING
             ||	geom->getGeometryTypeId() == geos::geom::GEOS_POINT) {
@@ -42,6 +44,8 @@ ComponentCoordinateExtracter::filter_rw(Geometry* geom)
 void
 ComponentCoordinateExtracter::filter_ro(const Geometry* geom)
 {
+    if (geom->isEmpty())
+        return;
     //if (	typeid( *geom ) == typeid( LineString )
     //	||	typeid( *geom ) == typeid( Point ) )
     if(geom->getGeometryTypeId() == geos::geom::GEOS_LINEARRING
@@ -64,4 +68,3 @@ ComponentCoordinateExtracter::getCoordinates(const Geometry& geom, std::vector<c
 } // namespace geos.geom.util
 } // namespace geos.geom
 } // namespace geos
-

--- a/src/noding/MCIndexSegmentSetMutualIntersector.cpp
+++ b/src/noding/MCIndexSegmentSetMutualIntersector.cpp
@@ -45,9 +45,10 @@ MCIndexSegmentSetMutualIntersector::addToIndex(SegmentString* segStr)
 void
 MCIndexSegmentSetMutualIntersector::addToMonoChains(SegmentString* segStr)
 {
+    if (segStr->size() == 0)
+        return;
     MonotoneChainBuilder::getChains(segStr->getCoordinates(),
                                     segStr, monoChains);
-
 }
 
 
@@ -75,6 +76,8 @@ MCIndexSegmentSetMutualIntersector::setBaseSegments(SegmentString::ConstVect* se
     // NOTE - mloskot: const qualifier is removed silently, dirty.
 
     for(const SegmentString* css: *segStrings) {
+        if (css->size() == 0)
+            continue;
         SegmentString* ss = const_cast<SegmentString*>(css);
         addToIndex(ss);
     }
@@ -117,4 +120,3 @@ MCIndexSegmentSetMutualIntersector::SegmentOverlapAction::overlap(
 
 } // geos::noding
 } // geos
-

--- a/tests/unit/geom/prep/PreparedGeometryTest.cpp
+++ b/tests/unit/geom/prep/PreparedGeometryTest.cpp
@@ -1,0 +1,71 @@
+//
+// Test Suite for PreparedGeometry methods
+
+// tut
+#include <tut/tut.hpp>
+#include <utility.h>
+// geos
+#include <geos/geom/prep/PreparedGeometryFactory.h>
+#include <geos/geom/prep/PreparedGeometry.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/Geometry.h>
+#include <geos/io/WKTReader.h>
+// std
+#include <memory>
+
+using namespace geos::geom;
+using geos::geom::prep::PreparedGeometry;
+
+namespace tut {
+
+//
+// Test Group
+//
+
+struct test_preparedgeometry_data {
+    typedef geos::geom::GeometryFactory GeometryFactory;
+
+    geos::geom::GeometryFactory::Ptr factory;
+    geos::io::WKTReader reader;
+    std::unique_ptr<geos::geom::Geometry> g1;
+    std::unique_ptr<geos::geom::Geometry> g2;
+    std::unique_ptr<PreparedGeometry> pg1;
+    std::unique_ptr<PreparedGeometry> pg2;
+
+    test_preparedgeometry_data()
+        : factory(GeometryFactory::create())
+        , reader(factory.get())
+        , g1(nullptr)
+        , g2(nullptr)
+        , pg1(nullptr)
+        , pg2(nullptr)
+    {}
+};
+
+typedef test_group<test_preparedgeometry_data> group;
+typedef group::object object;
+
+group test_preparedgeometry_data("geos::geom::prep::PreparedGeometry");
+
+//
+// Test Cases
+//
+
+// 1 - Check EMPTY elements are handled correctly
+// See https://trac.osgeo.org/postgis/ticket/5224
+template<>
+template<>
+void object::test<1>
+()
+{
+    g1 = reader.read( "MULTIPOLYGON (((9 9, 9 1, 1 1, 2 4, 7 7, 9 9)), EMPTY)" );
+    g2 = reader.read( "MULTIPOLYGON (((7 6, 7 3, 4 3, 7 6)), EMPTY)" );
+
+    pg1 = prep::PreparedGeometryFactory::prepare(g1.get());
+
+    ensure( pg1->intersects(g2.get()));
+    ensure( pg1->contains(g2.get()));
+    ensure( pg1->covers(g2.get()));
+}
+
+} // namespace tut


### PR DESCRIPTION
Fixes handling of EMPTY elements in PreparedGeometry methods, by add empty coordinate sequence guards in several places.

See https://github.com/locationtech/jts/pull/904