### PR TITLE
Use indexed method for PreparedGeometry::isWithinDistance

### DIFF
--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -657,6 +657,16 @@ public:
     }
 
     /** \brief
+     * Computes the maximum distance between points in this and another Envelope.
+     */
+    double maxDistance(const Envelope& other) const
+    {
+        Coordinate p(std::min(minx, other.minx), std::min(miny, other.miny));
+        Coordinate q(std::max(maxx, other.maxx), std::max(maxy, other.maxy));
+        return p.distance(q);
+    }
+
+    /** \brief
      * Computes the square of the distance between this and another Envelope.
      *
      * The distance between overlapping Envelopes is 0. Otherwise, the

--- a/include/geos/geom/prep/PreparedLineString.h
+++ b/include/geos/geom/prep/PreparedLineString.h
@@ -59,6 +59,7 @@ public:
     bool intersects(const geom::Geometry* g) const override;
     std::unique_ptr<geom::CoordinateSequence> nearestPoints(const geom::Geometry* g) const override;
     double distance(const geom::Geometry* g) const override;
+    bool isWithinDistance(const geom::Geometry* g, double d) const override;
     operation::distance::IndexedFacetDistance* getIndexedFacetDistance() const;
 
 };

--- a/include/geos/geom/prep/PreparedLineStringDistance.h
+++ b/include/geos/geom/prep/PreparedLineStringDistance.h
@@ -40,6 +40,8 @@ public:
 
     double distance(const geom::Geometry* g) const;
 
+    bool isWithinDistance(const geom::Geometry* g, double d) const;
+
 protected:
 
     const PreparedLineString& prepLine;

--- a/include/geos/geom/prep/PreparedPolygon.h
+++ b/include/geos/geom/prep/PreparedPolygon.h
@@ -70,6 +70,7 @@ public:
     bool covers(const geom::Geometry* g) const override;
     bool intersects(const geom::Geometry* g) const override;
     double distance(const geom::Geometry* g) const override;
+    bool isWithinDistance(const geom::Geometry* g, double d) const override;
 
 };
 

--- a/include/geos/geom/prep/PreparedPolygonDistance.h
+++ b/include/geos/geom/prep/PreparedPolygonDistance.h
@@ -50,6 +50,8 @@ public:
 
     double distance(const geom::Geometry* g) const;
 
+    bool isWithinDistance(const geom::Geometry* g, double d) const;
+
 protected:
 
     const PreparedPolygon& prepPoly;

--- a/include/geos/index/strtree/TemplateSTRNodePair.h
+++ b/include/geos/index/strtree/TemplateSTRNodePair.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <geos/index/strtree/TemplateSTRNode.h>
+#include <utility>
 
 namespace geos {
 namespace index {
@@ -55,6 +56,10 @@ public:
         } else {
             return BoundsTraits::distance(getFirst().getBounds(), getSecond().getBounds());
         }
+    }
+
+    double maximumDistance() {
+        return BoundsTraits::maxDistance(getFirst().getBounds(), getSecond().getBounds());
     }
 
 private:

--- a/include/geos/index/strtree/TemplateSTRtree.h
+++ b/include/geos/index/strtree/TemplateSTRtree.h
@@ -250,6 +250,18 @@ public:
         return nearestNeighbour(env, item, id);
     }
 
+    template<typename ItemDistance>
+    bool isWithinDistance(TemplateSTRtreeImpl<ItemType, BoundsTraits>& other, double maxDistance) {
+        ItemDistance itemDist;
+
+        if (!getRoot() || !other.getRoot()) {
+            return false;
+        }
+
+        TemplateSTRtreeDistance<ItemType, BoundsTraits, ItemDistance> td(itemDist);
+        return td.isWithinDistance(*root, *other.root, maxDistance);
+    }
+
     /// @}
     /// \defgroup query Query
     /// @{
@@ -617,6 +629,10 @@ struct EnvelopeTraits {
 
     static double distance(const BoundsType& a, const BoundsType& b) {
         return a.distance(b);
+    }
+
+    static double maxDistance(const BoundsType& a, const BoundsType& b) {
+        return a.maxDistance(b);
     }
 
     static BoundsType empty() {

--- a/include/geos/operation/distance/IndexedFacetDistance.h
+++ b/include/geos/operation/distance/IndexedFacetDistance.h
@@ -58,7 +58,8 @@ public:
     ///
     /// \param g a Geometry, which may be of any type.
     IndexedFacetDistance(const geom::Geometry* g) :
-        cachedTree(FacetSequenceTreeBuilder::build(g))
+        cachedTree(FacetSequenceTreeBuilder::build(g)),
+        baseGeometry(*g)
     {}
 
     /// \brief Computes the distance between facets of two geometries.
@@ -85,6 +86,14 @@ public:
     /// \return the computed distance
     double distance(const geom::Geometry* g) const;
 
+    /// \brief Tests whether the base geometry lies within a specified distance of the given geometry.
+    ///
+    /// \param g the geometry to test
+    /// \param maxDistance the maximum distance to test
+    ///
+    /// \return true of the geometry lies within the specified distance
+    bool isWithinDistance(const geom::Geometry* g, double maxDistance) const;
+
     /// \brief Computes the nearest locations on the base geometry and the given geometry.
     ///
     /// \param g the geometry to compute the nearest location to
@@ -98,7 +107,15 @@ public:
     std::vector<geom::Coordinate> nearestPoints(const geom::Geometry* g) const;
 
 private:
+    struct FacetDistance {
+        double operator()(const FacetSequence* a, const FacetSequence* b) const
+        {
+            return a->distance(*b);
+        }
+    };
+
     std::unique_ptr<geos::index::strtree::TemplateSTRtree<const FacetSequence*>> cachedTree;
+    const geom::Geometry& baseGeometry;
 
 };
 }

--- a/src/geom/prep/PreparedLineString.cpp
+++ b/src/geom/prep/PreparedLineString.cpp
@@ -91,6 +91,12 @@ PreparedLineString::distance(const geom::Geometry* g) const
     return PreparedLineStringDistance::distance(*this, g);
 }
 
+bool
+PreparedLineString::isWithinDistance(const geom::Geometry* g, double d) const
+{
+    return PreparedLineStringDistance(*this).isWithinDistance(g, d);
+}
+
 
 } // namespace geos.geom.prep
 } // namespace geos.geom

--- a/src/geom/prep/PreparedLineStringDistance.cpp
+++ b/src/geom/prep/PreparedLineStringDistance.cpp
@@ -40,6 +40,17 @@ PreparedLineStringDistance::distance(const geom::Geometry* g) const
     return idf->distance(g);
 }
 
+bool
+PreparedLineStringDistance::isWithinDistance(const geom::Geometry* g, double d) const
+{
+    if ( prepLine.getGeometry().isEmpty() || g->isEmpty() )
+    {
+        return false;
+    }
+
+    return distance(g) <= d;
+}
+
 
 } // namespace geos.geom.prep
 } // namespace geos.geom

--- a/src/geom/prep/PreparedLineStringDistance.cpp
+++ b/src/geom/prep/PreparedLineStringDistance.cpp
@@ -48,7 +48,8 @@ PreparedLineStringDistance::isWithinDistance(const geom::Geometry* g, double d) 
         return false;
     }
 
-    return distance(g) <= d;
+    operation::distance::IndexedFacetDistance *idf = prepLine.getIndexedFacetDistance();
+    return idf->isWithinDistance(g, d);
 }
 
 

--- a/src/geom/prep/PreparedPolygon.cpp
+++ b/src/geom/prep/PreparedPolygon.cpp
@@ -161,6 +161,12 @@ PreparedPolygon::distance(const geom::Geometry* g) const
     return PreparedPolygonDistance::distance(*this, g);
 }
 
+bool
+PreparedPolygon::isWithinDistance(const geom::Geometry* g, double d) const
+{
+    return PreparedPolygonDistance(*this).isWithinDistance(g, d);
+}
+
 } // namespace geos.geom.prep
 } // namespace geos.geom
 } // namespace geos

--- a/src/geom/prep/PreparedPolygonDistance.cpp
+++ b/src/geom/prep/PreparedPolygonDistance.cpp
@@ -51,7 +51,10 @@ PreparedPolygonDistance::isWithinDistance(const geom::Geometry* g, double d) con
         return false;
     }
 
-    return distance(g) <= d;
+    if ( prepPoly.intersects(g) ) return true;
+
+    operation::distance::IndexedFacetDistance *idf = prepPoly.getIndexedFacetDistance();
+    return idf->isWithinDistance(g, d);
 }
 
 } // namespace geos.geom.prep

--- a/src/geom/prep/PreparedPolygonDistance.cpp
+++ b/src/geom/prep/PreparedPolygonDistance.cpp
@@ -43,6 +43,17 @@ PreparedPolygonDistance::distance(const geom::Geometry* g) const
     return idf->distance(g);
 }
 
+bool
+PreparedPolygonDistance::isWithinDistance(const geom::Geometry* g, double d) const
+{
+    if ( prepPoly.getGeometry().isEmpty() || g->isEmpty() )
+    {
+        return false;
+    }
+
+    return distance(g) <= d;
+}
+
 } // namespace geos.geom.prep
 } // namespace geos.geom
 } // namespace geos

--- a/tests/unit/operation/distance/IndexedFacetDistanceTest.cpp
+++ b/tests/unit/operation/distance/IndexedFacetDistanceTest.cpp
@@ -240,8 +240,13 @@ void object::test<8>
     GeomPtr g0(_wktreader.read(wkt0));
     GeomPtr g1(_wktreader.read(wkt1));
     IndexedFacetDistance ifd(g0.get());
-    double d = ifd.distance(g1.get());
-    ensure_equals(d, 50);
+    double expected_distance = 50;
+
+    double actual_distance = ifd.distance(g1.get());
+    ensure_equals(actual_distance, expected_distance);
+
+    ensure(ifd.isWithinDistance(g1.get(), expected_distance));
+    ensure(!ifd.isWithinDistance(g1.get(), expected_distance - 1e-6));
 }
 
 // Invalid polygon collapsed to a line


### PR DESCRIPTION
This seems preferable to delegating to the brute-force method of the underlying geometry.