### PR TITLE
Refactor LineIntersector

### DIFF
--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -332,8 +332,6 @@ private:
      * Test whether a point lies in the envelopes of both input segments.
      * A correctly computed intersection point should return true
      * for this test.
-     * Since this test is for debugging purposes only, no attempt is
-     * made to optimize the envelope test.
      *
      * @return true if the input point lies within both
      *         input segment envelopes

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -260,29 +260,6 @@ public:
     }
 
     /** \brief
-     * Computes the intIndex'th intersection point in the direction of
-     * a specified input line segment
-     *
-     * @param segmentIndex is 0 or 1
-     * @param intIndex is 0 or 1
-     *
-     * @return the intIndex'th intersection point in the direction of the
-     *         specified input line segment
-     */
-    const geom::Coordinate& getIntersectionAlongSegment(std::size_t segmentIndex, std::size_t intIndex);
-
-    /** \brief
-     * Computes the index of the intIndex'th intersection point in the direction of
-     * a specified input line segment
-     *
-     * @param segmentIndex is 0 or 1
-     * @param intIndex is 0 or 1
-     *
-     * @return the index of the intersection point along the segment (0 or 1)
-     */
-    std::size_t getIndexAlongSegment(std::size_t segmentIndex, std::size_t intIndex);
-
-    /** \brief
      * Computes the "edge distance" of an intersection point along the specified
      * input line segment.
      *
@@ -318,8 +295,6 @@ private:
     std::size_t intLineIndex[2][2];
 
     bool isProperVar;
-    //Coordinate &pa;
-    //Coordinate &pb;
 
     bool
     isCollinear() const
@@ -335,10 +310,6 @@ private:
     {
         return hasIntersection() && !isProperVar;
     }
-
-    void computeIntLineIndex();
-
-    void computeIntLineIndex(std::size_t segmentIndex);
 
     uint8_t computeCollinearIntersection(const geom::Coordinate& p1, const geom::Coordinate& p2,
                                          const geom::Coordinate& q1, const geom::Coordinate& q2);

--- a/include/geos/geomgraph/Edge.h
+++ b/include/geos/geomgraph/Edge.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <cassert>
 
+#include <geos/algorithm/LineIntersector.h>
 #include <geos/geomgraph/GraphComponent.h> // for inheritance
 #include <geos/geomgraph/Depth.h> // for member
 #include <geos/geomgraph/EdgeIntersectionList.h> // for composition
@@ -43,7 +44,6 @@ class IntersectionMatrix;
 class Coordinate;
 }
 namespace algorithm {
-class LineIntersector;
 }
 namespace geomgraph {
 class Node;
@@ -209,16 +209,16 @@ public:
      * Adds EdgeIntersections for one or both
      * intersections found for a segment of an edge to the edge intersection list.
      */
-    virtual void addIntersections(algorithm::LineIntersector* li, std::size_t segmentIndex,
-                                  std::size_t geomIndex);
+    virtual void addIntersections(const algorithm::LineIntersector::IntersectionResult& result, std::size_t segmentIndex,
+                                  const geom::Coordinate& p0, const geom::Coordinate& p1);
 
     /// Add an EdgeIntersection for intersection intIndex.
     //
     /// An intersection that falls exactly on a vertex of the edge is normalized
     /// to use the higher of the two possible segmentIndexes
     ///
-    virtual void addIntersection(algorithm::LineIntersector* li, std::size_t segmentIndex,
-                                 std::size_t geomIndex, std::size_t intIndex);
+    virtual void addIntersection(const algorithm::LineIntersector::IntersectionResult& result, std::size_t segmentIndex,
+                                 const geom::Coordinate& p0, const geom::Coordinate& p1, std::size_t intIndex);
 
     /// Update the IM with the contribution for this component.
     //

--- a/include/geos/geomgraph/index/SegmentIntersector.h
+++ b/include/geos/geomgraph/index/SegmentIntersector.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <geos/geom/Coordinate.h> // for composition
+#include <geos/algorithm/LineIntersector.h>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -29,7 +30,6 @@
 // Forward declarations
 namespace geos {
 namespace algorithm {
-class LineIntersector;
 }
 namespace geomgraph {
 class Node;
@@ -71,15 +71,15 @@ private:
     /// Elements are externally owned
     std::array<std::vector<Node*>*, 2> bdyNodes;
 
-    bool isTrivialIntersection(Edge* e0, std::size_t segIndex0, Edge* e1, std::size_t segIndex1);
+    bool isTrivialIntersection(const algorithm::LineIntersector::IntersectionResult& result, Edge* e0, std::size_t segIndex0, Edge* e1, std::size_t segIndex1) const;
 
-    bool isBoundaryPoint(algorithm::LineIntersector* p_li,
+    bool isBoundaryPoint(const algorithm::LineIntersector::IntersectionResult& result ,
                          std::array<std::vector<Node*>*, 2>& tstBdyNodes)
     {
-        return isBoundaryPoint(p_li, tstBdyNodes[0]) || isBoundaryPoint(p_li, tstBdyNodes[1]);
+        return isBoundaryPoint(result, tstBdyNodes[0]) || isBoundaryPoint(result, tstBdyNodes[1]);
     };
 
-    bool isBoundaryPoint(algorithm::LineIntersector* li,
+    bool isBoundaryPoint(const algorithm::LineIntersector::IntersectionResult& result,
                          std::vector<Node*>* tstBdyNodes);
 
 public:

--- a/include/geos/noding/IntersectionAdder.h
+++ b/include/geos/noding/IntersectionAdder.h
@@ -25,6 +25,7 @@
 #include <cstdlib> // for abs()
 
 #include <geos/geom/Coordinate.h>
+#include <geos/algorithm/LineIntersector.h>
 #include <geos/noding/SegmentIntersector.h> // for inheritance
 
 // Forward declarations
@@ -33,7 +34,6 @@ namespace noding {
 class SegmentString;
 }
 namespace algorithm {
-class LineIntersector;
 }
 }
 
@@ -77,7 +77,8 @@ private:
      * Note that closed edges require a special check for the point
      * shared by the beginning and end segments.
      */
-    bool isTrivialIntersection(const SegmentString* e0, std::size_t segIndex0,
+    bool isTrivialIntersection(const algorithm::LineIntersector::IntersectionResult& result,
+                               const SegmentString* e0, std::size_t segIndex0,
                                const SegmentString* e1, std::size_t segIndex1);
 
     // Declare type as noncopyable

--- a/include/geos/noding/NodedSegmentString.h
+++ b/include/geos/noding/NodedSegmentString.h
@@ -154,11 +154,11 @@ public:
      * intersections found for a segment of an edge to the edge
      * intersection list.
      */
-    void addIntersections(algorithm::LineIntersector* li,
+    void addIntersections(const algorithm::LineIntersector::IntersectionResult& result,
         std::size_t segmentIndex, std::size_t geomIndex)
     {
-        for (std::size_t i = 0, n = li->getIntersectionNum(); i < n; ++i) {
-            addIntersection(li, segmentIndex, geomIndex, i);
+        for (std::size_t i = 0, n = result.getIntersectionNum(); i < n; ++i) {
+            addIntersection(result, segmentIndex, geomIndex, i);
         }
     };
 
@@ -169,13 +169,13 @@ public:
      * of the SegmentString is normalized
      * to use the higher of the two possible segmentIndexes
      */
-    void addIntersection(algorithm::LineIntersector* li,
+    void addIntersection(const algorithm::LineIntersector::IntersectionResult& result,
         std::size_t segmentIndex,
         std::size_t geomIndex, std::size_t intIndex)
     {
         ::geos::ignore_unused_variable_warning(geomIndex);
 
-        const geom::Coordinate& intPt = li->getIntersection(intIndex);
+        const geom::Coordinate& intPt = result.getIntersection(intIndex);
         addIntersection(intPt, segmentIndex);
     };
 

--- a/include/geos/noding/NodingValidator.h
+++ b/include/geos/noding/NodingValidator.h
@@ -84,7 +84,7 @@ private:
      * @return true if there is an intersection point which is not an
      *         endpoint of the segment p0-p1
      */
-    bool hasInteriorIntersection(const algorithm::LineIntersector& aLi,
+    bool hasInteriorIntersection(const algorithm::LineIntersector::IntersectionResult& result,
                                  const geom::Coordinate& p0, const geom::Coordinate& p1) const;
 
     // Declare type as noncopyable

--- a/include/geos/operation/valid/IsSimpleOp.h
+++ b/include/geos/operation/valid/IsSimpleOp.h
@@ -152,7 +152,7 @@ private:
         // bool hasEqualSegments;
         // bool hasInteriorEndpointInt;
 
-        bool findIntersection(
+        geom::Coordinate findIntersection(
             noding::SegmentString* ss0, std::size_t segIndex0,
             noding::SegmentString* ss1, std::size_t segIndex1,
             const geom::Coordinate& p00, const geom::Coordinate& p01,
@@ -169,7 +169,8 @@ private:
         */
         bool isIntersectionEndpoint(
             const noding::SegmentString* ss, std::size_t ssIndex,
-            const algorithm::LineIntersector& li, std::size_t liSegmentIndex) const;
+            const algorithm::LineIntersector::IntersectionResult& result,
+            const geom::Coordinate& endPt0) const;
 
         /**
         * Finds the vertex index in a segment of an intersection
@@ -180,7 +181,8 @@ private:
         * @return the vertex index (0 or 1) in the segment vertex of the intersection point
         */
         std::size_t intersectionVertexIndex(
-            const algorithm::LineIntersector& li, std::size_t segmentIndex) const;
+            const algorithm::LineIntersector::IntersectionResult& result,
+            const geom::Coordinate& endPt0) const;
 
     public:
 

--- a/include/geos/operation/valid/PolygonIntersectionAnalyzer.h
+++ b/include/geos/operation/valid/PolygonIntersectionAnalyzer.h
@@ -52,7 +52,7 @@ private:
     Coordinate invalidLocation;
     Coordinate doubleTouchLocation;
 
-    int findInvalidIntersection(
+    TopologyValidationError findInvalidIntersection(
         const SegmentString* ss0, std::size_t segIndex0,
         const SegmentString* ss1, std::size_t segIndex1);
 

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -131,48 +131,6 @@ LineIntersector::isSameSignAndNonZero(double a, double b)
     return (a < 0 && b < 0) || (a > 0 && b > 0);
 }
 
-/*private*/
-void
-LineIntersector::computeIntLineIndex()
-{
-    computeIntLineIndex(0);
-    computeIntLineIndex(1);
-}
-
-
-/*public*/
-const Coordinate&
-LineIntersector::getIntersectionAlongSegment(std::size_t segmentIndex, std::size_t intIndex)
-{
-    // lazily compute int line array
-    computeIntLineIndex();
-    return intPt[intLineIndex[segmentIndex][intIndex]];
-}
-
-/*public*/
-size_t
-LineIntersector::getIndexAlongSegment(std::size_t segmentIndex, std::size_t intIndex)
-{
-    computeIntLineIndex();
-    return intLineIndex[segmentIndex][intIndex];
-}
-
-/*private*/
-void
-LineIntersector::computeIntLineIndex(std::size_t segmentIndex)
-{
-    double dist0 = getEdgeDistance(segmentIndex, 0);
-    double dist1 = getEdgeDistance(segmentIndex, 1);
-    if(dist0 > dist1) {
-        intLineIndex[segmentIndex][0] = 0;
-        intLineIndex[segmentIndex][1] = 1;
-    }
-    else {
-        intLineIndex[segmentIndex][0] = 1;
-        intLineIndex[segmentIndex][1] = 0;
-    }
-}
-
 /*public*/
 double
 LineIntersector::getEdgeDistance(std::size_t segmentIndex, std::size_t intIndex) const

--- a/src/coverage/InvalidSegmentDetector.cpp
+++ b/src/coverage/InvalidSegmentDetector.cpp
@@ -89,20 +89,20 @@ InvalidSegmentDetector::isCollinearOrInterior(
     CoverageRing* adj, std::size_t indexAdj)
 {
     LineIntersector li;
-    li.computeIntersection(tgt0, tgt1, adj0, adj1);
+    auto result = li.computeIntersection(tgt0, tgt1, adj0, adj1);
 
     //-- segments do not interact
-    if (! li.hasIntersection())
+    if (!result.hasIntersection())
         return false;
 
     //-- If the segments are collinear, they do not match, so are invalid.
-    if (li.getIntersectionNum() == 2) {
+    if (result.getIntersectionNum() == 2) {
         //TODO: assert segments are not equal?
         return true;
     }
 
     //-- target segment crosses, or segments touch at non-endpoint
-    if (li.isProper() || li.isInteriorIntersection()) {
+    if (result.isProper() || result.isInterior()) {
         return true;
     }
 
@@ -112,7 +112,7 @@ InvalidSegmentDetector::isCollinearOrInterior(
      *
      * Check if the target segment lies in the interior of the adj ring.
      */
-    const Coordinate& intVertex = li.getIntersection(0);
+    const Coordinate& intVertex = result.getIntersection(0);
     bool isInterior = isInteriorSegment(intVertex, tgt0, tgt1, adj, indexAdj);
     return isInterior;
 }

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -249,9 +249,9 @@ Coordinate
 LineSegment::intersection(const LineSegment& line) const
 {
     algorithm::LineIntersector li;
-    li.computeIntersection(p0, p1, line.p0, line.p1);
-    if(li.hasIntersection()) {
-        return li.getIntersection(0);
+    auto result = li.computeIntersection(p0, p1, line.p0, line.p1);
+    if(result.hasIntersection()) {
+        return result.getIntersection(0);
     }
     Coordinate rv;
     rv.setNull();

--- a/src/geomgraph/Edge.cpp
+++ b/src/geomgraph/Edge.cpp
@@ -150,14 +150,10 @@ Edge::getCollapsedEdge()
 
 /*public*/
 void
-Edge::addIntersections(LineIntersector* li, std::size_t segmentIndex, std::size_t geomIndex)
+Edge::addIntersections(const LineIntersector::IntersectionResult& result, std::size_t segmentIndex, const Coordinate& p0, const Coordinate& p1)
 {
-#if GEOS_DEBUG
-    std::cerr << "[" << this << "] Edge::addIntersections(" << li->toString() << ", " << segmentIndex << ", " << geomIndex <<
-         ") called" << std::endl;
-#endif
-    for(std::size_t i = 0; i < li->getIntersectionNum(); ++i) {
-        addIntersection(li, segmentIndex, geomIndex, i);
+    for(std::size_t i = 0; i < result.getIntersectionNum(); ++i) {
+        addIntersection(result, segmentIndex, p0, p1, i);
     }
 
     testInvariant();
@@ -165,16 +161,18 @@ Edge::addIntersections(LineIntersector* li, std::size_t segmentIndex, std::size_
 
 /*public*/
 void
-Edge::addIntersection(LineIntersector* li,
-                      std::size_t segmentIndex, std::size_t geomIndex, std::size_t intIndex)
+Edge::addIntersection(const LineIntersector::IntersectionResult& result,
+                      std::size_t segmentIndex, const Coordinate& p0, const Coordinate& p1, std::size_t intIndex)
 {
 #if GEOS_DEBUG
     std::cerr << "[" << this << "] Edge::addIntersection(" << li->toString() << ", " << segmentIndex << ", " << geomIndex <<
               ", " << intIndex << ") called" << std::endl;
 #endif
-    const Coordinate& intPt = li->getIntersection(intIndex);
+    const Coordinate& intPt = result.getIntersection(intIndex);
     auto normalizedSegmentIndex = segmentIndex;
-    double dist = li->getEdgeDistance(geomIndex, intIndex);
+    //double dist = li->getEdgeDistance(geomIndex, intIndex);
+
+    double dist = LineIntersector::computeEdgeDistance(intPt, p0, p1);
 
     // normalize the intersection point location
     auto nextSegIndex = normalizedSegmentIndex + 1;

--- a/src/noding/IntersectionAdder.cpp
+++ b/src/noding/IntersectionAdder.cpp
@@ -30,14 +30,15 @@ namespace noding { // geos.noding
 
 /*private*/
 bool
-IntersectionAdder::isTrivialIntersection(const SegmentString* e0,
-        std::size_t segIndex0, const SegmentString* e1, std::size_t segIndex1)
+IntersectionAdder::isTrivialIntersection(const algorithm::LineIntersector::IntersectionResult& result,
+                                         const SegmentString* e0, std::size_t segIndex0,
+                                         const SegmentString* e1, std::size_t segIndex1)
 {
     if(e0 != e1) {
         return false;
     }
 
-    if(li.getIntersectionNum() != 1) {
+    if(result.getIntersectionNum() != 1) {
         return false;
     }
 
@@ -77,18 +78,17 @@ IntersectionAdder::processIntersections(
     const Coordinate& p10 = e1->getCoordinate(segIndex1);
     const Coordinate& p11 = e1->getCoordinate(segIndex1 + 1);
 
-    li.computeIntersection(p00, p01, p10, p11);
-//if (li.hasIntersection() && li.isProper()) Debug.println(li);
+    const auto& result = li.computeIntersection(p00, p01, p10, p11);
 
     // No intersection, nothing to do
-    if(! li.hasIntersection()) {
+    if(!result.hasIntersection()) {
         return;
     }
 
     //intersectionFound = true;
     numIntersections++;
 
-    if(li.isInteriorIntersection()) {
+    if(result.isInterior()) {
         numInteriorIntersections++;
         hasInterior = true;
     }
@@ -97,19 +97,19 @@ IntersectionAdder::processIntersections(
     // one trivial intersection,
     // the shared endpoint.  Don't bother adding it if it
     // is the only intersection.
-    if(! isTrivialIntersection(e0, segIndex0, e1, segIndex1)) {
+    if(! isTrivialIntersection(result, e0, segIndex0, e1, segIndex1)) {
         hasIntersectionVar = true;
 
         NodedSegmentString* ee0 = detail::down_cast<NodedSegmentString*>(e0);
         NodedSegmentString* ee1 = detail::down_cast<NodedSegmentString*>(e1);
-        ee0->addIntersections(&li, segIndex0, 0);
-        ee1->addIntersections(&li, segIndex1, 1);
+        ee0->addIntersections(result, segIndex0, 0);
+        ee1->addIntersections(result, segIndex1, 1);
 
-        if(li.isProper()) {
+        if(result.isProper()) {
             numProperIntersections++;
             //Debug.println(li.toString());
             //Debug.println(li.getIntersection(0));
-            properIntersectionPoint = li.getIntersection(0);
+            properIntersectionPoint = result.getIntersection(0);
             hasProper = true;
             hasProperInterior = true;
         }

--- a/src/noding/IntersectionFinderAdder.cpp
+++ b/src/noding/IntersectionFinderAdder.cpp
@@ -45,20 +45,17 @@ IntersectionFinderAdder::processIntersections(
     const Coordinate& p10 = e1->getCoordinate(segIndex1);
     const Coordinate& p11 = e1->getCoordinate(segIndex1 + 1);
 
-    li.computeIntersection(p00, p01, p10, p11);
-//if (li.hasIntersection() && li.isProper()) Debug.println(li);
+    const auto& result = li.computeIntersection(p00, p01, p10, p11);
 
-    if(li.hasIntersection()) {
-        if(li.isInteriorIntersection()) {
-            for(std::size_t intIndex = 0, n = li.getIntersectionNum(); intIndex < n; ++intIndex) {
-                interiorIntersections.push_back(li.getIntersection(intIndex));
-            }
-
-            NodedSegmentString* ee0 = detail::down_cast<NodedSegmentString*>(e0);
-            NodedSegmentString* ee1 = detail::down_cast<NodedSegmentString*>(e1);
-            ee0->addIntersections(&li, segIndex0, 0);
-            ee1->addIntersections(&li, segIndex1, 1);
+    if(result.isInterior()) {
+        for(std::size_t intIndex = 0, n = result.getIntersectionNum(); intIndex < n; ++intIndex) {
+            interiorIntersections.push_back(result.getIntersection(intIndex));
         }
+
+        NodedSegmentString* ee0 = detail::down_cast<NodedSegmentString*>(e0);
+        NodedSegmentString* ee1 = detail::down_cast<NodedSegmentString*>(e1);
+        ee0->addIntersections(result, segIndex0, 0);
+        ee1->addIntersections(result, segIndex1, 1);
     }
 }
 

--- a/src/noding/NodingIntersectionFinder.cpp
+++ b/src/noding/NodingIntersectionFinder.cpp
@@ -71,11 +71,11 @@ NodingIntersectionFinder::processIntersections(
     bool isEnd10 = segIndex1 == 0;
     bool isEnd11 = segIndex1 + 2 == e1->size();
 
-    li.computeIntersection(p00, p01, p10, p11);
+    const auto& result = li.computeIntersection(p00, p01, p10, p11);
     /**
      * Check for an intersection in the interior of a segment
      */
-    bool isInteriorInt = li.hasIntersection() && li.isInteriorIntersection();
+    bool isInteriorInt = result.isInterior();
     /**
      * Check for an intersection between two vertices which are not both endpoints.
      */
@@ -91,7 +91,7 @@ NodingIntersectionFinder::processIntersections(
         intSegments.push_back(p10);
         intSegments.push_back(p11);
 
-        interiorIntersection = li.getIntersection(0);
+        interiorIntersection = result.getIntersection(0);
         // TODO: record endpoint intersection(s)
         // if (keepIntersections) intersections.add(interiorIntersection);
         intersectionCount++;

--- a/src/noding/NodingValidator.cpp
+++ b/src/noding/NodingValidator.cpp
@@ -126,11 +126,11 @@ NodingValidator::checkInteriorIntersections(
     const Coordinate& p10 = e1.getCoordinates()->getAt(segIndex1);
     const Coordinate& p11 = e1.getCoordinates()->getAt(segIndex1 + 1);
 
-    li.computeIntersection(p00, p01, p10, p11);
-    if(li.hasIntersection()) {
-        if(li.isProper()
-                || hasInteriorIntersection(li, p00, p01)
-                || hasInteriorIntersection(li, p10, p11)) {
+    const auto& result = li.computeIntersection(p00, p01, p10, p11);
+    if(result.hasIntersection()) {
+        if(result.isProper()
+                || hasInteriorIntersection(result, p00, p01)
+                || hasInteriorIntersection(result, p10, p11)) {
             throw util::TopologyException(
                 "found non-noded intersection at "
                 + p00.toString() + "-" + p01.toString()
@@ -183,11 +183,11 @@ NodingValidator::checkEndPtVertexIntersections(const Coordinate& testPt,
 
 /* private */
 bool
-NodingValidator::hasInteriorIntersection(const LineIntersector& aLi,
+NodingValidator::hasInteriorIntersection(const LineIntersector::IntersectionResult& result,
         const Coordinate& p0, const Coordinate& p1) const
 {
-    for(std::size_t i = 0, n = aLi.getIntersectionNum(); i < n; ++i) {
-        const Coordinate& intPt = aLi.getIntersection(i);
+    for(std::size_t i = 0, n = result.getIntersectionNum(); i < n; ++i) {
+        const Coordinate& intPt = result.getIntersection(i);
         if(!(intPt == p0 || intPt == p1)) {
             return true;
         }

--- a/src/noding/SegmentIntersectionDetector.cpp
+++ b/src/noding/SegmentIntersectionDetector.cpp
@@ -42,13 +42,13 @@ processIntersections(
     const geom::Coordinate& p10 = (*e1->getCoordinates())[ segIndex1 ];
     const geom::Coordinate& p11 = (*e1->getCoordinates())[ segIndex1 + 1 ];
 
-    li->computeIntersection(p00, p01, p10, p11);
+    const auto& result = li->computeIntersection(p00, p01, p10, p11);
 
-    if(li->hasIntersection()) {
+    if(result.hasIntersection()) {
         // record intersection info
         _hasIntersection = true;
 
-        bool isProper = li->isProper();
+        bool isProper = result.isProper();
 
         if(isProper) {
             _hasProperIntersection = true;
@@ -68,7 +68,7 @@ processIntersections(
 
         if(!intPt || saveLocation) {
             // record intersection location (approximate)
-            intPt = &li->getIntersection(0);
+            intPt = &result.getIntersection(0);
 
             delete intSegments;
 

--- a/src/noding/snap/SnappingIntersectionAdder.cpp
+++ b/src/noding/snap/SnappingIntersectionAdder.cpp
@@ -58,14 +58,14 @@ SnappingIntersectionAdder::processIntersections(SegmentString* seg0, std::size_t
      * due to the shared vertex of adjacent segments.
      */
     if (!isAdjacent(seg0, segIndex0, seg1, segIndex1)) {
-        li.computeIntersection(p00, p01, p10, p11);
+        const auto& result = li.computeIntersection(p00, p01, p10, p11);
         /**
          * Process single point intersections only.
          * Two-point (collinear) ones are handled by the near-vertex code
          */
-        if (li.hasIntersection() && li.getIntersectionNum() == 1) {
+        if (result.hasIntersection() && result.getIntersectionNum() == 1) {
 
-            const Coordinate& intPt = li.getIntersection(0);
+            const Coordinate& intPt = result.getIntersection(0);
             const Coordinate& snapPt = snapPointIndex.snap(intPt);
 
             static_cast<NodedSegmentString*>(seg0)->addIntersection(snapPt, segIndex0);

--- a/src/noding/snapround/HotPixel.cpp
+++ b/src/noding/snapround/HotPixel.cpp
@@ -221,20 +221,20 @@ HotPixel::intersectsPixelClosure(const Coordinate& p0, const Coordinate& p1) con
     corner[LOWER_LEFT]  = Coordinate(minx, miny);
     corner[LOWER_RIGHT] = Coordinate(maxx, miny);
 
-    li.computeIntersection(p0, p1, corner[UPPER_RIGHT], corner[UPPER_LEFT]);
-    if (li.hasIntersection()) {
+    auto result = li.computeIntersection(p0, p1, corner[UPPER_RIGHT], corner[UPPER_LEFT]);
+    if (result.hasIntersection()) {
         return true;
     }
-    li.computeIntersection(p0, p1, corner[UPPER_LEFT], corner[LOWER_LEFT]);
-    if (li.hasIntersection()) {
+    result = li.computeIntersection(p0, p1, corner[UPPER_LEFT], corner[LOWER_LEFT]);
+    if (result.hasIntersection()) {
         return true;
     }
-    li.computeIntersection(p0, p1, corner[LOWER_LEFT], corner[LOWER_RIGHT]);
-    if (li.hasIntersection()) {
+    result = li.computeIntersection(p0, p1, corner[LOWER_LEFT], corner[LOWER_RIGHT]);
+    if (result.hasIntersection()) {
         return true;
     }
-    li.computeIntersection(p0, p1, corner[LOWER_RIGHT], corner[UPPER_RIGHT]);
-    if (li.hasIntersection()) {
+    result = li.computeIntersection(p0, p1, corner[LOWER_RIGHT], corner[UPPER_RIGHT]);
+    if (result.hasIntersection()) {
         return true;
     }
 

--- a/src/noding/snapround/SnapRoundingIntersectionAdder.cpp
+++ b/src/noding/snapround/SnapRoundingIntersectionAdder.cpp
@@ -52,17 +52,15 @@ SnapRoundingIntersectionAdder::processIntersections(
     const Coordinate& p10 = e1->getCoordinate(segIndex1);
     const Coordinate& p11 = e1->getCoordinate(segIndex1 + 1);
 
-    li.computeIntersection(p00, p01, p10, p11);
-    if (li.hasIntersection()) {
-        if (li.isInteriorIntersection()) {
-            for (std::size_t intIndex = 0, intNum = li.getIntersectionNum(); intIndex < intNum; intIndex++) {
-                // Take a copy of the intersection coordinate
-                intersections->emplace_back(li.getIntersection(intIndex));
-            }
-            static_cast<NodedSegmentString*>(e0)->addIntersections(&li, segIndex0, 0);
-            static_cast<NodedSegmentString*>(e1)->addIntersections(&li, segIndex1, 1);
-            return;
+    const auto& result = li.computeIntersection(p00, p01, p10, p11);
+    if (result.isInterior()) {
+        for (std::size_t intIndex = 0, intNum = result.getIntersectionNum(); intIndex < intNum; intIndex++) {
+            // Take a copy of the intersection coordinate
+            intersections->emplace_back(result.getIntersection(intIndex));
         }
+        static_cast<NodedSegmentString*>(e0)->addIntersections(result, segIndex0, 0);
+        static_cast<NodedSegmentString*>(e1)->addIntersections(result, segIndex1, 1);
+        return;
     }
 
     /**

--- a/src/operation/buffer/OffsetSegmentGenerator.cpp
+++ b/src/operation/buffer/OffsetSegmentGenerator.cpp
@@ -320,8 +320,8 @@ OffsetSegmentGenerator::addCollinear(bool addStartPoint)
      * but the situation of exact collinearity should be fairly rare.
      */
 
-    li.computeIntersection(s0, s1, s1, s2);
-    auto numInt = li.getIntersectionNum();
+    const auto& result = li.computeIntersection(s0, s1, s1, s2);
+    auto numInt = result.getIntersectionNum();
 
     /*
      * if numInt is<2, the lines are parallel and in the same direction.
@@ -398,9 +398,9 @@ OffsetSegmentGenerator::addInsideTurn(int orientation, bool addStartPoint)
     ::geos::ignore_unused_variable_warning(addStartPoint);
 
     // add intersection point of offset segments (if any)
-    li.computeIntersection(offset0.p0, offset0.p1, offset1.p0, offset1.p1);
-    if(li.hasIntersection()) {
-        segList.addPt(li.getIntersection(0));
+    const auto& result = li.computeIntersection(offset0.p0, offset0.p1, offset1.p0, offset1.p1);
+    if(result.hasIntersection()) {
+        segList.addPt(result.getIntersection(0));
         return;
     }
 

--- a/src/operation/overlay/OverlayOp.cpp
+++ b/src/operation/overlay/OverlayOp.cpp
@@ -507,8 +507,8 @@ OverlayOp::mergeZ(Node* n, const LineString* line) const
     for(std::size_t i = 1, size = pts->size(); i < size; ++i) {
         const Coordinate& p0 = pts->getAt(i - 1);
         const Coordinate& p1 = pts->getAt(i);
-        p_li.computeIntersection(p, p0, p1);
-        if(p_li.hasIntersection()) {
+        const auto& result = p_li.computeIntersection(p, p0, p1);
+        if(result.hasIntersection()) {
             if(p == p0) {
                 n->addZ(p0.z);
             }

--- a/src/operation/predicate/SegmentIntersectionTester.cpp
+++ b/src/operation/predicate/SegmentIntersectionTester.cpp
@@ -64,8 +64,8 @@ SegmentIntersectionTester::hasIntersection(
             const Coordinate& pt10 = seq1.getAt(j - 1);
             const Coordinate& pt11 = seq1.getAt(j);
 
-            li.computeIntersection(pt00, pt01, pt10, pt11);
-            if(li.hasIntersection()) {
+            const auto& result = li.computeIntersection(pt00, pt01, pt10, pt11);
+            if(result.hasIntersection()) {
                 hasIntersectionVar = true;
             }
         }
@@ -103,8 +103,8 @@ SegmentIntersectionTester::hasIntersectionWithEnvelopeFilter(
             const Coordinate& pt00 = seq0.getAt(j - 1);
             const Coordinate& pt01 = seq0.getAt(j);
 
-            li.computeIntersection(pt00, pt01, pt10, pt11);
-            if(li.hasIntersection()) {
+            const auto& result = li.computeIntersection(pt00, pt01, pt10, pt11);
+            if(result.hasIntersection()) {
                 hasIntersectionVar = true;
             }
         }

--- a/src/operation/valid/PolygonTopologyAnalyzer.cpp
+++ b/src/operation/valid/PolygonTopologyAnalyzer.cpp
@@ -179,8 +179,8 @@ PolygonTopologyAnalyzer::intersectingSegIndex(const CoordinateSequence* ringPts,
 {
     algorithm::LineIntersector li;
     for (std::size_t i = 0; i < ringPts->size() - 1; i++) {
-      li.computeIntersection(*pt, ringPts->getAt(i), ringPts->getAt(i+1));
-      if (li.hasIntersection()) {
+      const auto& result = li.computeIntersection(*pt, ringPts->getAt(i), ringPts->getAt(i+1));
+      if (result.hasIntersection()) {
         //-- check if pt is the start point of the next segment
         if (pt->equals2D(ringPts->getAt(i + 1))) {
           return i + 1;

--- a/src/simplify/TaggedLineStringSimplifier.cpp
+++ b/src/simplify/TaggedLineStringSimplifier.cpp
@@ -229,8 +229,8 @@ TaggedLineStringSimplifier::hasInteriorIntersection(
     const LineSegment& seg0,
     const LineSegment& seg1) const
 {
-    li->computeIntersection(seg0.p0, seg0.p1, seg1.p0, seg1.p1);
-    return li->isInteriorIntersection();
+    const auto& result = li->computeIntersection(seg0.p0, seg0.p1, seg1.p0, seg1.p1);
+    return result.isInterior();
 }
 
 /*private*/

--- a/src/triangulate/tri/Tri.cpp
+++ b/src/triangulate/tri/Tri.cpp
@@ -223,6 +223,7 @@ Tri::validateAdjacent(TriIndex index)
     // assert(e1.equals2D(n0)); // Edge coord not equal
 
     //--- check that no edges cross
+#ifndef NDEBUG
     algorithm::LineIntersector li;
     for (TriIndex i = 0; i < 3; i++) {
         for (TriIndex j = 0; j < 3; j++) {
@@ -230,10 +231,11 @@ Tri::validateAdjacent(TriIndex index)
             const Coordinate& p01 = getCoordinate(next(i));
             const Coordinate& p10 = tri->getCoordinate(j);
             const Coordinate& p11 = tri->getCoordinate(next(j));
-            li.computeIntersection(p00,  p01,  p10, p11);
-            assert(!li.isProper());
+            auto result = li.computeIntersection(p00,  p01,  p10, p11);
+            assert(!result.isProper());
         }
     }
+#endif
 }
 
 /* public */

--- a/tests/unit/algorithm/RobustLineIntersectionTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectionTest.cpp
@@ -62,9 +62,9 @@ struct test_robustlineintersection_data {
                       double distanceTolerance)
     {
         geos::algorithm::LineIntersector li;
-        li.computeIntersection(pt[0], pt[1], pt[2], pt[3]);
+        auto result = li.computeIntersection(pt[0], pt[1], pt[2], pt[3]);
 
-        auto intNum = li.getIntersectionNum();
+        auto intNum = result.getIntersectionNum();
         ensure_equals(intNum, expectedIntersectionNum);
 
         if(intPt.empty()) {
@@ -76,32 +76,32 @@ struct test_robustlineintersection_data {
         // test that both points are represented here
         //bool isIntPointsCorrect = true;
         if(intNum == 1) {
-            checkIntPoints(intPt[0], li.getIntersection(0),
+            checkIntPoints(intPt[0], result.getIntersection(0),
                            distanceTolerance);
         }
         else if(intNum == 2) {
-            checkIntPoints(intPt[0], li.getIntersection(0),
+            checkIntPoints(intPt[0], result.getIntersection(0),
                            distanceTolerance);
-            checkIntPoints(intPt[1], li.getIntersection(0),
+            checkIntPoints(intPt[1], result.getIntersection(0),
                            distanceTolerance);
 
             if(!(
-                        equals(intPt[0], li.getIntersection(0), distanceTolerance)
+                        equals(intPt[0], result.getIntersection(0), distanceTolerance)
                         ||
-                        equals(intPt[0], li.getIntersection(1), distanceTolerance))) {
-                checkIntPoints(intPt[0], li.getIntersection(0),
+                        equals(intPt[0], result.getIntersection(1), distanceTolerance))) {
+                checkIntPoints(intPt[0], result.getIntersection(0),
                                distanceTolerance);
-                checkIntPoints(intPt[0], li.getIntersection(1),
+                checkIntPoints(intPt[0], result.getIntersection(1),
                                distanceTolerance);
             }
 
             else if(!(
-                        equals(intPt[1], li.getIntersection(0), distanceTolerance)
+                        equals(intPt[1], result.getIntersection(0), distanceTolerance)
                         ||
-                        equals(intPt[1], li.getIntersection(1), distanceTolerance))) {
-                checkIntPoints(intPt[1], li.getIntersection(0),
+                        equals(intPt[1], result.getIntersection(1), distanceTolerance))) {
+                checkIntPoints(intPt[1], result.getIntersection(0),
                                distanceTolerance);
-                checkIntPoints(intPt[1], li.getIntersection(1),
+                checkIntPoints(intPt[1], result.getIntersection(1),
                                distanceTolerance);
             }
         }

--- a/tests/unit/algorithm/RobustLineIntersectorTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectorTest.cpp
@@ -65,13 +65,14 @@ void object::test<1>
     Coordinate q1(20, 10);
     Coordinate q2(10, 20);
     Coordinate x(15, 15);
-    i.computeIntersection(p1, p2, q1, q2);
+    auto result = i.computeIntersection(p1, p2, q1, q2);
 
-    ensure_equals(i.getIntersectionNum(), (unsigned int)LineIntersector::POINT_INTERSECTION);
-    ensure_equals(i.getIntersectionNum(), 1UL);
-    ensure_equals(i.getIntersection(0), x);
-    ensure("isProper", i.isProper());
-    ensure("hasIntersection", i.hasIntersection());
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), (unsigned int)LineIntersector::POINT_INTERSECTION);
+    ensure_equals(result.getIntersectionNum(), 1UL);
+    ensure_equals(result.getIntersection(0), x);
+    ensure("isProper", result.isProper());
+    ensure("isInterior", result.isInterior());
 }
 
 // 2 - testCollinear1
@@ -84,15 +85,16 @@ void object::test<2>
     Coordinate p2(20, 10);
     Coordinate q1(22, 10);
     Coordinate q2(30, 10);
-    i.computeIntersection(p1, p2, q1, q2);
+    auto result = i.computeIntersection(p1, p2, q1, q2);
 
-    ensure_equals(i.getIntersectionNum(), LineIntersector::NO_INTERSECTION);
-    ensure_equals(i.getIntersectionNum(), 0UL);
-    ensure("!isProper", !i.isProper());
-    ensure("!hasIntersection", !i.hasIntersection());
+    ensure("!hasIntersection", !result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), LineIntersector::NO_INTERSECTION);
+    ensure_equals(result.getIntersectionNum(), 0UL);
+    ensure("!isProper", !result.isProper());
+    ensure("!isInterior", !result.isInterior());
 }
 
-// 3 - testCollinear2
+// 3 - testCollinear2 (endpoint intersection)
 template<>
 template<>
 void object::test<3>
@@ -102,12 +104,13 @@ void object::test<3>
     Coordinate p2(20, 10);
     Coordinate q1(20, 10);
     Coordinate q2(30, 10);
-    i.computeIntersection(p1, p2, q1, q2);
+    auto result = i.computeIntersection(p1, p2, q1, q2);
 
-    ensure_equals(i.getIntersectionNum(), LineIntersector::POINT_INTERSECTION);
-    ensure_equals(i.getIntersectionNum(), 1UL);
-    ensure("!isProper", !i.isProper());
-    ensure("hasIntersection", i.hasIntersection());
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), LineIntersector::POINT_INTERSECTION);
+    ensure_equals(result.getIntersectionNum(), 1UL);
+    ensure("!isProper", !result.isProper());
+    ensure("!isInterior", !result.isInterior());
 }
 
 // 4 - testCollinear3
@@ -120,12 +123,13 @@ void object::test<4>
     Coordinate p2(20, 10);
     Coordinate q1(15, 10);
     Coordinate q2(30, 10);
-    i.computeIntersection(p1, p2, q1, q2);
+    auto result = i.computeIntersection(p1, p2, q1, q2);
 
-    ensure_equals(i.getIntersectionNum(), LineIntersector::COLLINEAR_INTERSECTION);
-    ensure_equals(i.getIntersectionNum(), 2UL);
-    ensure("!isProper", !i.isProper());
-    ensure("hasIntersection", i.hasIntersection());
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), LineIntersector::COLLINEAR_INTERSECTION);
+    ensure_equals(result.getIntersectionNum(), 2UL);
+    ensure("!isProper", !result.isProper());
+    ensure("isInterior", result.isInterior());
 }
 
 // 5 - testCollinear4
@@ -138,12 +142,13 @@ void object::test<5>
     Coordinate p2(20, 10);
     Coordinate q1(10, 10);
     Coordinate q2(30, 10);
-    i.computeIntersection(p1, p2, q1, q2);
+    auto result = i.computeIntersection(p1, p2, q1, q2);
 
-    ensure_equals(i.getIntersectionNum(), LineIntersector::COLLINEAR_INTERSECTION);
-    ensure_equals(i.getIntersectionNum(), 2UL);
-    ensure("!isProper", !i.isProper());
-    ensure("hasIntersection", i.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), LineIntersector::COLLINEAR_INTERSECTION);
+    ensure_equals(result.getIntersectionNum(), 2UL);
+    ensure("!isProper", !result.isProper());
+    ensure("isInterior", result.isInterior());
+    ensure("hasIntersection", result.hasIntersection());
 }
 
 // 6 - testEndpointIntersection
@@ -152,10 +157,12 @@ template<>
 void object::test<6>
 ()
 {
-    i.computeIntersection(Coordinate(100, 100), Coordinate(10, 100),
-                          Coordinate(100, 10), Coordinate(100, 100));
-    ensure("hasIntersection", i.hasIntersection());
-    ensure_equals(i.getIntersectionNum(), 1UL);
+    auto result = i.computeIntersection(Coordinate(100, 100), Coordinate(10, 100),
+                                        Coordinate(100, 10), Coordinate(100, 100));
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), 1UL);
+    ensure("!isProper", !result.isProper());
+    ensure("!isInterior", !result.isInterior());
 }
 
 // 7 - testEndpointIntersection2
@@ -164,11 +171,13 @@ template<>
 void object::test<7>
 ()
 {
-    i.computeIntersection(Coordinate(190, 50), Coordinate(120, 100),
-                          Coordinate(120, 100), Coordinate(50, 150));
-    ensure("hasIntersection", i.hasIntersection());
-    ensure_equals(i.getIntersectionNum(), 1UL);
-    ensure_equals(i.getIntersection(1), Coordinate(120, 100));
+    auto result = i.computeIntersection(Coordinate(190, 50), Coordinate(120, 100),
+                                        Coordinate(120, 100), Coordinate(50, 150));
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), 1UL);
+    ensure_equals(result.getIntersection(1), Coordinate(120, 100));
+    ensure("!isProper", !result.isProper());
+    ensure("!isInterior", !result.isInterior());
 }
 
 // 8 - testOverlap
@@ -177,10 +186,12 @@ template<>
 void object::test<8>
 ()
 {
-    i.computeIntersection(Coordinate(180, 200), Coordinate(160, 180),
-                          Coordinate(220, 240), Coordinate(140, 160));
-    ensure("hasIntersection", i.hasIntersection());
-    ensure_equals(i.getIntersectionNum(), 2UL);
+    auto result = i.computeIntersection(Coordinate(180, 200), Coordinate(160, 180),
+                                        Coordinate(220, 240), Coordinate(140, 160));
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), 2UL);
+    ensure("!isProper", !result.isProper());
+    ensure("isInterior", result.isInterior());
 }
 
 // 9 - testIsProper1
@@ -189,11 +200,12 @@ template<>
 void object::test<9>
 ()
 {
-    i.computeIntersection(Coordinate(30, 10), Coordinate(30, 30),
-                          Coordinate(10, 10), Coordinate(90, 11));
-    ensure("hasIntersection", i.hasIntersection());
-    ensure_equals(i.getIntersectionNum(), 1UL);
-    ensure("isProper", i.isProper());
+    auto result = i.computeIntersection(Coordinate(30, 10), Coordinate(30, 30),
+                                        Coordinate(10, 10), Coordinate(90, 11));
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), 1UL);
+    ensure("isProper", result.isProper());
+    ensure("isInterior", result.isInterior());
 }
 
 // 10 - testIsProper2
@@ -202,11 +214,12 @@ template<>
 void object::test<10>
 ()
 {
-    i.computeIntersection(Coordinate(10, 30), Coordinate(10, 0),
-                          Coordinate(11, 90), Coordinate(10, 10));
-    ensure("hasIntersection", i.hasIntersection());
-    ensure_equals(i.getIntersectionNum(), 1UL);
-    ensure("!isProper", !i.isProper());
+    auto result = i.computeIntersection(Coordinate(10, 30), Coordinate(10, 0),
+                                        Coordinate(11, 90), Coordinate(10, 10));
+    ensure("hasIntersection", result.hasIntersection());
+    ensure_equals(result.getIntersectionNum(), 1UL);
+    ensure("!isProper", !result.isProper());
+    ensure("isInterior", result.isInterior());
 }
 
 // 11 - testIsCCW

--- a/tests/unit/algorithm/RobustLineIntersectorZTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectorZTest.cpp
@@ -45,18 +45,18 @@ struct test_robustlineintersectorz_data {
                 const Coordinate& p2)
     {
         RobustLineIntersector li;
-        li.computeIntersection(
+        auto result = li.computeIntersection(
             line1.p0, line1.p1,
             line2.p0, line2.p1);
 
-        ensure_equals(li.getIntersectionNum(), 2u);
+        ensure_equals(result.getIntersectionNum(), 2u);
 
-        Coordinate actual1 = li.getIntersection(0);
-        Coordinate actual2 = li.getIntersection(1);
+        Coordinate actual1 = result.getIntersection(0);
+        Coordinate actual2 = result.getIntersection(1);
         // normalize actual results
         if (actual1.compareTo(actual2) > 0) {
-            actual1 = li.getIntersection(1);
-            actual2 = li.getIntersection(0);
+            actual1 = result.getIntersection(1);
+            actual2 = result.getIntersection(0);
         }
 
         ensure_equals_xyz( actual1, p1 );
@@ -82,11 +82,11 @@ struct test_robustlineintersectorz_data {
             const Coordinate& p_pt)
     {
         RobustLineIntersector li;
-        li.computeIntersection(
+        auto result = li.computeIntersection(
             line1.p0, line1.p1,
             line2.p0, line2.p1);
-        ensure_equals(li.getIntersectionNum(), 1u);
-        Coordinate actual = li.getIntersection(0);
+        ensure_equals(result.getIntersectionNum(), 1u);
+        Coordinate actual = result.getIntersection(0);
         ensure_equals_xyz( actual, p_pt );
     }
 

--- a/tests/unit/geom/LinearRingTest.cpp
+++ b/tests/unit/geom/LinearRingTest.cpp
@@ -103,11 +103,11 @@ void object::test<1>
     try {
         // Create non-empty linearring instance
         geos::geom::LinearRing ring(coords, factory_.get());
-        ensure(!ring.isEmpty());
-        ensure(ring.isClosed());
-        ensure(ring.isRing());
-        ensure(ring.isSimple());
-        ensure(ring.isValid());
+        ensure("!ring.isEmpty()", !ring.isEmpty());
+        ensure("ring.isClosed()", ring.isClosed());
+        ensure("ring.isSimple()", ring.isSimple());
+        ensure("ring.isRing()", ring.isRing());
+        ensure("ring.isValid()", ring.isValid());
         //ensure_equals( rint.getNumPoints(), 7u );
     }
     catch(geos::util::IllegalArgumentException const& e) {

--- a/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
+++ b/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
@@ -205,7 +205,6 @@ void object::test<8>
     GeomPtr exp(wktreader.read(wkt_exp));
 
     GeomPtr simplified = TopologyPreservingSimplifier::simplify(g.get(), 10.0);
-
     ensure("Simplified geometry is invalid!", simplified->isValid());
     ensure_equals_geometry(exp.get(), simplified.get());
 }


### PR DESCRIPTION
This PR refactors the `LineIntersector` class to reduce its responsibilities and make it easier to extend it to variable coordinate dimensions using method overloads. Currently, the `LineIntersector` class is responsible for:

- Storing configuration (the precision model under which operations should take place)
- Storing inputs to (some) intersection operations
- Storing results to (some) intersection operations

The storage of inputs and outputs makes `LineIntersector` a convenient way to move line segments through algorithms. It can also be make its usage obscure; an intersection may be performed at a location distant in the call stack from when the input segments, intersection points, or intersection type are later retrieved.

This PR proposes to simplify `LineIntersector` by:

- storing only configuration (i.e., the `PrecisionModel` to be used for rounding coordinates)
- having all methods return an `IntersectionResult` object that can be queried for the nature of the intersection and any intersection points

The caller will be responsible for storing input segments if needed. This functionality was not used extensively in GEOS and the required changes in client code to drop it were minimal.

I think these changes 
- make client code somewhat easier to understand (we can follow an `IntersectionResult` object back through the code to find the operation that created it)
- make the `LineIntersector` itself easier to understand (we are no longer manipulating global variables like `isProperVar` in nested function calls)
- will make it easier to extend the class to difference coordinate types (XY, XYZM, etc.) without requiring that the intersector be templated on coordinate type (as I think would be the case if we stored coordinates of different types).

I had some concern about an adverse impact on performance (we are always returning an object with intersection points, even in the case of no intersection). However, I'm not able to detect any performance impact on my platform.

