### PR TITLE
CMake: Add -Wsign-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ target_compile_definitions(geos_developer_cxx_flags
 target_compile_options(geos_developer_cxx_flags
   INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:-W4>
-    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Werror -pedantic -Wall -Wextra -Wno-long-long -Wcast-align -Wconversion -Wchar-subscripts -Wdouble-promotion -Wpointer-arith -Wformat -Wformat-security -Wshadow -Wuninitialized -Wunused-parameter -fno-common>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Werror -pedantic -Wall -Wextra -Wno-long-long -Wcast-align -Wconversion -Wsign-conversion -Wchar-subscripts -Wdouble-promotion -Wpointer-arith -Wformat -Wformat-security -Wshadow -Wuninitialized -Wunused-parameter -fno-common>
     $<$<CXX_COMPILER_ID:GNU>:-fno-implicit-inline-templates -Wno-psabi>
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-unknown-warning-option>
     )

--- a/include/geos/operation/distance/FacetSequenceTreeBuilder.h
+++ b/include/geos/operation/distance/FacetSequenceTreeBuilder.h
@@ -30,10 +30,10 @@ namespace distance {
 class GEOS_DLL FacetSequenceTreeBuilder {
 private:
     // 6 seems to be a good facet sequence size
-    static const int FACET_SEQUENCE_SIZE = 6;
+    static const std::size_t FACET_SEQUENCE_SIZE = 6;
 
     // Seems to be better to use a minimum node capacity
-    static const int STR_TREE_NODE_CAPACITY = 4;
+    static const std::size_t STR_TREE_NODE_CAPACITY = 4;
 
     static void addFacetSequences(const geom::Geometry* geom,
                                   const geom::CoordinateSequence* pts,

--- a/tests/unit/capi/GEOSGeom_createCollectionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_createCollectionTest.cpp
@@ -90,7 +90,7 @@ void object::test<2>
     }};
     // takes ownership of individual geometries
     geom_ = GEOSGeom_createCollection_r(handle_, GEOS_MULTIPOINT,
-                                        geoms.data(), static_cast<int>(geoms.size()));
+                                        geoms.data(), static_cast<unsigned int>(geoms.size()));
     ensure_equals(GEOSGetNumGeometries_r(handle_, geom_), geom_size);
 }
 #endif


### PR DESCRIPTION
This is on by default for clang but not for gcc. This change makes it easier for developers working with gcc to reproduce CI failures without switching toolchains.