### PR TITLE
Convert more algorithms to `CoordinateXY`

### DIFF
--- a/include/geos/algorithm/Centroid.h
+++ b/include/geos/algorithm/Centroid.h
@@ -70,7 +70,7 @@ public:
      * @return `true` if a centroid could be computed,
      *         `false` otherwise (empty geom)
      */
-    static bool getCentroid(const geom::Geometry& geom, geom::Coordinate& cent);
+    static bool getCentroid(const geom::Geometry& geom, geom::CoordinateXY& cent);
 
     /** \brief
      * Creates a new instance for computing the centroid of a geometry
@@ -92,15 +92,15 @@ public:
      * @return `true` if a centroid could be computed,
      *         `false` otherwise (empty geom)
      */
-    bool getCentroid(geom::Coordinate& cent) const;
+    bool getCentroid(geom::CoordinateXY& cent) const;
 
 private:
 
-    std::unique_ptr<geom::Coordinate> areaBasePt;
-    geom::Coordinate triangleCent3;
-    geom::Coordinate cg3;
-    geom::Coordinate lineCentSum;
-    geom::Coordinate ptCentSum;
+    std::unique_ptr<geom::CoordinateXY> areaBasePt;
+    geom::CoordinateXY triangleCent3;
+    geom::CoordinateXY cg3;
+    geom::CoordinateXY lineCentSum;
+    geom::CoordinateXY ptCentSum;
     double areasum2;
     double totalLength;
     int ptCount;
@@ -112,7 +112,7 @@ private:
      */
     void add(const geom::Geometry& geom);
 
-    void setAreaBasePoint(const geom::Coordinate& basePt);
+    void setAreaBasePoint(const geom::CoordinateXY& basePt);
 
     void add(const geom::Polygon& poly);
 
@@ -120,7 +120,7 @@ private:
 
     void addHole(const geom::CoordinateSequence& pts);
 
-    void addTriangle(const geom::Coordinate& p0, const geom::Coordinate& p1, const geom::Coordinate& p2,
+    void addTriangle(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1, const geom::CoordinateXY& p2,
                      bool isPositiveArea);
 
     /**
@@ -128,14 +128,14 @@ private:
      * The factor of 3 is
      * left in to permit division to be avoided until later.
      */
-    static void centroid3(const geom::Coordinate& p1, const geom::Coordinate& p2, const geom::Coordinate& p3,
-                          geom::Coordinate& c);
+    static void centroid3(const geom::CoordinateXY& p1, const geom::CoordinateXY& p2, const geom::CoordinateXY& p3,
+                          geom::CoordinateXY& c);
 
     /**
      * Returns twice the signed area of the triangle p1-p2-p3.
      * The area is positive if the triangle is oriented CCW, and negative if CW.
      */
-    static double area2(const geom::Coordinate& p1, const geom::Coordinate& p2, const geom::Coordinate& p3);
+    static double area2(const geom::CoordinateXY& p1, const geom::CoordinateXY& p2, const geom::CoordinateXY& p3);
 
     /**
      * Adds the line segments defined by an array of coordinates
@@ -149,7 +149,7 @@ private:
      * Adds a point to the point centroid accumulator.
      * @param pt a {@link Coordinate}
      */
-    void addPoint(const geom::Coordinate& pt);
+    void addPoint(const geom::CoordinateXY& pt);
 };
 
 } // namespace geos::algorithm

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -143,7 +143,7 @@ public:
     /// The actual value of the intersection (if there is one)
     /// is equal to the value of <code>p</code>.
     ///
-    void computeIntersection(const geom::Coordinate& p, const geom::Coordinate& p1, const geom::Coordinate& p2);
+    void computeIntersection(const geom::CoordinateXY& p, const geom::CoordinateXY& p1, const geom::CoordinateXY& p2);
 
     /// Same as above but doesn't compute intersection point. Faster.
     static bool hasIntersection(const geom::CoordinateXY& p, const geom::CoordinateXY& p1, const geom::CoordinateXY& p2);

--- a/include/geos/algorithm/PolygonNodeTopology.h
+++ b/include/geos/algorithm/PolygonNodeTopology.h
@@ -21,11 +21,11 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 }
 }
 
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 
 
 namespace geos {
@@ -55,9 +55,9 @@ public:
     * @return true if the rings cross at the node
     */
     static bool
-    isCrossing(const Coordinate* nodePt,
-        const Coordinate* a0, const Coordinate* a1,
-        const Coordinate* b0, const Coordinate* b1);
+    isCrossing(const CoordinateXY* nodePt,
+        const CoordinateXY* a0, const CoordinateXY* a1,
+        const CoordinateXY* b0, const CoordinateXY* b1);
 
 
     /**
@@ -73,8 +73,8 @@ public:
     * @param b the other vertex of the test segment
     * @return true if the segment is interior to the ring corner
     */
-    static bool isInteriorSegment(const Coordinate* nodePt,
-        const Coordinate* a0, const Coordinate* a1, const Coordinate* b);
+    static bool isInteriorSegment(const CoordinateXY* nodePt,
+        const CoordinateXY* a0, const CoordinateXY* a1, const CoordinateXY* b);
 
 
 private:
@@ -91,9 +91,9 @@ private:
     * @param e1 the destination point of edge e1
     * @return true if p is between e0 and e1
     */
-    static bool isBetween(const Coordinate* origin,
-        const Coordinate* p,
-        const Coordinate* e0, const Coordinate* e1);
+    static bool isBetween(const CoordinateXY* origin,
+        const CoordinateXY* p,
+        const CoordinateXY* e0, const CoordinateXY* e1);
 
     /**
     * Tests if the angle with the origin of a vector P is greater than that of the
@@ -104,9 +104,9 @@ private:
     * @param q the endpoint of the vector Q
     * @return true if vector P has angle greater than Q
     */
-    static bool isAngleGreater(const Coordinate* origin, const Coordinate* p, const Coordinate* q);
+    static bool isAngleGreater(const CoordinateXY* origin, const CoordinateXY* p, const CoordinateXY* q);
 
-    static int quadrant(const Coordinate* origin, const Coordinate* p);
+    static int quadrant(const CoordinateXY* origin, const CoordinateXY* p);
 
 
 };

--- a/include/geos/algorithm/distance/DistanceToPoint.h
+++ b/include/geos/algorithm/distance/DistanceToPoint.h
@@ -49,19 +49,19 @@ public:
     DistanceToPoint() {}
 
     static void computeDistance(const geom::Geometry& geom,
-                                const geom::Coordinate& pt,
+                                const geom::CoordinateXY& pt,
                                 PointPairDistance& ptDist);
 
     static void computeDistance(const geom::LineString& geom,
-                                const geom::Coordinate& pt,
+                                const geom::CoordinateXY& pt,
                                 PointPairDistance& ptDist);
 
     static void computeDistance(const geom::LineSegment& geom,
-                                const geom::Coordinate& pt,
+                                const geom::CoordinateXY& pt,
                                 PointPairDistance& ptDist);
 
     static void computeDistance(const geom::Polygon& geom,
-                                const geom::Coordinate& pt,
+                                const geom::CoordinateXY& pt,
                                 PointPairDistance& ptDist);
 
 };

--- a/include/geos/geom/Coordinate.h
+++ b/include/geos/geom/Coordinate.h
@@ -34,6 +34,8 @@ struct CoordinateLessThen;
 
 class GEOS_DLL CoordinateXY {
 
+    static CoordinateXY _nullCoord;
+
 public:
     CoordinateXY()
         : x(0.0)
@@ -116,6 +118,8 @@ public:
         }
         return 0;
     };
+
+    static CoordinateXY& getNull();
 
     double distance(const CoordinateXY& p) const
     {

--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -404,7 +404,7 @@ public:
     /// @param ret the Coordinate to which the closest point on the line segment
     ///            to the point p will be written
     ///
-    void closestPoint(const Coordinate& p, Coordinate& ret) const;
+    void closestPoint(const CoordinateXY& p, CoordinateXY& ret) const;
 
     /** \brief
      * Compares this object with the specified object for order.
@@ -502,7 +502,7 @@ public:
     };
 
 private:
-    void project(double factor, Coordinate& ret) const;
+    void project(double factor, CoordinateXY& ret) const;
 
 };
 

--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -256,7 +256,7 @@ public:
     };
 
     /// Computes the distance between this line segment and a point.
-    double distance(const Coordinate& p) const
+    double distance(const CoordinateXY& p) const
     {
         return algorithm::Distance::pointToSegment(p, p0, p1);
     };
@@ -265,7 +265,7 @@ public:
      * Computes the perpendicular distance between the (infinite)
      * line defined by this line segment and a point.
      */
-    double distancePerpendicular(const Coordinate& p) const
+    double distancePerpendicular(const CoordinateXY& p) const
     {
         return algorithm::Distance::pointToLinePerpendicular(p, p0, p1);
     };
@@ -352,7 +352,7 @@ public:
      * @return the projection factor for the point
      *
      */
-    double projectionFactor(const Coordinate& p) const;
+    double projectionFactor(const CoordinateXY& p) const;
 
     /** \brief
      * Computes the fraction of distance (in <tt>[0.0, 1.0]</tt>)
@@ -369,7 +369,7 @@ public:
      * @return the fraction along the line segment the projection
      *         of the point occurs
      */
-    double segmentFraction(const Coordinate& inputPt) const;
+    double segmentFraction(const CoordinateXY& inputPt) const;
 
     /** \brief
      * Compute the projection of a point onto the line determined

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -183,7 +183,7 @@ public:
     double makePrecise(double val) const;
 
     /// Rounds the given Coordinate to the PrecisionModel grid.
-    void makePrecise(Coordinate& coord) const
+    void makePrecise(CoordinateXY& coord) const
     {
         // optimization for full precision
         if(modelType == FLOATING) {
@@ -194,7 +194,7 @@ public:
         coord.y = makePrecise(coord.y);
     };
 
-    void makePrecise(Coordinate* coord) const
+    void makePrecise(CoordinateXY* coord) const
     {
         assert(coord);
         return makePrecise(*coord);

--- a/include/geos/linearref/LocationIndexOfPoint.h
+++ b/include/geos/linearref/LocationIndexOfPoint.h
@@ -39,12 +39,12 @@ class LocationIndexOfPoint {
 private:
     const geom::Geometry* linearGeom;
 
-    LinearLocation indexOfFromStart(const geom::Coordinate& inputPt, const LinearLocation* minIndex) const;
+    LinearLocation indexOfFromStart(const geom::CoordinateXY& inputPt, const LinearLocation* minIndex) const;
 
 public:
-    static LinearLocation indexOf(const geom::Geometry* linearGeom, const geom::Coordinate& inputPt);
+    static LinearLocation indexOf(const geom::Geometry* linearGeom, const geom::CoordinateXY& inputPt);
 
-    static LinearLocation indexOfAfter(const geom::Geometry* linearGeom, const geom::Coordinate& inputPt,
+    static LinearLocation indexOfAfter(const geom::Geometry* linearGeom, const geom::CoordinateXY& inputPt,
                                        const LinearLocation* minIndex);
 
     LocationIndexOfPoint(const geom::Geometry* linearGeom);
@@ -56,7 +56,7 @@ public:
      * @param inputPt the coordinate to locate
      * @return the location of the nearest point
      */
-    LinearLocation indexOf(const geom::Coordinate& inputPt) const;
+    LinearLocation indexOf(const geom::CoordinateXY& inputPt) const;
 
     /** \brief
      * Find the nearest LinearLocation along the linear [Geometry](@ref geom::Geometry)
@@ -71,7 +71,7 @@ public:
      * @param minIndex the minimum location for the point location
      * @return the location of the nearest point
      */
-    LinearLocation indexOfAfter(const geom::Coordinate& inputPt, const LinearLocation* minIndex) const;
+    LinearLocation indexOfAfter(const geom::CoordinateXY& inputPt, const LinearLocation* minIndex) const;
 };
 }
 }

--- a/include/geos/operation/valid/IndexedNestedHoleTester.h
+++ b/include/geos/operation/valid/IndexedNestedHoleTester.h
@@ -36,7 +36,7 @@ namespace valid {     // geos.operation.valid
 
 using geos::geom::Polygon;
 using geos::geom::LinearRing;
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 
 
 class GEOS_DLL IndexedNestedHoleTester {
@@ -45,7 +45,7 @@ private:
 
     const Polygon* polygon;
     index::strtree::TemplateSTRtree<const LinearRing*> index;
-    Coordinate nestedPt;
+    CoordinateXY nestedPt;
 
     void loadIndex();
 
@@ -63,7 +63,7 @@ public:
     *
     * @return a point on a nested hole, or null if none are nested
     */
-    const Coordinate& getNestedPoint() { return nestedPt; }
+    const CoordinateXY& getNestedPoint() { return nestedPt; }
 
     /**
     * Tests if any hole is nested (contained) within another hole.

--- a/include/geos/operation/valid/IndexedNestedPolygonTester.h
+++ b/include/geos/operation/valid/IndexedNestedPolygonTester.h
@@ -28,6 +28,7 @@ namespace geom {
 class Coordinate;
 class Polygon;
 class LinearRing;
+class MultiPolygon;
 }
 }
 
@@ -39,7 +40,7 @@ namespace valid {     // geos.operation.valid
 using geos::geom::Polygon;
 using geos::geom::MultiPolygon;
 using geos::geom::LinearRing;
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 using algorithm::locate::IndexedPointInAreaLocator;
 using index::strtree::TemplateSTRtree;
 
@@ -51,7 +52,7 @@ private:
     TemplateSTRtree<const Polygon*> index;
     // std::vector<IndexedPointInAreaLocator> locators;
     std::map<const Polygon*, IndexedPointInAreaLocator> locators;
-    Coordinate nestedPt;
+    CoordinateXY nestedPt;
 
     void loadIndex();
 
@@ -60,7 +61,7 @@ private:
     bool findNestedPoint(const LinearRing* shell,
         const Polygon* possibleOuterPoly,
         IndexedPointInAreaLocator& locator,
-        Coordinate& coordNested);
+        CoordinateXY& coordNested);
 
     /**
     * Finds a point of a shell segment which lies inside a polygon, if any.
@@ -75,7 +76,7 @@ private:
     static bool findIncidentSegmentNestedPoint(
         const LinearRing* shell,
         const Polygon* poly,
-        Coordinate& coordNested);
+        CoordinateXY& coordNested);
 
     // Declare type as noncopyable
     IndexedNestedPolygonTester(const IndexedNestedPolygonTester& other) = delete;
@@ -90,7 +91,7 @@ public:
     *
     * @return a point on a nested polygon, or null if none are nested
     */
-    const Coordinate& getNestedPoint() const { return nestedPt; }
+    const CoordinateXY& getNestedPoint() const { return nestedPt; }
 
     /**
     * Tests if any polygon is nested (contained) within another polygon.

--- a/include/geos/operation/valid/IsValidOp.h
+++ b/include/geos/operation/valid/IsValidOp.h
@@ -182,7 +182,7 @@ private:
      * @param shell the polygon shell to test against
      * @return a hole point outside the shell, or null if it is inside
      */
-    const Coordinate * findHoleOutsideShellPoint(
+    const CoordinateXY* findHoleOutsideShellPoint(
         const geom::LinearRing* hole,
         const geom::LinearRing* shell);
 
@@ -266,7 +266,7 @@ public:
         return ivo.isValid();
     };
 
-    static bool isValid(const geom::Coordinate& coord)
+    static bool isValid(const geom::CoordinateXY& coord)
     {
         return isValid(&coord);
     }
@@ -286,7 +286,7 @@ public:
      * @param coord the coordinate to validate
      * @return <code>true</code> if the coordinate is valid
      */
-    static bool isValid(const geom::Coordinate* coord);
+    static bool isValid(const geom::CoordinateXY* coord);
 
     /**
      * Computes the validity of the geometry,

--- a/include/geos/operation/valid/PolygonIntersectionAnalyzer.h
+++ b/include/geos/operation/valid/PolygonIntersectionAnalyzer.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <geos/geom/Coordinate.h>
 #include <geos/noding/SegmentIntersector.h>
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/operation/valid/TopologyValidationError.h>
@@ -26,9 +27,6 @@
 
 // Forward declarations
 namespace geos {
-namespace geom {
-class Coordinate;
-}
 namespace noding {
 class SegmentString;
 }
@@ -38,7 +36,7 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 using geos::noding::SegmentString;
 
 class GEOS_DLL PolygonIntersectionAnalyzer : public noding::SegmentIntersector {
@@ -49,8 +47,8 @@ private:
     bool m_hasDoubleTouch = false;
     bool isInvertedRingValid = false;
     int invalidCode = TopologyValidationError::oNoInvalidIntersection;
-    Coordinate invalidLocation;
-    Coordinate doubleTouchLocation;
+    CoordinateXY invalidLocation;
+    CoordinateXY doubleTouchLocation;
 
     int findInvalidIntersection(
         const SegmentString* ss0, std::size_t segIndex0,
@@ -58,14 +56,14 @@ private:
 
     bool addDoubleTouch(
         const SegmentString* ss0, const SegmentString* ss1,
-        const Coordinate& intPt);
+        const CoordinateXY& intPt);
 
     void addSelfTouch(
-        const SegmentString* ss, const Coordinate& intPt,
-        const Coordinate* e00, const Coordinate* e01,
-        const Coordinate* e10, const Coordinate* e11);
+        const SegmentString* ss, const CoordinateXY& intPt,
+        const CoordinateXY* e00, const CoordinateXY* e01,
+        const CoordinateXY* e10, const CoordinateXY* e11);
 
-    const Coordinate& prevCoordinateInRing(
+    const CoordinateXY& prevCoordinateInRing(
         const SegmentString* ringSS, std::size_t segIndex) const;
 
     bool isAdjacentInRing(const SegmentString* ringSS,
@@ -81,8 +79,8 @@ public:
     */
     PolygonIntersectionAnalyzer(bool p_isInvertedRingValid)
         : isInvertedRingValid(p_isInvertedRingValid)
-        , invalidLocation(Coordinate::getNull())
-        , doubleTouchLocation(Coordinate::getNull())
+        , invalidLocation(CoordinateXY::getNull())
+        , doubleTouchLocation(CoordinateXY::getNull())
         {}
 
     void processIntersections(
@@ -103,7 +101,7 @@ public:
         return invalidCode;
     };
 
-    const Coordinate& getInvalidLocation() const
+    const CoordinateXY& getInvalidLocation() const
     {
         return invalidLocation;
     };
@@ -113,7 +111,7 @@ public:
         return m_hasDoubleTouch;
     };
 
-    const Coordinate& getDoubleTouchLocation() const
+    const CoordinateXY& getDoubleTouchLocation() const
     {
         return doubleTouchLocation;
     };

--- a/include/geos/operation/valid/PolygonRing.h
+++ b/include/geos/operation/valid/PolygonRing.h
@@ -27,7 +27,6 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
 class LinearRing;
 }
 }
@@ -36,7 +35,7 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 using geos::geom::LinearRing;
 
 
@@ -84,7 +83,7 @@ private:
     * @param pt the touch point
     * @return true if the rings touch only at the given point
     */
-    bool isOnlyTouch(const PolygonRing* polyRing, const Coordinate& pt) const;
+    bool isOnlyTouch(const PolygonRing* polyRing, const CoordinateXY& pt) const;
 
     /**
     * Detects whether the subgraph of holes linked by touch to this ring
@@ -94,7 +93,7 @@ private:
     *
     * @return a vertex in a hole cycle, or null if no cycle found
     */
-    const Coordinate* findHoleCycleLocation();
+    const CoordinateXY* findHoleCycleLocation();
 
     void init(PolygonRing* root, std::stack<PolygonRingTouch*>& touchStack);
 
@@ -106,7 +105,7 @@ private:
     * @param touchStack the stack of touches to scan
     * @return a vertex in a hole cycle if found, or null
     */
-    const Coordinate* scanForHoleCycle(PolygonRingTouch* currentTouch,
+    const CoordinateXY* scanForHoleCycle(PolygonRingTouch* currentTouch,
         PolygonRing* root,
         std::stack<PolygonRingTouch*>& touchStack);
 
@@ -133,7 +132,7 @@ private:
 
     std::vector<PolygonRingTouch*> getTouches() const;
 
-    void addTouch(PolygonRing* polyRing, const Coordinate& pt);
+    void addTouch(PolygonRing* polyRing, const CoordinateXY& pt);
 
 
 public:
@@ -175,7 +174,7 @@ public:
     * @param pt the location where they touch
     * @return true if the polygons already touch
     */
-    static bool addTouch(PolygonRing* ring0, PolygonRing* ring1, const Coordinate& pt);
+    static bool addTouch(PolygonRing* ring0, PolygonRing* ring1, const CoordinateXY& pt);
 
     /**
     * Finds a location (if any) where a chain of holes forms a cycle
@@ -186,7 +185,7 @@ public:
     * @param polyRings the list of rings to check
     * @return a vertex contained in a ring cycle, or null if none is found
     */
-    static const Coordinate* findHoleCycleLocation(std::vector<PolygonRing*> polyRings);
+    static const CoordinateXY* findHoleCycleLocation(std::vector<PolygonRing*> polyRings);
 
     /**
     * Finds a location of an interior self-touch in a list of rings,
@@ -197,7 +196,7 @@ public:
     * @param polyRings the list of rings to check
     * @return the location of an interior self-touch node, or null if there are none
     */
-    static const Coordinate* findInteriorSelfNode(std::vector<PolygonRing*> polyRings);
+    static const CoordinateXY* findInteriorSelfNode(std::vector<PolygonRing*> polyRings);
 
     bool isSamePolygon(const PolygonRing* polyRing) const
     {
@@ -209,9 +208,9 @@ public:
         return shell == this;
     };
 
-    void addSelfTouch(const Coordinate& origin,
-        const Coordinate* e00, const Coordinate* e01,
-        const Coordinate* e10, const Coordinate* e11);
+    void addSelfTouch(const CoordinateXY& origin,
+        const CoordinateXY* e00, const CoordinateXY* e01,
+        const CoordinateXY* e10, const CoordinateXY* e11);
 
     /**
     * Finds the location of an invalid interior self-touch in this ring,
@@ -219,7 +218,7 @@ public:
     *
     * @return the location of an interior self-touch node, or null if there are none
     */
-    const Coordinate* findInteriorSelfNode();
+    const CoordinateXY* findInteriorSelfNode();
 
 
 };

--- a/include/geos/operation/valid/PolygonRingSelfNode.h
+++ b/include/geos/operation/valid/PolygonRingSelfNode.h
@@ -26,27 +26,27 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 
 class GEOS_DLL PolygonRingSelfNode {
 
 private:
 
-    Coordinate nodePt;
-    const Coordinate* e00;
-    const Coordinate* e01;
-    const Coordinate* e10;
-    const Coordinate* e11;
+    CoordinateXY nodePt;
+    const CoordinateXY* e00;
+    const CoordinateXY* e01;
+    const CoordinateXY* e10;
+    const CoordinateXY* e11;
 
 
 public:
 
     PolygonRingSelfNode(
-        const Coordinate& p_nodePt,
-        const Coordinate* p_e00,
-        const Coordinate* p_e01,
-        const Coordinate* p_e10,
-        const Coordinate* p_e11)
+        const CoordinateXY& p_nodePt,
+        const CoordinateXY* p_e00,
+        const CoordinateXY* p_e01,
+        const CoordinateXY* p_e10,
+        const CoordinateXY* p_e11)
         : nodePt(p_nodePt)
         , e00(p_e00)
         , e01(p_e01)
@@ -59,7 +59,7 @@ public:
     *
     * @return
     */
-    const Coordinate* getCoordinate() const {
+    const CoordinateXY* getCoordinate() const {
         return &nodePt;
     }
 

--- a/include/geos/operation/valid/PolygonRingTouch.h
+++ b/include/geos/operation/valid/PolygonRingTouch.h
@@ -16,15 +16,13 @@
 #pragma once
 
 #include <geos/export.h>
+#include <geos/geom/Coordinate.h>
 
 
 #include <memory>
 
 // Forward declarations
 namespace geos {
-namespace geom {
-class Coordinate;
-}
 namespace operation {
 namespace valid {
 class PolygonRing;
@@ -36,28 +34,28 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 
 class GEOS_DLL PolygonRingTouch {
 
 private:
 
     PolygonRing* ring;
-    Coordinate touchPt;
+    CoordinateXY touchPt;
 
 
 public:
 
-    PolygonRingTouch(PolygonRing* p_ring, const Coordinate& p_pt)
+    PolygonRingTouch(PolygonRing* p_ring, const CoordinateXY& p_pt)
         : ring(p_ring)
         , touchPt(p_pt)
         {};
 
-    const Coordinate* getCoordinate() const;
+    const CoordinateXY* getCoordinate() const;
 
     PolygonRing* getRing() const;
 
-    bool isAtLocation(const Coordinate& pt) const;
+    bool isAtLocation(const CoordinateXY& pt) const;
 
 };
 

--- a/include/geos/operation/valid/PolygonTopologyAnalyzer.h
+++ b/include/geos/operation/valid/PolygonTopologyAnalyzer.h
@@ -17,6 +17,7 @@
 
 #include <geos/export.h>
 
+#include <geos/geom/Coordinate.h>
 #include <geos/operation/valid/PolygonIntersectionAnalyzer.h>
 #include <geos/operation/valid/PolygonRing.h>
 #include <geos/noding/BasicSegmentString.h>
@@ -27,7 +28,6 @@
 namespace geos {
 namespace geom {
 class Geometry;
-class Coordinate;
 }
 }
 
@@ -35,7 +35,7 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
 using geos::geom::CoordinateSequence;
 using geos::geom::Geometry;
 using geos::geom::LinearRing;
@@ -48,7 +48,7 @@ private:
     bool isInvertedRingValid = false;
     PolygonIntersectionAnalyzer segInt;
     std::vector<PolygonRing*> polyRings;
-    geom::Coordinate disconnectionPt;
+    geom::CoordinateXY disconnectionPt;
 
 
     // holding area for PolygonRings and SegmentStrings so we
@@ -64,8 +64,8 @@ private:
     PolygonRing* createPolygonRing(const LinearRing* p_ring);
     PolygonRing* createPolygonRing(const LinearRing* p_ring, int p_index, PolygonRing* p_shell);
 
-    static const Coordinate&
-    findNonEqualVertex(const LinearRing* ring, const Coordinate& p);
+    static const CoordinateXY&
+    findNonEqualVertex(const LinearRing* ring, const CoordinateXY& p);
 
     /**
      * Tests whether a touching segment is interior to a ring.
@@ -84,14 +84,14 @@ private:
      * @param ringPts the points of the ring
      * @return true if the segment is inside the ring.
      */
-    static bool isIncidentSegmentInRing(const Coordinate* p0, const Coordinate* p1,
+    static bool isIncidentSegmentInRing(const CoordinateXY* p0, const CoordinateXY* p1,
         const CoordinateSequence* ringPts);
 
-    static const Coordinate& findRingVertexPrev(const CoordinateSequence* ringPts,
-        std::size_t index, const Coordinate& node);
+    static const CoordinateXY& findRingVertexPrev(const CoordinateSequence* ringPts,
+        std::size_t index, const CoordinateXY& node);
 
-    static const Coordinate& findRingVertexNext(const CoordinateSequence* ringPts,
-        std::size_t index, const Coordinate& node);
+    static const CoordinateXY& findRingVertexNext(const CoordinateSequence* ringPts,
+        std::size_t index, const CoordinateXY& node);
 
     static std::size_t ringIndexPrev(const CoordinateSequence* ringPts, std::size_t index);
 
@@ -103,7 +103,7 @@ private:
      * @param pt the intersection point
      * @return the intersection segment index, or -1 if no intersection is found
      */
-    static std::size_t intersectingSegIndex(const CoordinateSequence* ringPts, const Coordinate* pt);
+    static std::size_t intersectingSegIndex(const CoordinateSequence* ringPts, const CoordinateXY* pt);
 
     std::vector<SegmentString*> createSegmentStrings(const Geometry* geom, bool isInvertedRingValid);
 
@@ -126,7 +126,7 @@ public:
      * @param ring the ring to analyze
      * @return a self-intersection point if one exists, or null
      */
-    static Coordinate findSelfIntersection(const LinearRing* ring);
+    static CoordinateXY findSelfIntersection(const LinearRing* ring);
 
     /**
      * Tests whether a ring is nested inside another ring.
@@ -158,7 +158,7 @@ public:
         return segInt.getInvalidCode();
     }
 
-    const Coordinate& getInvalidLocation() {
+    const CoordinateXY& getInvalidLocation() {
         return segInt.getInvalidLocation();
     }
 
@@ -172,7 +172,7 @@ public:
     */
     bool isInteriorDisconnected();
 
-    const Coordinate& getDisconnectionLocation() const
+    const CoordinateXY& getDisconnectionLocation() const
     {
         return disconnectionPt;
     };

--- a/include/geos/operation/valid/RepeatedPointTester.h
+++ b/include/geos/operation/valid/RepeatedPointTester.h
@@ -48,11 +48,11 @@ namespace valid { // geos::operation::valid
 class GEOS_DLL RepeatedPointTester {
 public:
     RepeatedPointTester() {}
-    geom::Coordinate& getCoordinate();
+    geom::CoordinateXY& getCoordinate();
     bool hasRepeatedPoint(const geom::Geometry* g);
     bool hasRepeatedPoint(const geom::CoordinateSequence* coord);
 private:
-    geom::Coordinate repeatedCoord;
+    geom::CoordinateXY repeatedCoord;
     bool hasRepeatedPoint(const geom::Polygon* p);
     bool hasRepeatedPoint(const geom::GeometryCollection* gc);
     bool hasRepeatedPoint(const geom::MultiPolygon* gc);

--- a/include/geos/util/Assert.h
+++ b/include/geos/util/Assert.h
@@ -21,7 +21,7 @@
 // Forward declarations
 namespace geos {
 namespace geom {
-class Coordinate;
+class CoordinateXY;
 }
 }
 
@@ -40,13 +40,13 @@ public:
     }
 
 
-    static void equals(const geom::Coordinate& expectedValue,
-                       const geom::Coordinate& actualValue,
+    static void equals(const geom::CoordinateXY& expectedValue,
+                       const geom::CoordinateXY& actualValue,
                        const std::string& message);
 
     static void
-    equals(const geom::Coordinate& expectedValue,
-           const geom::Coordinate& actualValue)
+    equals(const geom::CoordinateXY& expectedValue,
+           const geom::CoordinateXY& actualValue)
     {
         equals(expectedValue, actualValue, std::string());
     }

--- a/include/geos/util/GeometricShapeFactory.h
+++ b/include/geos/util/GeometricShapeFactory.h
@@ -68,12 +68,12 @@ protected:
     class Dimensions {
     public:
         Dimensions();
-        geom::Coordinate base;
-        geom::Coordinate centre;
+        geom::CoordinateXY base;
+        geom::CoordinateXY centre;
         double width;
         double height;
-        void setBase(const geom::Coordinate& newBase);
-        void setCentre(const geom::Coordinate& newCentre);
+        void setBase(const geom::CoordinateXY& newBase);
+        void setCentre(const geom::CoordinateXY& newCentre);
         void setSize(double size);
         void setWidth(double nWidth);
         void setHeight(double nHeight);
@@ -86,7 +86,7 @@ protected:
     Dimensions dim;
     uint32_t nPts;
 
-    geom::Coordinate coord(double x, double y) const;
+    geom::CoordinateXY coord(double x, double y) const;
 
 public:
 
@@ -149,7 +149,7 @@ public:
      *
      * @param base the base coordinate of the shape
      */
-    void setBase(const geom::Coordinate& base);
+    void setBase(const geom::CoordinateXY& base);
 
     /**
      * \brief
@@ -158,7 +158,7 @@ public:
      *
      * @param centre the centre coordinate of the shape
      */
-    void setCentre(const geom::Coordinate& centre);
+    void setCentre(const geom::CoordinateXY& centre);
 
     /**
      * \brief Sets the height of the shape.

--- a/src/algorithm/Centroid.cpp
+++ b/src/algorithm/Centroid.cpp
@@ -35,7 +35,7 @@ namespace algorithm { // geos.algorithm
 
 /* static public */
 bool
-Centroid::getCentroid(const Geometry& geom, Coordinate& pt)
+Centroid::getCentroid(const Geometry& geom, CoordinateXY& pt)
 {
     Centroid cent(geom);
     return cent.getCentroid(pt);
@@ -43,7 +43,7 @@ Centroid::getCentroid(const Geometry& geom, Coordinate& pt)
 
 /* public */
 bool
-Centroid::getCentroid(Coordinate& cent) const
+Centroid::getCentroid(CoordinateXY& cent) const
 {
     if(std::abs(areasum2) > 0.0) {
         cent.x = cg3.x / 3 / areasum2;
@@ -90,9 +90,9 @@ Centroid::add(const Geometry& geom)
 
 /* private */
 void
-Centroid::setAreaBasePoint(const Coordinate& basePt)
+Centroid::setAreaBasePoint(const CoordinateXY& basePt)
 {
-    areaBasePt.reset(new Coordinate(basePt));
+    areaBasePt.reset(new CoordinateXY(basePt));
 }
 
 /* private */
@@ -133,7 +133,7 @@ Centroid::addHole(const CoordinateSequence& pts)
 
 /* private */
 void
-Centroid::addTriangle(const Coordinate& p0, const Coordinate& p1, const Coordinate& p2, bool isPositiveArea)
+Centroid::addTriangle(const CoordinateXY& p0, const CoordinateXY& p1, const CoordinateXY& p2, bool isPositiveArea)
 {
     double sign = (isPositiveArea) ? 1.0 : -1.0;
     centroid3(p0, p1, p2, triangleCent3);
@@ -145,7 +145,7 @@ Centroid::addTriangle(const Coordinate& p0, const Coordinate& p1, const Coordina
 
 /* static private */
 void
-Centroid::centroid3(const Coordinate& p1, const Coordinate& p2, const Coordinate& p3, Coordinate& c)
+Centroid::centroid3(const CoordinateXY& p1, const CoordinateXY& p2, const CoordinateXY& p3, CoordinateXY& c)
 {
     c.x = p1.x + p2.x + p3.x;
     c.y = p1.y + p2.y + p3.y;
@@ -154,7 +154,7 @@ Centroid::centroid3(const Coordinate& p1, const Coordinate& p2, const Coordinate
 
 /* static private */
 double
-Centroid::area2(const Coordinate& p1, const Coordinate& p2, const Coordinate& p3)
+Centroid::area2(const CoordinateXY& p1, const CoordinateXY& p2, const CoordinateXY& p3)
 {
     return
         (p2.x - p1.x) * (p3.y - p1.y) -
@@ -188,7 +188,7 @@ Centroid::addLineSegments(const CoordinateSequence& pts)
 
 /* private */
 void
-Centroid::addPoint(const Coordinate& pt)
+Centroid::addPoint(const CoordinateXY& pt)
 {
     ptCount += 1;
     ptCentSum.x += pt.x;

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -249,7 +249,7 @@ LineIntersector::interpolateZ(const Coordinate& p,
 
 /*public*/
 void
-LineIntersector::computeIntersection(const Coordinate& p, const Coordinate& p1, const Coordinate& p2)
+LineIntersector::computeIntersection(const CoordinateXY& p, const CoordinateXY& p1, const CoordinateXY& p2)
 {
     isProperVar = false;
 

--- a/src/algorithm/PolygonNodeTopology.cpp
+++ b/src/algorithm/PolygonNodeTopology.cpp
@@ -26,12 +26,12 @@ namespace algorithm { // geos.algorithm
 
 /* public static */
 bool
-PolygonNodeTopology::isCrossing(const Coordinate* nodePt,
-    const Coordinate* a0, const Coordinate* a1,
-    const Coordinate* b0, const Coordinate* b1)
+PolygonNodeTopology::isCrossing(const CoordinateXY* nodePt,
+    const CoordinateXY* a0, const CoordinateXY* a1,
+    const CoordinateXY* b0, const CoordinateXY* b1)
 {
-    const Coordinate* aLo = a0;
-    const Coordinate* aHi = a1;
+    const CoordinateXY* aLo = a0;
+    const CoordinateXY* aHi = a1;
     if (isAngleGreater(nodePt, aLo, aHi)) {
         aLo = a1;
         aHi = a0;
@@ -48,11 +48,11 @@ PolygonNodeTopology::isCrossing(const Coordinate* nodePt,
 
 /* public static */
 bool
-PolygonNodeTopology::isInteriorSegment(const Coordinate* nodePt,
-    const Coordinate* a0, const Coordinate* a1, const Coordinate* b)
+PolygonNodeTopology::isInteriorSegment(const CoordinateXY* nodePt,
+    const CoordinateXY* a0, const CoordinateXY* a1, const CoordinateXY* b)
 {
-    const Coordinate* aLo = a0;
-    const Coordinate* aHi = a1;
+    const CoordinateXY* aLo = a0;
+    const CoordinateXY* aHi = a1;
     bool isInteriorBetween = true;
     if (isAngleGreater(nodePt, aLo, aHi)) {
         aLo = a1;
@@ -67,9 +67,9 @@ PolygonNodeTopology::isInteriorSegment(const Coordinate* nodePt,
 
 /* private static */
 bool
-PolygonNodeTopology::isBetween(const Coordinate* origin,
-    const Coordinate* p,
-    const Coordinate* e0, const Coordinate* e1)
+PolygonNodeTopology::isBetween(const CoordinateXY* origin,
+    const CoordinateXY* p,
+    const CoordinateXY* e0, const CoordinateXY* e1)
 {
     bool isGreater0 = isAngleGreater(origin, p, e0);
     if (! isGreater0) return false;
@@ -80,8 +80,8 @@ PolygonNodeTopology::isBetween(const Coordinate* origin,
 
 /* private static */
 bool
-PolygonNodeTopology::isAngleGreater(const Coordinate* origin,
-    const Coordinate* p, const Coordinate* q)
+PolygonNodeTopology::isAngleGreater(const CoordinateXY* origin,
+    const CoordinateXY* p, const CoordinateXY* q)
 {
     int quadrantP = quadrant(origin, p);
     int quadrantQ = quadrant(origin, q);
@@ -103,7 +103,7 @@ PolygonNodeTopology::isAngleGreater(const Coordinate* origin,
 
 /* private static */
 int
-PolygonNodeTopology::quadrant(const Coordinate* origin, const Coordinate* p)
+PolygonNodeTopology::quadrant(const CoordinateXY* origin, const CoordinateXY* p)
 {
     double dx = p->x - origin->x;
     double dy = p->y - origin->y;

--- a/src/algorithm/distance/DistanceToPoint.cpp
+++ b/src/algorithm/distance/DistanceToPoint.cpp
@@ -37,7 +37,7 @@ namespace distance { // geos.algorithm.distance
 /* public static */
 void
 DistanceToPoint::computeDistance(const geom::Geometry& geom,
-                                 const geom::Coordinate& pt,
+                                 const geom::CoordinateXY& pt,
                                  PointPairDistance& ptDist)
 {
     if(geom.getGeometryTypeId() == GEOS_LINESTRING) {
@@ -64,7 +64,7 @@ DistanceToPoint::computeDistance(const geom::Geometry& geom,
 /* public static */
 void
 DistanceToPoint::computeDistance(const geom::LineString& line,
-                                 const geom::Coordinate& pt,
+                                 const geom::CoordinateXY& pt,
                                  PointPairDistance& ptDist)
 {
     const CoordinateSequence* coordsRO = line.getCoordinatesRO();
@@ -92,7 +92,7 @@ DistanceToPoint::computeDistance(const geom::LineString& line,
 /* public static */
 void
 DistanceToPoint::computeDistance(const geom::LineSegment& segment,
-                                 const geom::Coordinate& pt,
+                                 const geom::CoordinateXY& pt,
                                  PointPairDistance& ptDist)
 {
     Coordinate closestPt;
@@ -103,7 +103,7 @@ DistanceToPoint::computeDistance(const geom::LineSegment& segment,
 /* public static */
 void
 DistanceToPoint::computeDistance(const geom::Polygon& poly,
-                                 const geom::Coordinate& pt,
+                                 const geom::CoordinateXY& pt,
                                  PointPairDistance& ptDist)
 {
     computeDistance(*(poly.getExteriorRing()), pt, ptDist);

--- a/src/geom/Coordinate.cpp
+++ b/src/geom/Coordinate.cpp
@@ -24,7 +24,14 @@
 namespace geos {
 namespace geom { // geos::geom
 
+CoordinateXY CoordinateXY::_nullCoord = CoordinateXY(DoubleNotANumber, DoubleNotANumber);
 Coordinate Coordinate::_nullCoord = Coordinate(DoubleNotANumber, DoubleNotANumber, DoubleNotANumber);
+
+CoordinateXY&
+CoordinateXY::getNull()
+{
+    return _nullCoord;
+}
 
 Coordinate&
 Coordinate::getNull()

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -47,7 +47,7 @@ LineSegment::reverse()
 
 /*public*/
 double
-LineSegment::projectionFactor(const Coordinate& p) const
+LineSegment::projectionFactor(const CoordinateXY& p) const
 {
     if(p == p0) {
         return 0.0;
@@ -75,7 +75,7 @@ LineSegment::projectionFactor(const Coordinate& p) const
 
 /*public*/
 double
-LineSegment::segmentFraction(const Coordinate& inputPt) const
+LineSegment::segmentFraction(const CoordinateXY& inputPt) const
 {
     double segFrac = projectionFactor(inputPt);
     if(segFrac < 0.0) {

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -100,12 +100,12 @@ LineSegment::project(const Coordinate& p, Coordinate& ret) const
 
 /*private*/
 void
-LineSegment::project(double factor, Coordinate& ret) const
+LineSegment::project(double factor, CoordinateXY& ret) const
 {
     if( factor == 1.0 )
         ret = p1;
     else
-        ret = Coordinate(p0.x + factor * (p1.x - p0.x), p0.y + factor * (p1.y - p0.y));
+        ret = CoordinateXY(p0.x + factor * (p1.x - p0.x), p0.y + factor * (p1.y - p0.y));
 }
 
 bool
@@ -140,7 +140,7 @@ LineSegment::project(const LineSegment& seg, LineSegment& ret) const
 
 //Coordinate*
 void
-LineSegment::closestPoint(const Coordinate& p, Coordinate& ret) const
+LineSegment::closestPoint(const CoordinateXY& p, CoordinateXY& ret) const
 {
     double factor = projectionFactor(p);
     if(factor > 0 && factor < 1) {

--- a/src/geom/util/SineStarFactory.cpp
+++ b/src/geom/util/SineStarFactory.cpp
@@ -56,7 +56,7 @@ SineStarFactory::createSineStar() const
     double centreX = env->getMinX() + radius;
     double centreY = env->getMinY() + radius;
 
-    std::vector<Coordinate> pts(nPts + 1);
+    std::vector<CoordinateXY> pts(nPts + 1);
     uint32_t iPt = 0;
     for(uint32_t i = 0; i < nPts; i++) {
         // the fraction of the way thru the current arm - in [0,1]

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -402,18 +402,20 @@ WKTWriter::appendLineStringText(const LineString* lineString, int p_level,
         writer->write("EMPTY");
     }
     else {
+        const CoordinateSequence* coords = lineString->getCoordinatesRO();
+
         if(doIndent) {
             indent(p_level, writer);
         }
         writer->write("(");
-        for(std::size_t i = 0, n = lineString->getNumPoints(); i < n; ++i) {
+        for(std::size_t i = 0, n = coords->size(); i < n; ++i) {
             if(i > 0) {
                 writer->write(", ");
                 if(i % 10 == 0) {
                     indent(p_level + 2, writer);
                 }
             }
-            appendCoordinate(&(lineString->getCoordinateN(i)), writer);
+            appendCoordinate(&coords->getAt(i), writer);
         }
         writer->write(")");
     }

--- a/src/linearref/LocationIndexOfLine.cpp
+++ b/src/linearref/LocationIndexOfLine.cpp
@@ -52,8 +52,8 @@ LocationIndexOfLine::indicesOf(const Geometry* subLine) const
     if(! firstLine || !lastLine) {
         throw util::IllegalArgumentException("LocationIndexOfLine::indicesOf only works with geometry collections of LineString");
     }
-    Coordinate startPt = firstLine->getCoordinateN(0);
-    Coordinate endPt = lastLine->getCoordinateN(lastLine->getNumPoints() - 1);
+    const CoordinateXY& startPt = firstLine->getCoordinateN(0);
+    const CoordinateXY& endPt = lastLine->getCoordinateN(lastLine->getNumPoints() - 1);
 
     LocationIndexOfPoint locPt(linearGeom);
     LinearLocation* subLineLoc = new LinearLocation[2];

--- a/src/linearref/LocationIndexOfPoint.cpp
+++ b/src/linearref/LocationIndexOfPoint.cpp
@@ -36,7 +36,7 @@ namespace geos {
 namespace linearref { // geos.linearref
 
 LinearLocation
-LocationIndexOfPoint::indexOfFromStart(const Coordinate& inputPt,
+LocationIndexOfPoint::indexOfFromStart(const CoordinateXY& inputPt,
                                        const LinearLocation* minIndex) const
 {
     double minDistance = DoubleInfinity;
@@ -74,14 +74,14 @@ LocationIndexOfPoint::indexOfFromStart(const Coordinate& inputPt,
 
 
 LinearLocation
-LocationIndexOfPoint::indexOf(const Geometry* linearGeom, const Coordinate& inputPt)
+LocationIndexOfPoint::indexOf(const Geometry* linearGeom, const CoordinateXY& inputPt)
 {
     LocationIndexOfPoint locater(linearGeom);
     return locater.indexOf(inputPt);
 }
 
 LinearLocation
-LocationIndexOfPoint::indexOfAfter(const Geometry* linearGeom, const Coordinate& inputPt,
+LocationIndexOfPoint::indexOfAfter(const Geometry* linearGeom, const CoordinateXY& inputPt,
                                    const LinearLocation* minIndex)
 {
     LocationIndexOfPoint locater(linearGeom);
@@ -93,13 +93,13 @@ LocationIndexOfPoint::LocationIndexOfPoint(const Geometry* p_linearGeom) :
 {}
 
 LinearLocation
-LocationIndexOfPoint::indexOf(const Coordinate& inputPt) const
+LocationIndexOfPoint::indexOf(const CoordinateXY& inputPt) const
 {
     return indexOfFromStart(inputPt, nullptr);
 }
 
 LinearLocation
-LocationIndexOfPoint::indexOfAfter(const Coordinate& inputPt,
+LocationIndexOfPoint::indexOfAfter(const CoordinateXY& inputPt,
                                    const LinearLocation* minIndex) const
 {
     if(!minIndex) {

--- a/src/operation/valid/IndexedNestedHoleTester.cpp
+++ b/src/operation/valid/IndexedNestedHoleTester.cpp
@@ -65,7 +65,7 @@ IndexedNestedHoleTester::isNested()
              * the topology of the incident edges.
              */
             if (PolygonTopologyAnalyzer::isRingNested(hole, testHole)) {
-                nestedPt = hole->getCoordinateN(0);
+                nestedPt = hole->getCoordinatesRO()->getAt(0);
                 return true;
             }
         }

--- a/src/operation/valid/IndexedNestedPolygonTester.cpp
+++ b/src/operation/valid/IndexedNestedPolygonTester.cpp
@@ -114,12 +114,14 @@ IndexedNestedPolygonTester::findNestedPoint(
     const LinearRing* shell,
     const Polygon* possibleOuterPoly,
     IndexedPointInAreaLocator& locator,
-    Coordinate& coordNested)
+    CoordinateXY& coordNested)
 {
     /**
      * Try checking two points, since checking point location is fast.
      */
-    const Coordinate& shellPt0 = shell->getCoordinateN(0);
+    const CoordinateSequence* shellCoords = shell->getCoordinatesRO();
+
+    const CoordinateXY& shellPt0 = shellCoords->front();
     Location loc0 = locator.locate(&shellPt0);
     if (loc0 == Location::EXTERIOR) return false;
     if (loc0 == Location::INTERIOR) {
@@ -127,7 +129,7 @@ IndexedNestedPolygonTester::findNestedPoint(
         return true;
     }
 
-    const Coordinate& shellPt1 = shell->getCoordinateN(1);
+    const CoordinateXY& shellPt1 = shellCoords->getAt(1);
     Location loc1 = locator.locate(&shellPt1);
     if (loc1 == Location::EXTERIOR) return false;
     if (loc1 == Location::INTERIOR) {
@@ -158,7 +160,7 @@ bool
 IndexedNestedPolygonTester::findIncidentSegmentNestedPoint(
     const LinearRing* shell,
     const Polygon* poly,
-    Coordinate& coordNested)
+    CoordinateXY& coordNested)
 {
     const LinearRing* polyShell = poly->getExteriorRing();
     if (polyShell->isEmpty())
@@ -184,7 +186,7 @@ IndexedNestedPolygonTester::findIncidentSegmentNestedPoint(
      * The shell is contained in the polygon, but is not contained in a hole.
      * This is invalid.
      */
-    coordNested = shell->getCoordinateN(0);
+    coordNested = shell->getCoordinatesRO()->getAt(0);
     return true;
 }
 

--- a/src/operation/valid/IsValidOp.cpp
+++ b/src/operation/valid/IsValidOp.cpp
@@ -49,7 +49,7 @@ IsValidOp::isValid()
 
 /* public static */
 bool
-IsValidOp::isValid(const Coordinate* coord)
+IsValidOp::isValid(const CoordinateXY* coord)
 {
     if (std::isfinite(coord->x) && std::isfinite(coord->y)) {
         return true;
@@ -378,7 +378,7 @@ IsValidOp::checkAreaIntersections(PolygonTopologyAnalyzer& areaAnalyzer)
 void
 IsValidOp::checkRingSimple(const LinearRing* ring)
 {
-    Coordinate intPt = PolygonTopologyAnalyzer::findSelfIntersection(ring);
+    CoordinateXY intPt = PolygonTopologyAnalyzer::findSelfIntersection(ring);
     if (! intPt.isNull()) {
         logInvalid(TopologyValidationError::eRingSelfIntersection,
             intPt);
@@ -418,10 +418,10 @@ IsValidOp::checkHolesInShell(const Polygon* poly)
 
 
 /* private */
-const Coordinate *
+const CoordinateXY*
 IsValidOp::findHoleOutsideShellPoint(const LinearRing* hole, const LinearRing* shell)
 {
-    const Coordinate& holePt0 = hole->getCoordinateN(0);
+    const CoordinateXY& holePt0 = hole->getCoordinateN(0);
     /**
      * If hole envelope is not covered by shell, it must be outside
      */

--- a/src/operation/valid/PolygonIntersectionAnalyzer.cpp
+++ b/src/operation/valid/PolygonIntersectionAnalyzer.cpp
@@ -117,14 +117,14 @@ PolygonIntersectionAnalyzer::findInvalidIntersection(
      * Check topology of a vertex intersection.
      * The ring(s) must not cross.
      */
-    const Coordinate* e00 = &p00;
-    const Coordinate* e01 = &p01;
+    const CoordinateXY* e00 = &p00;
+    const CoordinateXY* e01 = &p01;
     if (intPt.equals2D(p00)) {
         e00 = &(prevCoordinateInRing(ss0, segIndex0));
         e01 = &p01;
     }
-    const Coordinate* e10 = &p10;
-    const Coordinate* e11 = &p11;
+    const CoordinateXY* e10 = &p10;
+    const CoordinateXY* e11 = &p11;
     if (intPt.equals2D(p10)) {
         e10 = &(prevCoordinateInRing(ss1, segIndex1));
         e11 = &p11;
@@ -164,7 +164,7 @@ PolygonIntersectionAnalyzer::findInvalidIntersection(
 bool
 PolygonIntersectionAnalyzer::addDoubleTouch(
     const SegmentString* ss0, const SegmentString* ss1,
-    const Coordinate& intPt)
+    const CoordinateXY& intPt)
 {
     return PolygonRing::addTouch(
         const_cast<PolygonRing*>(static_cast<const PolygonRing*>(ss0->getData())),
@@ -175,9 +175,9 @@ PolygonIntersectionAnalyzer::addDoubleTouch(
 /* private */
 void
 PolygonIntersectionAnalyzer::addSelfTouch(
-    const SegmentString* ss, const Coordinate& intPt,
-    const Coordinate* e00, const Coordinate* e01,
-    const Coordinate* e10, const Coordinate* e11)
+    const SegmentString* ss, const CoordinateXY& intPt,
+    const CoordinateXY* e00, const CoordinateXY* e01,
+    const CoordinateXY* e10, const CoordinateXY* e11)
 {
     const PolygonRing* constPolyRing = static_cast<const PolygonRing*>(ss->getData());
     PolygonRing* polyRing = const_cast<PolygonRing*>(constPolyRing);
@@ -188,7 +188,7 @@ PolygonIntersectionAnalyzer::addSelfTouch(
 }
 
 /* private */
-const Coordinate&
+const CoordinateXY&
 PolygonIntersectionAnalyzer::prevCoordinateInRing(
     const SegmentString* ringSS, std::size_t segIndex) const
 {

--- a/src/operation/valid/PolygonRing.cpp
+++ b/src/operation/valid/PolygonRing.cpp
@@ -39,7 +39,7 @@ PolygonRing::isShell(const PolygonRing* polyRing)
 
 /* public static */
 bool
-PolygonRing::addTouch(PolygonRing* ring0, PolygonRing* ring1, const Coordinate& pt)
+PolygonRing::addTouch(PolygonRing* ring0, PolygonRing* ring1, const CoordinateXY& pt)
 {
     //--- skip if either polygon does not have holes
     if (ring0 == nullptr || ring1 == nullptr)
@@ -58,12 +58,12 @@ PolygonRing::addTouch(PolygonRing* ring0, PolygonRing* ring1, const Coordinate& 
 
 
 /* public static */
-const Coordinate*
+const CoordinateXY*
 PolygonRing::findHoleCycleLocation(std::vector<PolygonRing*> polyRings)
 {
     for (PolygonRing* polyRing : polyRings) {
         if (! polyRing->isInTouchSet()) {
-            const Coordinate* holeCycleLoc = polyRing->findHoleCycleLocation();
+            const CoordinateXY* holeCycleLoc = polyRing->findHoleCycleLocation();
             if (holeCycleLoc != nullptr) return holeCycleLoc;
         }
     }
@@ -72,11 +72,11 @@ PolygonRing::findHoleCycleLocation(std::vector<PolygonRing*> polyRings)
 
 
 /* public static */
-const Coordinate*
+const CoordinateXY*
 PolygonRing::findInteriorSelfNode(std::vector<PolygonRing*> polyRings)
 {
     for (PolygonRing* polyRing : polyRings) {
-        const Coordinate* interiorSelfNode = polyRing->findInteriorSelfNode();
+        const CoordinateXY* interiorSelfNode = polyRing->findInteriorSelfNode();
         if (interiorSelfNode != nullptr) {
             return interiorSelfNode;
         }
@@ -100,7 +100,7 @@ PolygonRing::getTouches() const
 
 /* private */
 void
-PolygonRing::addTouch(PolygonRing* polyRing, const Coordinate& pt)
+PolygonRing::addTouch(PolygonRing* polyRing, const CoordinateXY& pt)
 {
     std::size_t nTouches = touches.count(polyRing->id);
     if (nTouches == 0) {
@@ -115,9 +115,9 @@ PolygonRing::addTouch(PolygonRing* polyRing, const Coordinate& pt)
 
 /* public */
 void
-PolygonRing::addSelfTouch(const Coordinate& origin,
-    const Coordinate* e00, const Coordinate* e01,
-    const Coordinate* e10, const Coordinate* e11)
+PolygonRing::addSelfTouch(const CoordinateXY& origin,
+    const CoordinateXY* e00, const CoordinateXY* e01,
+    const CoordinateXY* e10, const CoordinateXY* e11)
 {
     selfNodes.emplace_back(origin, e00, e01, e10, e11);
 }
@@ -125,7 +125,7 @@ PolygonRing::addSelfTouch(const Coordinate& origin,
 
 /* private */
 bool
-PolygonRing::isOnlyTouch(const PolygonRing* polyRing, const Coordinate& pt) const
+PolygonRing::isOnlyTouch(const PolygonRing* polyRing, const CoordinateXY& pt) const
 {
     //--- no touches for this ring
     if (touches.empty()) return true;
@@ -143,7 +143,7 @@ PolygonRing::isOnlyTouch(const PolygonRing* polyRing, const Coordinate& pt) cons
 
 
 /* private */
-const Coordinate*
+const CoordinateXY*
 PolygonRing::findHoleCycleLocation()
 {
     //--- the touch set including this ring is already processed
@@ -163,7 +163,7 @@ PolygonRing::findHoleCycleLocation()
     while (! touchStack.empty()) {
         PolygonRingTouch* touch = touchStack.top();
         touchStack.pop();
-        const Coordinate* holeCyclePt = scanForHoleCycle(touch, root, touchStack);
+        const CoordinateXY* holeCyclePt = scanForHoleCycle(touch, root, touchStack);
         if (holeCyclePt != nullptr) {
             return holeCyclePt;
         }
@@ -184,13 +184,13 @@ PolygonRing::init(PolygonRing* root, std::stack<PolygonRingTouch*>& touchStack)
 
 
 /* private */
-const Coordinate*
+const CoordinateXY*
 PolygonRing::scanForHoleCycle(PolygonRingTouch* currentTouch,
     PolygonRing* root,
     std::stack<PolygonRingTouch*>& touchStack)
 {
     PolygonRing* polyRing = currentTouch->getRing();
-    const Coordinate* currentPt = currentTouch->getCoordinate();
+    const CoordinateXY* currentPt = currentTouch->getCoordinate();
 
     /**
      * Scan the touched rings
@@ -228,7 +228,7 @@ PolygonRing::scanForHoleCycle(PolygonRingTouch* currentTouch,
 
 
 /* public */
-const Coordinate*
+const CoordinateXY*
 PolygonRing::findInteriorSelfNode()
 {
     if (selfNodes.empty()) return nullptr;

--- a/src/operation/valid/PolygonRingTouch.cpp
+++ b/src/operation/valid/PolygonRingTouch.cpp
@@ -25,7 +25,7 @@ namespace valid {     // geos.operation.valid
 using namespace geos::geom;
 
 /* public */
-const Coordinate*
+const CoordinateXY*
 PolygonRingTouch::getCoordinate() const
 {
     return &touchPt;
@@ -40,7 +40,7 @@ PolygonRingTouch::getRing() const
 
 /* public */
 bool
-PolygonRingTouch::isAtLocation(const Coordinate& pt) const
+PolygonRingTouch::isAtLocation(const CoordinateXY& pt) const
 {
     return touchPt.equals2D(pt);
 }

--- a/src/operation/valid/PolygonTopologyAnalyzer.cpp
+++ b/src/operation/valid/PolygonTopologyAnalyzer.cpp
@@ -62,7 +62,7 @@ PolygonTopologyAnalyzer::PolygonTopologyAnalyzer(const Geometry* geom, bool p_is
 
 
 /* public static */
-Coordinate
+CoordinateXY
 PolygonTopologyAnalyzer::findSelfIntersection(const LinearRing* ring)
 {
     PolygonTopologyAnalyzer ata(ring, false);
@@ -76,7 +76,7 @@ bool
 PolygonTopologyAnalyzer::isRingNested(const LinearRing* test,
     const LinearRing* target)
 {
-    const Coordinate& p0 = test->getCoordinateN(0);
+    const CoordinateXY& p0 = test->getCoordinateN(0);
     const CoordinateSequence* targetPts = target->getCoordinatesRO();
     Location loc = algorithm::PointLocation::locateInRing(p0, *targetPts);
     if (loc == Location::EXTERIOR) return false;
@@ -87,13 +87,13 @@ PolygonTopologyAnalyzer::isRingNested(const LinearRing* test,
      * Use the topology at the node to check if the segment
      * is inside or outside the ring.
      */
-    Coordinate p1 = findNonEqualVertex(test, p0);
+    const CoordinateXY& p1 = findNonEqualVertex(test, p0);
     return isIncidentSegmentInRing(&p0, &p1, targetPts);
 }
 
 /* private static */
-const Coordinate&
-PolygonTopologyAnalyzer::findNonEqualVertex(const LinearRing* ring, const Coordinate& p)
+const CoordinateXY&
+PolygonTopologyAnalyzer::findNonEqualVertex(const LinearRing* ring, const CoordinateXY& p)
 {
     std::size_t i = 1;
     const Coordinate* next = &(ring->getCoordinateN(i));
@@ -107,18 +107,18 @@ PolygonTopologyAnalyzer::findNonEqualVertex(const LinearRing* ring, const Coordi
 /* private static */
 bool
 PolygonTopologyAnalyzer::isIncidentSegmentInRing(
-    const Coordinate* p0, const Coordinate* p1,
+    const CoordinateXY* p0, const CoordinateXY* p1,
     const CoordinateSequence* ringPts)
 {
     std::size_t index = intersectingSegIndex(ringPts, p0);
-    const Coordinate* rPrev = &findRingVertexPrev(ringPts, index, *p0);
-    const Coordinate* rNext = &findRingVertexNext(ringPts, index, *p0);
+    const CoordinateXY* rPrev = &findRingVertexPrev(ringPts, index, *p0);
+    const CoordinateXY* rNext = &findRingVertexNext(ringPts, index, *p0);
     /**
     * If ring orientation is not normalized, flip the corner orientation
     */
     bool isInteriorOnRight = ! algorithm::Orientation::isCCW(ringPts);
     if (! isInteriorOnRight) {
-        const Coordinate* temp = rPrev;
+        const CoordinateXY* temp = rPrev;
         rPrev = rNext;
         rNext = temp;
     }
@@ -126,11 +126,11 @@ PolygonTopologyAnalyzer::isIncidentSegmentInRing(
 }
 
 /* private static */
-const Coordinate&
-PolygonTopologyAnalyzer::findRingVertexPrev(const CoordinateSequence* ringPts, std::size_t index, const Coordinate& node)
+const CoordinateXY&
+PolygonTopologyAnalyzer::findRingVertexPrev(const CoordinateSequence* ringPts, std::size_t index, const CoordinateXY& node)
 {
     std::size_t iPrev = index;
-    const Coordinate* prev = &(ringPts->getAt(iPrev));
+    const CoordinateXY* prev = &(ringPts->getAt(iPrev));
     while (prev->equals2D(node)) {
       iPrev = ringIndexPrev(ringPts, iPrev);
       prev = &(ringPts->getAt(iPrev));
@@ -139,12 +139,12 @@ PolygonTopologyAnalyzer::findRingVertexPrev(const CoordinateSequence* ringPts, s
 }
 
 /* private static */
-const Coordinate&
-PolygonTopologyAnalyzer::findRingVertexNext(const CoordinateSequence* ringPts, std::size_t index, const Coordinate& node)
+const CoordinateXY&
+PolygonTopologyAnalyzer::findRingVertexNext(const CoordinateSequence* ringPts, std::size_t index, const CoordinateXY& node)
 {
     //-- safe, since index is always the start of a ring segment
     std::size_t iNext = index + 1;
-    const Coordinate* next = &(ringPts->getAt(iNext));
+    const CoordinateXY* next = &(ringPts->getAt(iNext));
     while (next->equals2D(node)) {
       iNext = ringIndexNext(ringPts, iNext);
       next = &(ringPts->getAt(iNext));
@@ -175,7 +175,7 @@ PolygonTopologyAnalyzer::ringIndexNext(const CoordinateSequence* ringPts, std::s
 /* private static */
 std::size_t
 PolygonTopologyAnalyzer::intersectingSegIndex(const CoordinateSequence* ringPts,
-    const Coordinate* pt)
+    const CoordinateXY* pt)
 {
     algorithm::LineIntersector li;
     for (std::size_t i = 0; i < ringPts->size() - 1; i++) {
@@ -220,7 +220,7 @@ void
 PolygonTopologyAnalyzer::checkInteriorDisconnectedBySelfTouch()
 {
     if (! polyRings.empty()) {
-        const Coordinate* dPt = PolygonRing::findInteriorSelfNode(polyRings);
+        const CoordinateXY* dPt = PolygonRing::findInteriorSelfNode(polyRings);
         if (dPt)
             disconnectionPt = *dPt;
     }
@@ -235,7 +235,7 @@ PolygonTopologyAnalyzer::checkInteriorDisconnectedByHoleCycle()
     * PolyRings will be null for empty, no hole or LinearRing inputs
     */
     if (! polyRings.empty()) {
-        const Coordinate* dPt = PolygonRing::findHoleCycleLocation(polyRings);
+        const CoordinateXY* dPt = PolygonRing::findHoleCycleLocation(polyRings);
         if (dPt)
             disconnectionPt = *dPt;
     }

--- a/src/operation/valid/RepeatedPointTester.cpp
+++ b/src/operation/valid/RepeatedPointTester.cpp
@@ -37,7 +37,7 @@ namespace geos {
 namespace operation { // geos.operation
 namespace valid { // geos.operation.valid
 
-Coordinate&
+CoordinateXY&
 RepeatedPointTester::getCoordinate()
 {
     return repeatedCoord;

--- a/src/util/Assert.cpp
+++ b/src/util/Assert.cpp
@@ -38,8 +38,8 @@ Assert::isTrue(bool assertion, const std::string& message)
 }
 
 void
-Assert::equals(const Coordinate& expectedValue,
-               const Coordinate& actualValue, const std::string& message)
+Assert::equals(const CoordinateXY& expectedValue,
+               const CoordinateXY& actualValue, const std::string& message)
 {
     if(!(actualValue == expectedValue)) {
         throw  AssertionFailedException("Expected " + expectedValue.toString() + " but encountered "

--- a/src/util/GeometricShapeFactory.cpp
+++ b/src/util/GeometricShapeFactory.cpp
@@ -46,13 +46,13 @@ GeometricShapeFactory::GeometricShapeFactory(const GeometryFactory* factory)
 }
 
 void
-GeometricShapeFactory::setBase(const Coordinate& base)
+GeometricShapeFactory::setBase(const CoordinateXY& base)
 {
     dim.setBase(base);
 }
 
 void
-GeometricShapeFactory::setCentre(const Coordinate& centre)
+GeometricShapeFactory::setCentre(const CoordinateXY& centre)
 {
     dim.setCentre(centre);
 }
@@ -94,7 +94,7 @@ GeometricShapeFactory::createRectangle()
     double XsegLen = env->getWidth() / nSide;
     double YsegLen = env->getHeight() / nSide;
 
-    std::vector<Coordinate> vc(4 * nSide + 1);
+    std::vector<CoordinateXY> vc(4 * nSide + 1);
 
     for(i = 0; i < nSide; i++) {
         double x = env->getMinX() + i * XsegLen;
@@ -134,7 +134,7 @@ GeometricShapeFactory::createCircle()
     double centreY = env->getMinY() + yRadius;
     env.reset();
 
-    std::vector<Coordinate> pts(nPts + 1);
+    std::vector<CoordinateXY> pts(nPts + 1);
     uint32_t iPt = 0;
     for(uint32_t i = 0; i < nPts; i++) {
         double ang = i * (2 * 3.14159265358979 / nPts);
@@ -166,7 +166,7 @@ GeometricShapeFactory::createArc(double startAng, double angExtent)
     }
     double angInc = angSize / (nPts - 1);
 
-    std::vector<Coordinate> pts(nPts);
+    std::vector<CoordinateXY> pts(nPts);
     uint32_t iPt = 0;
     for(uint32_t i = 0; i < nPts; i++) {
         double ang = startAng + i * angInc;
@@ -196,7 +196,7 @@ GeometricShapeFactory::createArcPolygon(double startAng, double angExtent)
     }
     double angInc = angSize / (nPts - 1);
 
-    std::vector<Coordinate> pts(nPts + 2);
+    std::vector<CoordinateXY> pts(nPts + 2);
     uint32_t iPt = 0;
     pts[iPt++] = coord(centreX, centreY);
     for(uint32_t i = 0; i < nPts; i++) {
@@ -215,19 +215,19 @@ GeometricShapeFactory::createArcPolygon(double startAng, double angExtent)
 
 GeometricShapeFactory::Dimensions::Dimensions()
     :
-    base(Coordinate::getNull()),
-    centre(Coordinate::getNull())
+    base(CoordinateXY::getNull()),
+    centre(CoordinateXY::getNull())
 {
 }
 
 void
-GeometricShapeFactory::Dimensions::setBase(const Coordinate& newBase)
+GeometricShapeFactory::Dimensions::setBase(const CoordinateXY& newBase)
 {
     base = newBase;
 }
 
 void
-GeometricShapeFactory::Dimensions::setCentre(const Coordinate& newCentre)
+GeometricShapeFactory::Dimensions::setCentre(const CoordinateXY& newCentre)
 {
     centre = newCentre;
 }
@@ -264,10 +264,10 @@ GeometricShapeFactory::Dimensions::getEnvelope() const
 }
 
 /*protected*/
-Coordinate
+CoordinateXY
 GeometricShapeFactory::coord(double x, double y) const
 {
-    Coordinate ret(x, y);
+    CoordinateXY ret(x, y);
     precModel->makePrecise(&ret);
     return ret;
 }


### PR DESCRIPTION
This PR continues #701 by using the `CoordinateXY` type for more 2D algorithms.

To safely use true 2D CoordinateSequences, as supported by #721, we would need to convert all coordinate access to be either 2D-only or to switch between algorithm implementations depending on the dimension.