### PR TITLE
Add CoordinateSequenceIterator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ xxxx-xx-xx
     CoverageGapFinder, CoverageUnion (JTS-900, Martin Davis & Paul Ramsey)
   - CAPI: GEOSPreparedContainsXY, GEOSPreparedContainsProperlyXY,
     GEOSPreparedIntersectsXY (GH-677, Dan Baston)
+  - Add CoordinateSequenceIterator (GH-685, Dan Baston)
 
 - Fixes/Improvements:
   - WKTReader: Fix parsing of Z and M flags in WKTReader (#676 and GH-669, Dan Baston)

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -43,6 +43,8 @@ public:
 
     const Coordinate& getAt(std::size_t pos) const override;
 
+    Coordinate& getAt(std::size_t pos) override;
+
     /// Copy Coordinate at position i to Coordinate c
     void getAt(std::size_t i, Coordinate& c) const override;
 

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -17,6 +17,7 @@
 #include <geos/export.h>
 
 #include <geos/geom/Coordinate.h> // for applyCoordinateFilter
+#include <geos/geom/CoordinateSequenceIterator.h>
 
 #include <vector>
 #include <iosfwd> // ostream
@@ -51,6 +52,9 @@ protected:
 
 public:
 
+    using iterator = CoordinateSequenceIterator<CoordinateSequence, Coordinate>;
+    using const_iterator = CoordinateSequenceIterator<const CoordinateSequence, const Coordinate>;
+
     typedef std::unique_ptr<CoordinateSequence> Ptr;
 
     virtual
@@ -69,6 +73,8 @@ public:
      */
     virtual const Coordinate& getAt(std::size_t i) const = 0;
 
+    virtual Coordinate& getAt(std::size_t i) = 0;
+
     /// Return last Coordinate in the sequence
     const Coordinate&
     back() const
@@ -85,6 +91,12 @@ public:
 
     const Coordinate&
     operator[](std::size_t i) const
+    {
+        return getAt(i);
+    }
+
+    Coordinate&
+    operator[](std::size_t i)
     {
         return getAt(i);
     }
@@ -288,6 +300,13 @@ public:
         }
     }
 
+    iterator begin();
+
+    iterator end();
+
+    const_iterator cbegin() const;
+
+    const_iterator cend() const;
 };
 
 GEOS_DLL std::ostream& operator<< (std::ostream& os, const CoordinateSequence& cs);

--- a/include/geos/geom/CoordinateSequenceIterator.h
+++ b/include/geos/geom/CoordinateSequenceIterator.h
@@ -1,0 +1,126 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 ISciences, LLC
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+
+namespace geos {
+namespace geom {
+
+template<typename SequenceType, typename CoordinateType>
+class CoordinateSequenceIterator {
+
+public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = CoordinateType;
+    using reference = CoordinateType&;
+    using pointer = CoordinateType;
+    using difference_type = std::ptrdiff_t;
+
+private:
+    SequenceType* m_seq;
+    difference_type m_pos;
+
+public:
+    CoordinateSequenceIterator(SequenceType* seq) : m_seq(seq), m_pos(0) {}
+
+    CoordinateSequenceIterator(SequenceType* seq, std::size_t size) : m_seq(seq), m_pos(static_cast<difference_type>(size)) {}
+
+    reference operator*() const {
+        return (*m_seq)[static_cast<std::size_t>(m_pos)];
+    }
+
+    pointer operator->() const {
+        return &(*m_seq)[static_cast<std::size_t>(m_pos)];
+    }
+
+    CoordinateSequenceIterator& operator++() {
+        m_pos++;
+        return *this;
+    }
+
+    CoordinateSequenceIterator operator++(int) {
+        CoordinateSequenceIterator ret = *this;
+        m_pos++;
+        return ret;
+    }
+
+    CoordinateSequenceIterator& operator--() {
+        m_pos--;
+        return *this;
+    }
+
+    CoordinateSequenceIterator operator--(int) {
+        CoordinateSequenceIterator ret = *this;
+        m_pos--;
+        return ret;
+    }
+
+    difference_type operator-(const CoordinateSequenceIterator& other) const {
+        return this->m_pos - other.m_pos;
+    }
+
+    CoordinateSequenceIterator operator+(difference_type n) const {
+        return CoordinateSequenceIterator(m_seq, static_cast<std::size_t>(m_pos + n));
+    }
+
+    CoordinateSequenceIterator operator+=(difference_type n) {
+        this->m_pos += n;
+        return *this;
+    }
+
+    CoordinateSequenceIterator operator-(difference_type n) const {
+        return CoordinateSequenceIterator(m_seq, static_cast<std::size_t>(m_pos - n));
+    }
+
+    CoordinateSequenceIterator operator-=(difference_type n) {
+        this->m_pos -= n;
+        return *this;
+    }
+
+    CoordinateType& operator[](difference_type n) const {
+        return *(*this + n);
+    }
+
+    bool operator==(const CoordinateSequenceIterator& other) const {
+        return this->m_pos == other.m_pos;
+    }
+
+    bool operator!=(const CoordinateSequenceIterator& other) const {
+        return !(*this == other);
+    }
+
+    bool operator<(const CoordinateSequenceIterator& other) const {
+        return this->m_pos < other.m_pos;
+    }
+
+    bool operator<=(const CoordinateSequenceIterator& other) const {
+        return this->m_pos <= other.m_pos;
+    }
+
+    bool operator>(const CoordinateSequenceIterator& other) const {
+        return this->m_pos > other.m_pos;
+    }
+
+    bool operator>=(const CoordinateSequenceIterator& other) const {
+        return this->m_pos >= other.m_pos;
+    }
+
+};
+
+}
+}

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -44,6 +44,10 @@ namespace geom {
             return m_data[i];
         }
 
+        Coordinate& getAt(std::size_t i) final override {
+            return m_data[i];
+        }
+
         void getAt(std::size_t i, Coordinate& c) const final override {
             c = m_data[i];
         }

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -193,6 +193,12 @@ CoordinateArraySequence::getAt(std::size_t pos) const
     return vect[pos];
 }
 
+Coordinate&
+CoordinateArraySequence::getAt(std::size_t pos)
+{
+    return vect[pos];
+}
+
 void
 CoordinateArraySequence::getAt(std::size_t pos, Coordinate& c) const
 {

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -223,6 +223,26 @@ CoordinateSequence::getEnvelope() const {
     return e;
 }
 
+CoordinateSequence::iterator
+CoordinateSequence::begin() {
+    return {this};
+}
+
+CoordinateSequence::iterator
+CoordinateSequence::end() {
+    return {this, getSize()};
+}
+
+CoordinateSequence::const_iterator
+CoordinateSequence::cbegin() const {
+    return {this};
+}
+
+CoordinateSequence::const_iterator
+CoordinateSequence::cend() const {
+    return {this, getSize()};
+}
+
 std::ostream&
 operator<< (std::ostream& os, const CoordinateSequence& cs)
 {

--- a/tests/unit/geom/CoordinateSequenceIteratorTest.cpp
+++ b/tests/unit/geom/CoordinateSequenceIteratorTest.cpp
@@ -1,0 +1,169 @@
+#include <tut/tut.hpp>
+#include <geos/geom/LineSegment.h>
+#include <geos/geom/CoordinateArraySequence.h>
+#include <numeric>
+
+namespace tut {
+
+using geos::geom::Coordinate;
+using geos::geom::CoordinateArraySequence;
+
+struct test_coordinatesequenceiterator_data {
+
+    CoordinateArraySequence seq_;
+
+    test_coordinatesequenceiterator_data() : seq_(10) {
+        for (size_t i = 0; i < seq_.size(); i++) {
+            seq_[i] = {static_cast<double>(i), static_cast<double>(i)};
+        }
+    }
+};
+
+typedef test_group<test_coordinatesequenceiterator_data> group;
+typedef group::object object;
+
+group test_coordinatesequenceiterator_group("geos::geom::CoordinateSequenceIterator");
+
+// Test iteration
+template<>
+template<>
+void object::test<1>()
+{
+    // Use modifying iterator to set y values
+    for (auto& coord : seq_) {
+        coord.y = 2*coord.x;
+    }
+
+    // Use const iterator to check values
+    std::size_t i = 0;
+    for (const auto& coord : seq_) {
+        ensure_equals(coord.x, static_cast<double>(i));
+        ensure_equals(coord.y, 2*coord.x);
+        i++;
+    }
+
+    ensure_equals(i, seq_.size());
+}
+
+// Test equality operators
+template<>
+template<>
+void object::test<2>()
+{
+    auto a = seq_.begin();
+    auto b = seq_.begin();
+
+    // Test equality
+    ensure(a == b);
+    ensure(!(a != b));
+
+    ++b;
+    ++b;
+
+    ensure(a != b);
+    std::advance(a, 2);
+    ensure(a == b);
+}
+
+// Test comparison operators
+template<>
+template<>
+void object::test<3>()
+{
+    auto a = seq_.begin();
+    auto b = seq_.begin();
+
+    ensure(a <= b);
+    ensure(a >= b);
+    ensure(!(a < b));
+    ensure(!(b > a));
+
+    a++;
+    ensure(a > b);
+    ensure(!(b >a));
+    ensure(a >= b);
+    ensure(!(b >= a));
+    ensure(b < a);
+    ensure(!(a < b));
+    ensure(b <= a);
+    ensure(!(a <= b));
+}
+
+// Test integer add/subtract
+template<>
+template<>
+void object::test<4>()
+{
+    auto a = seq_.begin();
+    auto n = static_cast<long>(seq_.size());
+
+    ensure(a + n ==  seq_.end());
+    a += n;
+    ensure(a == seq_.end());
+    ensure(a - n == seq_.begin());
+    a -= n;
+    ensure(a == seq_.begin());
+
+    ensure_equals(seq_.end() - seq_.begin(), n);
+}
+
+// Test offset deference operator
+template<>
+template<>
+void object::test<5>()
+{
+    auto a = seq_.begin();
+    std::advance(a, 5);
+
+    ensure_equals(a[0], seq_[5]);
+    ensure_equals(a[-5], seq_[0]);
+    ensure_equals(a[4], seq_[9]);
+}
+
+// Test increment/decrement operators
+template<>
+template<>
+void object::test<6>()
+{
+    auto a = seq_.begin();
+
+    // Prefix increment
+    auto b = ++a;
+    ensure_equals(a - seq_.begin(), 1);
+    ensure(b == a);
+
+    // Postfix increment
+    auto c = a++;
+    ensure_equals(a - seq_.begin(), 2);
+    ensure(c == b);
+
+    // Prefix decrement
+    auto d = --a;
+    ensure_equals(a - seq_.begin(), 1);
+    ensure(d == a);
+
+    // Postfix decrement
+    auto e = a--;
+    ensure_equals(a - seq_.begin(), 0);
+    ensure(e == d);
+}
+
+template<>
+template<>
+void object::test<7>()
+{
+    std::vector<Coordinate> coords{ Coordinate(8, 7), Coordinate(1, 1), Coordinate(1, 7) };
+
+    auto coords2 = coords; // copy
+    CoordinateArraySequence seq(std::move(coords2));
+
+    std::sort(coords.begin(), coords.end());
+    std::sort(seq.begin(), seq.end());
+
+    for (size_t i = 0; i < seq.getSize(); i++) {
+        ensure_equals(coords[i], seq[i]);
+    }
+
+}
+
+}


### PR DESCRIPTION
This adds an iterator to `CoordinateSequence` so that class can be used with STL algortithms

```
std::sort(seq.begin(), seq.end());
```

 and range for loops,

```
    for (auto& coord : seq_) {
        coord.y = 2*coord.x;
    }

    // Use const iterator to check values
    std::size_t i = 0;
    for (const auto& coord : seq_) {
        ensure_equals(coord.x, static_cast<double>(i));
        ensure_equals(coord.y, 2*coord.x);
        i++;
    }
```

This does not reduce the overhead of virtual Coordinate access; that requires #674 .