### PR TITLE
Remove raw pointer Geometry ctrs / GeometryFactory  methods

### DIFF
--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -935,6 +935,10 @@ protected:
         return gv;
     }
 
+    static std::vector<std::unique_ptr<Geometry>> toGeometryArray(std::vector<std::unique_ptr<Geometry>> && v) {
+        return std::move(v);
+    }
+
 protected:
 
     virtual int getSortIndex() const = 0;

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -204,17 +204,8 @@ protected:
      *	Elements may be empty <code>Geometry</code>s,
      *	but not <code>null</code>s.
      *
-     *	If construction succeed the created object will take
-     *	ownership of newGeoms vector and elements.
-     *
-     *	If construction	fails "IllegalArgumentException *"
-     *	is thrown and it is your responsibility to delete newGeoms
-     *	vector and content.
-     *
      * @param newFactory the GeometryFactory used to create this geometry
      */
-    GeometryCollection(std::vector<Geometry*>* newGeoms, const GeometryFactory* newFactory);
-
     GeometryCollection(std::vector<std::unique_ptr<Geometry>> && newGeoms, const GeometryFactory& newFactory);
 
     /// Convenience constructor to build a GeometryCollection from vector of Geometry subclass pointers

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -123,8 +123,8 @@ public:
 
 //Skipped a lot of list to array convertors
 
-    Point* createPointFromInternalCoord(const Coordinate* coord,
-                                        const Geometry* exemplar) const;
+    static std::unique_ptr<Point> createPointFromInternalCoord(const Coordinate* coord,
+                                        const Geometry* exemplar);
 
     /// Converts an Envelope to a Geometry.
     ///
@@ -144,16 +144,14 @@ public:
     std::unique_ptr<Point> createPoint(std::size_t coordinateDimension = 2) const;
 
     /// Creates a Point using the given Coordinate
-    Point* createPoint(const Coordinate& coordinate) const;
+    std::unique_ptr<Point> createPoint(const Coordinate& coordinate) const;
     std::unique_ptr<Point> createPoint(const CoordinateXY& coordinate) const;
 
     /// Creates a Point taking ownership of the given CoordinateSequence
-    Point* createPoint(CoordinateSequence* coordinates) const;
+    std::unique_ptr<Point> createPoint(std::unique_ptr<CoordinateSequence>&& coordinates) const;
 
     /// Creates a Point with a deep-copy of the given CoordinateSequence.
-    Point* createPoint(const CoordinateSequence& coordinates) const;
-
-    std::unique_ptr<Point> createPoint(std::unique_ptr<CoordinateSequence>&& coordinates) const;
+    std::unique_ptr<Point> createPoint(const CoordinateSequence& coordinates) const;
 
     /// Construct an EMPTY GeometryCollection
     std::unique_ptr<GeometryCollection> createGeometryCollection() const;
@@ -162,9 +160,6 @@ public:
     std::unique_ptr<Geometry> createEmptyGeometry() const;
 
     /// Construct a GeometryCollection taking ownership of given arguments
-    GeometryCollection* createGeometryCollection(
-        std::vector<Geometry*>* newGeoms) const;
-
     template<typename T>
     std::unique_ptr<GeometryCollection> createGeometryCollection(
             std::vector<std::unique_ptr<T>> && newGeoms) const {
@@ -173,20 +168,17 @@ public:
     }
 
     /// Constructs a GeometryCollection with a deep-copy of args
-    GeometryCollection* createGeometryCollection(
+    std::unique_ptr<GeometryCollection> createGeometryCollection(
         const std::vector<const Geometry*>& newGeoms) const;
 
     /// Construct an EMPTY MultiLineString
     std::unique_ptr<MultiLineString> createMultiLineString() const;
 
-    /// Construct a MultiLineString taking ownership of given arguments
-    MultiLineString* createMultiLineString(
-        std::vector<Geometry*>* newLines) const;
-
     /// Construct a MultiLineString with a deep-copy of given arguments
-    MultiLineString* createMultiLineString(
+    std::unique_ptr<MultiLineString> createMultiLineString(
         const std::vector<const Geometry*>& fromLines) const;
 
+    /// Construct a MultiLineString taking ownership of given arguments
     std::unique_ptr<MultiLineString> createMultiLineString(
             std::vector<std::unique_ptr<LineString>> && fromLines) const;
 
@@ -196,13 +188,11 @@ public:
     /// Construct an EMPTY MultiPolygon
     std::unique_ptr<MultiPolygon> createMultiPolygon() const;
 
-    /// Construct a MultiPolygon taking ownership of given arguments
-    MultiPolygon* createMultiPolygon(std::vector<Geometry*>* newPolys) const;
-
     /// Construct a MultiPolygon with a deep-copy of given arguments
-    MultiPolygon* createMultiPolygon(
+    std::unique_ptr<MultiPolygon> createMultiPolygon(
         const std::vector<const Geometry*>& fromPolys) const;
 
+    /// Construct a MultiPolygon taking ownership of given arguments
     std::unique_ptr<MultiPolygon> createMultiPolygon(
         std::vector<std::unique_ptr<Polygon>> && fromPolys) const;
 
@@ -213,56 +203,47 @@ public:
     std::unique_ptr<LinearRing> createLinearRing() const;
 
     /// Construct a LinearRing taking ownership of given arguments
-    LinearRing* createLinearRing(CoordinateSequence* newCoords) const;
-
     std::unique_ptr<LinearRing> createLinearRing(
         std::unique_ptr<CoordinateSequence> && newCoords) const;
 
     /// Construct a LinearRing with a deep-copy of given arguments
-    LinearRing* createLinearRing(
+    std::unique_ptr<LinearRing> createLinearRing(
         const CoordinateSequence& coordinates) const;
 
     /// Constructs an EMPTY <code>MultiPoint</code>.
     std::unique_ptr<MultiPoint> createMultiPoint() const;
-
-    /// Construct a MultiPoint taking ownership of given arguments
-    MultiPoint* createMultiPoint(std::vector<Geometry*>* newPoints) const;
 
     template<typename T>
     std::unique_ptr<MultiPoint> createMultiPoint(const T& fromCoords) const
     {
         std::vector<std::unique_ptr<Geometry>> pts;
         pts.reserve(fromCoords.size());
-        for (const Coordinate& c : fromCoords) {
+        for (const auto& c : fromCoords) {
             pts.emplace_back(createPoint(c));
         }
 
         return createMultiPoint(std::move(pts));
     }
 
-    std::unique_ptr<MultiPoint> createMultiPoint(std::vector<CoordinateXY> && newPoints) const;
-
+    /// Construct a MultiPoint taking ownership of given arguments
     std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Point>> && newPoints) const;
 
     std::unique_ptr<MultiPoint> createMultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints) const;
 
     /// Construct a MultiPoint with a deep-copy of given arguments
-    MultiPoint* createMultiPoint(
+    std::unique_ptr<MultiPoint> createMultiPoint(
         const std::vector<const Geometry*>& fromPoints) const;
 
     /// \brief
     /// Construct a MultiPoint containing a Point geometry
     /// for each Coordinate in the given list.
-    MultiPoint* createMultiPoint(
+    std::unique_ptr<MultiPoint> createMultiPoint(
         const CoordinateSequence& fromCoords) const;
 
     /// Construct an EMPTY Polygon
     std::unique_ptr<Polygon> createPolygon(std::size_t coordinateDimension = 2) const;
 
     /// Construct a Polygon taking ownership of given arguments
-    Polygon* createPolygon(LinearRing* shell,
-                           std::vector<LinearRing*>* holes) const;
-
     std::unique_ptr<Polygon> createPolygon(std::unique_ptr<LinearRing> && shell) const;
 
     std::unique_ptr<Polygon> createPolygon(std::unique_ptr<LinearRing> && shell,
@@ -282,13 +263,11 @@ public:
     std::unique_ptr<LineString> createLineString(const LineString& ls) const;
 
     /// Construct a LineString taking ownership of given argument
-    LineString* createLineString(CoordinateSequence* coordinates) const;
-
     std::unique_ptr<LineString> createLineString(
         std::unique_ptr<CoordinateSequence> && coordinates) const;
 
     /// Construct a LineString with a deep-copy of given argument
-    LineString* createLineString(
+    std::unique_ptr<LineString> createLineString(
         const CoordinateSequence& coordinates) const;
 
     /**
@@ -330,8 +309,6 @@ public:
      * NOTE: the returned Geometry will take ownership of the
      *       given vector AND its elements
      */
-    Geometry* buildGeometry(std::vector<Geometry*>* geoms) const;
-
     std::unique_ptr<Geometry> buildGeometry(std::vector<std::unique_ptr<Geometry>> && geoms) const;
 
     std::unique_ptr<Geometry> buildGeometry(std::vector<std::unique_ptr<Point>> && geoms) const;
@@ -409,7 +386,7 @@ public:
      * The difference is that this version will copy needed data
      * leaving ownership to the caller.
      */
-    Geometry* buildGeometry(const std::vector<const Geometry*>& geoms) const;
+    std::unique_ptr<Geometry> buildGeometry(const std::vector<const Geometry*>& geoms) const;
 
     int getSRID() const
     {
@@ -417,7 +394,7 @@ public:
     };
 
     /// Returns a clone of given Geometry.
-    Geometry* createGeometry(const Geometry* g) const;
+    std::unique_ptr<Geometry> createGeometry(const Geometry* g) const;
 
     /// Destroy a Geometry, or release it
     void destroyGeometry(Geometry* g) const;

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -203,9 +203,6 @@ protected:
     /// \brief
     /// Constructs a LineString taking ownership the
     /// given CoordinateSequence.
-    LineString(CoordinateSequence* pts, const GeometryFactory* newFactory);
-
-    /// Hopefully cleaner version of the above
     LineString(CoordinateSequence::Ptr && pts,
                const GeometryFactory& newFactory);
 

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -75,15 +75,8 @@ public:
      * @param newFactory the GeometryFactory used to create this geometry
      *
      */
-    LinearRing(CoordinateSequence* points,
-               const GeometryFactory* newFactory);
-
-    /// Hopefully cleaner version of the above
     LinearRing(CoordinateSequence::Ptr && points,
             const GeometryFactory& newFactory);
-
-    LinearRing(std::vector<Coordinate> && pts,
-               const GeometryFactory& newFactory);
 
     std::unique_ptr<LinearRing> clone() const
     {

--- a/include/geos/geom/MultiLineString.h
+++ b/include/geos/geom/MultiLineString.h
@@ -114,9 +114,6 @@ protected:
      *       the vector and its elements.
      *
      */
-    MultiLineString(std::vector<Geometry*>* newLines,
-                    const GeometryFactory* newFactory);
-
     MultiLineString(std::vector<std::unique_ptr<LineString>> && newLines,
             const GeometryFactory& newFactory);
 

--- a/include/geos/geom/MultiPoint.h
+++ b/include/geos/geom/MultiPoint.h
@@ -112,8 +112,6 @@ protected:
      *	Caller must keep the factory alive for the life-time
      *	of the constructed MultiPoint.
      */
-    MultiPoint(std::vector<Geometry*>* newPoints, const GeometryFactory* newFactory);
-
     MultiPoint(std::vector<std::unique_ptr<Point>> && newPoints, const GeometryFactory& newFactory);
 
     MultiPoint(std::vector<std::unique_ptr<Geometry>> && newPoints, const GeometryFactory& newFactory);

--- a/include/geos/geom/MultiPolygon.h
+++ b/include/geos/geom/MultiPolygon.h
@@ -116,8 +116,6 @@ protected:
      *	Caller must keep the factory alive for the life-time
      *	of the constructed MultiPolygon.
      */
-    MultiPolygon(std::vector<Geometry*>* newPolys, const GeometryFactory* newFactory);
-
     MultiPolygon(std::vector<std::unique_ptr<Polygon>> && newPolys,
             const GeometryFactory& newFactory);
 

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -168,7 +168,7 @@ protected:
      *
      * @param newFactory the GeometryFactory used to create this geometry
      */
-    Point(CoordinateSequence* newCoords, const GeometryFactory* newFactory);
+    Point(CoordinateSequence&& newCoords, const GeometryFactory* newFactory);
 
     Point(const Coordinate& c, const GeometryFactory* newFactory);
 

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -187,14 +187,11 @@ protected:
      *
      * Polygon will take ownership of Shell and Holes LinearRings
      */
-    Polygon(LinearRing* newShell, std::vector<LinearRing*>* newHoles,
-            const GeometryFactory* newFactory);
-
     Polygon(std::unique_ptr<LinearRing> && newShell,
+            std::vector<std::unique_ptr<LinearRing>> && newHoles,
             const GeometryFactory& newFactory);
 
     Polygon(std::unique_ptr<LinearRing> && newShell,
-            std::vector<std::unique_ptr<LinearRing>> && newHoles,
             const GeometryFactory& newFactory);
 
     Polygon* cloneImpl() const override { return new Polygon(*this); }

--- a/include/geos/linearref/LinearGeometryBuilder.h
+++ b/include/geos/linearref/LinearGeometryBuilder.h
@@ -40,14 +40,14 @@ class LinearGeometryBuilder {
 private:
     const geom::GeometryFactory* geomFact;
 
-    typedef std::vector<const geom::Geometry*> GeomPtrVect;
+    typedef std::vector<std::unique_ptr<geom::Geometry>> GeomPtrVect;
 
     // Geometry elements owned by this class
     GeomPtrVect lines;
 
     bool ignoreInvalidLines;
     bool fixInvalidLines;
-    geom::CoordinateSequence* coordList;
+    std::unique_ptr<geom::CoordinateSequence> coordList;
 
     geom::Coordinate lastPt;
 
@@ -98,7 +98,7 @@ public:
     /// Terminate the current LineString.
     void endLine();
 
-    geom::Geometry* getGeometry();
+    std::unique_ptr<geom::Geometry> getGeometry();
 };
 
 } // namespace geos.linearref

--- a/include/geos/operation/intersection/Rectangle.h
+++ b/include/geos/operation/intersection/Rectangle.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <geos/export.h>
+#include <memory>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -108,9 +109,9 @@ public:
      *
      * @note Ownership transferred to caller
      */
-    geom::Polygon* toPolygon(const geom::GeometryFactory& f) const;
+    std::unique_ptr<geom::Polygon> toPolygon(const geom::GeometryFactory& f) const;
 
-    geom::LinearRing* toLinearRing(const geom::GeometryFactory& f) const;
+    std::unique_ptr<geom::LinearRing> toLinearRing(const geom::GeometryFactory& f) const;
 
     /**
      * @brief Position with respect to a clipping rectangle

--- a/include/geos/operation/linemerge/EdgeString.h
+++ b/include/geos/operation/linemerge/EdgeString.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <geos/export.h>
+#include <memory>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -55,7 +56,7 @@ class GEOS_DLL EdgeString {
 private:
     const geom::GeometryFactory* factory;
     std::vector<LineMergeDirectedEdge*> directedEdges;
-    geom::CoordinateSequence* getCoordinates();
+    std::unique_ptr<geom::CoordinateSequence> getCoordinates() const;
 public:
     /**
      * \brief
@@ -74,7 +75,7 @@ public:
     /**
      * Converts this EdgeString into a LineString.
      */
-    geom::LineString* toLineString();
+    std::unique_ptr<geom::LineString> toLineString() const;
 };
 
 } // namespace geos::operation::linemerge

--- a/include/geos/operation/overlay/PolygonBuilder.h
+++ b/include/geos/operation/overlay/PolygonBuilder.h
@@ -82,7 +82,7 @@ public:
              const std::vector<geomgraph::Node*>* nodes);
     // throw(const TopologyException &)
 
-    std::vector<geom::Geometry*>* getPolygons();
+    std::vector<std::unique_ptr<geom::Geometry>> getPolygons();
 
 private:
 
@@ -190,7 +190,7 @@ private:
     geomgraph::EdgeRing* findEdgeRingContaining(geomgraph::EdgeRing* testEr,
             std::vector<FastPIPRing>& newShellList);
 
-    std::vector<geom::Geometry*>* computePolygons(
+    std::vector<std::unique_ptr<geom::Geometry>> computePolygons(
         std::vector<geomgraph::EdgeRing*>& newShellList);
 
     /**

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -557,30 +557,29 @@ Geometry::Union(const Geometry* other) const
         std::size_t ngeomsOther = other->getNumGeometries();
 
         // Allocated for ownership transfer
-        std::vector<Geometry*>* v = new std::vector<Geometry*>();
-        v->reserve(ngeomsThis + ngeomsOther);
+        std::vector<std::unique_ptr<Geometry>> v;
+        v.reserve(ngeomsThis + ngeomsOther);
 
 
         if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(this))) {
             for(std::size_t i = 0; i < ngeomsThis; ++i) {
-                v->push_back(coll->getGeometryN(i)->clone().release());
+                v.push_back(coll->getGeometryN(i)->clone());
             }
         }
         else {
-            v->push_back(this->clone().release());
+            v.push_back(this->clone());
         }
 
         if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(other))) {
             for(std::size_t i = 0; i < ngeomsOther; ++i) {
-                v->push_back(coll->getGeometryN(i)->clone().release());
+                v.push_back(coll->getGeometryN(i)->clone());
             }
         }
         else {
-            v->push_back(other->clone().release());
+            v.push_back(other->clone());
         }
 
-        std::unique_ptr<Geometry>out(_factory->buildGeometry(v));
-        return out;
+        return _factory->buildGeometry(std::move(v));
     }
 #endif
 
@@ -636,29 +635,29 @@ Geometry::symDifference(const Geometry* other) const
         std::size_t ngeomsOther = other->getNumGeometries();
 
         // Allocated for ownership transfer
-        std::vector<Geometry*>* v = new std::vector<Geometry*>();
-        v->reserve(ngeomsThis + ngeomsOther);
+        std::vector<std::unique_ptr<Geometry>> v;
+        v.reserve(ngeomsThis + ngeomsOther);
 
 
         if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(this))) {
             for(std::size_t i = 0; i < ngeomsThis; ++i) {
-                v->push_back(coll->getGeometryN(i)->clone().release());
+                v.push_back(coll->getGeometryN(i)->clone());
             }
         }
         else {
-            v->push_back(this->clone().release());
+            v.push_back(this->clone());
         }
 
         if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(other))) {
             for(std::size_t i = 0; i < ngeomsOther; ++i) {
-                v->push_back(coll->getGeometryN(i)->clone().release());
+                v.push_back(coll->getGeometryN(i)->clone());
             }
         }
         else {
-            v->push_back(other->clone().release());
+            v.push_back(other->clone());
         }
 
-        return std::unique_ptr<Geometry>(_factory->buildGeometry(v));
+        return _factory->buildGeometry(std::move(v));
     }
 
     return HeuristicOverlay(this, other, OverlayOp::opSYMDIFFERENCE);

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -45,25 +45,6 @@ GeometryCollection::GeometryCollection(const GeometryCollection& gc)
     }
 }
 
-/*protected*/
-GeometryCollection::GeometryCollection(std::vector<Geometry*>* newGeoms, const GeometryFactory* factory):
-    Geometry(factory)
-{
-    if(newGeoms == nullptr) {
-        return;
-    }
-    if(hasNullElements(newGeoms)) {
-        throw  util::IllegalArgumentException("geometries must not contain null elements\n");
-    }
-    for (const auto& geom : *newGeoms) {
-        geometries.emplace_back(geom);
-    }
-    delete newGeoms;
-
-    // Set SRID for inner geoms
-    setSRID(getSRID());
-}
-
 GeometryCollection::GeometryCollection(std::vector<std::unique_ptr<Geometry>> && newGeoms, const GeometryFactory& factory) :
     Geometry(&factory),
     geometries(std::move(newGeoms)) {

--- a/src/geom/HeuristicOverlay.cpp
+++ b/src/geom/HeuristicOverlay.cpp
@@ -614,10 +614,10 @@ HeuristicOverlay(const Geometry* g0, const Geometry* g1, int opCode)
                 ret.reset(OverlayOp::overlayOp(rG0.get(), rG1.get(), OverlayOp::OpCode(opCode)));
                 // restore original precision (least precision between inputs)
                 if(g0->getFactory()->getPrecisionModel()->compareTo(g1->getFactory()->getPrecisionModel()) < 0) {
-                    ret.reset(g0->getFactory()->createGeometry(ret.get()));
+                    ret = g0->getFactory()->createGeometry(ret.get());
                 }
                 else {
-                    ret.reset(g1->getFactory()->createGeometry(ret.get()));
+                    ret = g1->getFactory()->createGeometry(ret.get());
                 }
 
 #if GEOS_CHECK_PRECISION_REDUCTION_VALIDITY

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -68,7 +68,7 @@ LineString::reverseImpl() const
     auto seq = points->clone();
     seq->reverse();
     assert(getFactory());
-    return getFactory()->createLineString(seq.release());
+    return getFactory()->createLineString(std::move(seq)).release();
 }
 
 
@@ -84,16 +84,6 @@ LineString::validateConstruction()
     if(points->size() == 1) {
         throw util::IllegalArgumentException("point array must contain 0 or >1 elements\n");
     }
-}
-
-/*protected*/
-LineString::LineString(CoordinateSequence* newCoords,
-                       const GeometryFactory* factory)
-    :
-    Geometry(factory),
-    points(newCoords)
-{
-    validateConstruction();
 }
 
 /*public*/

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -35,15 +35,6 @@ namespace geom { // geos::geom
 LinearRing::LinearRing(const LinearRing& lr): LineString(lr) {}
 
 /*public*/
-LinearRing::LinearRing(CoordinateSequence* newCoords,
-                       const GeometryFactory* newFactory)
-    :
-    LineString(newCoords, newFactory)
-{
-    validateConstruction();
-}
-
-/*public*/
 LinearRing::LinearRing(CoordinateSequence::Ptr && newCoords,
                        const GeometryFactory& newFactory)
         : LineString(std::move(newCoords), newFactory)

--- a/src/geom/MultiLineString.cpp
+++ b/src/geom/MultiLineString.cpp
@@ -35,13 +35,6 @@ namespace geos {
 namespace geom { // geos::geom
 
 /*protected*/
-MultiLineString::MultiLineString(std::vector<Geometry*>* newLines,
-                                 const GeometryFactory* factory)
-    :
-    GeometryCollection(newLines, factory)
-{
-}
-
 MultiLineString::MultiLineString(std::vector<std::unique_ptr<LineString>> && newLines,
         const GeometryFactory& factory)
         : GeometryCollection(std::move(newLines), factory)

--- a/src/geom/MultiPoint.cpp
+++ b/src/geom/MultiPoint.cpp
@@ -29,12 +29,6 @@ namespace geos {
 namespace geom { // geos::geom
 
 /*protected*/
-MultiPoint::MultiPoint(std::vector<Geometry*>* newPoints, const GeometryFactory* factory)
-    :
-    GeometryCollection(newPoints, factory)
-{
-}
-
 MultiPoint::MultiPoint(std::vector<std::unique_ptr<Point>> && newPoints, const GeometryFactory& factory)
     :
     GeometryCollection(std::move(newPoints), factory)

--- a/src/geom/MultiPolygon.cpp
+++ b/src/geom/MultiPolygon.cpp
@@ -35,10 +35,6 @@ namespace geos {
 namespace geom { // geos::geom
 
 /*protected*/
-MultiPolygon::MultiPolygon(std::vector<Geometry*>* newPolys, const GeometryFactory* factory)
-      : GeometryCollection(newPolys, factory)
-{}
-
 MultiPolygon::MultiPolygon(std::vector<std::unique_ptr<Polygon>> && newPolys, const GeometryFactory& factory)
       : GeometryCollection(std::move(newPolys), factory)
 {}

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -42,14 +42,11 @@ namespace geom { // geos::geom
 
 
 /*protected*/
-Point::Point(CoordinateSequence* newCoords, const GeometryFactory* factory)
+Point::Point(CoordinateSequence&& newCoords, const GeometryFactory* factory)
     : Geometry(factory)
+    , coordinates(newCoords)
 {
-    std::unique_ptr<CoordinateSequence> coords(newCoords); // Take ownership in case of exception
-
-    if (coords->getSize() <= 1) {
-        coordinates = *(coords.get());
-    } else if (coords->getSize() > 1) {
+    if (coordinates.getSize() > 1) {
         throw util::IllegalArgumentException("Point coordinate list must contain a single element");
     }
 }

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -60,32 +60,6 @@ Polygon::Polygon(const Polygon& p)
     }
 }
 
-/*protected*/
-Polygon::Polygon(LinearRing* newShell, std::vector<LinearRing*>* newHoles,
-                 const GeometryFactory* newFactory):
-    Geometry(newFactory)
-{
-    if(newShell == nullptr) {
-        shell = getFactory()->createLinearRing();
-    }
-    else {
-        if(newHoles != nullptr && newShell->isEmpty() && hasNonEmptyElements(newHoles)) {
-            throw util::IllegalArgumentException("shell is empty but holes are not");
-        }
-        shell.reset(newShell);
-    }
-
-    if(newHoles != nullptr) {
-        if(hasNullElements(newHoles)) {
-            throw util::IllegalArgumentException("holes must not contain null elements");
-        }
-        for (const auto& hole : *newHoles) {
-            holes.emplace_back(hole);
-        }
-        delete newHoles;
-    }
-}
-
 Polygon::Polygon(std::unique_ptr<LinearRing> && newShell,
                  const GeometryFactory& newFactory) :
         Geometry(&newFactory),

--- a/src/geom/util/CoordinateOperation.cpp
+++ b/src/geom/util/CoordinateOperation.cpp
@@ -48,7 +48,7 @@ CoordinateOperation::edit(const Geometry* geometry,
     if(const Point* point = dynamic_cast<const Point*>(geometry)) {
         auto coords = point->getCoordinatesRO();
         auto newCoords = edit(coords, geometry);
-        return std::unique_ptr<Geometry>(factory->createPoint(newCoords.release()));
+        return factory->createPoint(std::move(newCoords));
     }
 
     return geometry->clone();

--- a/src/geom/util/GeometryEditor.cpp
+++ b/src/geom/util/GeometryEditor.cpp
@@ -126,7 +126,7 @@ GeometryEditor::editPolygon(const Polygon* polygon, GeometryEditorOperation* ope
         return std::unique_ptr<Polygon>(factory->createPolygon(polygon->getCoordinateDimension()));
     }
 
-    auto holes = detail::make_unique<std::vector<LinearRing*>>();
+    std::vector<std::unique_ptr<LinearRing>> holes;
     for(std::size_t i = 0, n = newPolygon->getNumInteriorRing(); i < n; ++i) {
 
         std::unique_ptr<LinearRing> hole(detail::down_cast<LinearRing*>(
@@ -135,10 +135,10 @@ GeometryEditor::editPolygon(const Polygon* polygon, GeometryEditorOperation* ope
         if(hole->isEmpty()) {
             continue;
         }
-        holes->push_back(hole.release());
+        holes.push_back(std::move(hole));
     }
 
-    return std::unique_ptr<Polygon>(factory->createPolygon(shell.release(), holes.release()));
+    return factory->createPolygon(std::move(shell), std::move(holes));
 }
 
 std::unique_ptr<GeometryCollection>

--- a/src/geom/util/GeometryTransformer.cpp
+++ b/src/geom/util/GeometryTransformer.cpp
@@ -136,7 +136,7 @@ GeometryTransformer::transformPoint(
     CoordinateSequence::Ptr cs(transformCoordinates(
                                    geom->getCoordinatesRO(), geom));
 
-    return Geometry::Ptr(factory->createPoint(cs.release()));
+    return factory->createPoint(std::move(cs));
 }
 
 Geometry::Ptr

--- a/src/linearref/LinearGeometryBuilder.cpp
+++ b/src/linearref/LinearGeometryBuilder.cpp
@@ -71,7 +71,7 @@ void
 LinearGeometryBuilder::add(const Coordinate& pt, bool allowRepeatedPoints)
 {
     if(!coordList) {
-        coordList = new CoordinateSequence();
+        coordList = detail::make_unique<CoordinateSequence>();
     }
     coordList->add(pt, allowRepeatedPoints);
     lastPt = pt;
@@ -94,8 +94,7 @@ LinearGeometryBuilder::endLine()
     if(coordList->size() < 2) {
         if(ignoreInvalidLines) {
             if(coordList) {
-                delete coordList;
-                coordList = nullptr;
+                coordList.reset();
             }
             return;
         }
@@ -114,9 +113,9 @@ LinearGeometryBuilder::endLine()
         }
     }
 
-    LineString* line = nullptr;
+    std::unique_ptr<LineString> line;
     try {
-        line = geomFact->createLineString(coordList);
+        line = geomFact->createLineString(std::move(coordList));
     }
     catch(util::IllegalArgumentException & ex) {
         // exception is due to too few points in line.
@@ -128,29 +127,24 @@ LinearGeometryBuilder::endLine()
     }
 
     if(line) {
-        lines.push_back(line);
+        lines.push_back(std::move(line));
     }
-    coordList = nullptr;
 }
 
 /* public */
-Geometry*
+std::unique_ptr<Geometry>
 LinearGeometryBuilder::getGeometry()
 {
     // end last line in case it was not done by user
     endLine();
 
     // NOTE: lines elements are cloned
-    return geomFact->buildGeometry(lines);
+    return geomFact->buildGeometry(std::move(lines));
 }
 
 /* public */
 LinearGeometryBuilder::~LinearGeometryBuilder()
 {
-    for(GeomPtrVect::const_iterator i = lines.begin(), e = lines.end();
-            i != e; ++i) {
-        delete *i;
-    }
 }
 
 } // namespace geos.linearref

--- a/src/operation/intersection/Rectangle.cpp
+++ b/src/operation/intersection/Rectangle.cpp
@@ -39,14 +39,13 @@ Rectangle::Rectangle(double x1, double y1, double x2, double y2)
     }
 }
 
-geom::Polygon*
+std::unique_ptr<geom::Polygon>
 Rectangle::toPolygon(const geom::GeometryFactory& f) const
 {
-    geom::LinearRing* ls = toLinearRing(f);
-    return f.createPolygon(ls, nullptr);
+    return f.createPolygon(toLinearRing(f));
 }
 
-geom::LinearRing*
+std::unique_ptr<geom::LinearRing>
 Rectangle::toLinearRing(const geom::GeometryFactory& f) const
 {
     auto seq = detail::make_unique<geom::CoordinateSequence>(5u, false, false, false);
@@ -55,7 +54,7 @@ Rectangle::toLinearRing(const geom::GeometryFactory& f) const
     seq->setAt(geom::Coordinate(xMax, yMax), 2);
     seq->setAt(geom::Coordinate(xMax, yMin), 3);
     seq->setAt(seq->getAt(0), 4); // close
-    return f.createLinearRing(seq.release());
+    return f.createLinearRing(std::move(seq));
 }
 
 } // namespace geos::operation::intersection

--- a/src/operation/intersection/RectangleIntersection.cpp
+++ b/src/operation/intersection/RectangleIntersection.cpp
@@ -420,9 +420,9 @@ RectangleIntersection::clip_polygon_to_linestrings(const geom::Polygon* g,
     for(std::size_t i = 0, n = g->getNumInteriorRing(); i < n; ++i) {
         if(clip_linestring_parts(g->getInteriorRingN(i), parts, rect)) {
             // clones
-            LinearRing* hole = new LinearRing(*(g->getInteriorRingN(i)));
+            auto hole =g->getInteriorRingN(i)->clone();
             // becomes exterior
-            Polygon* poly = _gf->createPolygon(hole, nullptr);
+            Polygon* poly = _gf->createPolygon(std::move(hole)).release();
             toParts.add(poly);
         }
         else if(!parts.empty()) {
@@ -492,8 +492,8 @@ RectangleIntersection::clip_polygon_to_polygons(const geom::Polygon* g,
         const LinearRing* hole = g->getInteriorRingN(i);
         if(clip_linestring_parts(hole, holeparts, rect)) {
             // becomes exterior
-            LinearRing* cloned = new LinearRing(*hole);
-            Polygon* poly = _gf->createPolygon(cloned, nullptr);
+            auto cloned = hole->clone();
+            Polygon* poly = _gf->createPolygon(std::move(cloned)).release();
             parts.add(poly);
         }
         else {

--- a/src/operation/linemerge/EdgeString.cpp
+++ b/src/operation/linemerge/EdgeString.cpp
@@ -55,8 +55,8 @@ EdgeString::add(LineMergeDirectedEdge* directedEdge)
     directedEdges.push_back(directedEdge);
 }
 
-CoordinateSequence*
-EdgeString::getCoordinates()
+std::unique_ptr<CoordinateSequence>
+EdgeString::getCoordinates() const
 {
     int forwardDirectedEdges = 0;
     int reverseDirectedEdges = 0;
@@ -79,14 +79,14 @@ EdgeString::getCoordinates()
     if(reverseDirectedEdges > forwardDirectedEdges) {
         coordinates->reverse();
     }
-    return coordinates.release();
+    return coordinates;
 }
 
 /*
  * Converts this EdgeString into a new LineString.
  */
-LineString*
-EdgeString::toLineString()
+std::unique_ptr<LineString>
+EdgeString::toLineString() const
 {
     return factory->createLineString(getCoordinates());
 }

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -197,7 +197,7 @@ LineSequencer::computeSequence()
 Geometry*
 LineSequencer::buildSequencedGeometry(const Sequences& sequences)
 {
-    std::unique_ptr<Geometry::NonConstVect> lines(new Geometry::NonConstVect);
+    std::vector<std::unique_ptr<Geometry>> lines;
 
     for(Sequences::const_iterator
             i1 = sequences.begin(), i1End = sequences.end();
@@ -211,24 +211,24 @@ LineSequencer::buildSequencedGeometry(const Sequences& sequences)
             const LineString* line = e->getLine();
 
             // lineToAdd will be a *copy* of input things
-            LineString* lineToAdd;
+            std::unique_ptr<LineString> lineToAdd;
 
             if(! de->getEdgeDirection() && ! line->isClosed()) {
-                lineToAdd = line->reverse().release();
+                lineToAdd = line->reverse();
             }
             else {
-                lineToAdd = line->clone().release();
+                lineToAdd = line->clone();
             }
 
-            lines->push_back(lineToAdd);
+            lines.push_back(std::move(lineToAdd));
         }
     }
 
-    if(lines->empty()) {
+    if(lines.empty()) {
         return nullptr;
     }
     else {
-        return factory->buildGeometry(lines.release());
+        return factory->buildGeometry(std::move(lines)).release();
     }
 }
 

--- a/src/operation/overlay/LineBuilder.cpp
+++ b/src/operation/overlay/LineBuilder.cpp
@@ -188,8 +188,8 @@ LineBuilder::buildLines(OverlayOp::OpCode /* opCode */)
 #if COMPUTE_Z
         propagateZ(cs.get());
 #endif
-        LineString* line = geometryFactory->createLineString(cs.release());
-        resultLineList->push_back(line);
+        auto line = geometryFactory->createLineString(std::move(cs));
+        resultLineList->push_back(line.release());
         e->setInResult(true);
     }
 }

--- a/src/operation/overlay/PointBuilder.cpp
+++ b/src/operation/overlay/PointBuilder.cpp
@@ -97,7 +97,7 @@ PointBuilder::filterCoveredNodeToPoint(const Node* n)
 {
     const Coordinate& coord = n->getCoordinate();
     if(!op->isCoveredByLA(coord)) {
-        Point* pt = geometryFactory->createPoint(coord);
+        Point* pt = geometryFactory->createPoint(coord).release();
         resultPointList->push_back(pt);
     }
 }

--- a/src/operation/overlay/PolygonBuilder.cpp
+++ b/src/operation/overlay/PolygonBuilder.cpp
@@ -129,10 +129,10 @@ PolygonBuilder::add(const std::vector<DirectedEdge*>* dirEdges,
 }
 
 /*public*/
-std::vector<Geometry*>*
+std::vector<std::unique_ptr<Geometry>>
 PolygonBuilder::getPolygons()
 {
-    std::vector<Geometry*>* resultPolyList = computePolygons(shellList);
+    std::vector<std::unique_ptr<Geometry>> resultPolyList = computePolygons(shellList);
     return resultPolyList;
 }
 
@@ -359,19 +359,19 @@ PolygonBuilder::findEdgeRingContaining(EdgeRing* testEr,
 }
 
 /*private*/
-std::vector<Geometry*>*
+std::vector<std::unique_ptr<Geometry>>
 PolygonBuilder::computePolygons(std::vector<EdgeRing*>& newShellList)
 {
 #if GEOS_DEBUG
     std::cerr << "PolygonBuilder::computePolygons: got " << newShellList.size() << " shells" << std::endl;
 #endif
-    std::vector<Geometry*>* resultPolyList = new std::vector<Geometry*>();
+    std::vector<std::unique_ptr<Geometry>> resultPolyList;
 
     // add Polygons for all shells
     for(std::size_t i = 0, n = newShellList.size(); i < n; i++) {
         EdgeRing* er = newShellList[i];
-        Polygon* poly = er->toPolygon(geometryFactory).release();
-        resultPolyList->push_back(poly);
+        auto poly = er->toPolygon(geometryFactory);
+        resultPolyList.push_back(std::move(poly));
     }
     return resultPolyList;
 }

--- a/src/operation/polygonize/EdgeRing.cpp
+++ b/src/operation/polygonize/EdgeRing.cpp
@@ -238,7 +238,7 @@ EdgeRing::getRingInternal()
 
     getCoordinates();
     try {
-        ring.reset(factory->createLinearRing(*ringPts));
+        ring = factory->createLinearRing(*ringPts);
     }
     catch(const geos::util::IllegalArgumentException& e) {
 #if GEOS_DEBUG

--- a/src/operation/union/PointGeometryUnion.cpp
+++ b/src/operation/union/PointGeometryUnion.cpp
@@ -64,16 +64,14 @@ PointGeometryUnion::Union() const
     std::unique_ptr<Geometry> ptComp;
 
     if(exteriorCoords.size() == 1) {
-        ptComp.reset(geomFact->createPoint(*(exteriorCoords.begin())));
+        ptComp = geomFact->createPoint(*(exteriorCoords.begin()));
     }
     else {
         ptComp = geomFact->createMultiPoint(exteriorCoords);
     }
 
     // add point component to the other geometry
-    return std::unique_ptr<Geometry> (
-               GeometryCombiner::combine(ptComp.get(), &otherGeom)
-           );
+    return GeometryCombiner::combine(ptComp.get(), &otherGeom);
 }
 
 /* public  static */

--- a/src/precision/GeometryPrecisionReducer.cpp
+++ b/src/precision/GeometryPrecisionReducer.cpp
@@ -121,7 +121,7 @@ GeometryPrecisionReducer::fixPolygonalTopology(const Geometry& geom)
 
     if(! newFactory) {
         tmpFactory = createFactory(*geom.getFactory(), targetPM);
-        tmp.reset(tmpFactory->createGeometry(&geom));
+        tmp = tmpFactory->createGeometry(&geom);
         geomToBuffer = tmp.get();
     }
 
@@ -129,7 +129,7 @@ GeometryPrecisionReducer::fixPolygonalTopology(const Geometry& geom)
 
     if(! newFactory) {
         // a slick way to copy the geometry with the original precision factory
-        bufGeom.reset(geom.getFactory()->createGeometry(bufGeom.get()));
+        bufGeom = geom.getFactory()->createGeometry(bufGeom.get());
     }
 
     return bufGeom;

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -447,7 +447,7 @@ QuadEdgeSubdivision::getEdges(const geom::GeometryFactory& geomFact)
         coordSeq->setAt(qe->orig().getCoordinate(), 0);
         coordSeq->setAt(qe->dest().getCoordinate(), 1);
 
-        edges.emplace_back(geomFact.createLineString(coordSeq.release()));
+        edges.emplace_back(geomFact.createLineString(std::move(coordSeq)));
     }
 
     return geomFact.createMultiLineString(std::move(edges));

--- a/tests/bigtest/GeometryTestFactory.cpp
+++ b/tests/bigtest/GeometryTestFactory.cpp
@@ -17,24 +17,25 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/Coordinate.h>
+#include <geos/util.h>
 #include "bigtest.h"
 
 #define PI 3.14159265358979
 
 using namespace geos::geom;
 
-Polygon*
+std::unique_ptr<Polygon>
 GeometryTestFactory::createBox(GeometryFactory* fact, double minx, double miny, int nSide, double segLen)
 {
-    CoordinateSequence* pts = createBox(minx, miny, nSide, segLen);
-    return fact->createPolygon(fact->createLinearRing(pts), nullptr);
+    auto pts = createBox(minx, miny, nSide, segLen);
+    return fact->createPolygon(fact->createLinearRing(std::move(pts)));
 }
 
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 GeometryTestFactory::createBox(double minx, double miny, int nSide, double segLen)
 {
     int i;
-    CoordinateSequence* pts = new CoordinateSequence();
+    auto pts = detail::make_unique<CoordinateSequence>();
     double maxx = minx + nSide * segLen;
     double maxy = miny + nSide * segLen;
 
@@ -69,10 +70,10 @@ GeometryTestFactory::createBox(double minx, double miny, int nSide, double segLe
  * @param size the size of the envelope of the star
  * @param nPts the number of points in the star
  */
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 GeometryTestFactory::createCircle(double basex, double basey, double size, uint32_t nPts)
 {
-    CoordinateSequence* pts = new CoordinateSequence(nPts + 1);
+    auto pts = detail::make_unique<CoordinateSequence>(nPts + 1);
     double len = size / 2.0;
 
     for(uint32_t i = 0; i < nPts; i++) {
@@ -85,11 +86,11 @@ GeometryTestFactory::createCircle(double basex, double basey, double size, uint3
     return pts;
 }
 
-Polygon*
+std::unique_ptr<Polygon>
 GeometryTestFactory::createCircle(GeometryFactory* fact, double basex, double basey, double size, uint32_t nPts)
 {
-    CoordinateSequence* pts = createCircle(basex, basey, size, nPts);
-    return fact->createPolygon(fact->createLinearRing(pts), nullptr);
+    auto pts = createCircle(basex, basey, size, nPts);
+    return fact->createPolygon(fact->createLinearRing(std::move(pts)));
 }
 
 /**
@@ -101,7 +102,7 @@ GeometryTestFactory::createCircle(GeometryFactory* fact, double basex, double ba
  * @param nArms the number of arms of the star
  * @param nPts the number of points in the star
  */
-CoordinateSequence*
+std::unique_ptr<CoordinateSequence>
 GeometryTestFactory::createSineStar(double basex, double basey, double size, double armLen, int nArms, int nPts)
 {
     double armBaseLen = size / 2 - armLen;
@@ -116,7 +117,7 @@ GeometryTestFactory::createSineStar(double basex, double basey, double size, dou
     }
 
     //int nPts2=nArmPt*nArms;
-    CoordinateSequence* pts = new CoordinateSequence();
+    auto pts = detail::make_unique<CoordinateSequence>();
 
     double starAng = 0.0;
 
@@ -138,10 +139,10 @@ GeometryTestFactory::createSineStar(double basex, double basey, double size, dou
     return pts;
 }
 
-Polygon*
+std::unique_ptr<Polygon>
 GeometryTestFactory::createSineStar(GeometryFactory* fact, double basex, double basey, double size, double armLen,
                                     int nArms, int nPts)
 {
-    CoordinateSequence* pts = createSineStar(basex, basey, size, armLen, nArms, nPts);
-    return fact->createPolygon(fact->createLinearRing(pts), nullptr);
+    auto pts = createSineStar(basex, basey, size, armLen, nArms, nPts);
+    return fact->createPolygon(fact->createLinearRing(std::move(pts)));
 }

--- a/tests/bigtest/TestSweepLineSpeed.cpp
+++ b/tests/bigtest/TestSweepLineSpeed.cpp
@@ -39,18 +39,16 @@ run(int nPts, GeometryFactory* fact)
     double size = 100.0;
     double armLen = 50.0;
     int nArms = 10;
-    Polygon* poly = GeometryTestFactory::createSineStar(fact, 0.0, 0.0, size, armLen, nArms, nPts);
-    Polygon* box = GeometryTestFactory::createSineStar(fact, 0.0, size / 2, size, armLen, nArms, nPts);
+    auto poly = GeometryTestFactory::createSineStar(fact, 0.0, 0.0, size, armLen, nArms, nPts);
+    auto box = GeometryTestFactory::createSineStar(fact, 0.0, size / 2, size, armLen, nArms, nPts);
     //Polygon *box=GeometryTestFactory::createBox(fact,0,0,1,100.0);
 
     startTime = clock();
-    poly->intersects(box);
+    poly->intersects(box.get());
     endTime = clock();
     double totalTime = (double)(endTime - startTime);
     printf("n Pts: %i  Executed in %6.0f ms.\n", nPts, totalTime);
     //cout << "n Pts: " << nPts << "   Executed in " << totalTime << endl;
-
-    // FIXME - mloskot: Why generated test geometries are not destroyed?"
 }
 
 int

--- a/tests/bigtest/bigtest.h
+++ b/tests/bigtest/bigtest.h
@@ -33,13 +33,13 @@ class GeometryFactory;
 
 class GeometryTestFactory {
 public:
-    static geom::Polygon* createBox(geom::GeometryFactory* fact, double minx, double miny, int nSide, double segLen);
-    static geom::CoordinateSequence* createBox(double minx, double miny, int nSide, double segLen);
-    static geom::CoordinateSequence* createCircle(double basex, double basey, double size, uint32_t nPts);
-    static geom::Polygon* createCircle(geom::GeometryFactory* fact, double basex, double basey, double size, uint32_t nPts);
-    static geom::CoordinateSequence* createSineStar(double basex, double basey, double size, double armLen, int nArms,
+    static std::unique_ptr<geom::Polygon> createBox(geom::GeometryFactory* fact, double minx, double miny, int nSide, double segLen);
+    static std::unique_ptr<geom::CoordinateSequence> createBox(double minx, double miny, int nSide, double segLen);
+    static std::unique_ptr<geom::CoordinateSequence> createCircle(double basex, double basey, double size, uint32_t nPts);
+    static std::unique_ptr<geom::Polygon> createCircle(geom::GeometryFactory* fact, double basex, double basey, double size, uint32_t nPts);
+    static std::unique_ptr<geom::CoordinateSequence> createSineStar(double basex, double basey, double size, double armLen, int nArms,
             int nPts);
-    static geom::Polygon* createSineStar(geom::GeometryFactory* fact, double basex, double basey, double size,
+    static std::unique_ptr<geom::Polygon> createSineStar(geom::GeometryFactory* fact, double basex, double basey, double size,
                                          double armLen, int nArms, int nPts);
 };
 

--- a/tests/unit/geom/LineStringTest.cpp
+++ b/tests/unit/geom/LineStringTest.cpp
@@ -36,21 +36,19 @@ struct test_linestring_data {
     geos::geom::GeometryFactory::Ptr factory_;
     geos::io::WKTReader reader_;
 
-    LineStringPtr empty_line_;
+    std::unique_ptr<geos::geom::LineString> empty_line_;
 
     test_linestring_data()
         : pm_(1000)
         , factory_(geos::geom::GeometryFactory::create(&pm_, 0))
         , reader_(factory_.get())
-        , empty_line_(factory_->createLineString(new geos::geom::CoordinateSequence()))
+        , empty_line_(factory_->createLineString())
     {
         assert(nullptr != empty_line_);
     }
 
     ~test_linestring_data()
     {
-        factory_->destroyGeometry(empty_line_);
-        empty_line_ = nullptr;
     }
 };
 

--- a/tests/unit/index/strtree/SimpleSTRtreeTest.cpp
+++ b/tests/unit/index/strtree/SimpleSTRtreeTest.cpp
@@ -37,9 +37,9 @@ void object::test<1>
     for (int i = 0; i < gridSize; ++i) {
         for (int j = 0; j < gridSize; ++j) {
             geom::Coordinate c((double)i, (double)j);
-            geom::Point* pt = gf->createPoint(c);
-            geoms.emplace_back(pt);
-            t.insert(pt);
+            auto pt = gf->createPoint(c);
+            t.insert(pt.get());
+            geoms.emplace_back(std::move(pt));
         }
     }
 
@@ -90,12 +90,12 @@ void object::test<2>
         for (int j = 0; j < gridSize; ++j) {
             geom::Coordinate c1((double)i, (double)j);
             geom::Coordinate c2((double)(i+gridSize+1), (double)(j+gridSize+1));
-            geom::Point *pt1 = gf->createPoint(c1);
-            geom::Point *pt2 = gf->createPoint(c2);
-            geoms.emplace_back(pt1);
-            geoms.emplace_back(pt2);
-            t1.insert(pt1);
-            t2.insert(pt2);
+            auto pt1 = gf->createPoint(c1);
+            auto pt2 = gf->createPoint(c2);
+            t1.insert(pt1.get());
+            t2.insert(pt2.get());
+            geoms.emplace_back(std::move(pt1));
+            geoms.emplace_back(std::move(pt2));
         }
     }
 

--- a/tests/unit/index/strtree/TemplateSTRtreeTest.cpp
+++ b/tests/unit/index/strtree/TemplateSTRtreeTest.cpp
@@ -39,8 +39,8 @@ struct test_templatestrtree_data {
             for (std::size_t j = 0; j < grid.ny; ++j) {
                 geom::Coordinate c(grid.x0 + grid.dx*static_cast<double>(i),
                                    grid.y0 + grid.dy*static_cast<double>(j));
-                geom::Point* pt = gf->createPoint(c);
-                ret.emplace_back(pt);
+                auto pt = gf->createPoint(c);
+                ret.emplace_back(std::move(pt));
             }
         }
 

--- a/tests/unit/io/WKBWriterTest.cpp
+++ b/tests/unit/io/WKBWriterTest.cpp
@@ -141,12 +141,10 @@ template<>
 void object::test<4>
 ()
 {
-    typedef geos::geom::Geometry Geom;
-    typedef std::vector<Geom*> GeomVect;
-    GeomVect* geoms = new GeomVect;
-    geoms->push_back(wktreader.read("POLYGON((0 0,1 0,1 1,0 1,0 0))").release());
-    geoms->back()->setSRID(4326);
-    Geom* geom = gf->createGeometryCollection(geoms);
+    std::vector<std::unique_ptr<geos::geom::Geometry>> geoms;
+    geoms.push_back(wktreader.read("POLYGON((0 0,1 0,1 1,0 1,0 0))"));
+    geoms.back()->setSRID(4326);
+    auto geom = gf->createGeometryCollection(std::move(geoms));
     geom->setSRID(4326);
     std::stringstream result_stream;
 
@@ -154,7 +152,6 @@ void object::test<4>
     wkbwriter.setByteOrder(1);
     wkbwriter.setIncludeSRID(1);
     wkbwriter.writeHEX(*geom, result_stream);
-    delete geom;
 
     std::string actual = result_stream.str();
     ensure_equals(actual,

--- a/tests/unit/noding/NodedSegmentStringTest.cpp
+++ b/tests/unit/noding/NodedSegmentStringTest.cpp
@@ -49,13 +49,13 @@ struct test_nodedsegmentstring_data {
     std::unique_ptr<Geometry>
     toLines(SegmentString::NonConstVect& ss, const GeometryFactory* gf)
     {
-        std::vector<Geometry *> *lines = new std::vector<Geometry *>();
+        std::vector<std::unique_ptr<Geometry>> lines;
         for (auto s: ss)
         {
             std::unique_ptr<CoordinateSequence> cs = s->getCoordinates()->clone();
-            lines->push_back(gf->createLineString(*cs));
+            lines.push_back(gf->createLineString(std::move(cs)));
         }
-        return std::unique_ptr<Geometry>(gf->createMultiLineString(lines));
+        return gf->createMultiLineString(std::move(lines));
     }
 
     void

--- a/tests/unit/noding/snapround/MCIndexSnapRounderTest.cpp
+++ b/tests/unit/noding/snapround/MCIndexSnapRounderTest.cpp
@@ -61,12 +61,12 @@ struct test_mcidxsnprndr_data {
     GeomPtr
     getGeometry(SegStrVct& vct)
     {
-        GeomVct* lines = new GeomVct;
+        std::vector<std::unique_ptr<Geometry>> lines;
         for(SegStrVct::size_type i = 0, n = vct.size(); i < n; ++i) {
             SegmentString* ss = vct[i];
-            lines->push_back(gf_->createLineString(*(ss->getCoordinates())));
+            lines.push_back(gf_->createLineString(*(ss->getCoordinates())));
         }
-        return GeomPtr(gf_->createMultiLineString(lines));
+        return gf_->createMultiLineString(std::move(lines));
     }
 
     void

--- a/tests/unit/operation/distance/DistanceOpTest.cpp
+++ b/tests/unit/operation/distance/DistanceOpTest.cpp
@@ -532,8 +532,8 @@ void object::test<20>()
     seq1->setAt(b0, 0);
     seq1->setAt(b1, 1);
 
-    GeomPtr g0(gfact->createLineString(seq0.release()));
-    GeomPtr g1(gfact->createLineString(seq1.release()));
+    auto g0 = gfact->createLineString(std::move(seq0));
+    auto g1 = gfact->createLineString(std::move(seq1));
 
     DistanceOp dist(g0.get(), g1.get());
     CSPtr seq(dist.nearestPoints());

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -1866,12 +1866,7 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
 
 
             auto polys = plgnzr.getPolygons();
-            std::vector<geom::Geometry*>* newgeoms = new std::vector<geom::Geometry*>;
-            for(unsigned int i = 0; i < polys.size(); i++) {
-                newgeoms->push_back(polys[i].release());
-            }
-
-            GeomPtr gRealRes(factory->createGeometryCollection(newgeoms));
+            GeomPtr gRealRes(factory->createGeometryCollection(std::move(polys)));
             gRealRes->normalize();
 
 


### PR DESCRIPTION
This PR removes remaining usages and implementations of Geometry constructors and GeometryFactory methods dealing in raw pointers instead of managed pointers.