### PR TITLE
Improve Geometry:::Union() performance using clustering 

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -607,6 +607,12 @@ extern "C" {
     }
 
     Geometry*
+    GEOSDisjointSubsetUnion(const Geometry* g)
+    {
+        return GEOSDisjointSubsetUnion_r(handle, g);
+    }
+
+    Geometry*
     GEOSNode(const Geometry* g)
     {
         return GEOSNode_r(handle, g);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -891,6 +891,11 @@ extern GEOSGeometry GEOS_DLL *GEOSCoverageUnion_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g);
 
+/** \see GEOSDisjointSubsetUnion */
+extern GEOSGeometry GEOS_DLL *GEOSDisjointSubsetUnion_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g);
+
 /** \see GEOSPointOnSurface */
 extern GEOSGeometry GEOS_DLL *GEOSPointOnSurface_r(
     GEOSContextHandle_t handle,
@@ -3291,6 +3296,16 @@ extern GEOSGeometry GEOS_DLL *GEOSUnaryUnionPrec(
 * Caller is responsible for freeing with GEOSGeom_destroy().
 */
 extern GEOSGeometry GEOS_DLL *GEOSCoverageUnion(const GEOSGeometry *g);
+
+/**
+* Optimized union algorithm for inputs that can be divided into subsets
+* that do not intersect. If there is only one such subset, performance
+* can be expected to be worse than GEOSUnionaryUnion.
+* \param g The input geometry
+* \return A newly allocated geometry of the union, or NULL on exception.
+* Caller is responsible for freeing with GEOSGeom_destroy().
+*/
+extern GEOSGeometry GEOS_DLL *GEOSDisjointSubsetUnion(const GEOSGeometry *g);
 
 /**
 * Intersection optimized for a rectangular clipping polygon.

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -78,6 +78,7 @@
 #include <geos/operation/sharedpaths/SharedPathsOp.h>
 #include <geos/operation/union/CascadedPolygonUnion.h>
 #include <geos/operation/union/CoverageUnion.h>
+#include <geos/operation/union/DisjointSubsetUnion.h>
 #include <geos/operation/valid/IsValidOp.h>
 #include <geos/operation/valid/MakeValid.h>
 #include <geos/operation/valid/RepeatedPointRemover.h>
@@ -1479,6 +1480,16 @@ extern "C" {
     {
         return execute(extHandle, [&]() {
             auto g3 = geos::operation::geounion::CoverageUnion::Union(g);
+            g3->setSRID(g->getSRID());
+            return g3.release();
+        });
+    }
+
+    Geometry*
+    GEOSDisjointSubsetUnion_r(GEOSContextHandle_t extHandle, const Geometry* g)
+    {
+        return execute(extHandle, [&]() {
+            auto g3 = geos::operation::geounion::DisjointSubsetUnion::Union(g);
             g3->setSRID(g->getSRID());
             return g3.release();
         });

--- a/include/geos/operation/cluster/DisjointOperation.h
+++ b/include/geos/operation/cluster/DisjointOperation.h
@@ -26,10 +26,17 @@ namespace cluster {
 
 class GEOS_DLL DisjointOperation {
 public:
-    DisjointOperation(AbstractClusterFinder& finder) : m_finder(finder) {}
+    DisjointOperation(AbstractClusterFinder& finder) : m_finder(finder), m_split_inputs(false) {}
+
+    /** Splits multipart geometries into their underlying components before identifying
+     *  disjoint subsets.
+     */
+    void setSplitInputs(bool b) {
+        m_split_inputs = b;
+    }
 
     /** Decompose a geometry into disjoint subsets using the provided `ClusterFinder`,
-     *  process each subset using `f`, and combine the results. It is assumed that
+     *  process each subset using `f`, and combine/flatten the results. It is assumed that
      *  the processed results of each subset will also be disjoint; therefore, this
      *  algorithm may not be suitable for operations such as buffering.
      *
@@ -43,7 +50,7 @@ public:
             return f(g);
         }
 
-        auto flattened = operation::cluster::GeometryFlattener::flatten(g.clone());
+        auto flattened = m_split_inputs ? operation::cluster::GeometryFlattener::flatten(g.clone()) : g.clone();
         auto clustered = m_finder.clusterToVector(std::move(flattened));
 
         for (auto& subset : clustered) {
@@ -57,6 +64,7 @@ public:
 
 private:
     AbstractClusterFinder& m_finder;
+    bool m_split_inputs;
 };
 
 

--- a/include/geos/operation/union/DisjointSubsetUnion.h
+++ b/include/geos/operation/union/DisjointSubsetUnion.h
@@ -1,0 +1,49 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2022 ISciences LLC
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/export.h>
+#include <geos/geom/Geometry.h>
+#include <geos/operation/cluster/DisjointOperation.h>
+#include <geos/operation/cluster/GeometryIntersectsClusterFinder.h>
+#include <geos/operation/overlayng/OverlayNGRobust.h>
+
+namespace geos {
+namespace operation {
+namespace geounion {
+
+class GEOS_DLL DisjointSubsetUnion {
+public:
+    /** Perform a unary union on a geometry by combining the results of
+     *  unary unions performed on its disjoint subsets.
+     *
+     * @brief Union
+     * @param g the geometry to union
+     * @return result geometry
+     */
+    static std::unique_ptr<geom::Geometry> Union(const geom::Geometry* g) {
+        operation::cluster::GeometryIntersectsClusterFinder f;
+        operation::cluster::DisjointOperation op(f);
+        op.setSplitInputs(true);
+
+        return op.processDisjointSubsets(*g, [](const geom::Geometry& subset) {
+            return subset.Union();
+        });
+    }
+};
+
+}
+}
+}

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -557,11 +557,7 @@ Geometry::Ptr
 Geometry::Union() const
 {
     using geos::operation::geounion::UnaryUnionOp;
-#ifdef DISABLE_OVERLAYNG
     return UnaryUnionOp::Union(*this);
-#else
-    return operation::overlayng::OverlayNGRobust::Union(this);
-#endif
 }
 
 std::unique_ptr<Geometry>

--- a/src/operation/cluster/AbstractClusterFinder.cpp
+++ b/src/operation/cluster/AbstractClusterFinder.cpp
@@ -108,7 +108,10 @@ AbstractClusterFinder::process(const std::vector<const Geometry*> & components,
             if (uf.different(i, j)) {
                 const geom::Geometry* gj = components[j];
 
-                if (shouldJoin(gi, gj)) {
+                // Only call shouldJoin with the more complex geometry in the LHS, where it will become
+                // the prepared geometry.
+                // TODO move point check to subclasses that benefit to avoid for those that don't?
+                if (gi->getNumPoints() >= gj->getNumPoints() && shouldJoin(gi, gj)) {
                     uf.join(i, j);
                 }
             }

--- a/tests/unit/capi/GEOSDisjointSubsetUnionTest.cpp
+++ b/tests/unit/capi/GEOSDisjointSubsetUnionTest.cpp
@@ -1,0 +1,52 @@
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_capidisjointsubsetunion_data : public capitest::utility {};
+
+
+typedef test_group<test_capidisjointsubsetunion_data> group;
+typedef group::object object;
+
+group test_capidisjointsubsetunion_group("capi::GEOSDisjointSubsetUnion");
+
+//
+// Test Cases
+//
+
+
+template<>
+template<>
+void object::test<1>()
+{
+    input_ = GEOSGeomFromWKT("POLYGON EMPTY");
+    GEOSSetSRID(input_, 1234);
+
+    result_ = GEOSDisjointSubsetUnion(input_);
+
+    ensure(GEOSisEmpty(result_));
+    ensure_equals(GEOSGetSRID(input_), GEOSGetSRID(result_));
+}
+
+template<>
+template<>
+void object::test<2>()
+{
+    input_ = GEOSGeomFromWKT("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((1 0, 2 0, 2 1, 1 1, 1 0)), ((3 3, 4 3, 4 4, 3 3)))");
+    expected_ = GEOSGeomFromWKT("MULTIPOLYGON (((0 0, 1 0, 2 0, 2 1, 1 1, 0 1, 0 0)), ((3 3, 4 3, 4 4, 3 3)))");
+    result_ = GEOSDisjointSubsetUnion(input_);
+
+    ensure_geometry_equals(result_, expected_);
+}
+
+
+} // namespace tut
+

--- a/tests/unit/capi/GEOSUnaryUnionTest.cpp
+++ b/tests/unit/capi/GEOSUnaryUnionTest.cpp
@@ -128,9 +128,10 @@ void object::test<6>
     geom2_ = GEOSUnaryUnion(geom1_);
     ensure(nullptr != geom2_);
 
-    ensure_equals(toWKT(geom2_), std::string(
-                      "GEOMETRYCOLLECTION (POINT (6 7), POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (5 6, 7 6, 7 8, 5 8, 5 6)))"
-                  ));
+    expected_ = GEOSGeomFromWKT("GEOMETRYCOLLECTION (POINT (6 7), POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (5 6, 7 6, 7 8, 5 8, 5 6)))");
+    ensure(nullptr != expected_);
+
+    ensure(GEOSEquals(geom2_, expected_));
 }
 
 // Self-union a collection of lineal and polygonal geometries


### PR DESCRIPTION
This PR implements a pre-clustering step for `Geometry::Union()` to divide inputs into disjoint sets before performing the union operation. Performance testing shows a large benefit in datasets with many disjoint polygons and no significant penalty in datasets with no disjoint polygons.

I tried using envelope intersection, geometry intersection, and geometry distance as the basis for the clustering. The testing results show that geometry distance is preferred, since its performance is essentially equivalent to geometry intersection and is safe in the case where snap-rounding causes connected outputs from disjoint inputs. Timings are as follows, using `geosop union` with 5 repeats (`-r 5`) for all except the most complex dataset where only one iteration was performed.

| Dataset         | Iterations | Geometry Clusters | `main`  [s]  | Geom isect [s] | Speedup    | Geom dist [s] | Speedup    | Env isect [s] | Speedup       |  Env Clusters    |
| --------------- | -------- | -------- | ------- | ------------------- | ------ | --------------- | ------ | --------------- | ------ | ---- |
| world           | 5 | 8226     | 12.496  | 1.62                | 87.0%  | 1.86            | 85.1%  | 7.42            | 40.6%  | 2549 |
| watersheds      | 5 | 1        | 11.273  | 11.1                | 1.5%   | 10.94           | 3.0%   | 11.33           | \-0.5% | 1    |
| watersheds\_buf | 5 | 1        | 15.414  | 15.87               | \-3.0% | 15.83           | \-2.7% | 15.18           | 1.5%   | 1    |
| counties        | 5 | 98       | 107.776 | 105.7               | 1.9%   | 107.4           | 0.3%   | 102.065         | 5.3%   | 66   |
| subdiv          | 1 | 175694   | 217     | 44.6                | 79.4%  | 53              | 75.6%  | 196             | 9.7%   | 7278 |
| voronoi | 50 |1 | 2.5 | | | 2.8 | -10.8% | 
| vt parcels | 1 | 1 | 90 | | | 110 | -23.6% | 94 | -5.6% | 1

The datasets are available in https://drive.google.com/drive/folders/1YNDsce_YiewgOiafPeJJOF4_AXlenX1C?usp=sharing
