### PR TITLE
Add CoordinateXY type

### DIFF
--- a/include/geos/algorithm/Angle.h
+++ b/include/geos/algorithm/Angle.h
@@ -74,8 +74,8 @@ public:
     /// @return the normalized angle (in radians) that p0-p1 makes
     ///         with the positive x-axis.
     ///
-    static double angle(const geom::Coordinate& p0,
-                        const geom::Coordinate& p1);
+    static double angle(const geom::CoordinateXY& p0,
+                        const geom::CoordinateXY& p1);
 
     /// \brief
     /// Returns the angle that the vector from (0,0) to p,
@@ -86,7 +86,7 @@ public:
     /// @return the normalized angle (in radians) that p makes
     ///          with the positive x-axis.
     ///
-    static double angle(const geom::Coordinate& p);
+    static double angle(const geom::CoordinateXY& p);
 
     /// Tests whether the angle between p0-p1-p2 is acute.
     ///
@@ -99,9 +99,9 @@ public:
     /// @param p1 the base of the angle
     /// @param p2 the other endpoint of the angle
     ///
-    static bool isAcute(const geom::Coordinate& p0,
-                        const geom::Coordinate& p1,
-                        const geom::Coordinate& p2);
+    static bool isAcute(const geom::CoordinateXY& p0,
+                        const geom::CoordinateXY& p1,
+                        const geom::CoordinateXY& p2);
 
     /// Tests whether the angle between p0-p1-p2 is obtuse.
     ///
@@ -114,9 +114,9 @@ public:
     /// @param p1 the base of the angle
     /// @param p2 the other endpoint of the angle
     ///
-    static bool isObtuse(const geom::Coordinate& p0,
-                         const geom::Coordinate& p1,
-                         const geom::Coordinate& p2);
+    static bool isObtuse(const geom::CoordinateXY& p0,
+                         const geom::CoordinateXY& p1,
+                         const geom::CoordinateXY& p2);
 
     /// Returns the unoriented smallest angle between two vectors.
     ///
@@ -127,9 +127,9 @@ public:
     /// @param tip2 the tip of the other vector
     /// @return the angle between tail-tip1 and tail-tip2
     ///
-    static double angleBetween(const geom::Coordinate& tip1,
-                               const geom::Coordinate& tail,
-                               const geom::Coordinate& tip2);
+    static double angleBetween(const geom::CoordinateXY& tip1,
+                               const geom::CoordinateXY& tail,
+                               const geom::CoordinateXY& tip2);
 
     /// Returns the oriented smallest angle between two vectors.
     ///
@@ -143,9 +143,9 @@ public:
     /// @param tip2 the tip of v2
     /// @return the angle between v1 and v2, relative to v1
     ///
-    static double angleBetweenOriented(const geom::Coordinate& tip1,
-                                       const geom::Coordinate& tail,
-                                       const geom::Coordinate& tip2);
+    static double angleBetweenOriented(const geom::CoordinateXY& tip1,
+                                       const geom::CoordinateXY& tail,
+                                       const geom::CoordinateXY& tip2);
 
     /// Computes the interior angle between two segments of a ring.
     ///
@@ -160,9 +160,9 @@ public:
     ///          the next point of the ring
     /// @return the interior angle based at <code>p1</code>
     ///
-    static double interiorAngle(const geom::Coordinate& p0,
-                                const geom::Coordinate& p1,
-                                const geom::Coordinate& p2);
+    static double interiorAngle(const geom::CoordinateXY& p0,
+                                const geom::CoordinateXY& p1,
+                                const geom::CoordinateXY& p2);
 
     /// \brief
     /// Returns whether an angle must turn clockwise or counterclockwise

--- a/include/geos/algorithm/CGAlgorithmsDD.h
+++ b/include/geos/algorithm/CGAlgorithmsDD.h
@@ -24,7 +24,7 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 class CoordinateSequence;
 }
 }
@@ -64,9 +64,9 @@ public:
      * @return -1 if q is clockwise (right) from p1-p2
      * @return 0 if q is collinear with p1-p2
      */
-    static int orientationIndex(const geom::Coordinate& p1,
-                                const geom::Coordinate& p2,
-                                const geom::Coordinate& q);
+    static int orientationIndex(const geom::CoordinateXY& p1,
+                                const geom::CoordinateXY& p2,
+                                const geom::CoordinateXY& q);
 
 
     static int orientationIndex(double p1x, double p1y,
@@ -151,8 +151,8 @@ public:
      * @param q2 an endpoint of line segment 2
      * @return an intersection point if one exists, or null if the lines are parallel
      */
-    static geom::Coordinate intersection(const geom::Coordinate& p1, const geom::Coordinate& p2,
-                             const geom::Coordinate& q1, const geom::Coordinate& q2);
+    static geom::CoordinateXY intersection(const geom::CoordinateXY& p1, const geom::CoordinateXY& p2,
+                                           const geom::CoordinateXY& q1, const geom::CoordinateXY& q2);
 
     static int signOfDet2x2(double dx1, double dy1, double dx2, double dy2);
 
@@ -172,7 +172,7 @@ public:
      *
      * This method uses @ref geos::math::DD extended-precision arithmetic to provide more accurate
      * results than [circumcentre(Coordinate, Coordinate, Coordinate)]
-     * (@ref geos::geom::Triangle::circumcentre(const Coordinate& p0, const Coordinate& p1, const Coordinate& p2)).
+     * (@ref geos::geom::Triangle::circumcentre(const CoordinateXY& p0, const CoordinateXY& p1, const CoordinateXY& p2)).
      *
      * @param a
      *          a vertex of the triangle
@@ -182,7 +182,7 @@ public:
      *          a vertex of the triangle
      * @return the circumcentre of the triangle
      */
-    static geom::Coordinate circumcentreDD(const geom::Coordinate& a, const geom::Coordinate& b, const geom::Coordinate& c);
+    static geom::CoordinateXY circumcentreDD(const geom::CoordinateXY& a, const geom::CoordinateXY& b, const geom::CoordinateXY& c);
 
 protected:
 

--- a/include/geos/algorithm/Distance.h
+++ b/include/geos/algorithm/Distance.h
@@ -49,10 +49,10 @@ public:
      *          another point of the line (must be different to A)
      */
     // formerly distanceLineLine
-    static double segmentToSegment(const geom::Coordinate& A,
-                                   const geom::Coordinate& B,
-                                   const geom::Coordinate& C,
-                                   const geom::Coordinate& D);
+    static double segmentToSegment(const geom::CoordinateXY& A,
+                                   const geom::CoordinateXY& B,
+                                   const geom::CoordinateXY& C,
+                                   const geom::CoordinateXY& D);
 
     /**
     * Computes the distance from a point to a sequence of line segments.
@@ -63,7 +63,7 @@ public:
     *          a sequence of contiguous line segments defined by their vertices
     * @return the minimum distance between the point and the line segments
     */
-    static double pointToSegmentString(const geom::Coordinate& p,
+    static double pointToSegmentString(const geom::CoordinateXY& p,
                                        const geom::CoordinateSequence* seq);
 
     /**
@@ -80,9 +80,9 @@ public:
     * @return the distance from p to line segment AB
     */
     // formerly distancePointLine
-    static double pointToSegment(const geom::Coordinate& p,
-                                 const geom::Coordinate& A,
-                                 const geom::Coordinate& B);
+    static double pointToSegment(const geom::CoordinateXY& p,
+                                 const geom::CoordinateXY& A,
+                                 const geom::CoordinateXY& B);
 
     /**
     * Computes the perpendicular distance from a point p to the (infinite) line
@@ -97,9 +97,9 @@ public:
     * @return the distance from p to line AB
     */
     // formerly distancePointLinePerpendicular
-    static double pointToLinePerpendicular(const geom::Coordinate& p,
-                                           const geom::Coordinate& A,
-                                           const geom::Coordinate& B);
+    static double pointToLinePerpendicular(const geom::CoordinateXY& p,
+                                           const geom::CoordinateXY& A,
+                                           const geom::CoordinateXY& B);
 
 };
 

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -146,7 +146,7 @@ public:
     void computeIntersection(const geom::Coordinate& p, const geom::Coordinate& p1, const geom::Coordinate& p2);
 
     /// Same as above but doesn't compute intersection point. Faster.
-    static bool hasIntersection(const geom::Coordinate& p, const geom::Coordinate& p1, const geom::Coordinate& p2);
+    static bool hasIntersection(const geom::CoordinateXY& p, const geom::CoordinateXY& p1, const geom::CoordinateXY& p2);
 
     enum intersection_type : uint8_t {
         /// Indicates that line segments do not intersect

--- a/include/geos/algorithm/MinimumBoundingCircle.h
+++ b/include/geos/algorithm/MinimumBoundingCircle.h
@@ -44,18 +44,18 @@ private:
 
     // member variables
     const geom::Geometry* input;
-    std::vector<geom::Coordinate> extremalPts;
-    geom::Coordinate centre;
+    std::vector<geom::CoordinateXY> extremalPts;
+    geom::CoordinateXY centre;
     double radius;
 
     void computeCentre();
     void compute();
     void computeCirclePoints();
-    geom::Coordinate lowestPoint(std::vector<geom::Coordinate>& pts);
-    geom::Coordinate pointWitMinAngleWithX(std::vector<geom::Coordinate>& pts, geom::Coordinate& P);
-    geom::Coordinate pointWithMinAngleWithSegment(std::vector<geom::Coordinate>& pts,
-            geom::Coordinate& P, geom::Coordinate& Q);
-    std::vector<geom::Coordinate> farthestPoints(std::vector<geom::Coordinate>& pts);
+    geom::CoordinateXY lowestPoint(std::vector<geom::CoordinateXY>& pts);
+    geom::CoordinateXY pointWitMinAngleWithX(std::vector<geom::CoordinateXY>& pts, geom::CoordinateXY& P);
+    geom::CoordinateXY pointWithMinAngleWithSegment(std::vector<geom::CoordinateXY>& pts,
+            geom::CoordinateXY& P, geom::CoordinateXY& Q);
+    std::vector<geom::CoordinateXY> farthestPoints(std::vector<geom::CoordinateXY>& pts);
 
 
 public:
@@ -113,7 +113,7 @@ public:
     *
     * @return the points defining the Minimum Bounding Circle
     */
-    std::vector<geom::Coordinate> getExtremalPoints();
+    std::vector<geom::CoordinateXY> getExtremalPoints();
 
     /**
     * Gets the centre point of the computed Minimum Bounding Circle.
@@ -121,7 +121,7 @@ public:
     * @return the centre point of the Minimum Bounding Circle
     * @return null if the input is empty
     */
-    geom::Coordinate getCentre();
+    geom::CoordinateXY getCentre();
 
     /**
     * Gets the radius of the computed Minimum Bounding Circle.

--- a/include/geos/algorithm/Orientation.h
+++ b/include/geos/algorithm/Orientation.h
@@ -64,8 +64,8 @@ public:
      * ( `Orientation::COUNTERCLOCKWISE`,
      * `Orientation::CLOCKWISE`, or `Orientation::STRAIGHT` )
      */
-    static int index(const geom::Coordinate& p1, const geom::Coordinate& p2,
-                     const geom::Coordinate& q);
+    static int index(const geom::CoordinateXY& p1, const geom::CoordinateXY& p2,
+                     const geom::CoordinateXY& q);
 
     /**
     * Computes whether a ring defined by a geom::CoordinateSequence is

--- a/include/geos/algorithm/PointLocation.h
+++ b/include/geos/algorithm/PointLocation.h
@@ -45,7 +45,7 @@ public:
      * @return true if the point is a vertex of the line or lies in the interior
      *         of a line segment in the line
      */
-    static bool isOnLine(const geom::Coordinate& p, const geom::CoordinateSequence* line);
+    static bool isOnLine(const geom::CoordinateXY& p, const geom::CoordinateSequence* line);
 
     /** \brief
      * Tests whether a point lies inside or on a ring.
@@ -63,8 +63,8 @@ public:
      *
      * @see RayCrossingCounter::locatePointInRing()
      */
-    static bool isInRing(const geom::Coordinate& p, const std::vector<const geom::Coordinate*>& ring);
-    static bool isInRing(const geom::Coordinate& p, const geom::CoordinateSequence* ring);
+    static bool isInRing(const geom::CoordinateXY& p, const std::vector<const geom::Coordinate*>& ring);
+    static bool isInRing(const geom::CoordinateXY& p, const geom::CoordinateSequence* ring);
 
     /** \brief
      * Determines whether a point lies in the interior, on the boundary, or in the
@@ -78,8 +78,8 @@ public:
      *             first point identical to last point)
      * @return the [Location](@ref geom::Location) of p relative to the ring
      */
-    static geom::Location locateInRing(const geom::Coordinate& p, const std::vector<const geom::Coordinate*>& ring);
-    static geom::Location locateInRing(const geom::Coordinate& p, const geom::CoordinateSequence& ring);
+    static geom::Location locateInRing(const geom::CoordinateXY& p, const std::vector<const geom::Coordinate*>& ring);
+    static geom::Location locateInRing(const geom::CoordinateXY& p, const geom::CoordinateSequence& ring);
 
 };
 

--- a/include/geos/algorithm/PointLocator.h
+++ b/include/geos/algorithm/PointLocator.h
@@ -25,7 +25,7 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 class Geometry;
 class LinearRing;
 class LineString;
@@ -66,7 +66,7 @@ public:
      *
      * @return the Location of the point relative to the input Geometry
      */
-    geom::Location locate(const geom::Coordinate& p, const geom::Geometry* geom);
+    geom::Location locate(const geom::CoordinateXY& p, const geom::Geometry* geom);
 
     /**
      * Convenience method to test a point for intersection with
@@ -77,7 +77,7 @@ public:
      * @return <code>true</code> if the point is in the interior or boundary of the Geometry
      */
     bool
-    intersects(const geom::Coordinate& p, const geom::Geometry* geom)
+    intersects(const geom::CoordinateXY& p, const geom::Geometry* geom)
     {
         return locate(p, geom) != geom::Location::EXTERIOR;
     }
@@ -88,17 +88,17 @@ private:
 
     int numBoundaries;    // the number of sub-elements whose boundaries the point lies in
 
-    void computeLocation(const geom::Coordinate& p, const geom::Geometry* geom);
+    void computeLocation(const geom::CoordinateXY& p, const geom::Geometry* geom);
 
     void updateLocationInfo(geom::Location loc);
 
-    geom::Location locate(const geom::Coordinate& p, const geom::Point* pt);
+    geom::Location locate(const geom::CoordinateXY& p, const geom::Point* pt);
 
-    geom::Location locate(const geom::Coordinate& p, const geom::LineString* l);
+    geom::Location locate(const geom::CoordinateXY& p, const geom::LineString* l);
 
-    geom::Location locateInPolygonRing(const geom::Coordinate& p, const geom::LinearRing* ring);
+    geom::Location locateInPolygonRing(const geom::CoordinateXY& p, const geom::LinearRing* ring);
 
-    geom::Location locate(const geom::Coordinate& p, const geom::Polygon* poly);
+    geom::Location locate(const geom::CoordinateXY& p, const geom::Polygon* poly);
 
 };
 

--- a/include/geos/algorithm/RayCrossingCounter.h
+++ b/include/geos/algorithm/RayCrossingCounter.h
@@ -28,6 +28,7 @@
 namespace geos {
 namespace geom {
 class Coordinate;
+class CoordinateXY;
 class CoordinateSequence;
 }
 }
@@ -63,7 +64,7 @@ namespace algorithm {
  */
 class GEOS_DLL RayCrossingCounter {
 private:
-    const geom::Coordinate& point;
+    const geom::CoordinateXY& point;
 
     int crossingCount;
 
@@ -84,14 +85,14 @@ public:
      * @param ring an array of Coordinates forming a ring
      * @return the location of the point in the ring
      */
-    static geom::Location locatePointInRing(const geom::Coordinate& p,
+    static geom::Location locatePointInRing(const geom::CoordinateXY& p,
                                  const geom::CoordinateSequence& ring);
 
     /// Semantically equal to the above, just different args encoding
-    static geom::Location locatePointInRing(const geom::Coordinate& p,
+    static geom::Location locatePointInRing(const geom::CoordinateXY& p,
                                  const std::vector<const geom::Coordinate*>& ring);
 
-    RayCrossingCounter(const geom::Coordinate& p_point)
+    RayCrossingCounter(const geom::CoordinateXY& p_point)
         : point(p_point),
           crossingCount(0),
           isPointOnSegment(false)
@@ -103,8 +104,8 @@ public:
      * @param p1 an endpoint of the segment
      * @param p2 another endpoint of the segment
      */
-    void countSegment(const geom::Coordinate& p1,
-                      const geom::Coordinate& p2);
+    void countSegment(const geom::CoordinateXY& p1,
+                      const geom::CoordinateXY& p2);
 
     /** \brief
      * Reports whether the point lies exactly on one of the supplied segments.

--- a/include/geos/algorithm/construct/LargestEmptyCircle.h
+++ b/include/geos/algorithm/construct/LargestEmptyCircle.h
@@ -121,8 +121,8 @@ private:
     bool done;
     std::unique_ptr<algorithm::locate::IndexedPointInAreaLocator> ptLocator;
     std::unique_ptr<operation::distance::IndexedFacetDistance> boundaryDistance;
-    geom::Coordinate centerPt;
-    geom::Coordinate radiusPt;
+    geom::CoordinateXY centerPt;
+    geom::CoordinateXY radiusPt;
 
     /* private methods */
     void setBoundary(const geom::Geometry* obstacles);

--- a/include/geos/algorithm/construct/MaximumInscribedCircle.h
+++ b/include/geos/algorithm/construct/MaximumInscribedCircle.h
@@ -117,8 +117,8 @@ private:
     IndexedPointInAreaLocator ptLocator;
     const geom::GeometryFactory* factory;
     bool done;
-    geom::Coordinate centerPt;
-    geom::Coordinate radiusPt;
+    geom::CoordinateXY centerPt;
+    geom::CoordinateXY radiusPt;
 
     /* private methods */
     double distanceToBoundary(const geom::Coordinate& c);

--- a/include/geos/algorithm/distance/DiscreteFrechetDistance.h
+++ b/include/geos/algorithm/distance/DiscreteFrechetDistance.h
@@ -137,7 +137,7 @@ public:
         return ptDist.getDistance();
     }
 
-    const std::array<geom::Coordinate, 2>
+    const std::array<geom::CoordinateXY, 2>
     getCoordinates() const
     {
         return ptDist.getCoordinates();

--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -138,7 +138,7 @@ public:
         return ptDist.getDistance();
     }
 
-    const std::array<geom::Coordinate, 2>
+    const std::array<geom::CoordinateXY, 2>
     getCoordinates() const
     {
         return ptDist.getCoordinates();

--- a/include/geos/algorithm/distance/PointPairDistance.h
+++ b/include/geos/algorithm/distance/PointPairDistance.h
@@ -49,7 +49,7 @@ public:
     }
 
     void
-    initialize(const geom::Coordinate& p0, const geom::Coordinate& p1)
+    initialize(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1)
     {
         pt[0] = p0;
         pt[1] = p1;
@@ -63,13 +63,13 @@ public:
         return std::sqrt(distanceSquared);
     }
 
-    const std::array<geom::Coordinate, 2>&
+    const std::array<geom::CoordinateXY, 2>&
     getCoordinates() const
     {
         return pt;
     }
 
-    const geom::Coordinate&
+    const geom::CoordinateXY&
     getCoordinate(std::size_t i) const
     {
         assert(i < pt.size());
@@ -83,7 +83,7 @@ public:
     }
 
     void
-    setMaximum(const geom::Coordinate& p0, const geom::Coordinate& p1)
+    setMaximum(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1)
     {
         if(isNull) {
             initialize(p0, p1);
@@ -102,7 +102,7 @@ public:
     }
 
     void
-    setMinimum(const geom::Coordinate& p0, const geom::Coordinate& p1)
+    setMinimum(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1)
     {
         if(isNull) {
             initialize(p0, p1);
@@ -129,7 +129,7 @@ private:
      * @param dist the distance between p0 and p1
      */
     void
-    initialize(const geom::Coordinate& p0, const geom::Coordinate& p1,
+    initialize(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1,
                double distSquared)
     {
         pt[0] = p0;
@@ -138,7 +138,7 @@ private:
         isNull = false;
     }
 
-    std::array<geom::Coordinate, 2> pt;
+    std::array<geom::CoordinateXY, 2> pt;
 
     double distanceSquared;
 

--- a/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
+++ b/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
@@ -119,7 +119,7 @@ public:
      * @param p the point to test
      * @return the location of the point in the geometry
      */
-    geom::Location locate(const geom::Coordinate* /*const*/ p) override;
+    geom::Location locate(const geom::CoordinateXY* /*const*/ p) override;
 
 };
 

--- a/include/geos/algorithm/locate/PointOnGeometryLocator.h
+++ b/include/geos/algorithm/locate/PointOnGeometryLocator.h
@@ -19,7 +19,7 @@
 
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 }
 }
 
@@ -47,7 +47,7 @@ public:
      * @param p the point to test
      * @return the location of the point in the geometry
      */
-    virtual geom::Location locate(const geom::Coordinate* /*const*/ p) = 0;
+    virtual geom::Location locate(const geom::CoordinateXY* /*const*/ p) = 0;
 };
 
 } // geos::algorithm::locate

--- a/include/geos/algorithm/locate/SimplePointInAreaLocator.h
+++ b/include/geos/algorithm/locate/SimplePointInAreaLocator.h
@@ -47,8 +47,8 @@ class GEOS_DLL SimplePointInAreaLocator : public PointOnGeometryLocator {
 
 public:
 
-    static geom::Location locate(const geom::Coordinate& p,
-                      const geom::Geometry* geom);
+    static geom::Location locate(const geom::CoordinateXY& p,
+                                 const geom::Geometry* geom);
 
     /** \brief
      * Determines the Location of a point in a [Polygon](@ref geom::Polygon).
@@ -69,8 +69,8 @@ public:
      * @param poly the geometry to test
      * @return the Location of the point in the polygon
      */
-    static geom::Location locatePointInPolygon(const geom::Coordinate& p,
-                                    const geom::Polygon* poly);
+    static geom::Location locatePointInPolygon(const geom::CoordinateXY& p,
+                                               const geom::Polygon* poly);
 
     /** \brief
      * Determines whether a point is contained in a [Geometry](@ref geom::Geometry),
@@ -84,7 +84,7 @@ public:
      * @param geom the geometry to test
      * @return true if the point lies in or on the geometry
      */
-    static bool isContained(const geom::Coordinate& p,
+    static bool isContained(const geom::CoordinateXY& p,
                             const geom::Geometry* geom);
 
     SimplePointInAreaLocator(const geom::Geometry* p_g)
@@ -92,15 +92,15 @@ public:
     { }
 
     geom::Location
-    locate(const geom::Coordinate* p) override
+    locate(const geom::CoordinateXY* p) override
     {
         return locate(*p, g);
     }
 
 private:
 
-    static geom::Location locateInGeometry(const geom::Coordinate& p,
-                                const geom::Geometry* geom);
+    static geom::Location locateInGeometry(const geom::CoordinateXY& p,
+                                           const geom::Geometry* geom);
 
     const geom::Geometry* g;
 

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -53,11 +53,17 @@ public:
     // See dox in CoordinateSequence.h
     void toVector(std::vector<Coordinate>&) const override;
 
+    void toVector(std::vector<CoordinateXY>&) const override;
+
     /// Construct an empty sequence
     CoordinateArraySequence();
 
     /// Construct sequence moving from given Coordinate vector
     CoordinateArraySequence(std::vector<Coordinate> && coords,
+                            std::size_t dimension = 0);
+
+    /// Construct sequence moving from given Coordinate vector
+    CoordinateArraySequence(std::vector<CoordinateXY> && coords,
                             std::size_t dimension = 0);
 
     /// Construct sequence taking ownership of given Coordinate vector

--- a/include/geos/geom/CoordinateArraySequenceFactory.h
+++ b/include/geos/geom/CoordinateArraySequenceFactory.h
@@ -59,6 +59,13 @@ public:
         return std::unique_ptr<CoordinateSequence>(new CoordinateArraySequence(std::move(coords), dimension));
     };
 
+    std::unique_ptr<CoordinateSequence> create(
+        std::vector<CoordinateXY> && coords,
+        size_t dimension) const override
+    {
+        return std::unique_ptr<CoordinateSequence>(new CoordinateArraySequence(std::move(coords), dimension));
+    };
+
     /** @see CoordinateSequenceFactory::create(std::size_t, int) */
     std::unique_ptr<CoordinateSequence> create(std::size_t size, std::size_t dimension) const override
     {

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -126,11 +126,17 @@ public:
     ///
     virtual void toVector(std::vector<Coordinate>& coords) const = 0;
 
+    virtual void toVector(std::vector<CoordinateXY>& coords) const = 0;
+
     /// Returns <code>true</code> it list contains no coordinates.
     virtual bool isEmpty() const = 0;
 
     /// Copy Coordinate c to position pos
     virtual void setAt(const Coordinate& c, std::size_t pos) = 0;
+
+    virtual void setAt(const CoordinateXY& c, std::size_t pos) {
+            setAt(Coordinate(c), pos);
+    }
 
     /// Get a string representation of CoordinateSequence
     std::string toString() const;

--- a/include/geos/geom/CoordinateSequenceFactory.h
+++ b/include/geos/geom/CoordinateSequenceFactory.h
@@ -28,6 +28,7 @@ namespace geos {
 namespace geom {
 class CoordinateSequence;
 class Coordinate;
+class CoordinateXY;
 }
 }
 
@@ -77,6 +78,10 @@ public:
      */
     virtual std::unique_ptr<CoordinateSequence> create(
             std::vector<Coordinate> && coordinates,
+            std::size_t dimension = 0) const = 0;
+
+    virtual std::unique_ptr<CoordinateSequence> create(
+            std::vector<CoordinateXY> && coordinates,
             std::size_t dimension = 0) const = 0;
 
     /** \brief

--- a/include/geos/geom/DefaultCoordinateSequenceFactory.h
+++ b/include/geos/geom/DefaultCoordinateSequenceFactory.h
@@ -36,6 +36,10 @@ public:
         return detail::make_unique<CoordinateArraySequence>(std::move(coords), dims);
     }
 
+    std::unique_ptr <CoordinateSequence> create(std::vector <CoordinateXY> &&coords, std::size_t dims = 0) const final override {
+        return detail::make_unique<CoordinateArraySequence>(std::move(coords), dims);
+    }
+
     std::unique_ptr <CoordinateSequence> create(std::size_t size, std::size_t dims = 0) const final override {
         switch(size) {
             case 5: return detail::make_unique<FixedSizeCoordinateSequence<5>>(dims);

--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -92,7 +92,7 @@ public:
      * @param  p1  the first Coordinate
      * @param  p2  the second Coordinate
      */
-    Envelope(const Coordinate& p1, const Coordinate& p2)
+    Envelope(const CoordinateXY& p1, const CoordinateXY& p2)
     {
         init(p1, p2);
     }
@@ -102,7 +102,7 @@ public:
      *
      * @param  p  the Coordinate
      */
-    explicit Envelope(const Coordinate& p)
+    explicit Envelope(const CoordinateXY& p)
     {
         init(p);
     }
@@ -122,8 +122,8 @@ public:
      * @param q the point to test for intersection
      * @return `true` if q intersects the envelope p1-p2
      */
-    static bool intersects(const Coordinate& p1, const Coordinate& p2,
-                           const Coordinate& q);
+    static bool intersects(const CoordinateXY& p1, const CoordinateXY& p2,
+                           const CoordinateXY& q);
 
     /** \brief
      * Test the envelope defined by `p1-p2` for intersection
@@ -137,8 +137,8 @@ public:
      * @return `true` if Q intersects P
      */
     static bool intersects(
-        const Coordinate& p1, const Coordinate& p2,
-        const Coordinate& q1, const Coordinate& q2)
+        const CoordinateXY& p1, const CoordinateXY& p2,
+        const CoordinateXY& q1, const CoordinateXY& q2)
     {
         double minq = std::min(q1.x, q2.x);
         double maxq = std::max(q1.x, q2.x);
@@ -171,7 +171,7 @@ public:
      * @param b another point
      * @return `true` if the extents intersect
      */
-    bool intersects(const Coordinate& a, const Coordinate& b) const;
+    bool intersects(const CoordinateXY& a, const CoordinateXY& b) const;
 
     /** \brief
      *  Initialize to a null Envelope.
@@ -215,7 +215,7 @@ public:
      * @param  p1  the first Coordinate
      * @param  p2  the second Coordinate
      */
-    void init(const Coordinate& p1, const Coordinate& p2)
+    void init(const CoordinateXY& p1, const CoordinateXY& p2)
     {
         init(p1.x, p2.x, p1.y, p2.y);
     };
@@ -225,7 +225,7 @@ public:
      *
      * @param  p  the Coordinate
      */
-    void init(const Coordinate& p)
+    void init(const CoordinateXY& p)
     {
         init(p.x, p.x, p.y, p.y);
     };
@@ -350,7 +350,7 @@ public:
      * @param centre The coordinate to write results into
      * @return `false` if the center could not be found (null envelope).
      */
-    bool centre(Coordinate& centre) const;
+    bool centre(CoordinateXY& centre) const;
 
     /** \brief
      * Computes the intersection of two [Envelopes](@ref Envelope).
@@ -399,7 +399,7 @@ public:
      *
      * @param  p the Coordinate to include
      */
-    void expandToInclude(const Coordinate& p)
+    void expandToInclude(const CoordinateXY& p)
     {
         expandToInclude(p.x, p.y);
     };
@@ -506,7 +506,7 @@ public:
      *         of this Envelope.
      */
     bool
-    contains(const Coordinate& p) const
+    contains(const CoordinateXY& p) const
     {
         return covers(p.x, p.y);
     }
@@ -533,7 +533,7 @@ public:
      * @param other the Coordinate to be tested
      * @return true if the point intersects this Envelope
      */
-    bool intersects(const Coordinate& other) const
+    bool intersects(const CoordinateXY& other) const
     {
         return (other.x <= maxx && other.x >= minx &&
                 other.y <= maxy && other.y >= miny);
@@ -610,7 +610,7 @@ public:
      * @param p the point which this Envelope is being checked for containing
      * @return `true` if the point lies in the interior or on the boundary of this Envelope.
      */
-    bool covers(const Coordinate* p) const
+    bool covers(const CoordinateXY* p) const
     {
         return covers(p->x, p->y);
     }
@@ -694,9 +694,9 @@ public:
      * @param p1 second coordinate defining an envelope.
      */
     static double distanceToCoordinate(
-        const Coordinate& c,
-        const Coordinate& p0,
-        const Coordinate& p1)
+        const CoordinateXY& c,
+        const CoordinateXY& p0,
+        const CoordinateXY& p1)
     {
         return std::sqrt(distanceSquaredToCoordinate(c, p0, p1));
     };
@@ -711,9 +711,9 @@ public:
      * @param p1 second coordinate defining an envelope.
      */
     static double distanceSquaredToCoordinate(
-        const Coordinate& c,
-        const Coordinate& p0,
-        const Coordinate& p1)
+        const CoordinateXY& c,
+        const CoordinateXY& p0,
+        const CoordinateXY& p1)
     {
         double xa = c.x - p0.x;
         double xb = c.x - p1.x;

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -108,6 +108,12 @@ namespace geom {
             out.insert(out.end(), m_data.begin(), m_data.end());
         }
 
+        void toVector(std::vector<CoordinateXY> & out) const final override {
+            for (const auto& pt : m_data) {
+                out.push_back(pt);
+            }
+        }
+
         void setPoints(const std::vector<Coordinate> & v) final override {
             bool nonZero = N > 0;
             if (nonZero) {

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -281,7 +281,7 @@ public:
     const PrecisionModel* getPrecisionModel() const;
 
     /// Returns a vertex of this Geometry, or NULL if this is the empty geometry.
-    virtual const Coordinate* getCoordinate() const = 0; //Abstract
+    virtual const CoordinateXY* getCoordinate() const = 0; //Abstract
 
     /**
      * \brief
@@ -902,7 +902,7 @@ protected:
 
     int compare(const std::vector<std::unique_ptr<Geometry>> & a, const std::vector<std::unique_ptr<Geometry>> & b) const;
 
-    bool equal(const Coordinate& a, const Coordinate& b,
+    bool equal(const CoordinateXY& a, const CoordinateXY& b,
                double tolerance) const;
     int SRID;
 

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -150,7 +150,7 @@ public:
 
     void normalize() override;
 
-    const Coordinate* getCoordinate() const override;
+    const CoordinateXY* getCoordinate() const override;
 
     /// Returns the total area of this collection
     double getArea() const override;

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -169,6 +169,7 @@ public:
 
     /// Creates a Point using the given Coordinate
     Point* createPoint(const Coordinate& coordinate) const;
+    std::unique_ptr<Point> createPoint(const CoordinateXY& coordinate) const;
 
     /// Creates a Point taking ownership of the given CoordinateSequence
     Point* createPoint(CoordinateSequence* coordinates) const;
@@ -253,6 +254,8 @@ public:
     MultiPoint* createMultiPoint(std::vector<Geometry*>* newPoints) const;
 
     std::unique_ptr<MultiPoint> createMultiPoint(std::vector<Coordinate> && newPoints) const;
+
+    std::unique_ptr<MultiPoint> createMultiPoint(std::vector<CoordinateXY> && newPoints) const;
 
     std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Point>> && newPoints) const;
 

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -181,7 +181,7 @@ public:
     //was protected
     int compareToSameClass(const Geometry* ls) const override;
 
-    const Coordinate* getCoordinate() const override;
+    const CoordinateXY* getCoordinate() const override;
 
     double getLength() const override;
 

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -125,7 +125,7 @@ protected:
 
     MultiPoint* reverseImpl() const override { return new MultiPoint(*this); }
 
-    const Coordinate* getCoordinateN(std::size_t n) const;
+    const CoordinateXY* getCoordinateN(std::size_t n) const;
 
     int
     getSortIndex() const override

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -165,6 +165,8 @@ protected:
 
     Point(const Coordinate& c, const GeometryFactory* newFactory);
 
+    Point(const CoordinateXY& c, const GeometryFactory* newFactory);
+
     Point(const Point& p);
 
     Point* cloneImpl() const override { return new Point(*this); }

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -150,7 +150,7 @@ public:
 
     std::unique_ptr<Polygon> reverse() const { return std::unique_ptr<Polygon>(reverseImpl()); }
 
-    const Coordinate* getCoordinate() const override;
+    const CoordinateXY* getCoordinate() const override;
 
     double getArea() const override;
 

--- a/include/geos/geom/Triangle.h
+++ b/include/geos/geom/Triangle.h
@@ -27,9 +27,9 @@ namespace geom { // geos::geom
  */
 class GEOS_DLL Triangle {
 public:
-    Coordinate p0, p1, p2;
+    CoordinateXY p0, p1, p2;
 
-    Triangle(const Coordinate& nP0, const Coordinate& nP1, const Coordinate& nP2)
+    Triangle(const CoordinateXY& nP0, const CoordinateXY& nP1, const CoordinateXY& nP2)
         : p0(nP0)
         , p1(nP1)
         , p2(nP2) {}
@@ -43,7 +43,7 @@ public:
      *
      * @param resultPoint the point into which to write the inCentre of the triangle
      */
-    void inCentre(Coordinate& resultPoint);
+    void inCentre(CoordinateXY& resultPoint);
 
     /** \brief
      * Computes the circumcentre of a triangle.
@@ -62,12 +62,12 @@ public:
      *
      * @param resultPoint the point into which to write the inCentre of the triangle
      */
-    void circumcentre(Coordinate& resultPoint);
-    void circumcentreDD(Coordinate& resultPoint);
+    void circumcentre(CoordinateXY& resultPoint);
+    void circumcentreDD(CoordinateXY& resultPoint);
 
     /** Computes the circumcentre of a triangle. */
-    static const Coordinate circumcentre(
-        const Coordinate& p0, const Coordinate& p1, const Coordinate& p2);
+    static const CoordinateXY circumcentre(
+        const CoordinateXY& p0, const CoordinateXY& p1, const CoordinateXY& p2);
 
     bool isIsoceles();
 
@@ -84,7 +84,7 @@ public:
     * @param c a vertex of the triangle
     * @return true if the triangle is acute
     */
-    static bool isAcute(const Coordinate& a, const Coordinate& b, const Coordinate& c);
+    static bool isAcute(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c);
 
     /**
     * Tests whether a triangle is oriented counter-clockwise.
@@ -94,7 +94,7 @@ public:
     * @param c a vertex of the triangle
     * @return true if the triangle orientation is counter-clockwise
     */
-    static bool isCCW(const Coordinate& a, const Coordinate& b, const Coordinate& c);
+    static bool isCCW(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c);
 
 
     /**
@@ -106,8 +106,8 @@ public:
     * @param p the point to test
     * @return true if the triangle intersects the point
     */
-    static bool intersects(const Coordinate& a, const Coordinate& b, const Coordinate& c,
-        const Coordinate& p);
+    static bool intersects(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c,
+        const CoordinateXY& p);
 
 
     /**
@@ -115,7 +115,7 @@ public:
     * @param p the point to test
     * @return true if the triangle intersects the point
     */
-    bool intersects(const Coordinate& p) { return intersects(p0, p1, p2, p); };
+    bool intersects(const CoordinateXY& p) { return intersects(p0, p1, p2, p); };
 
     /**
     * Tests whether this triangle is oriented counter-clockwise.
@@ -138,9 +138,9 @@ public:
     * @return the length of the longest side of the triangle
     */
     static double longestSideLength(
-        const Coordinate& a,
-        const Coordinate& b,
-        const Coordinate& c);
+        const CoordinateXY& a,
+        const CoordinateXY& b,
+        const CoordinateXY& c);
 
     /**
     * Compute the length of the perimeter of a triangle
@@ -150,7 +150,7 @@ public:
     * @param c a vertex of the triangle
     * @return the length of the triangle perimeter
     */
-    static double length(const Coordinate& a, const Coordinate& b, const Coordinate& c);
+    static double length(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c);
 
     /**
     * Computes the length of the perimeter of this triangle.
@@ -168,7 +168,7 @@ public:
     * @return the area of the triangle
     *
     */
-    static double area(const Coordinate& a, const Coordinate& b, const Coordinate& c);
+    static double area(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c);
 
     double area() const;
 

--- a/include/geos/geom/prep/BasicPreparedGeometry.h
+++ b/include/geos/geom/prep/BasicPreparedGeometry.h
@@ -58,7 +58,7 @@ namespace prep { // geos::geom::prep
 class BasicPreparedGeometry: public PreparedGeometry {
 private:
     const geom::Geometry* baseGeom;
-    Coordinate::ConstVect representativePts;
+    std::vector<const CoordinateXY*> representativePts;
 
 protected:
     /**
@@ -103,7 +103,7 @@ public:
      *
      * @return a List of Coordinate
      */
-    const Coordinate::ConstVect*
+    const std::vector<const CoordinateXY*>*
     getRepresentativePoints()  const
     {
         return &representativePts;

--- a/include/geos/geom/prep/PreparedPolygonPredicate.h
+++ b/include/geos/geom/prep/PreparedPolygonPredicate.h
@@ -117,7 +117,7 @@ protected:
      * @return true if any component intersects the areal test geometry
      */
     bool isAnyTargetComponentInAreaTest(const geom::Geometry* testGeom,
-                                        const geom::Coordinate::ConstVect* targetRepPts) const;
+                                        const std::vector<const geom::CoordinateXY*>* targetRepPts) const;
 
 public:
     /** \brief

--- a/include/geos/geom/util/ComponentCoordinateExtracter.h
+++ b/include/geos/geom/util/ComponentCoordinateExtracter.h
@@ -42,13 +42,13 @@ public:
      * efficient to create a single ComponentCoordinateFilter instance
      * and pass it to multiple geometries.
      */
-    static void getCoordinates(const Geometry& geom, std::vector<const Coordinate*>& ret);
+    static void getCoordinates(const Geometry& geom, std::vector<const CoordinateXY*>& ret);
 
     /**
      * Constructs a ComponentCoordinateFilter with a list in which
      * to store Coordinates found.
      */
-    ComponentCoordinateExtracter(std::vector<const Coordinate*>& newComps);
+    ComponentCoordinateExtracter(std::vector<const CoordinateXY*>& newComps);
 
     void filter_rw(Geometry* geom) override;
 
@@ -56,7 +56,7 @@ public:
 
 private:
 
-    Coordinate::ConstVect& comps;
+    std::vector<const CoordinateXY*>& comps;
 
     // Declare type as noncopyable
     ComponentCoordinateExtracter(const ComponentCoordinateExtracter& other) = delete;

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -34,6 +34,7 @@
 namespace geos {
 namespace geom {
 class Coordinate;
+class CoordinateXY;
 class CoordinateSequence;
 class Geometry;
 class GeometryCollection;
@@ -121,6 +122,7 @@ public:
      * @return the WKT
      */
     static std::string toPoint(const geom::Coordinate& p0);
+    static std::string toPoint(const geom::CoordinateXY& p0);
 
     /**
      * Sets the rounding precision when writing the WKT

--- a/include/geos/operation/distance/ConnectedElementPointFilter.h
+++ b/include/geos/operation/distance/ConnectedElementPointFilter.h
@@ -27,7 +27,7 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 class Geometry;
 }
 }
@@ -46,7 +46,7 @@ namespace distance { // geos::operation::distance
 class GEOS_DLL ConnectedElementPointFilter: public geom::GeometryFilter {
 
 private:
-    std::vector<const geom::Coordinate*>* pts;
+    std::vector<const geom::CoordinateXY*>* pts;
 
 public:
     /**
@@ -54,9 +54,9 @@ public:
      * found inside the specified geometry. Thus, if the specified geometry is
      * not a GeometryCollection, an empty list will be returned.
      */
-    static std::vector<const geom::Coordinate*>* getCoordinates(const geom::Geometry* geom);
+    static std::vector<const geom::CoordinateXY*>* getCoordinates(const geom::Geometry* geom);
 
-    ConnectedElementPointFilter(std::vector<const geom::Coordinate*>* newPts)
+    ConnectedElementPointFilter(std::vector<const geom::CoordinateXY*>* newPts)
         :
         pts(newPts)
     {}

--- a/include/geos/operation/distance/GeometryLocation.h
+++ b/include/geos/operation/distance/GeometryLocation.h
@@ -51,7 +51,7 @@ private:
     const geom::Geometry* component;
     std::size_t segIndex;
     bool inside_area;
-    geom::Coordinate pt;
+    geom::CoordinateXY pt;
 public:
     /** \brief
      * A Special value of segmentIndex used for locations
@@ -72,7 +72,7 @@ public:
      * @param pt the coordinate of the location
      */
     GeometryLocation(const geom::Geometry* component,
-                     std::size_t segIndex, const geom::Coordinate& pt);
+                     std::size_t segIndex, const geom::CoordinateXY& pt);
 
     /** \brief
      * Constructs a GeometryLocation specifying a point inside an
@@ -82,7 +82,7 @@ public:
      * @param pt the coordinate of the location
      */
     GeometryLocation(const geom::Geometry* component,
-                     const geom::Coordinate& pt);
+                     const geom::CoordinateXY& pt);
 
     /**
      * Returns the geometry component on (or in) which this location occurs.
@@ -102,7 +102,7 @@ public:
     /**
      * Returns the geom::Coordinate of this location.
      */
-    geom::Coordinate& getCoordinate();
+    geom::CoordinateXY& getCoordinate();
 
     /** \brief
      * Tests whether this location represents a point

--- a/include/geos/operation/distance/IndexedFacetDistance.h
+++ b/include/geos/operation/distance/IndexedFacetDistance.h
@@ -77,7 +77,7 @@ public:
     /// \param g1 a geometry
     /// \param g2 a geometry
     /// \return the nearest points on the facets of the geometries
-    static std::vector<geom::Coordinate> nearestPoints(const geom::Geometry* g1, const geom::Geometry* g2);
+    static std::vector<geom::CoordinateXY> nearestPoints(const geom::Geometry* g1, const geom::Geometry* g2);
 
     /// \brief Computes the distance from the base geometry to the given geometry.
     ///
@@ -104,7 +104,7 @@ public:
     ///
     /// \param g the geometry to compute the nearest point to
     /// \return the nearest points
-    std::vector<geom::Coordinate> nearestPoints(const geom::Geometry* g) const;
+    std::vector<geom::CoordinateXY> nearestPoints(const geom::Geometry* g) const;
 
 private:
     struct FacetDistance {

--- a/include/geos/operation/overlayng/IndexedPointOnLineLocator.h
+++ b/include/geos/operation/overlayng/IndexedPointOnLineLocator.h
@@ -53,7 +53,7 @@ public:
         : inputGeom(geomLinear)
         {}
 
-    geom::Location locate(const geom::Coordinate* p) override;
+    geom::Location locate(const geom::CoordinateXY* p) override;
 
 };
 

--- a/include/geos/operation/valid/IsValidOp.h
+++ b/include/geos/operation/valid/IsValidOp.h
@@ -24,7 +24,7 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 class Geometry;
 class Point;
 class MultiPoint;
@@ -77,7 +77,7 @@ private:
     }
 
 
-    void logInvalid(int code, const geom::Coordinate* pt);
+    void logInvalid(int code, const geom::CoordinateXY* pt);
 
     bool isValidGeometry(const geom::Geometry* g);
 

--- a/src/algorithm/Angle.cpp
+++ b/src/algorithm/Angle.cpp
@@ -41,8 +41,8 @@ Angle::toRadians(double angleDegrees)
 
 /* public static */
 double
-Angle::angle(const geom::Coordinate& p0,
-             const geom::Coordinate& p1)
+Angle::angle(const geom::CoordinateXY& p0,
+             const geom::CoordinateXY& p1)
 {
     double dx = p1.x - p0.x;
     double dy = p1.y - p0.y;
@@ -51,16 +51,16 @@ Angle::angle(const geom::Coordinate& p0,
 
 /* public static */
 double
-Angle::angle(const geom::Coordinate& p)
+Angle::angle(const geom::CoordinateXY& p)
 {
     return atan2(p.y, p.x);
 }
 
 /* public static */
 bool
-Angle::isAcute(const geom::Coordinate& p0,
-               const geom::Coordinate& p1,
-               const geom::Coordinate& p2)
+Angle::isAcute(const geom::CoordinateXY& p0,
+               const geom::CoordinateXY& p1,
+               const geom::CoordinateXY& p2)
 {
     // relies on fact that A dot B is positive iff A ang B is acute
     double dx0 = p0.x - p1.x;
@@ -73,9 +73,9 @@ Angle::isAcute(const geom::Coordinate& p0,
 
 /* public static */
 bool
-Angle::isObtuse(const geom::Coordinate& p0,
-                const geom::Coordinate& p1,
-                const geom::Coordinate& p2)
+Angle::isObtuse(const geom::CoordinateXY& p0,
+                const geom::CoordinateXY& p1,
+                const geom::CoordinateXY& p2)
 {
     // relies on fact that A dot B is negative iff A ang B is obtuse
     double dx0 = p0.x - p1.x;
@@ -88,9 +88,9 @@ Angle::isObtuse(const geom::Coordinate& p0,
 
 /* public static */
 double
-Angle::angleBetween(const geom::Coordinate& tip1,
-                    const geom::Coordinate& tail,
-                    const geom::Coordinate& tip2)
+Angle::angleBetween(const geom::CoordinateXY& tip1,
+                    const geom::CoordinateXY& tail,
+                    const geom::CoordinateXY& tip2)
 {
     double a1 = angle(tail, tip1);
     double a2 = angle(tail, tip2);
@@ -100,9 +100,9 @@ Angle::angleBetween(const geom::Coordinate& tip1,
 
 /* public static */
 double
-Angle::angleBetweenOriented(const geom::Coordinate& tip1,
-                            const geom::Coordinate& tail,
-                            const geom::Coordinate& tip2)
+Angle::angleBetweenOriented(const geom::CoordinateXY& tip1,
+                            const geom::CoordinateXY& tail,
+                            const geom::CoordinateXY& tip2)
 {
     double a1 = angle(tail, tip1);
     double a2 = angle(tail, tip2);
@@ -120,8 +120,8 @@ Angle::angleBetweenOriented(const geom::Coordinate& tip1,
 
 /* public static */
 double
-Angle::interiorAngle(const geom::Coordinate& p0, const geom::Coordinate& p1,
-                     const geom::Coordinate& p2)
+Angle::interiorAngle(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1,
+                     const geom::CoordinateXY& p2)
 {
     double anglePrev = angle(p1, p0);
     double angleNext = angle(p1, p2);

--- a/src/algorithm/CGAlgorithmsDD.cpp
+++ b/src/algorithm/CGAlgorithmsDD.cpp
@@ -82,9 +82,9 @@ CGAlgorithmsDD::orientationIndex(double p1x, double p1y,
 
 // inlining this method worsened performance slighly
 int
-CGAlgorithmsDD::orientationIndex(const Coordinate& p1,
-                                 const Coordinate& p2,
-                                 const Coordinate& q)
+CGAlgorithmsDD::orientationIndex(const CoordinateXY& p1,
+                                 const CoordinateXY& p2,
+                                 const CoordinateXY& q)
 {
 
     return orientationIndex(p1.x, p1.y, p2.x, p2.y, q.x, q.y);
@@ -113,9 +113,9 @@ CGAlgorithmsDD::signOfDet2x2(double dx1, double dy1, double dx2, double dy2)
     return CGAlgorithmsDD::signOfDet2x2(x1, y1, x2, y2);
 }
 
-Coordinate
-CGAlgorithmsDD::intersection(const Coordinate& p1, const Coordinate& p2,
-                             const Coordinate& q1, const Coordinate& q2)
+CoordinateXY
+CGAlgorithmsDD::intersection(const CoordinateXY& p1, const CoordinateXY& p2,
+                             const CoordinateXY& q1, const CoordinateXY& q2)
 {
     DD q1x(q1.x);
     DD q1y(q1.y);
@@ -155,8 +155,8 @@ CGAlgorithmsDD::intersection(const Coordinate& p1, const Coordinate& p2,
 }
 
 /* public static */
-Coordinate
-CGAlgorithmsDD::circumcentreDD(const Coordinate& a, const Coordinate& b, const Coordinate& c)
+CoordinateXY
+CGAlgorithmsDD::circumcentreDD(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
     DD ax = DD(a.x) - DD(c.x);
     DD ay = DD(a.y) - DD(c.y);

--- a/src/algorithm/Distance.cpp
+++ b/src/algorithm/Distance.cpp
@@ -29,9 +29,9 @@ namespace algorithm { // geos.algorithm
 
 /*public static*/
 double
-Distance::pointToSegment(const geom::Coordinate& p,
-                         const geom::Coordinate& A,
-                         const geom::Coordinate& B)
+Distance::pointToSegment(const geom::CoordinateXY& p,
+                         const geom::CoordinateXY& A,
+                         const geom::CoordinateXY& B)
 {
     /* if start==end, then use pt distance */
     if(A == B) {
@@ -80,8 +80,8 @@ Distance::pointToSegment(const geom::Coordinate& p,
 
 /*public static*/
 double
-Distance::pointToLinePerpendicular(const geom::Coordinate& p,
-                                   const geom::Coordinate& A, const geom::Coordinate& B)
+Distance::pointToLinePerpendicular(const geom::CoordinateXY& p,
+                                   const geom::CoordinateXY& A, const geom::CoordinateXY& B)
 {
     /*
         use comp.graphics.algorithms method
@@ -102,9 +102,9 @@ Distance::pointToLinePerpendicular(const geom::Coordinate& p,
 
 /*public static*/
 double
-Distance::segmentToSegment(const geom::Coordinate& A,
-                           const geom::Coordinate& B, const geom::Coordinate& C,
-                           const geom::Coordinate& D)
+Distance::segmentToSegment(const geom::CoordinateXY& A,
+                           const geom::CoordinateXY& B, const geom::CoordinateXY& C,
+                           const geom::CoordinateXY& D)
 {
     /* Check for zero-length segments */
     if(A == B) {
@@ -177,7 +177,7 @@ Distance::segmentToSegment(const geom::Coordinate& A,
 
 /*public static*/
 double
-Distance::pointToSegmentString(const geom::Coordinate& p,
+Distance::pointToSegmentString(const geom::CoordinateXY& p,
                                const geom::CoordinateSequence* seq)
 {
     if(seq->isEmpty()) {

--- a/src/algorithm/InteriorPointArea.cpp
+++ b/src/algorithm/InteriorPointArea.cpp
@@ -134,7 +134,7 @@ public:
     }
 
     bool
-    getInteriorPoint(Coordinate& ret) const
+    getInteriorPoint(CoordinateXY& ret) const
     {
         ret = interiorPoint;
         return true;
@@ -172,7 +172,7 @@ private:
     const Polygon& polygon;
     double interiorPointY;
     double interiorSectionWidth = 0.0;
-    Coordinate interiorPoint;
+    CoordinateXY interiorPoint;
 
     void scanRing(const LinearRing& ring, std::vector<double>& crossings)
     {

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -270,7 +270,7 @@ LineIntersector::computeIntersection(const Coordinate& p, const Coordinate& p1, 
 
 /* public static */
 bool
-LineIntersector::hasIntersection(const Coordinate& p, const Coordinate& p1, const Coordinate& p2)
+LineIntersector::hasIntersection(const CoordinateXY& p, const CoordinateXY& p1, const CoordinateXY& p2)
 {
     if(Envelope::intersects(p1, p2, p)) {
         if((Orientation::index(p1, p2, p) == 0) &&

--- a/src/algorithm/MinimumBoundingCircle.cpp
+++ b/src/algorithm/MinimumBoundingCircle.cpp
@@ -78,7 +78,7 @@ MinimumBoundingCircle::getMaximumDiameter()
             return input->getFactory()->createLineString(std::move(cs));
         }
         default: {
-            std::vector<Coordinate> fp = farthestPoints(extremalPts);
+            const auto& fp = farthestPoints(extremalPts);
             auto cs = input->getFactory()->getCoordinateSequenceFactory()->create(len, dims);
             cs->setAt(fp.front(), 0);
             cs->setAt(fp.back(), 1);
@@ -89,10 +89,10 @@ MinimumBoundingCircle::getMaximumDiameter()
 }
 
 /* private */
-std::vector<Coordinate>
-MinimumBoundingCircle::farthestPoints(std::vector<Coordinate>& pts)
+std::vector<CoordinateXY>
+MinimumBoundingCircle::farthestPoints(std::vector<CoordinateXY>& pts)
 {
-    std::vector<Coordinate> fp;
+    std::vector<CoordinateXY> fp;
     double dist01 = pts[0].distance(pts[1]);
     double dist12 = pts[1].distance(pts[2]);
     double dist20 = pts[2].distance(pts[0]);
@@ -134,7 +134,7 @@ MinimumBoundingCircle::getDiameter()
 
 
 /*public*/
-std::vector<Coordinate>
+std::vector<CoordinateXY>
 MinimumBoundingCircle::getExtremalPoints()
 {
     compute();
@@ -142,7 +142,7 @@ MinimumBoundingCircle::getExtremalPoints()
 }
 
 /*public*/
-Coordinate
+CoordinateXY
 MinimumBoundingCircle::getCentre()
 {
     compute();
@@ -222,7 +222,7 @@ MinimumBoundingCircle::computeCirclePoints()
     std::unique_ptr<Geometry> convexHull(input->convexHull());
 
     std::unique_ptr<CoordinateSequence> cs(convexHull->getCoordinates());
-    std::vector<Coordinate> pts;
+    std::vector<CoordinateXY> pts;
     cs->toVector(pts);
 
     // strip duplicate final point, if any
@@ -239,10 +239,10 @@ MinimumBoundingCircle::computeCirclePoints()
     }
 
     // find a point P with minimum Y ordinate
-    Coordinate P = lowestPoint(pts);
+    CoordinateXY P = lowestPoint(pts);
 
     // find a point Q such that the angle that PQ makes with the x-axis is minimal
-    Coordinate Q = pointWitMinAngleWithX(pts, P);
+    CoordinateXY Q = pointWitMinAngleWithX(pts, P);
 
     /*
      * Iterate over the remaining points to find
@@ -253,7 +253,7 @@ MinimumBoundingCircle::computeCirclePoints()
      */
     std::size_t i = 0, n = pts.size();
     while(i++ < n) {
-        Coordinate R = pointWithMinAngleWithSegment(pts, P, Q);
+        CoordinateXY R = pointWithMinAngleWithSegment(pts, P, Q);
 
         // if PRQ is obtuse, then MBC is determined by P and Q
         if(algorithm::Angle::isObtuse(P, R, Q)) {
@@ -282,10 +282,10 @@ MinimumBoundingCircle::computeCirclePoints()
 }
 
 /*private*/
-Coordinate
-MinimumBoundingCircle::lowestPoint(std::vector<Coordinate>& pts)
+CoordinateXY
+MinimumBoundingCircle::lowestPoint(std::vector<CoordinateXY>& pts)
 {
-    const Coordinate* min = &(pts[0]);
+    const CoordinateXY* min = &(pts[0]);
     for(const auto& pt : pts) {
         if(pt.y < min->y) {
             min = &pt;
@@ -296,11 +296,11 @@ MinimumBoundingCircle::lowestPoint(std::vector<Coordinate>& pts)
 
 
 /*private*/
-Coordinate
-MinimumBoundingCircle::pointWitMinAngleWithX(std::vector<Coordinate>& pts, Coordinate& P)
+CoordinateXY
+MinimumBoundingCircle::pointWitMinAngleWithX(std::vector<CoordinateXY>& pts, CoordinateXY& P)
 {
     double minSin = DoubleInfinity;
-    Coordinate minAngPt;
+    CoordinateXY minAngPt;
     minAngPt.setNull();
     for(const auto& p : pts) {
 
@@ -329,12 +329,12 @@ MinimumBoundingCircle::pointWitMinAngleWithX(std::vector<Coordinate>& pts, Coord
 
 
 /*private*/
-Coordinate
-MinimumBoundingCircle::pointWithMinAngleWithSegment(std::vector<Coordinate>& pts, Coordinate& P, Coordinate& Q)
+CoordinateXY
+MinimumBoundingCircle::pointWithMinAngleWithSegment(std::vector<CoordinateXY>& pts, CoordinateXY& P, CoordinateXY& Q)
 {
     assert(!pts.empty());
     double minAng = DoubleInfinity;
-    const Coordinate* minAngPt = &pts[0];
+    const CoordinateXY* minAngPt = &pts[0];
 
     for(const auto& p : pts) {
         if(p == P) {

--- a/src/algorithm/Orientation.cpp
+++ b/src/algorithm/Orientation.cpp
@@ -33,8 +33,8 @@ namespace algorithm { // geos.algorithm
 /* public static */
 // inlining this method worsened performance slightly
 int
-Orientation::index(const geom::Coordinate& p1, const geom::Coordinate& p2,
-                   const geom::Coordinate& q)
+Orientation::index(const geom::CoordinateXY& p1, const geom::CoordinateXY& p2,
+                   const geom::CoordinateXY& q)
 {
     return CGAlgorithmsDD::orientationIndex(p1, p2, q);
 }

--- a/src/algorithm/PointLocation.cpp
+++ b/src/algorithm/PointLocation.cpp
@@ -32,7 +32,7 @@ namespace algorithm { // geos.algorithm
 
 /* public static */
 bool
-PointLocation::isOnLine(const geom::Coordinate& p, const geom::CoordinateSequence* pt)
+PointLocation::isOnLine(const geom::CoordinateXY& p, const geom::CoordinateSequence* pt)
 {
     std::size_t ptsize = pt->getSize();
     if(ptsize == 0) {
@@ -52,7 +52,7 @@ PointLocation::isOnLine(const geom::Coordinate& p, const geom::CoordinateSequenc
 
 /* public static */
 bool
-PointLocation::isInRing(const geom::Coordinate& p,
+PointLocation::isInRing(const geom::CoordinateXY& p,
                         const std::vector<const geom::Coordinate*>& ring)
 {
     return PointLocation::locateInRing(p, ring) != geom::Location::EXTERIOR;
@@ -60,7 +60,7 @@ PointLocation::isInRing(const geom::Coordinate& p,
 
 /* public static */
 bool
-PointLocation::isInRing(const geom::Coordinate& p,
+PointLocation::isInRing(const geom::CoordinateXY& p,
                         const geom::CoordinateSequence* ring)
 {
     return PointLocation::locateInRing(p, *ring) != geom::Location::EXTERIOR;
@@ -68,7 +68,7 @@ PointLocation::isInRing(const geom::Coordinate& p,
 
 /* public static */
 geom::Location
-PointLocation::locateInRing(const geom::Coordinate& p,
+PointLocation::locateInRing(const geom::CoordinateXY& p,
                             const std::vector<const geom::Coordinate*>& ring)
 {
     return RayCrossingCounter::locatePointInRing(p, ring);
@@ -76,7 +76,7 @@ PointLocation::locateInRing(const geom::Coordinate& p,
 
 /* public static */
 geom::Location
-PointLocation::locateInRing(const geom::Coordinate& p,
+PointLocation::locateInRing(const geom::CoordinateXY& p,
                             const geom::CoordinateSequence& ring)
 {
     return RayCrossingCounter::locatePointInRing(p, ring);

--- a/src/algorithm/PointLocator.cpp
+++ b/src/algorithm/PointLocator.cpp
@@ -40,7 +40,7 @@ namespace algorithm { // geos.algorithm
 
 
 Location
-PointLocator::locate(const Coordinate& p, const Geometry* geom)
+PointLocator::locate(const CoordinateXY& p, const Geometry* geom)
 {
     if (geom->isEmpty()) {
         return Location::EXTERIOR;
@@ -72,7 +72,7 @@ PointLocator::locate(const Coordinate& p, const Geometry* geom)
 
 /* private */
 void
-PointLocator::computeLocation(const Coordinate& p, const Geometry* geom)
+PointLocator::computeLocation(const CoordinateXY& p, const Geometry* geom)
 {
 
     GeometryTypeId geomTypeId = geom->getGeometryTypeId();
@@ -149,7 +149,7 @@ PointLocator::updateLocationInfo(geom::Location loc)
 
 /* private */
 Location
-PointLocator::locate(const Coordinate& p, const Point* pt)
+PointLocator::locate(const CoordinateXY& p, const Point* pt)
 {
     // no point in doing envelope test, since equality test is just as fast
     const Coordinate* ptCoord = pt->getCoordinate();
@@ -161,7 +161,7 @@ PointLocator::locate(const Coordinate& p, const Point* pt)
 
 /* private */
 Location
-PointLocator::locate(const Coordinate& p, const LineString* l)
+PointLocator::locate(const CoordinateXY& p, const LineString* l)
 {
     if(!l->getEnvelopeInternal()->intersects(p)) {
         return Location::EXTERIOR;
@@ -181,7 +181,7 @@ PointLocator::locate(const Coordinate& p, const LineString* l)
 
 /* private */
 Location
-PointLocator::locateInPolygonRing(const Coordinate& p, const LinearRing* ring)
+PointLocator::locateInPolygonRing(const CoordinateXY& p, const LinearRing* ring)
 {
     if(!ring->getEnvelopeInternal()->intersects(p)) {
         return Location::EXTERIOR;
@@ -200,7 +200,7 @@ PointLocator::locateInPolygonRing(const Coordinate& p, const LinearRing* ring)
 
 /* private */
 Location
-PointLocator::locate(const Coordinate& p, const Polygon* poly)
+PointLocator::locate(const CoordinateXY& p, const Polygon* poly)
 {
     if(poly->isEmpty()) {
         return Location::EXTERIOR;

--- a/src/algorithm/RayCrossingCounter.cpp
+++ b/src/algorithm/RayCrossingCounter.cpp
@@ -38,7 +38,7 @@ namespace algorithm {
 // public:
 //
 /*static*/ geom::Location
-RayCrossingCounter::locatePointInRing(const geom::Coordinate& point,
+RayCrossingCounter::locatePointInRing(const geom::CoordinateXY& point,
                                       const geom::CoordinateSequence& ring)
 {
     RayCrossingCounter rcc(point);
@@ -57,7 +57,7 @@ RayCrossingCounter::locatePointInRing(const geom::Coordinate& point,
 }
 
 /*static*/ geom::Location
-RayCrossingCounter::locatePointInRing(const geom::Coordinate& point,
+RayCrossingCounter::locatePointInRing(const geom::CoordinateXY& point,
                                       const std::vector<const geom::Coordinate*>& ring)
 {
     RayCrossingCounter rcc(point);
@@ -76,8 +76,8 @@ RayCrossingCounter::locatePointInRing(const geom::Coordinate& point,
 }
 
 void
-RayCrossingCounter::countSegment(const geom::Coordinate& p1,
-                                 const geom::Coordinate& p2)
+RayCrossingCounter::countSegment(const geom::CoordinateXY& p1,
+                                 const geom::CoordinateXY& p2)
 {
     // For each segment, check if it crosses
     // a horizontal ray running from the test point in

--- a/src/algorithm/construct/LargestEmptyCircle.cpp
+++ b/src/algorithm/construct/LargestEmptyCircle.cpp
@@ -222,7 +222,7 @@ LargestEmptyCircle::compute()
 
     // if ptLocator is not present then result is degenerate (represented as zero-radius circle)
     if (!ptLocator) {
-        const Coordinate* pt = obstacles->getCoordinate();
+        const CoordinateXY* pt = obstacles->getCoordinate();
         centerPt = *pt;
         radiusPt = *pt;
         done = true;
@@ -274,7 +274,7 @@ LargestEmptyCircle::compute()
 
     // compute radius point
     std::unique_ptr<Point> centerPoint(factory->createPoint(centerPt));
-    std::vector<geom::Coordinate> nearestPts = obstacleDistance.nearestPoints(centerPoint.get());
+    const auto& nearestPts = obstacleDistance.nearestPoints(centerPoint.get());
     radiusPt = nearestPts[0];
 
     // flag computation

--- a/src/algorithm/construct/MaximumInscribedCircle.cpp
+++ b/src/algorithm/construct/MaximumInscribedCircle.cpp
@@ -83,8 +83,7 @@ std::unique_ptr<Point>
 MaximumInscribedCircle::getCenter()
 {
     compute();
-    auto pt = factory->createPoint(centerPt);
-    return std::unique_ptr<Point>(pt);
+    return factory->createPoint(centerPt);
 }
 
 /* public */
@@ -92,8 +91,7 @@ std::unique_ptr<Point>
 MaximumInscribedCircle::getRadiusPoint()
 {
     compute();
-    auto pt = factory->createPoint(radiusPt);
-    return std::unique_ptr<Point>(pt);
+    return factory->createPoint(radiusPt);
 }
 
 /* public */
@@ -220,7 +218,7 @@ MaximumInscribedCircle::compute()
 
     // compute radius point
     std::unique_ptr<Point> centerPoint(factory->createPoint(centerPt));
-    std::vector<geom::Coordinate> nearestPts = indexedDistance.nearestPoints(centerPoint.get());
+    const auto& nearestPts = indexedDistance.nearestPoints(centerPoint.get());
     radiusPt = nearestPts[0];
 
     // flag computation

--- a/src/algorithm/locate/IndexedPointInAreaLocator.cpp
+++ b/src/algorithm/locate/IndexedPointInAreaLocator.cpp
@@ -99,7 +99,7 @@ IndexedPointInAreaLocator::IndexedPointInAreaLocator(const geom::Geometry& g)
 }
 
 geom::Location
-IndexedPointInAreaLocator::locate(const geom::Coordinate* /*const*/ p)
+IndexedPointInAreaLocator::locate(const geom::CoordinateXY* /*const*/ p)
 {
     if (index == nullptr) {
         buildIndex(areaGeom);

--- a/src/algorithm/locate/SimplePointInAreaLocator.cpp
+++ b/src/algorithm/locate/SimplePointInAreaLocator.cpp
@@ -38,19 +38,19 @@ namespace locate { // geos.algorithm
  * is more complex, since it has to take into account the boundaryDetermination rule
  */
 geom::Location
-SimplePointInAreaLocator::locate(const Coordinate& p, const Geometry* geom)
+SimplePointInAreaLocator::locate(const CoordinateXY& p, const Geometry* geom)
 {
     return locateInGeometry(p, geom);
 }
 
 bool
-SimplePointInAreaLocator::isContained(const Coordinate& p, const Geometry* geom)
+SimplePointInAreaLocator::isContained(const CoordinateXY& p, const Geometry* geom)
 {
     return Location::EXTERIOR != locate(p, geom);
 }
 
 geom::Location
-SimplePointInAreaLocator::locateInGeometry(const Coordinate& p, const Geometry* geom)
+SimplePointInAreaLocator::locateInGeometry(const CoordinateXY& p, const Geometry* geom)
 {
     /*
      * Do a fast check against the geometry envelope first
@@ -80,7 +80,7 @@ SimplePointInAreaLocator::locateInGeometry(const Coordinate& p, const Geometry* 
 }
 
 geom::Location
-SimplePointInAreaLocator::locatePointInPolygon(const Coordinate& p, const Polygon* poly)
+SimplePointInAreaLocator::locatePointInPolygon(const CoordinateXY& p, const Polygon* poly)
 {
     if(poly->isEmpty()) {
         return Location::EXTERIOR;

--- a/src/geom/Coordinate.cpp
+++ b/src/geom/Coordinate.cpp
@@ -40,6 +40,21 @@ Coordinate::toString() const
     return s.str();
 }
 
+std::string
+CoordinateXY::toString() const
+{
+    std::ostringstream s;
+    s << std::setprecision(17) << *this;
+    return s.str();
+}
+
+std::ostream&
+operator<< (std::ostream& os, const CoordinateXY& c)
+{
+    os << c.x << " " << c.y;
+    return os;
+}
+
 std::ostream&
 operator<< (std::ostream& os, const Coordinate& c)
 {

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -47,6 +47,16 @@ CoordinateArraySequence::CoordinateArraySequence(std::vector<Coordinate> && coor
 {
 }
 
+CoordinateArraySequence::CoordinateArraySequence(std::vector<CoordinateXY> && coords, std::size_t dimension_in):
+        vect(coords.size()),
+        dimension(dimension_in)
+{
+    // FIXME remove copy
+    for (size_t i = 0; i < coords.size(); i++) {
+        vect[i] = Coordinate(coords[i]);
+    }
+}
+
 CoordinateArraySequence::CoordinateArraySequence(
     std::vector<Coordinate>* coords, std::size_t dimension_in)
     : dimension(dimension_in)
@@ -116,6 +126,14 @@ void
 CoordinateArraySequence::toVector(std::vector<Coordinate>& out) const
 {
     out.insert(out.end(), vect.begin(), vect.end());
+}
+
+void
+CoordinateArraySequence::toVector(std::vector<CoordinateXY>& out) const
+{
+    for (const auto& pt : vect) {
+        out.push_back(pt);
+    }
 }
 
 void

--- a/src/geom/Envelope.cpp
+++ b/src/geom/Envelope.cpp
@@ -38,8 +38,8 @@ namespace geom { // geos::geom
 
 /*public*/
 bool
-Envelope::intersects(const Coordinate& p1, const Coordinate& p2,
-                     const Coordinate& q)
+Envelope::intersects(const CoordinateXY& p1, const CoordinateXY& p2,
+                     const CoordinateXY& q)
 {
     //OptimizeIt shows that Math#min and Math#max here are a bottleneck.
     //Replace with direct comparisons. [Jon Aquino]
@@ -52,7 +52,7 @@ Envelope::intersects(const Coordinate& p1, const Coordinate& p2,
 
 /*public*/
 bool
-Envelope::intersects(const Coordinate& a, const Coordinate& b) const
+Envelope::intersects(const CoordinateXY& a, const CoordinateXY& b) const
 {
     // These comparisons look redundant, but an alternative using
     // std::minmax performs no better and compiles down to more
@@ -185,7 +185,7 @@ Envelope::split(const std::string& str, const std::string& delimiters)
 
 /*public*/
 bool
-Envelope::centre(Coordinate& p_centre) const
+Envelope::centre(CoordinateXY& p_centre) const
 {
     if(isNull()) {
         return false;

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -848,7 +848,7 @@ GeometryGreaterThen::operator()(const Geometry* first, const Geometry* second)
 }
 
 bool
-Geometry::equal(const Coordinate& a, const Coordinate& b,
+Geometry::equal(const CoordinateXY& a, const CoordinateXY& b,
                 double tolerance) const
 {
     if(tolerance == 0) {

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -282,7 +282,7 @@ GeometryCollection::compareToSameClass(const Geometry* g) const
     return compare(geometries, gc->geometries);
 }
 
-const Coordinate*
+const CoordinateXY*
 GeometryCollection::getCoordinate() const
 {
     for(const auto& g : geometries) {

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -294,6 +294,17 @@ GeometryFactory::createPoint(std::size_t coordinateDimension) const
     return std::unique_ptr<Point>(new Point(nullptr, this));
 }
 
+std::unique_ptr<Point>
+GeometryFactory::createPoint(const CoordinateXY& coordinate) const
+{
+    if(coordinate.isNull()) {
+        return createPoint();
+    }
+    else {
+        return std::unique_ptr<Point>(new Point(coordinate, this));
+    }
+}
+
 /*public*/
 Point*
 GeometryFactory::createPoint(const Coordinate& coordinate) const
@@ -498,6 +509,17 @@ GeometryFactory::createMultiPoint(std::vector<Coordinate> && newPoints) const {
 
     for(std::size_t i = 0; i < newPoints.size(); ++i) {
         pts[i].reset(createPoint(newPoints[i]));
+    }
+
+    return std::unique_ptr<MultiPoint>(new MultiPoint(std::move(pts), *this));
+}
+
+std::unique_ptr<MultiPoint>
+GeometryFactory::createMultiPoint(std::vector<CoordinateXY> && newPoints) const {
+    std::vector<std::unique_ptr<Geometry>> pts(newPoints.size());
+
+    for(std::size_t i = 0; i < newPoints.size(); ++i) {
+        pts[i] = createPoint(newPoints[i]);
     }
 
     return std::unique_ptr<MultiPoint>(new MultiPoint(std::move(pts), *this));

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -382,7 +382,7 @@ LineString::compareToSameClass(const Geometry* ls) const
     return 0;
 }
 
-const Coordinate*
+const CoordinateXY*
 LineString::getCoordinate() const
 {
     if(isEmpty()) {

--- a/src/geom/MultiPoint.cpp
+++ b/src/geom/MultiPoint.cpp
@@ -73,7 +73,7 @@ MultiPoint::getBoundary() const
     return std::unique_ptr<Geometry>(getFactory()->createGeometryCollection());
 }
 
-const Coordinate*
+const CoordinateXY*
 MultiPoint::getCoordinateN(std::size_t n) const
 {
     return geometries[n]->getCoordinate();

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -75,6 +75,14 @@ Point::Point(const Coordinate & c, const GeometryFactory* factory)
     coordinates.setAt(c, 0);
 }
 
+Point::Point(const CoordinateXY & c, const GeometryFactory* factory)
+    : Geometry(factory)
+    , empty2d(false)
+    , empty3d(false)
+{
+    coordinates.setAt(Coordinate(c), 0);
+}
+
 /*protected*/
 Point::Point(const Point& p)
     : Geometry(p)
@@ -263,8 +271,8 @@ Point::equalsExact(const Geometry* other, double tolerance) const
         return false;
     }
 
-    const Coordinate* this_coord = getCoordinate();
-    const Coordinate* other_coord = other->getCoordinate();
+    const CoordinateXY* this_coord = getCoordinate();
+    const CoordinateXY* other_coord = other->getCoordinate();
 
     // assume the isEmpty checks above worked :)
     assert(this_coord && other_coord);

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -399,7 +399,7 @@ Polygon::normalize(LinearRing* ring, bool clockwise)
     ring->setPoints(uniqueCoordinates.get());
 }
 
-const Coordinate*
+const CoordinateXY*
 Polygon::getCoordinate() const
 {
     return shell->getCoordinate();

--- a/src/geom/Triangle.cpp
+++ b/src/geom/Triangle.cpp
@@ -38,7 +38,7 @@ Triangle::isIsoceles()
 }
 
 void
-Triangle::inCentre(Coordinate& result)
+Triangle::inCentre(CoordinateXY& result)
 {
     // the lengths of the sides, labelled by their opposite vertex
     double len0 = p1.distance(p2);
@@ -48,11 +48,11 @@ Triangle::inCentre(Coordinate& result)
     double inCentreX = (len0 * p0.x + len1 * p1.x + len2 * p2.x)  / circum;
     double inCentreY = (len0 * p0.y + len1 * p1.y + len2 * p2.y)  / circum;
 
-    result = Coordinate(inCentreX, inCentreY);
+    result = CoordinateXY(inCentreX, inCentreY);
 }
 
 void
-Triangle::circumcentre(Coordinate& result)
+Triangle::circumcentre(CoordinateXY& result)
 {
     double cx = p2.x;
     double cy = p2.y;
@@ -68,21 +68,21 @@ Triangle::circumcentre(Coordinate& result)
     double ccx = cx - numx / denom;
     double ccy = cy + numy / denom;
 
-    result = Coordinate(ccx, ccy);
+    result = CoordinateXY(ccx, ccy);
 }
 
 void
-Triangle::circumcentreDD(Coordinate& result)
+Triangle::circumcentreDD(CoordinateXY& result)
 {
     result = algorithm::CGAlgorithmsDD::circumcentreDD(p0, p1, p2);
 }
 
 /* public static */
-const Coordinate
-Triangle::circumcentre(const Coordinate& p0, const Coordinate& p1, const Coordinate& p2)
+const CoordinateXY
+Triangle::circumcentre(const CoordinateXY& p0, const CoordinateXY& p1, const CoordinateXY& p2)
 {
     Triangle t(p0, p1, p2);
-    Coordinate c;
+    CoordinateXY c;
     t.circumcentre(c);
     return c;
 }
@@ -97,7 +97,7 @@ Triangle::det(double m00, double m01, double m10, double m11) const
 
 /* public static */
 bool
-Triangle::isAcute(const Coordinate& a, const Coordinate& b, const Coordinate& c)
+Triangle::isAcute(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
     if (!Angle::isAcute(a, b, c))
         return false;
@@ -111,7 +111,7 @@ Triangle::isAcute(const Coordinate& a, const Coordinate& b, const Coordinate& c)
 
 /* public static */
 bool
-Triangle::isCCW(const Coordinate& a, const Coordinate& b, const Coordinate& c)
+Triangle::isCCW(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
     return Orientation::COUNTERCLOCKWISE == Orientation::index(a, b, c);
 }
@@ -119,7 +119,7 @@ Triangle::isCCW(const Coordinate& a, const Coordinate& b, const Coordinate& c)
 
 /* public static */
 bool
-Triangle::intersects(const Coordinate& a, const Coordinate& b, const Coordinate& c, const Coordinate& p)
+Triangle::intersects(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c, const CoordinateXY& p)
 {
     int exteriorIndex = isCCW(a, b, c) ?
         Orientation::CLOCKWISE : Orientation::COUNTERCLOCKWISE;
@@ -135,7 +135,7 @@ Triangle::intersects(const Coordinate& a, const Coordinate& b, const Coordinate&
 
 /* public static */
 double
-Triangle::length(const Coordinate& a, const Coordinate& b, const Coordinate& c)
+Triangle::length(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
     return a.distance(b) + b.distance(c) + c.distance(a);
 }
@@ -149,7 +149,7 @@ Triangle::length() const
 
 /* public static */
 double
-Triangle::area(const Coordinate& a, const Coordinate& b, const Coordinate& c)
+Triangle::area(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
     return std::abs(((c.x - a.x) * (b.y - a.y) - (b.x - a.x) * (c.y - a.y)) / 2);
 }
@@ -163,7 +163,7 @@ Triangle::area() const
 
 /* public static */
 double
-Triangle::longestSideLength(const Coordinate& a, const Coordinate& b, const Coordinate& c)
+Triangle::longestSideLength(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
     double lenAB = a.distance(b);
     double lenBC = b.distance(c);

--- a/src/geom/prep/BasicPreparedGeometry.cpp
+++ b/src/geom/prep/BasicPreparedGeometry.cpp
@@ -79,9 +79,8 @@ BasicPreparedGeometry::isAnyTargetComponentInTest(const geom::Geometry* testGeom
 {
     algorithm::PointLocator locator;
 
-    for(std::size_t i = 0, n = representativePts.size(); i < n; i++) {
-        const geom::Coordinate& c = *(representativePts[i]);
-        if(locator.intersects(c, testGeom)) {
+    for(const auto& c : representativePts) {
+        if(locator.intersects(*c, testGeom)) {
             return true;
         }
     }

--- a/src/geom/prep/PreparedLineStringIntersects.cpp
+++ b/src/geom/prep/PreparedLineStringIntersects.cpp
@@ -41,12 +41,11 @@ PreparedLineStringIntersects::isAnyTestPointInTarget(const geom::Geometry* testG
      */
     PointLocator  locator;
 
-    geom::Coordinate::ConstVect coords;
+    std::vector<const CoordinateXY*> coords;
     ComponentCoordinateExtracter::getCoordinates(*testGeom, coords);
 
-    for(std::size_t i = 0, n = coords.size(); i < n; i++) {
-        const geom::Coordinate& c = *(coords[i]);
-        if(locator.intersects(c, &(prepLine.getGeometry()))) {
+    for(const auto& c : coords) {
+        if(locator.intersects(*c, &(prepLine.getGeometry()))) {
             return true;
         }
     }

--- a/src/geom/prep/PreparedPolygonPredicate.cpp
+++ b/src/geom/prep/PreparedPolygonPredicate.cpp
@@ -49,7 +49,7 @@ struct LocationMatchingFilter : public GeometryComponentFilter {
     void filter_ro(const Geometry* g) override {
         if (g->isEmpty())
             return;
-        const Coordinate* pt = g->getCoordinate();
+        const CoordinateXY* pt = g->getCoordinate();
         const auto loc = pt_locator->locate(pt);
 
         if (loc == test_loc) {
@@ -73,7 +73,7 @@ struct LocationNotMatchingFilter : public GeometryComponentFilter {
     void filter_ro(const Geometry* g) override {
         if (g->isEmpty())
             return;
-        const Coordinate* pt = g->getCoordinate();
+        const CoordinateXY* pt = g->getCoordinate();
         const auto loc = pt_locator->locate(pt);
 
         if (loc != test_loc) {
@@ -99,7 +99,7 @@ struct OutermostLocationFilter : public GeometryComponentFilter {
     void filter_ro(const Geometry* g) override {
         if (g->isEmpty())
             return;
-        const Coordinate* pt = g->getCoordinate();
+        const CoordinateXY* pt = g->getCoordinate();
         auto loc = pt_locator->locate(pt);
 
         if (outermost_loc == Location::NONE || outermost_loc == Location::INTERIOR) {
@@ -161,12 +161,11 @@ PreparedPolygonPredicate::isAnyTestComponentInTargetInterior(
 bool
 PreparedPolygonPredicate::isAnyTargetComponentInAreaTest(
     const geom::Geometry* testGeom,
-    const geom::Coordinate::ConstVect* targetRepPts) const
+    const std::vector<const CoordinateXY*>* targetRepPts) const
 {
     algorithm::locate::SimplePointInAreaLocator piaLoc(testGeom);
 
-    for(std::size_t i = 0, ni = targetRepPts->size(); i < ni; i++) {
-        const geom::Coordinate* pt = (*targetRepPts)[i];
+    for(const auto& pt : *targetRepPts) {
         const Location loc = piaLoc.locate(pt);
         if(geom::Location::EXTERIOR != loc) {
             return true;

--- a/src/geom/util/ComponentCoordinateExtracter.cpp
+++ b/src/geom/util/ComponentCoordinateExtracter.cpp
@@ -20,7 +20,7 @@ namespace geos {
 namespace geom { // geos.geom
 namespace util { // geos.geom.util
 
-ComponentCoordinateExtracter::ComponentCoordinateExtracter(std::vector<const Coordinate*>& newComps)
+ComponentCoordinateExtracter::ComponentCoordinateExtracter(std::vector<const CoordinateXY*>& newComps)
     :
     comps(newComps)
 {}
@@ -59,7 +59,7 @@ ComponentCoordinateExtracter::filter_ro(const Geometry* geom)
 
 
 void
-ComponentCoordinateExtracter::getCoordinates(const Geometry& geom, std::vector<const Coordinate*>& ret)
+ComponentCoordinateExtracter::getCoordinates(const Geometry& geom, std::vector<const CoordinateXY*>& ret)
 {
     ComponentCoordinateExtracter cce(ret);
     geom.apply_ro(&cce);

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -130,6 +130,15 @@ WKTWriter::toPoint(const Coordinate& p0)
     return ret.str();
 }
 
+std::string
+WKTWriter::toPoint(const CoordinateXY& p0)
+{
+    std::stringstream ret(std::ios_base::in | std::ios_base::out);
+    ret << "POINT (";
+    ret << p0.x << " " << p0.y  << " )";
+    return ret.str();
+}
+
 void
 WKTWriter::setRoundingPrecision(int p0)
 {

--- a/src/operation/buffer/BufferCurveSetBuilder.cpp
+++ b/src/operation/buffer/BufferCurveSetBuilder.cpp
@@ -438,7 +438,7 @@ BufferCurveSetBuilder::isTriangleErodedCompletely(
 {
     Triangle tri(triangleCoord->getAt(0), triangleCoord->getAt(1), triangleCoord->getAt(2));
 
-    Coordinate inCentre;
+    CoordinateXY inCentre;
     tri.inCentre(inCentre);
     double distToCentre = Distance::pointToSegment(inCentre, tri.p0, tri.p1);
     bool ret = distToCentre < std::fabs(bufferDistance);

--- a/src/operation/distance/ConnectedElementPointFilter.cpp
+++ b/src/operation/distance/ConnectedElementPointFilter.cpp
@@ -37,10 +37,10 @@ namespace distance { // geos.operation.distance
  * found inside the specified geometry. Thus, if the specified geometry is
  * not a GeometryCollection, an empty list will be returned.
  */
-std::vector<const Coordinate*>*
+std::vector<const CoordinateXY*>*
 ConnectedElementPointFilter::getCoordinates(const Geometry* geom)
 {
-    std::vector<const Coordinate*>* points = new std::vector<const Coordinate*>();
+    std::vector<const CoordinateXY*>* points = new std::vector<const CoordinateXY*>();
     ConnectedElementPointFilter c(points);
     geom->apply_ro(&c);
     return points;

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -131,11 +131,11 @@ DistanceOp::nearestPoints()
         return nullptr;
     }
 
-    std::unique_ptr<std::vector<Coordinate>> nearestPts(new std::vector<Coordinate>(2));
-    (*nearestPts)[0] = locs[0]->getCoordinate();
-    (*nearestPts)[1] = locs[1]->getCoordinate();
+    std::vector<Coordinate> nearestPts(2);
+    nearestPts[0] = Coordinate(locs[0]->getCoordinate());
+    nearestPts[1] = Coordinate(locs[1]->getCoordinate());
 
-    return std::unique_ptr<CoordinateSequence>(new CoordinateArraySequence(nearestPts.release()));
+    return std::unique_ptr<CoordinateSequence>(new CoordinateArraySequence(std::move(nearestPts)));
 }
 
 void
@@ -256,7 +256,7 @@ DistanceOp::computeInside(std::vector<std::unique_ptr<GeometryLocation>> & locs,
 {
     for(auto& loc : locs) {
         for(const auto& poly : polys) {
-			const Coordinate& pt = loc->getCoordinate();
+            const auto& pt = loc->getCoordinate();
 
 			if (Location::EXTERIOR != ptLocator.locate(pt, static_cast<const Geometry*>(poly))) {
 				minDistance = 0.0;

--- a/src/operation/distance/GeometryLocation.cpp
+++ b/src/operation/distance/GeometryLocation.cpp
@@ -21,7 +21,7 @@
 #include <sstream>
 
 using geos::geom::Geometry;
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 
 namespace geos {
 namespace operation { // geos.operation
@@ -31,7 +31,7 @@ namespace distance { // geos.operation.distance
  * Constructs a GeometryLocation specifying a point on a geometry, as well as the
  * segment that the point is on (or INSIDE_AREA if the point is not on a segment).
  */
-GeometryLocation::GeometryLocation(const Geometry* newComponent, std::size_t newSegIndex, const Coordinate& newPt)
+GeometryLocation::GeometryLocation(const Geometry* newComponent, std::size_t newSegIndex, const CoordinateXY& newPt)
 {
     component = newComponent;
     segIndex = newSegIndex;
@@ -42,7 +42,7 @@ GeometryLocation::GeometryLocation(const Geometry* newComponent, std::size_t new
 /**
  * Constructs a GeometryLocation specifying a point inside an area geometry.
  */
-GeometryLocation::GeometryLocation(const Geometry* newComponent, const Coordinate& newPt)
+GeometryLocation::GeometryLocation(const Geometry* newComponent, const CoordinateXY& newPt)
 {
     component = newComponent;
     inside_area = true;
@@ -72,7 +72,7 @@ GeometryLocation::getSegmentIndex()
 /**
  * Returns the location.
  */
-Coordinate&
+CoordinateXY&
 GeometryLocation::getCoordinate()
 {
     return pt;

--- a/src/operation/distance/IndexedFacetDistance.cpp
+++ b/src/operation/distance/IndexedFacetDistance.cpp
@@ -36,7 +36,7 @@ IndexedFacetDistance::distance(const Geometry* g1, const Geometry* g2)
 }
 
 /*public static*/
-std::vector<geom::Coordinate>
+std::vector<geom::CoordinateXY>
 IndexedFacetDistance::nearestPoints(const geom::Geometry* g1, const geom::Geometry* g2)
 {
     IndexedFacetDistance dist(g1);
@@ -88,11 +88,11 @@ IndexedFacetDistance::nearestLocations(const geom::Geometry* g) const
     return nearest.first->nearestLocations(*nearest.second);
 }
 
-std::vector<Coordinate>
+std::vector<CoordinateXY>
 IndexedFacetDistance::nearestPoints(const geom::Geometry* g) const
 {
     std::vector<GeometryLocation> minDistanceLocation = nearestLocations(g);
-    std::vector<Coordinate> nearestPts;
+    std::vector<CoordinateXY> nearestPts;
     nearestPts.push_back(minDistanceLocation[0].getCoordinate());
     nearestPts.push_back(minDistanceLocation[1].getCoordinate());
     return nearestPts;

--- a/src/operation/overlayng/IndexedPointOnLineLocator.cpp
+++ b/src/operation/overlayng/IndexedPointOnLineLocator.cpp
@@ -28,7 +28,7 @@ namespace overlayng { // geos.operation.overlayng
 
 /*public*/
 geom::Location
-IndexedPointOnLineLocator::locate(const geom::Coordinate* p) {
+IndexedPointOnLineLocator::locate(const geom::CoordinateXY* p) {
     // TODO: optimize this with a segment index
     algorithm::PointLocator locator;
     return locator.locate(*p, &inputGeom);

--- a/src/operation/valid/IsValidOp.cpp
+++ b/src/operation/valid/IsValidOp.cpp
@@ -71,9 +71,9 @@ IsValidOp::getValidationError()
 
 /* private */
 void
-IsValidOp::logInvalid(int code, const Coordinate* pt)
+IsValidOp::logInvalid(int code, const CoordinateXY* pt)
 {
-    validErr.reset(new TopologyValidationError(code, *pt));
+    validErr.reset(new TopologyValidationError(code, Coordinate(*pt)));
 }
 
 
@@ -403,7 +403,7 @@ IsValidOp::checkHolesInShell(const Polygon* poly)
         const LinearRing* hole = poly->getInteriorRingN(i);
         if (hole->isEmpty()) continue;
 
-        const Coordinate* invalidPt = nullptr;
+        const CoordinateXY* invalidPt = nullptr;
         if (isShellEmpty) {
             invalidPt = hole->getCoordinate();
         }

--- a/tests/unit/algorithm/MinimumBoundingCircleTest.cpp
+++ b/tests/unit/algorithm/MinimumBoundingCircleTest.cpp
@@ -34,14 +34,16 @@ namespace tut {
 // Test Group
 //
 
+using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
+using geos::geom::Geometry;
+using geos::geom::GeometryFactory;
+using geos::geom::PrecisionModel;
+using geos::algorithm::MinimumBoundingCircle;
+
+
 // dummy data, not used
 struct test_minimumboundingcircle_data {
-    typedef geos::geom::Geometry Geometry;
-    typedef geos::geom::Coordinate Coordinate;
-    typedef geos::geom::PrecisionModel PrecisionModel;
-    typedef geos::geom::GeometryFactory GeometryFactory;
-    typedef geos::algorithm::MinimumBoundingCircle MinimumBoundingCircle;
-
     geos::io::WKTReader reader;
     std::unique_ptr<Geometry> geom;
     std::unique_ptr<Geometry> geomOut;
@@ -57,10 +59,10 @@ struct test_minimumboundingcircle_data {
 
         geom = reader.read(wktIn);
         MinimumBoundingCircle mbc(geom.get());
-        std::vector<Coordinate> exPts = mbc.getExtremalPoints();
-        std::unique_ptr<Geometry> actual(geomFact->createMultiPoint(exPts));
+        std::vector<CoordinateXY> exPts = mbc.getExtremalPoints();
+        const auto& actual = geomFact->createMultiPoint(std::move(exPts));
         double actualRadius = mbc.getRadius();
-        geos::geom::Coordinate actualCentre = mbc.getCentre();
+        geos::geom::CoordinateXY actualCentre = mbc.getCentre();
 
         geomOut = reader.read(wktOut);
         bool isEqual = actual->equals(geomOut.get());

--- a/tests/unit/geom/CoordinateTest.cpp
+++ b/tests/unit/geom/CoordinateTest.cpp
@@ -13,6 +13,9 @@ namespace tut {
 // Test Group
 //
 
+using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
+
 // Common data used by tests
 struct test_coordinate_data {
     const double x;
@@ -43,8 +46,10 @@ template<>
 void object::test<1>
 ()
 {
-    // TODO - mloskot - discuss about adding default constructor
-    ensure("NOTE: Coordinate has no default constructor.", true);
+    geos::geom::Coordinate coord;
+    ensure_equals(coord.x, 0.0);
+    ensure_equals(coord.y, 0.0);
+    ensure(std::isnan(coord.z));
 }
 
 // Test of overridden constructor
@@ -53,10 +58,10 @@ template<>
 void object::test<2>
 ()
 {
-    geos::geom::Coordinate coord;
-    ensure_equals(coord.x, 0.0);
-    ensure_equals(coord.y, 0.0);
-    ensure(0 != std::isnan(coord.z));
+    geos::geom::Coordinate coord(1, 2, 3);
+    ensure_equals(coord.x, 1);
+    ensure_equals(coord.y, 2);
+    ensure_equals(coord.z, 3);
 }
 
 // Test of copy constructor and assignment operator
@@ -202,8 +207,6 @@ template<>
 void object::test<10>
 ()
 {
-    using geos::geom::Coordinate;
-
     std::unordered_set<Coordinate, Coordinate::HashCode> coords;
 
     coords.emplace(1, 2);
@@ -216,6 +219,22 @@ void object::test<10>
     // and considers X and Y only
     coords.emplace(1, 2, 3);
     ensure_equals(coords.size(), 2ul);
+}
+
+// Test 2D -> 3D conversion
+template<>
+template<>
+void object::test<11>
+()
+{
+    CoordinateXY a(1, 2);
+    Coordinate b(a);
+
+    ensure_equals(b.x, a.x);
+    ensure_equals(b.y, a.y);
+    ensure(std::isnan(b.z));
+
+    ensure_equals(a, b);
 }
 
 } // namespace tut

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -300,6 +300,7 @@ void object::test<9>
     ensure(geo != nullptr);
     ensure(!geo->isEmpty());
 
+    ensure_equals(pt->getCoordinateDimension(), 3u);
     ensure_equals(pt->getGeometryTypeId(), geos::geom::GEOS_POINT);
     ensure_equals(pt->getDimension(), geos::geom::Dimension::P);
     ensure_equals(pt->getBoundaryDimension(), geos::geom::Dimension::False);
@@ -1250,6 +1251,54 @@ void object::test<37>
 
     ensure_equals(mp->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT);
     ensure_equals(mp->getNumGeometries(), 2u);
+}
+
+// Test of createPoint(const Coordinate &coordinate) const
+template<>
+template<>
+void object::test<38>
+()
+{
+    geos::geom::CoordinateXY coord(x_, y_);
+
+    auto pt = factory_->createPoint(coord);
+
+    ensure("createPoint() returned null pointer.", pt != nullptr);
+    ensure("createPoint() returned empty point.", !pt->isEmpty());
+    ensure(pt->isSimple());
+    ensure(pt->isValid());
+    ensure(pt->getCoordinate() != nullptr);
+
+    CoordinateCPtr pcoord = pt->getCoordinate();
+    ensure(pcoord != nullptr);
+    ensure_equals(pcoord->x, x_);
+    ensure_equals(pcoord->y, y_);
+    ensure(std::isnan(pcoord->z));
+
+    std::unique_ptr<geos::geom::Geometry> geo;
+    geo = pt->getEnvelope();
+    ensure(geo != nullptr);
+    ensure(!geo->isEmpty());
+
+    geo = pt->getCentroid();
+    ensure(geo != nullptr);
+    ensure(!geo->isEmpty());
+
+    geo = pt->getBoundary();
+    ensure(geo != nullptr);
+    ensure(geo->isEmpty());
+
+    geo = pt->convexHull();
+    ensure(geo != nullptr);
+    ensure(!geo->isEmpty());
+
+    ensure_equals(pt->getCoordinateDimension(), 2u);
+    ensure_equals(pt->getGeometryTypeId(), geos::geom::GEOS_POINT);
+    ensure_equals(pt->getDimension(), geos::geom::Dimension::P);
+    ensure_equals(pt->getBoundaryDimension(), geos::geom::Dimension::False);
+    ensure_equals(pt->getNumPoints(), 1u);
+    ensure_equals(pt->getLength(), 0.0);
+    ensure_equals(pt->getArea(), 0.0);
 }
 
 } // namespace tut

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -460,7 +460,7 @@ void object::test<31>
     ensure(poly_ != nullptr);
     // "POLYGON((0 10, 5 5, 10 5, 15 10, 10 15, 5 15, 0 10))"
 
-    CoordinateCPtr coord = poly_->getCoordinate();
+    const auto* coord = poly_->getCoordinate();
     ensure(coord != nullptr);
     ensure_equals(coord->x, 0);
     ensure_equals(coord->y, 10);

--- a/tests/unit/geom/TriangleTest.cpp
+++ b/tests/unit/geom/TriangleTest.cpp
@@ -194,8 +194,8 @@ void object::test<7>
     Coordinate y2(193601.10666666666, 469345.0175);
     Coordinate y3(193601.10666666666, 469345.355);
 
-    Coordinate cc1 = CGAlgorithmsDD::circumcentreDD(x1, x2, x3);
-    Coordinate cc2 = CGAlgorithmsDD::circumcentreDD(y1, y2, y3);
+    auto cc1 = CGAlgorithmsDD::circumcentreDD(x1, x2, x3);
+    auto cc2 = CGAlgorithmsDD::circumcentreDD(y1, y2, y3);
 
     ensure(cc1 == cc2);
 }

--- a/tests/unit/io/WKBWriterTest.cpp
+++ b/tests/unit/io/WKBWriterTest.cpp
@@ -74,7 +74,9 @@ void object::test<1>
     ensure(geom->getCoordinateDimension() == 2);
     ensure(geom->getCoordinate()->x == -117.0);
     ensure(geom->getCoordinate()->y == 33.0);
-    ensure(std::isnan(geom->getCoordinate()->z) != 0);
+
+    auto coords = geom->getCoordinates();
+    ensure(std::isnan(coords->getAt(0).z));
 }
 
 // 2 - Test writing a 3D geometry with the WKBWriter in 3D output dimension.
@@ -94,10 +96,12 @@ void object::test<2>
     result_stream.seekg(0);
     geom = wkbreader.read(result_stream);
 
-    ensure(geom->getCoordinateDimension() == 3);
-    ensure(geom->getCoordinate()->x == -117.0);
-    ensure(geom->getCoordinate()->y == 33.0);
-    ensure(geom->getCoordinate()->z == 11.0);
+    ensure_equals(geom->getCoordinateDimension(), 3u);
+    ensure_equals(geom->getCoordinate()->x, -117.0);
+    ensure_equals(geom->getCoordinate()->y, 33.0);
+
+    auto coords = geom->getCoordinates();
+    ensure_equals(coords->getAt(0).z, 11.0);
 }
 
 // 3 - Test writing a 3D geometry with the WKBWriter in 2D output dimension.
@@ -120,7 +124,9 @@ void object::test<3>
     ensure(geom->getCoordinateDimension() == 2);
     ensure(geom->getCoordinate()->x == -117.0);
     ensure(geom->getCoordinate()->y == 33.0);
-    ensure(std::isnan(geom->getCoordinate()->z) != 0);
+
+    auto coords = geom->getCoordinates();
+    ensure(std::isnan(coords->getAt(0).z));
 }
 
 // 4 - Test that SRID is output only once
@@ -286,7 +292,9 @@ void object::test<10>
     ensure(geom->getCoordinateDimension() == 3);
     ensure(geom->getCoordinate()->x == -117.0);
     ensure(geom->getCoordinate()->y == 33.0);
-    ensure(geom->getCoordinate()->z == 11.0);
+
+    auto coords = geom->getCoordinates();
+    ensure_equals(coords->getAt(0).z, 11.0);
 
     result_stream.str("");
     wkbwriter.writeHEX(*geom, result_stream);

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -96,8 +96,8 @@ struct test_lengthindexedline_data {
     {
         GeomPtr input(reader.read(inputStr));
         GeomPtr testPoint(reader.read(testPtWKT));
-        const Coordinate* testPt = testPoint->getCoordinate();
-        bool resultOK = indexOfAfterCheck(input.get(), *testPt);
+        const Coordinate testPt(*testPoint->getCoordinate());
+        bool resultOK = indexOfAfterCheck(input.get(), testPt);
         ensure(resultOK);
     }
 
@@ -108,11 +108,11 @@ struct test_lengthindexedline_data {
         GeomPtr input(reader.read(inputWKT));
         GeomPtr testPoint(reader.read(testPtWKT));
         GeomPtr expectedPoint(reader.read(expectedPtWKT));
-        const Coordinate* testPt = testPoint->getCoordinate();
-        const Coordinate* expectedPt = expectedPoint->getCoordinate();
-        Coordinate offsetPt = extractOffsetAt(input.get(), *testPt, offsetDistance);
+        const Coordinate testPt(*testPoint->getCoordinate());
+        const Coordinate expectedPt(*expectedPoint->getCoordinate());
+        Coordinate offsetPt = extractOffsetAt(input.get(), testPt, offsetDistance);
 
-        bool isOk = offsetPt.distance(*expectedPt) < TOLERANCE_DIST;
+        bool isOk = offsetPt.distance(expectedPt) < TOLERANCE_DIST;
         if(! isOk) {
             cout << "Expected = " << *expectedPoint << "  Actual = " << offsetPt << endl;
         }

--- a/tests/unit/operation/distance/IndexedFacetDistanceTest.cpp
+++ b/tests/unit/operation/distance/IndexedFacetDistanceTest.cpp
@@ -64,8 +64,7 @@ struct test_facetdistanceop_data {
         using geos::operation::distance::IndexedFacetDistance;
         GeomPtr g1(_wktreader.read(wkt1));
         GeomPtr g2(_wktreader.read(wkt2));
-        std::vector<geos::geom::Coordinate> pts;
-        pts = IndexedFacetDistance::nearestPoints(g1.get(), g2.get());
+        const auto& pts = IndexedFacetDistance::nearestPoints(g1.get(), g2.get());
         ensure(fabs(pts[0].distance(pts[1])-distance) < 1e08);
         ensure(fabs(pts[0].x - p1.x) < 1e-08);
         ensure(fabs(pts[0].y - p1.y) < 1e-08);
@@ -264,7 +263,7 @@ void object::test<9>
     double d = ifd.distance(g1.get());
     ensure_equals("incorrect distance", d, 0.0, 0.001);
 
-    std::vector<geos::geom::Coordinate> nearestPts = ifd.nearestPoints(g1.get());
+    const auto& nearestPts = ifd.nearestPoints(g1.get());
     ensure_equals("nearest points x", nearestPts[0].x, nearestPts[1].x, 0.00001);
     ensure_equals("nearest points y", nearestPts[0].y, nearestPts[1].y, 0.00001);
 }


### PR DESCRIPTION
This PR adds a `CoordinateXY` type and uses it throughout portions of the `algorithm` namespace that only work in 2D.

The current `Coordinate` type is changed to inherit from `CoordinateXY`. There are no virtual methods, so there is no penalty compared to the current implementation.