### PR TITLE
Improve CoverageUnion performance by pre-sorting inputs

### DIFF
--- a/include/geos/operation/union/CoverageUnion.h
+++ b/include/geos/operation/union/CoverageUnion.h
@@ -24,6 +24,7 @@ namespace geos {
     namespace geom {
         class Polygon;
         class LineString;
+        class LinearRing;
         class GeometryFactory;
     }
 }
@@ -39,11 +40,14 @@ namespace geounion {
     private:
         CoverageUnion() = default;
 
-        void extractSegments(const geom::Polygon* geom);
-        void extractSegments(const geom::Geometry* geom);
+        void extractRings(const geom::Polygon* geom);
+        void extractRings(const geom::Geometry* geom);
         void extractSegments(const geom::LineString* geom);
+        void sortRings();
 
         std::unique_ptr<geom::Geometry> polygonize(const geom::GeometryFactory* gf);
+
+        std::vector<const geom::LinearRing*> rings;
         std::unordered_set<geos::geom::LineSegment, geos::geom::LineSegment::HashCode> segments;
         static constexpr double AREA_PCT_DIFF_TOL = 1e-6;
     };

--- a/src/shape/fractal/HilbertEncoder.cpp
+++ b/src/shape/fractal/HilbertEncoder.cpp
@@ -59,34 +59,7 @@ HilbertEncoder::encode(const geom::Envelope* env)
 void
 HilbertEncoder::sort(std::vector<geom::Geometry*>& geoms)
 {
-    struct HilbertComparator {
-
-        HilbertEncoder& enc;
-
-        HilbertComparator(HilbertEncoder& e)
-            : enc(e) {};
-
-        bool
-        operator()(const geom::Geometry* a, const geom::Geometry* b)
-        {
-            return enc.encode(a->getEnvelopeInternal()) > enc.encode(b->getEnvelopeInternal());
-        }
-    };
-
-    geom::Envelope extent;
-    for (const geom::Geometry* geom: geoms)
-    {
-        if (extent.isNull())
-            extent = *(geom->getEnvelopeInternal());
-        else
-            extent.expandToInclude(*(geom->getEnvelopeInternal()));
-    }
-    if (extent.isNull()) return;
-
-    HilbertEncoder encoder(12, extent);
-    HilbertComparator hilbertCompare(encoder);
-    std::sort(geoms.begin(), geoms.end(), hilbertCompare);
-    return;
+    sort(geoms.begin(), geoms.end());
 }
 
 


### PR DESCRIPTION
This PR makes `CoverageUnion` pre-sort its inputs using `HilbertEncoder`. This improves performance by about 50% on my test data set:

Before:

```
bin/geosop -t -q -a ~/data/tl_2021_counties_unsorted.wkt coverageUnion
Ran 1 coverageUnion ops ( 8,092,118 vertices)  -- 4,654,931 usec    (GEOS 3.12.0dev)
```

After:

```
bin/geosop -t -q -a ~/data/tl_2021_counties_unsorted.wkt coverageUnion
Ran 1 coverageUnion ops ( 8,092,118 vertices)  -- 2,238,353 usec    (GEOS 3.12.0dev)
```