### PR TITLE
Fix RelateOp for empty geometry and closed linear geometry

### DIFF
--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -252,6 +252,8 @@ public:
     /// Construct a MultiPoint taking ownership of given arguments
     MultiPoint* createMultiPoint(std::vector<Geometry*>* newPoints) const;
 
+    std::unique_ptr<MultiPoint> createMultiPoint(std::vector<Coordinate> && newPoints) const;
+
     std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Point>> && newPoints) const;
 
     std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints) const;

--- a/include/geos/operation/BoundaryOp.h
+++ b/include/geos/operation/BoundaryOp.h
@@ -1,0 +1,120 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 ISciences LLC
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: operation/BoundaryOp.java fd5aebb
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/algorithm/BoundaryNodeRule.h>
+#include <geos/geom/Geometry.h>
+#include <map>
+
+namespace geos {
+namespace geom {
+class LineString;
+class MultiLineString;
+}
+}
+
+namespace geos {
+namespace operation {
+
+/**
+ * Computes the boundary of a Geometry.
+ * Allows specifying the BoundaryNodeRule to be used.
+ * This operation will always return a Geometry of the appropriate
+ * dimension for the boundary (even if the input geometry is empty).
+ * The boundary of zero-dimensional geometries (Points) is
+ * always the empty GeometryCollection.
+ *
+ * @author Martin Davis
+ * @version 1.7
+ */
+class GEOS_DLL BoundaryOp {
+
+public:
+  /**
+   * Creates a new instance for the given geometry.
+   *
+   * @param geom the input geometry
+   */
+  BoundaryOp(const geom::Geometry& geom);
+
+  /**
+   * Creates a new instance for the given geometry.
+   *
+   * @param geom the input geometry
+   * @param bnRule the Boundary Node Rule to use
+   */
+  BoundaryOp(const geom::Geometry& geom, const algorithm::BoundaryNodeRule& bnRule);
+
+ /**
+   * Computes a geometry representing the boundary of a geometry.
+   *
+   * @param g the input geometry
+   * @return the computed boundary
+   */
+  static std::unique_ptr<geom::Geometry> getBoundary(const geom::Geometry& g);
+
+  /**
+   * Computes a geometry representing the boundary of a geometry,
+   * using an explicit BoundaryNodeRule.
+   *
+   * @param g the input geometry
+   * @param bnRule the Boundary Node Rule to use
+   * @return the computed boundary
+   */
+  static std::unique_ptr<geom::Geometry> getBoundary(const geom::Geometry& g, const algorithm::BoundaryNodeRule& bnRule);
+
+  /**
+   * Tests if a geometry has a boundary (it is non-empty).
+   * The semantics are:
+   * <ul>
+   * <li>Empty geometries do not have boundaries.
+   * <li>Points do not have boundaries.
+   * <li>For linear geometries the existence of the boundary
+   * is determined by the BoundaryNodeRule.
+   * <li>Non-empty polygons always have a boundary.
+   * </ul>
+   *
+   * @param geom the geometry providing the boundary
+   * @param boundaryNodeRule  the Boundary Node Rule to use
+   * @return true if the boundary exists
+   */
+  static bool hasBoundary(const geom::Geometry& geom, const algorithm::BoundaryNodeRule& boundaryNodeRule);
+
+  /**
+   * Gets the computed boundary.
+   *
+   * @return the boundary geometry
+   */
+  std::unique_ptr<geom::Geometry> getBoundary();
+
+private:
+  const geom::Geometry& m_geom;
+  const geom::GeometryFactory& m_geomFact;
+  const algorithm::BoundaryNodeRule& m_bnRule;
+
+  std::unique_ptr<geom::Geometry> boundaryMultiLineString(const geom::MultiLineString& mLine);
+
+  std::vector<geom::Coordinate> computeBoundaryCoordinates(const geom::MultiLineString& mLine);
+
+  std::unique_ptr<geom::Geometry> boundaryLineString(const geom::LineString& line);
+};
+
+}
+}
+

--- a/include/geos/operation/relate/RelateComputer.h
+++ b/include/geos/operation/relate/RelateComputer.h
@@ -38,6 +38,9 @@
 
 // Forward declarations
 namespace geos {
+namespace algorithm {
+class BoundaryNodeRule;
+}
 namespace geom {
 class Geometry;
 }
@@ -110,7 +113,8 @@ private:
      * If the Geometries are disjoint, we need to enter their dimension and
      * boundary dimension in the Ext rows in the IM
      */
-    void computeDisjointIM(geom::IntersectionMatrix* imX);
+    void computeDisjointIM(geom::IntersectionMatrix* imX,
+                           const algorithm::BoundaryNodeRule& boundaryNodeRule);
 
     void labelNodeEdges();
 
@@ -118,6 +122,21 @@ private:
      * update the IM with the sum of the IMs for each component
      */
     void updateIM(geom::IntersectionMatrix& imX);
+
+    /**
+     * Compute the IM entry for the intersection of the boundary
+     * of a geometry with the Exterior.
+     * This is the nominal dimension of the boundary
+     * unless the boundary is empty, in which case it is {@link Dimension#FALSE}.
+     * For linear geometries the Boundary Node Rule determines
+     * whether the boundary is empty.
+     *
+     * @param geom the geometry providing the boundary
+     * @param boundaryNodeRule  the Boundary Node Rule to use
+     * @return the IM dimension entry
+     */
+    static int getBoundaryDim(const geom::Geometry& geom,
+                              const algorithm::BoundaryNodeRule& boundaryNodeRule);
 
     /**
      * Processes isolated edges by computing their labelling and adding them

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -493,6 +493,17 @@ GeometryFactory::createMultiPoint(std::vector<Geometry*>* newPoints) const
 }
 
 std::unique_ptr<MultiPoint>
+GeometryFactory::createMultiPoint(std::vector<Coordinate> && newPoints) const {
+    std::vector<std::unique_ptr<Geometry>> pts(newPoints.size());
+
+    for(std::size_t i = 0; i < newPoints.size(); ++i) {
+        pts[i].reset(createPoint(newPoints[i]));
+    }
+
+    return std::unique_ptr<MultiPoint>(new MultiPoint(std::move(pts), *this));
+}
+
+std::unique_ptr<MultiPoint>
 GeometryFactory::createMultiPoint(std::vector<std::unique_ptr<Point>> && newPoints) const
 {
     return std::unique_ptr<MultiPoint>(new MultiPoint(std::move(newPoints), *this));

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -35,6 +35,7 @@
 #include <geos/geom/Point.h>
 #include <geos/geom/MultiPoint.h> // for getBoundary
 #include <geos/geom/Envelope.h>
+#include <geos/operation/BoundaryOp.h>
 
 #include <algorithm>
 #include <typeinfo>
@@ -233,19 +234,8 @@ LineString::getGeometryType() const
 std::unique_ptr<Geometry>
 LineString::getBoundary() const
 {
-    if(isEmpty()) {
-        return std::unique_ptr<Geometry>(getFactory()->createMultiPoint());
-    }
-
-    // using the default OGC_SFS MOD2 rule, the boundary of a
-    // closed LineString is empty
-    if(isClosed()) {
-        return std::unique_ptr<Geometry>(getFactory()->createMultiPoint());
-    }
-    std::vector<std::unique_ptr<Point>> pts(2);
-    pts[0] = getStartPoint();
-    pts[1] = getEndPoint();
-    return getFactory()->createMultiPoint(std::move(pts));
+    operation::BoundaryOp bop(*this);
+    return bop.getBoundary();
 }
 
 bool

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -21,6 +21,7 @@
 #include <geos/geomgraph/GeometryGraph.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/MultiLineString.h>
+#include <geos/operation/BoundaryOp.h>
 
 #include <vector>
 #include <cassert>
@@ -89,13 +90,8 @@ MultiLineString::isClosed() const
 std::unique_ptr<Geometry>
 MultiLineString::getBoundary() const
 {
-    if(isEmpty()) {
-        return getFactory()->createGeometryCollection();
-    }
-
-    GeometryGraph gg(0, this);
-    CoordinateSequence* pts = gg.getBoundaryPoints();
-    return std::unique_ptr<Geometry>(getFactory()->createMultiPoint(*pts));
+    operation::BoundaryOp bop(*this);
+    return bop.getBoundary();
 }
 
 GeometryTypeId

--- a/src/operation/BoundaryOp.cpp
+++ b/src/operation/BoundaryOp.cpp
@@ -1,0 +1,173 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 ISciences LLC
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: operation/BoundaryOp.java fd5aebb
+ *
+ **********************************************************************/
+
+#include <geos/operation/BoundaryOp.h>
+#include <geos/algorithm/BoundaryNodeRule.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/MultiLineString.h>
+#include <map>
+
+using geos::geom::Coordinate;
+using geos::geom::Dimension;
+using geos::geom::Geometry;
+using geos::geom::LineString;
+using geos::geom::MultiLineString;
+using geos::geom::Point;
+using geos::algorithm::BoundaryNodeRule;
+
+namespace geos {
+namespace operation {
+
+BoundaryOp::BoundaryOp(const Geometry& geom) :
+    m_geom(geom),
+    m_geomFact(*geom.getFactory()),
+    m_bnRule(BoundaryNodeRule::getBoundaryRuleMod2())
+{}
+
+BoundaryOp::BoundaryOp(const geom::Geometry& geom, const algorithm::BoundaryNodeRule& bnRule) :
+    m_geom(geom),
+    m_geomFact(*geom.getFactory()),
+    m_bnRule(bnRule)
+{}
+
+std::unique_ptr<geom::Geometry>
+BoundaryOp::getBoundary()
+{
+    if (auto ls = dynamic_cast<const LineString*>(&m_geom)) {
+        return boundaryLineString(*ls);
+    }
+
+    if (auto mls = dynamic_cast<const MultiLineString*>(&m_geom)) {
+        return boundaryMultiLineString(*mls);
+    }
+
+    return m_geom.getBoundary();
+}
+
+std::unique_ptr<geom::Geometry>
+BoundaryOp::getBoundary(const geom::Geometry& g)
+{
+    BoundaryOp bop(g);
+    return bop.getBoundary();
+}
+
+std::unique_ptr<geom::Geometry>
+BoundaryOp::getBoundary(const geom::Geometry& g, const algorithm::BoundaryNodeRule& bnRule)
+{
+    BoundaryOp bop(g, bnRule);
+    return bop.getBoundary();
+}
+
+bool
+BoundaryOp::hasBoundary(const geom::Geometry& geom, const algorithm::BoundaryNodeRule& boundaryNodeRule)
+{
+    // Note that this does not handle geometry collections with a non-empty linear element
+    if (geom.isEmpty()) {
+        return false;
+    }
+
+    switch (geom.getDimension()) {
+        case Dimension::P: return false;
+        /**
+         * Linear geometries might have an empty boundary due to boundary node rule.
+         */
+        case Dimension::L:
+            {
+
+            auto boundary = getBoundary(geom, boundaryNodeRule);
+            return !boundary->isEmpty();
+            }
+        default:
+            return true;
+        }
+}
+
+std::unique_ptr<Geometry>
+BoundaryOp::boundaryLineString(const geom::LineString& line)
+{
+    if (m_geom.isEmpty()) {
+        return m_geomFact.createMultiPoint();
+    }
+
+    if (line.isClosed()) {
+        // check whether endpoints of valence 2 are on the boundary or not
+        bool closedEndpointOnBoundary = m_bnRule.isInBoundary(2);
+        if (closedEndpointOnBoundary) {
+            return line.getStartPoint();
+        }
+        else {
+            return m_geomFact.createMultiPoint();
+        }
+    }
+
+    std::vector<std::unique_ptr<Point>> pts(2);
+    pts[0] = line.getStartPoint();
+    pts[1] = line.getEndPoint();
+
+    return m_geomFact.createMultiPoint(std::move(pts));
+}
+
+std::unique_ptr<Geometry>
+BoundaryOp::boundaryMultiLineString(const geom::MultiLineString& mLine)
+{
+    if (m_geom.isEmpty()) {
+        return m_geomFact.createMultiPoint();
+    }
+
+    auto bdyPts = computeBoundaryCoordinates(mLine);
+
+    // return Point or MultiPoint
+    if (bdyPts.size() == 1) {
+        return std::unique_ptr<Geometry>(m_geomFact.createPoint(bdyPts[0]));
+    }
+    // this handles 0 points case as well
+    return m_geomFact.createMultiPoint(std::move(bdyPts));
+}
+
+std::vector<geom::Coordinate>
+BoundaryOp::computeBoundaryCoordinates(const geom::MultiLineString& mLine)
+{
+    std::vector<Coordinate> bdyPts;
+    std::map<Coordinate, int> endpointMap;
+
+    for (std::size_t i = 0; i < mLine.getNumGeometries(); i++) {
+      const LineString* line = mLine.getGeometryN(i);
+
+      if (line->getNumPoints() == 0) {
+        continue;
+      }
+
+      endpointMap[line->getCoordinateN(0)]++;
+      endpointMap[line->getCoordinateN(line->getNumPoints() - 1)]++;
+    }
+
+    for (const auto& entry: endpointMap) {
+        auto valence = entry.second;
+        if (m_bnRule.isInBoundary(valence)) {
+            bdyPts.push_back(entry.first);
+        }
+    }
+
+    return bdyPts;
+}
+
+
+}
+}

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -1234,4 +1234,21 @@ void object::test<36>
     }
 }
 
+// Test of
+// createMultiPoint(std::vector<Coordinate> &&)
+template<>
+template<>
+void object::test<37>
+()
+{
+    std::vector<geos::geom::Coordinate> coords;
+    coords.emplace_back(1, 1);
+    coords.emplace_back(2, 2);
+
+    auto mp = factory_->createMultiPoint(std::move(coords));
+
+    ensure_equals(mp->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT);
+    ensure_equals(mp->getNumGeometries(), 2u);
+}
+
 } // namespace tut

--- a/tests/unit/operation/BoundaryOpTest.cpp
+++ b/tests/unit/operation/BoundaryOpTest.cpp
@@ -1,0 +1,193 @@
+#include <tut/tut.hpp>
+// geos
+#include <geos/geom/Geometry.h>
+#include <geos/io/WKTReader.h>
+#include <geos/algorithm/BoundaryNodeRule.h>
+#include <geos/operation/BoundaryOp.h>
+// std
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <memory>
+
+using namespace geos::algorithm;
+using namespace geos::geom;
+using geos::operation::BoundaryOp;
+
+namespace tut {
+//----------------------------------------------
+// Test Group
+//----------------------------------------------
+
+struct test_boundaryop_data {
+    geos::io::WKTReader wktreader;
+
+    void runBoundaryTest(const std::string& wkt, const BoundaryNodeRule& bnRule, const std::string& wktExpected)
+    {
+        auto g = wktreader.read(wkt);
+        auto expected = wktreader.read(wktExpected);
+
+        BoundaryOp op(*g, bnRule);
+        auto boundary = op.getBoundary();
+
+        ensure(boundary->equals(expected.get()));
+    }
+
+    void checkHasBoundary(const std::string& wkt)
+    {
+        checkHasBoundary(wkt, BoundaryNodeRule::getBoundaryRuleMod2(), true);
+    }
+
+    void checkHasBoundary(const std::string& wkt, bool expected)
+    {
+        checkHasBoundary(wkt, BoundaryNodeRule::getBoundaryRuleMod2(), expected);
+    }
+
+    void checkHasBoundary(const std::string& wkt, const BoundaryNodeRule& bnRule, bool expected)
+    {
+        auto g = wktreader.read(wkt);
+        ensure_equals(expected, BoundaryOp::hasBoundary(*g, bnRule));
+    }
+
+};
+
+typedef test_group<test_boundaryop_data> group;
+typedef group::object object;
+
+group test_boundaryop_group("geos::operation::BoundaryOp");
+
+// test1
+template<>
+template<>
+void object::test<1>()
+{
+    std::string a = "MULTILINESTRING ((0 0, 10 10), (10 10, 20 20))";
+    // under MultiValent, the common point is the only point on the boundary
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryMultivalentEndPoint(),
+            "POINT (10 10)"  );
+}
+
+// test2LinesTouchAtEndpoint2
+template<>
+template<>
+void object::test<2>()
+{
+    std::string a = "MULTILINESTRING ((0 0, 10 10), (10 10, 20 20))";
+    // under Mod-2, the common point is not on the boundary
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryRuleMod2(),
+            "MULTIPOINT ((0 0), (20 20))" );
+    // under Endpoint, the common point is on the boundary
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryEndPoint(),
+            "MULTIPOINT ((0 0), (10 10), (20 20))"  );
+    // under MonoValent, the common point is not on the boundary
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryMonovalentEndPoint(),
+            "MULTIPOINT ((0 0), (20 20))"  );
+    // under MultiValent, the common point is the only point on the boundary
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryMultivalentEndPoint(),
+            "POINT (10 10)"  );
+}
+
+// test3LinesTouchAtEndpoint2
+template<>
+template<>
+void object::test<3>()
+{
+    std::string a = "MULTILINESTRING ((0 0, 10 10), (10 10, 20 20), (10 10, 10 20))";
+    // under Mod-2, the common point is on the boundary (3 mod 2 = 1)
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryRuleMod2(),
+            "MULTIPOINT ((0 0), (10 10), (10 20), (20 20))" );
+    // under Endpoint, the common point is on the boundary (it is an endpoint)
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryEndPoint(),
+            "MULTIPOINT ((0 0), (10 10), (10 20), (20 20))"  );
+    // under MonoValent, the common point is not on the boundary (it has valence > 1)
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryMonovalentEndPoint(),
+            "MULTIPOINT ((0 0), (10 20), (20 20))"  );
+    // under MultiValent, the common point is the only point on the boundary
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryMultivalentEndPoint(),
+            "POINT (10 10)"  );
+}
+
+// testMultiLinestd::stringWithRingTouchAtEndpoint
+template<>
+template<>
+void object::test<4>()
+{
+    std::string a = "MULTILINESTRING ((100 100, 20 20, 200 20, 100 100), (100 200, 100 100))";
+    // under Mod-2, the ring has no boundary, so the line intersects the interior ==> not simple
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryRuleMod2(),
+            "MULTIPOINT ((100 100), (100 200))" );
+    // under Endpoint, the ring has a boundary point, so the line does NOT intersect the interior ==> simple
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryEndPoint(),
+            "MULTIPOINT ((100 100), (100 200))"  );
+}
+
+// testRing
+template<>
+template<>
+void object::test<5>()
+{
+    std::string a = "LINESTRING (100 100, 20 20, 200 20, 100 100)";
+    // rings are simple under all rules
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryRuleMod2(),
+            "MULTIPOINT EMPTY");
+    runBoundaryTest(a, BoundaryNodeRule::getBoundaryEndPoint(),
+            "POINT (100 100)"  );
+}
+
+// testHasBoundaryPoint
+template<>
+template<>
+void object::test<6>()
+{
+    checkHasBoundary( "POINT (0 0)", false);
+}
+
+// testHasBoundaryPointEmpty
+template<>
+template<>
+void object::test<7>()
+{
+    checkHasBoundary( "POINT EMPTY", false);
+}
+
+// testHasBoundaryRingClosed
+template<>
+template<>
+void object::test<8>()
+{
+    checkHasBoundary( "LINESTRING (100 100, 20 20, 200 20, 100 100)", false);
+}
+
+// testHasBoundaryMultiLinestd::stringClosed
+template<>
+template<>
+void object::test<9>()
+{
+    checkHasBoundary( "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))", false);
+}
+
+// testHasBoundaryMultiLinestd::stringOpen
+template<>
+template<>
+void object::test<10>()
+{
+    checkHasBoundary( "MULTILINESTRING ((0 0, 0 2), (0 1, 1 1, 1 0, 0 0))");
+}
+
+// testHasBoundaryPolygon
+template<>
+template<>
+void object::test<11>()
+{
+    checkHasBoundary( "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))");
+}
+
+// testHasBoundaryPolygonEmpty
+template<>
+template<>
+void object::test<12>()
+{
+    checkHasBoundary( "POLYGON EMPTY", false);
+}
+
+}

--- a/tests/unit/operation/relate/RelateBoundaryNodeRuleTest.cpp
+++ b/tests/unit/operation/relate/RelateBoundaryNodeRuleTest.cpp
@@ -1,0 +1,130 @@
+#include <tut/tut.hpp>
+// geos
+#include <geos/geom/Geometry.h>
+#include <geos/io/WKTReader.h>
+#include <geos/algorithm/BoundaryNodeRule.h>
+#include <geos/operation/relate/RelateOp.h>
+// std
+#include <cmath>
+#include <string>
+#include <memory>
+
+using namespace geos::algorithm;
+using namespace geos::geom;
+using namespace geos::operation::relate;
+
+namespace tut {
+//----------------------------------------------
+// Test Group
+//----------------------------------------------
+
+struct test_relateboundarynoderule_data {
+    geos::io::WKTReader wktreader;
+
+    void runRelateTest(const std::string& wkt1, const std::string& wkt2, const BoundaryNodeRule& bnRule, const std::string& imExpected)
+    {
+        auto g1 = wktreader.read(wkt1);
+        auto g2 = wktreader.read(wkt2);
+
+        auto im = RelateOp::relate(g1.get(), g2.get(), bnRule);
+        auto imActual = im->toString();
+
+        ensure_equals(imExpected, imActual);
+    }
+};
+
+typedef test_group<test_relateboundarynoderule_data> group;
+typedef group::object object;
+
+group test_relateboundarynoderule_group("geos::operation::relate::RelateBoundaryNodeRule");
+
+// testMultiLineStringSelfIntTouchAtEndpoint
+template<>
+template<>
+void object::test<1>()
+{
+    std::string a = "MULTILINESTRING ((20 20, 100 100, 100 20, 20 100), (60 60, 60 140))";
+    std::string b = "LINESTRING (60 60, 20 60)";
+    // under EndPoint, A has a boundary node - A.bdy / B.bdy = 0
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryEndPoint(),  "FF1F00102");
+}
+
+// testLinestd::stringSelfIntTouchAtEndpoint
+template<>
+template<>
+void object::test<2>()
+{
+    std::string a = "LINESTRING (20 20, 100 100, 100 20, 20 100)";
+    std::string b = "LINESTRING (60 60, 20 60)";
+    // results for both rules are the same
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryOGCSFS(),   "F01FF0102");
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryEndPoint(),  "F01FF0102");
+}
+
+// testMultiLinestd::stringTouchAtEndpoint
+template<>
+template<>
+void object::test<3>()
+{
+    std::string a = "MULTILINESTRING ((0 0, 10 10), (10 10, 20 20))";
+    std::string b = "LINESTRING (10 10, 20 0)";
+
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryEndPoint(),  "FF1F00102");
+}
+
+// testLineRingTouchAtEndpoints
+template<>
+template<>
+void object::test<4>()
+{
+    std::string a = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+    std::string b = "LINESTRING (20 20, 20 100)";
+
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryMultivalentEndPoint(),  "0F1FFF1F2");
+}
+
+// testLineRingTouchAtEndpointAndInterior
+template<>
+template<>
+void object::test<5>()
+{
+    std::string a = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+    std::string b = "LINESTRING (20 20, 40 100)";
+
+    // this is the same result as for the above test
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryOGCSFS(),   "F01FFF102");
+    // this result is different - the A node is now on the boundary, so A.bdy/B.ext = 0
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryEndPoint(),  "F01FF0102");
+}
+
+// testPolygonEmptyRing
+template<>
+template<>
+void object::test<6>()
+{
+    std::string a = "POLYGON EMPTY";
+    std::string b = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+
+    // closed line has no boundary under SFS rule
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryOGCSFS(),   "FFFFFF1F2");
+
+    // closed line has boundary under ENDPOINT rule
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryEndPoint(),  "FFFFFF102");
+}
+
+// testPolygonEmptyMultiLinestd::stringClosed
+template<>
+template<>
+void object::test<7>()
+{
+    std::string a = "POLYGON EMPTY";
+    std::string b = "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))";
+
+    // closed line has no boundary under SFS rule
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryOGCSFS(),   "FFFFFF1F2");
+
+    // closed line has boundary under ENDPOINT rule
+    runRelateTest(a, b,  BoundaryNodeRule::getBoundaryEndPoint(),  "FFFFFF102");
+}
+
+}

--- a/tests/xmltester/tests/general/TestRelateLA.xml
+++ b/tests/xmltester/tests/general/TestRelateLA.xml
@@ -187,4 +187,30 @@
   </test>
 </case>
 
+<case>
+<desc>LA - closed line / empty polygon</desc>
+  <a>
+    LINESTRING(110 60, 20 150, 200 150, 110 60)
+  </a>
+  <b>
+    POLYGON EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
+
+<case>
+<desc>LA - closed multiline / empty polygon</desc>
+  <a>
+    MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))
+  </a>
+  <b>
+    POLYGON EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
+
 </run>

--- a/tests/xmltester/tests/general/TestRelateLL.xml
+++ b/tests/xmltester/tests/general/TestRelateLL.xml
@@ -307,5 +307,17 @@
   </test>
 </case>
 
+<case>
+<desc>LA - closed multiline / empty line</desc>
+  <a>
+    MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))
+  </a>
+  <b>
+    LINESTRING EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
 
 </run>


### PR DESCRIPTION
This PR fixes the following Trac ticket: https://trac.osgeo.org/geos/ticket/1096. It ports https://github.com/locationtech/jts/pull/671.

As a side effect, it brings along the `BoundaryOp` class that has been in JTS for some time, and its associated tests.