### PR TITLE
Remove RETURN_UNIQUE_PTR and support for gcc-4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,6 @@ jobs:
           cmake_extra: '-DBUILD_BENCHMARKS=ON'
           os: ubuntu-18.04
           
-        - cxx_compiler: g++-4.8
-          c_compiler: gcc-4.8
-          build_type: Release
-          cxxstd: 11
-          arch: 32
-          packages: 'g++-4.8-multilib gcc-4.8-multilib g++-multilib gcc-multilib'
-          cmake: 3.13.*
-          os: ubuntu-18.04
-
         - cxx_compiler: g++-5
           c_compiler: gcc-5
           build_type: Release

--- a/include/geos/geom/FixedSizeCoordinateSequence.h
+++ b/include/geos/geom/FixedSizeCoordinateSequence.h
@@ -37,7 +37,7 @@ namespace geom {
         std::unique_ptr<CoordinateSequence> clone() const final override {
             auto seq = detail::make_unique<FixedSizeCoordinateSequence<N>>(dimension);
             seq->m_data = m_data;
-            return RETURN_UNIQUE_PTR(seq);
+            return seq;
         }
 
         const Coordinate& getAt(std::size_t i) const final override {

--- a/include/geos/util.h
+++ b/include/geos/util.h
@@ -95,17 +95,6 @@ template<typename To, typename From> inline To down_cast(From* f)
     return static_cast<To>(f);
 }
 
-// Avoid "redundant move" warning when calling std::move() to return
-// unique_ptr<Derived> from a function with return type unique_ptr<Base>
-// The std::move is required for the gcc 4.9 series, which has not addressed
-// CWG defect 1579 ("return by converting move constructor")
-// http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1579
-#if __GNUC__ > 0 && __GNUC__ < 5
-#define RETURN_UNIQUE_PTR(x) (std::move(x))
-#else
-#define RETURN_UNIQUE_PTR(x) (x)
-#endif
-
 } // namespace detail
 } // namespace geos
 

--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -85,7 +85,7 @@ WKTReader::getCoordinates(StringTokenizer* tokenizer, OrdinateSet& ordinateFlags
         nextToken = getNextCloserOrComma(tokenizer);
     }
 
-    return RETURN_UNIQUE_PTR(coordinates);
+    return coordinates;
 }
 
 void

--- a/src/noding/SegmentNodeList.cpp
+++ b/src/noding/SegmentNodeList.cpp
@@ -261,7 +261,7 @@ SegmentNodeList::createSplitEdgePts(const SegmentNode* ei0, const SegmentNode* e
         auto pts = detail::make_unique<FixedSizeCoordinateSequence<2>>();
         pts->setAt(ei0->coord, 0);
         pts->setAt(ei1->coord, 1);
-        return RETURN_UNIQUE_PTR(pts);
+        return pts;
     }
 
     const Coordinate& lastSegStartPt = edge.getCoordinate(ei1->segmentIndex);


### PR DESCRIPTION
Closes #589. RHEL7 (uses gcc 4.8) is fully EOL in spring of 2024, so we'll be rolling this out only about 9 months before then.