### PR TITLE
Optimize prepared polygon distance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,8 @@ xxxx-xx-xx
   - GeometryPrecisionReducer: Return correct dimensionality for empty results (GH-684, Dan Baston)
   - Improve performance of coverage union (GH-681, Dan Baston)
   - Improve performance of prepared polygon intersection (GH-690, Dan Baston)
-  - Implement indexed calculations for prepared geometry distance (GH-691, Dan Baston)
+  - Improve performance of prepared polygon distance (GH-693, Dan Baston)
+  - Implement indexed calculations for prepared geometry isWithinDistance (GH-691, Dan Baston)
 
 
 ## Changes in 3.11.0

--- a/include/geos/geom/prep/PreparedPolygonDistance.h
+++ b/include/geos/geom/prep/PreparedPolygonDistance.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <geos/geom/prep/PreparedPolygonPredicate.h>
+
 // Forward declarations
 namespace geos {
     namespace geom {
@@ -35,7 +37,7 @@ namespace prep { // geos::geom::prep
 
 class PreparedPolygon;
 
-class PreparedPolygonDistance {
+class PreparedPolygonDistance : public PreparedPolygonPredicate {
 public:
 
     static double distance(const PreparedPolygon& prep, const geom::Geometry* geom)
@@ -45,7 +47,7 @@ public:
     }
 
     PreparedPolygonDistance(const PreparedPolygon& prep)
-        : prepPoly(prep)
+        : PreparedPolygonPredicate(&prep)
     { }
 
     double distance(const geom::Geometry* g) const;
@@ -53,8 +55,6 @@ public:
     bool isWithinDistance(const geom::Geometry* g, double d) const;
 
 protected:
-
-    const PreparedPolygon& prepPoly;
 
     // Declare type as noncopyable
     PreparedPolygonDistance(const PreparedPolygonDistance& other) = delete;

--- a/tests/unit/capi/GEOSPreparedDistanceTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceTest.cpp
@@ -60,6 +60,7 @@ group test_capigeosprepareddistance_group("capi::GEOSPreparedDistance");
 // Test Cases
 //
 
+// Two empty inputs
 template<>
 template<>
 void object::test<1>
@@ -72,6 +73,7 @@ void object::test<1>
     );
 }
 
+// Disjoint polygons
 template<>
 template<>
 void object::test<2>
@@ -85,6 +87,7 @@ void object::test<2>
 
 }
 
+// Point contained in polygon
 template<>
 template<>
 void object::test<3>
@@ -97,6 +100,7 @@ void object::test<3>
     );
 }
 
+// Disjoint line and point
 template<>
 template<>
 void object::test<4>
@@ -109,6 +113,7 @@ void object::test<4>
     );
 }
 
+// Intersecting lines
 template<>
 template<>
 void object::test<5>
@@ -121,6 +126,7 @@ void object::test<5>
     );
 }
 
+// Intersecting polygon and line
 template<>
 template<>
 void object::test<6>
@@ -133,6 +139,7 @@ void object::test<6>
     );
 }
 
+// Empty geometries
 template<>
 template<>
 void object::test<7>
@@ -145,6 +152,7 @@ void object::test<7>
     );
 }
 
+// Empty geometries
 template<>
 template<>
 void object::test<8>
@@ -154,6 +162,19 @@ void object::test<8>
         "POINT EMPTY",
         "LINESTRING EMPTY",
         geos::DoubleInfinity
+    );
+}
+
+// Prepared geometry contained in test geometry
+template<>
+template<>
+void object::test<9>
+()
+{
+    checkDistance(
+        "POLYGON((1 1,1 5,5 5,5 1,1 1))",
+        "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))",
+        0
     );
 }
 

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -58,6 +58,7 @@ group test_capigeosprepareddistancewithin_group("capi::GEOSPreparedDistanceWithi
 // Test Cases
 //
 
+// Empty inputs
 template<>
 template<>
 void object::test<1>
@@ -71,6 +72,7 @@ void object::test<1>
     );
 }
 
+// Disjoint polygons
 template<>
 template<>
 void object::test<2>
@@ -85,6 +87,7 @@ void object::test<2>
 
 }
 
+// Point contained in polygon
 template<>
 template<>
 void object::test<3>
@@ -98,6 +101,7 @@ void object::test<3>
     );
 }
 
+// Disjoint line and point
 template<>
 template<>
 void object::test<4>
@@ -111,6 +115,7 @@ void object::test<4>
     );
 }
 
+// Intersecting lines
 template<>
 template<>
 void object::test<5>
@@ -124,6 +129,7 @@ void object::test<5>
     );
 }
 
+// Intersecting polygon and line
 template<>
 template<>
 void object::test<6>
@@ -137,6 +143,7 @@ void object::test<6>
     );
 }
 
+// Empty geometries
 template<>
 template<>
 void object::test<7>
@@ -150,6 +157,7 @@ void object::test<7>
     );
 }
 
+// Empty geometries
 template<>
 template<>
 void object::test<8>
@@ -163,6 +171,7 @@ void object::test<8>
     );
 }
 
+// Mixed empty and non-empty
 template<>
 template<>
 void object::test<9>
@@ -176,6 +185,7 @@ void object::test<9>
     );
 }
 
+// Mixed empty and non-empty
 template<>
 template<>
 void object::test<10>
@@ -186,6 +196,20 @@ void object::test<10>
         "POLYGON EMPTY",
         geos::DoubleInfinity,
         0
+    );
+}
+
+// Prepared geometry contained in test geometry
+template<>
+template<>
+void object::test<11>
+()
+{
+    checkDistanceWithin(
+        "POLYGON((1 1,1 5,5 5,5 1,1 1))",
+        "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))",
+        0,
+        1
     );
 }
 

--- a/util/geosop/GeomFunction.cpp
+++ b/util/geosop/GeomFunction.cpp
@@ -37,6 +37,7 @@
 #include <geos/operation/buffer/BufferOp.h>
 #include <geos/operation/buffer/BufferParameters.h>
 #include <geos/operation/buffer/OffsetCurve.h>
+#include <geos/operation/cluster/GeometryDistanceClusterFinder.h>
 #include <geos/operation/cluster/GeometryIntersectsClusterFinder.h>
 #include <geos/coverage/CoverageValidator.h>
 #include <geos/operation/linemerge/LineMerger.h>
@@ -255,6 +256,12 @@ GeomFunction::init()
         [](const std::unique_ptr<Geometry>& geom, const std::unique_ptr<Geometry>& geomB, double d)->Result* {
             (void) geomB; (void)d;  // prevent unused variable warning
             geos::operation::cluster::GeometryIntersectsClusterFinder f;
+            return new Result(f.clusterToCollection(*geom));
+    });
+    addAgg("clusterWithin", 0, Result::typeGeometry, catRel, "cluster geometries based on distance",
+        [](const std::unique_ptr<Geometry>& geom, const std::unique_ptr<Geometry>& geomB, double d)->Result* {
+            (void) geomB;  // prevent unused variable warning
+            geos::operation::cluster::GeometryDistanceClusterFinder f(d);
             return new Result(f.clusterToCollection(*geom));
     });
     add("convexHull", Result::typeGeometry, catConst,


### PR DESCRIPTION
The implementation of `PreparedPolygonDistance` begins with a call to `PreparedPolygonIntersects` to cover the case where a containment relationship exists between the target and test geometries. However, the segment intersection test performed by `PreparedPolygonIntersects` is unnecessary. If any segment intersect, they will be found by `IndexedFacetDistance`.

This PR improves the performance of `PreparedPolygonDistance` by performing the PIP containment tests directly within `PreparedPolygonDistance` and avoiding the call to `PreparedPolygonIntersects`. In the following performance test, which relies heavily on `PreparedPolygonDistance`, runtime is reduced by 45%.

`bin/geosop clusterWithin 1e-3 -t -q -a ~/data/world.wkt`

This should bring additional performance improvements to #692.