### PR TITLE
geos: add missing <cstdint> includes for gcc-13

### DIFF
--- a/include/geos/geomgraph/Depth.h
+++ b/include/geos/geomgraph/Depth.h
@@ -24,6 +24,7 @@
 #include <geos/geom/Location.h>
 #include <geos/geom/Position.h>
 #include <string>
+#include <cstdint>
 
 // Forward declarations
 namespace geos {

--- a/include/geos/geomgraph/TopologyLocation.h
+++ b/include/geos/geomgraph/TopologyLocation.h
@@ -27,6 +27,7 @@
 #include <array>
 #include <string>
 #include <cassert>
+#include <cstdint>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <cctype>
+#include <cstdint>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/include/geos/operation/overlayng/OverlayLabel.h
+++ b/include/geos/operation/overlayng/OverlayLabel.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <geos/geom/Location.h>
 #include <geos/geom/Position.h>
 #include <geos/export.h>

--- a/include/geos/shape/fractal/HilbertCode.h
+++ b/include/geos/shape/fractal/HilbertCode.h
@@ -17,6 +17,7 @@
 
 #include <geos/export.h>
 #include <string>
+#include <cstdint>
 
 // Forward declarations
 namespace geos {

--- a/include/geos/shape/fractal/MortonCode.h
+++ b/include/geos/shape/fractal/MortonCode.h
@@ -17,6 +17,7 @@
 
 #include <geos/export.h>
 #include <string>
+#include <cstdint>
 
 // Forward declarations
 namespace geos {


### PR DESCRIPTION
Without the change build on `gcc-13` fails as:

    geos/include/geos/geomgraph/TopologyLocation.h:143:52: error: 'uint32_t' has not been declared
      143 |     bool isEqualOnSide(const TopologyLocation& le, uint32_t locIndex) const
          |                                                    ^~~~~~~~