### PR TITLE
Pull CoordinateSequence into SegmentString base class

### DIFF
--- a/include/geos/noding/BasicSegmentString.h
+++ b/include/geos/noding/BasicSegmentString.h
@@ -53,37 +53,11 @@ public:
     BasicSegmentString(geom::CoordinateSequence* newPts,
                        const void* newContext)
         :
-        SegmentString(newContext),
-        pts(newPts)
+        SegmentString(newContext, newPts)
     {}
 
     ~BasicSegmentString() override
     {}
-
-    // see dox in SegmentString.h
-    size_t
-    size() const override
-    {
-        return pts->size();
-    }
-
-    // see dox in SegmentString.h
-    const geom::Coordinate& getCoordinate(std::size_t i) const override
-    {
-        return pts->getAt(i);
-    };
-
-    /// @see SegmentString::getCoordinates() const
-    geom::CoordinateSequence* getCoordinates() const override
-    {
-        return pts;
-    };
-
-    // see dox in SegmentString.h
-    bool isClosed() const override
-    {
-        return pts->getAt(0) == pts->getAt(size() - 1);
-    };
 
     // see dox in SegmentString.h
     std::ostream& print(std::ostream& os) const override;
@@ -104,8 +78,6 @@ public:
     };
 
 private:
-
-    geom::CoordinateSequence* pts;
 
     // Declare type as noncopyable
     BasicSegmentString(const BasicSegmentString& other) = delete;

--- a/include/geos/noding/NodableSegmentString.h
+++ b/include/geos/noding/NodableSegmentString.h
@@ -37,9 +37,9 @@ class GEOS_DLL NodableSegmentString : public SegmentString {
 private:
 protected:
 public:
-    NodableSegmentString(const void* newContext)
+    NodableSegmentString(const void* newContext, geom::CoordinateSequence* newSeq)
         :
-        SegmentString(newContext)
+        SegmentString(newContext, newSeq)
     { }
 
     /**

--- a/include/geos/noding/SegmentString.h
+++ b/include/geos/noding/SegmentString.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <geos/export.h>
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateSequence.h>
 #include <geos/noding/SegmentNodeList.h>
 
 #include <vector>
@@ -53,9 +55,11 @@ public:
     /// \brief Construct a SegmentString.
     ///
     /// @param newContext the context associated to this SegmentString
+    /// @param newSeq coordinates of this SegmentString
     ///
-    SegmentString(const void* newContext)
+    SegmentString(const void* newContext, geom::CoordinateSequence* newSeq)
         :
+        seq(newSeq),
         context(newContext)
     {}
 
@@ -84,10 +88,13 @@ public:
         context = data;
     }
 
+    std::size_t size() const {
+        return seq->size();
+    }
 
-    virtual std::size_t size() const = 0;
-
-    virtual const geom::Coordinate& getCoordinate(std::size_t i) const = 0;
+    const geom::Coordinate& getCoordinate(std::size_t i) const {
+        return seq->getAt(i);
+    }
 
     /// \brief
     /// Return a pointer to the CoordinateSequence associated
@@ -95,14 +102,24 @@ public:
     ///
     /// @note The CoordinateSequence is owned by this SegmentString!
     ///
-    virtual geom::CoordinateSequence* getCoordinates() const = 0;
+    const geom::CoordinateSequence* getCoordinates() const {
+        return seq;
+    }
 
-    virtual bool isClosed() const = 0;
+    geom::CoordinateSequence* getCoordinates() {
+        return seq;
+    }
+
+    bool isClosed() const {
+        return seq->front().equals(seq->back());
+    }
 
     virtual std::ostream& print(std::ostream& os) const;
 
-private:
+protected:
+    geom::CoordinateSequence* seq;
 
+private:
     const void* context;
 
     // Declare type as noncopyable

--- a/include/geos/operation/overlayng/Edge.h
+++ b/include/geos/operation/overlayng/Edge.h
@@ -198,7 +198,7 @@ public:
     static bool isCollapsed(const geom::CoordinateSequence* pts);
 
     // takes ownership of pts from caller
-    Edge(geom::CoordinateSequence* p_pts, const EdgeSourceInfo* info);
+    Edge(std::unique_ptr<geom::CoordinateSequence>&& p_pts, const EdgeSourceInfo* info);
 
     // return a clone of the underlying points
     std::unique_ptr<geom::CoordinateSequence> getCoordinates()

--- a/src/noding/BasicSegmentString.cpp
+++ b/src/noding/BasicSegmentString.cpp
@@ -30,7 +30,7 @@ std::ostream&
 BasicSegmentString::print(std::ostream& os) const
 {
     os << "BasicSegmentString: " << std::endl;
-    os << " LINESTRING" << *(pts) << ";" << std::endl;
+    os << " LINESTRING" << *(getCoordinates()) << ";" << std::endl;
 
     return os;
 }

--- a/src/noding/NodedSegmentString.cpp
+++ b/src/noding/NodedSegmentString.cpp
@@ -74,31 +74,12 @@ NodedSegmentString::getNodedSubstrings(
     return resultEdgelist;
 }
 
-/* virtual public */
-const geom::Coordinate&
-NodedSegmentString::getCoordinate(std::size_t i) const
-{
-    return pts->getAt(i);
-}
-
-/* virtual public */
-geom::CoordinateSequence*
-NodedSegmentString::getCoordinates() const
-{
-    return pts.get();
-}
-
-geom::CoordinateSequence*
+std::unique_ptr<geom::CoordinateSequence>
 NodedSegmentString::releaseCoordinates()
 {
-    return pts.release();
-}
-
-/* virtual public */
-bool
-NodedSegmentString::isClosed() const
-{
-    return pts->getAt(0) == pts->getAt(size() - 1);
+    auto ret = std::unique_ptr<CoordinateSequence>(seq);
+    seq = nullptr;
+    return ret;
 }
 
 /* public virtual */
@@ -106,7 +87,7 @@ std::ostream&
 NodedSegmentString::print(std::ostream& os) const
 {
     os << "NodedSegmentString: " << std::endl;
-    os << " LINESTRING" << *(pts) << ";" << std::endl;
+    os << " LINESTRING" << *(getCoordinates()) << ";" << std::endl;
     os << " Nodes: " << nodeList.size() << std::endl;
 
     return os;

--- a/src/operation/overlayng/Edge.cpp
+++ b/src/operation/overlayng/Edge.cpp
@@ -27,14 +27,14 @@ using namespace geos::geom;
 using geos::util::GEOSException;
 
 /*public*/
-Edge::Edge(CoordinateSequence* p_pts, const EdgeSourceInfo* info)
+Edge::Edge(std::unique_ptr<CoordinateSequence>&& p_pts, const EdgeSourceInfo* info)
     : aDim(OverlayLabel::DIM_UNKNOWN)
     , aDepthDelta(0)
     , aIsHole(false)
     , bDim(OverlayLabel::DIM_UNKNOWN)
     , bDepthDelta(0)
     , bIsHole(false)
-    , pts(p_pts)
+    , pts(std::move(p_pts))
 {
     copyInfo(info);
 }

--- a/tests/unit/operation/overlayng/OverlayGraphTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayGraphTest.cpp
@@ -53,7 +53,7 @@ struct test_overlaygraph_data {
         std::unique_ptr<CoordinateSequence> cs = line->getCoordinates();
 
         EdgeSourceInfo esi(0);
-        Edge e(cs.release(), &esi);
+        Edge e(std::move(cs), &esi);
         std::unique_ptr<CoordinateSequence> pts = e.getCoordinates();
 
         graph->addEdge(&e);


### PR DESCRIPTION
Since all SegmentStrings are backed by a CoordinateSequence, we can pull the CoordinateSequence into the base class so that SegmentString::getCoordinate will no longer be virtual and can be inlined. When tested on top of #721 it provides about a 2% performance gain, but it can be applied independently.

![image](https://user-images.githubusercontent.com/6318931/200990285-25e029a0-6c63-4347-a627-b63d23f89865.png)
