### PR TITLE
Fix DepthSegment comparison op

### DIFF
--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -116,6 +116,30 @@ public:
         return p1;
     };
 
+    /// gets the minimum X ordinate value
+    double minX() const
+    {
+        return std::min(p0.x, p1.x);
+    };
+
+    /// gets the maximum X ordinate value
+    double maxX() const
+    {
+        return std::min(p0.x, p1.x);
+    };
+
+    /// gets the minimum Y ordinate value
+    double minY() const
+    {
+        return std::min(p0.y, p1.y);
+    };
+
+    /// gets the maximum Y ordinate value
+    double maxY() const
+    {
+        return std::max(p0.y, p1.y);
+    };
+
     /// Computes the length of the line segment.
     double getLength() const
     {
@@ -488,26 +512,3 @@ private:
 
 } // namespace geos::geom
 } // namespace geos
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/operation/buffer/SubgraphDepthLocater.cpp
+++ b/src/operation/buffer/SubgraphDepthLocater.cpp
@@ -55,28 +55,6 @@ class DepthSegment {
 private:
     geom::LineSegment upwardSeg;
 
-    /*
-     * Compare two collinear segments for left-most ordering.
-     * If segs are vertical, use vertical ordering for comparison.
-     * If segs are equal, return 0.
-     * Segments are assumed to be directed so that the second
-     * coordinate is >= to the first
-     * (e.g. up and to the right).
-     *
-     * @param seg0 a segment to compare
-     * @param seg1 a segment to compare
-     * @return
-     */
-    static int
-    compareX(const geom::LineSegment* seg0, const geom::LineSegment* seg1)
-    {
-        int compare0 = seg0->p0.compareTo(seg1->p0);
-        if(compare0 != 0) {
-            return compare0;
-        }
-        return seg0->p1.compareTo(seg1->p1);
-    }
-
 public:
 
     int leftDepth;


### PR DESCRIPTION
Fixes the `DepthSegment` comparator to ensure it meets the standard contract for comparisons.

Fixes #703.