### PR TITLE
Handle CoordinateSequence as a value

### DIFF
--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -206,6 +206,8 @@ public:
     std::unique_ptr<LinearRing> createLinearRing(
         std::unique_ptr<CoordinateSequence> && newCoords) const;
 
+    std::unique_ptr<LinearRing> createLinearRing(CoordinateSequence && newCoords) const;
+
     /// Construct a LinearRing with a deep-copy of given arguments
     std::unique_ptr<LinearRing> createLinearRing(
         const CoordinateSequence& coordinates) const;
@@ -265,6 +267,8 @@ public:
     /// Construct a LineString taking ownership of given argument
     std::unique_ptr<LineString> createLineString(
         std::unique_ptr<CoordinateSequence> && coordinates) const;
+
+    std::unique_ptr<LineString> createLineString(CoordinateSequence && coordinates) const;
 
     /// Construct a LineString with a deep-copy of given argument
     std::unique_ptr<LineString> createLineString(

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -203,7 +203,7 @@ protected:
     /// \brief
     /// Constructs a LineString taking ownership the
     /// given CoordinateSequence.
-    LineString(CoordinateSequence::Ptr && pts,
+    LineString(CoordinateSequence && pts,
                const GeometryFactory& newFactory);
 
     LineString* cloneImpl() const override { return new LineString(*this); }
@@ -212,7 +212,7 @@ protected:
 
     Envelope::Ptr computeEnvelopeInternal() const override;
 
-    CoordinateSequence::Ptr points;
+    CoordinateSequence points;
 
     int
     getSortIndex() const override
@@ -222,7 +222,7 @@ protected:
 
 private:
 
-    void validateConstruction();
+    void validateConstruction() const;
     void normalizeClosed();
 
 

--- a/include/geos/geom/LinearRing.h
+++ b/include/geos/geom/LinearRing.h
@@ -75,7 +75,7 @@ public:
      * @param newFactory the GeometryFactory used to create this geometry
      *
      */
-    LinearRing(CoordinateSequence::Ptr && points,
+    LinearRing(CoordinateSequence && points,
             const GeometryFactory& newFactory);
 
     std::unique_ptr<LinearRing> clone() const
@@ -117,7 +117,7 @@ protected:
 
 private:
 
-    void validateConstruction();
+    void validateConstruction() const;
 };
 
 

--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -158,7 +158,7 @@ private:
 
     std::unique_ptr<geom::GeometryCollection> readGeometryCollection();
 
-    std::unique_ptr<geom::CoordinateSequence> readCoordinateSequence(unsigned int); // throws IOException
+    geom::CoordinateSequence readCoordinateSequence(unsigned int); // throws IOException
 
     void minMemSize(int geomType, uint64_t size);
 

--- a/include/geos/io/WKTReader.h
+++ b/include/geos/io/WKTReader.h
@@ -112,7 +112,7 @@ public:
     std::unique_ptr<geom::Geometry> read(const std::string& wellKnownText) const;
 
 protected:
-    std::unique_ptr<geom::CoordinateSequence> getCoordinates(io::StringTokenizer* tokenizer, OrdinateSet& ordinates) const;
+    geom::CoordinateSequence getCoordinates(io::StringTokenizer* tokenizer, OrdinateSet& ordinates) const;
     static double getNextNumber(io::StringTokenizer* tokenizer);
     static std::string getNextEmptyOrOpener(io::StringTokenizer* tokenizer, OrdinateSet& dim);
     static std::string getNextCloserOrComma(io::StringTokenizer* tokenizer);

--- a/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
@@ -356,7 +356,7 @@ public:
 
 private:
     typedef std::stack<QuadEdge*> QuadEdgeStack;
-    typedef std::vector<std::unique_ptr<geom::CoordinateSequence>> TriList;
+    typedef std::vector<geom::CoordinateSequence> TriList;
 
     /** \brief
      * The quadedges forming a single triangle.

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -367,11 +367,22 @@ std::unique_ptr<LinearRing>
 GeometryFactory::createLinearRing() const
 {
     // Can't use make_unique with protected constructor
-    return std::unique_ptr<LinearRing>(new LinearRing(nullptr, *this));
+    return std::unique_ptr<LinearRing>(new LinearRing(CoordinateSequence(), *this));
 }
 
 std::unique_ptr<LinearRing>
 GeometryFactory::createLinearRing(CoordinateSequence::Ptr && newCoords) const
+{
+    // Can't use make_unique with protected constructor
+    auto ret = std::unique_ptr<LinearRing>(new LinearRing(
+                                           newCoords == nullptr ? CoordinateSequence() : std::move(*newCoords),
+                                           *this));
+    newCoords.reset();
+    return ret;
+}
+
+std::unique_ptr<LinearRing>
+GeometryFactory::createLinearRing(CoordinateSequence && newCoords) const
 {
     // Can't use make_unique with protected constructor
     return std::unique_ptr<LinearRing>(new LinearRing(std::move(newCoords), *this));
@@ -505,6 +516,18 @@ GeometryFactory::createLineString(CoordinateSequence::Ptr && newCoords)
 const
 {
     // Can't use make_unique with protected constructor
+    auto ret = std::unique_ptr<LineString>(new LineString(
+                           newCoords == nullptr ? CoordinateSequence() : std::move(*newCoords),
+                           *this));
+    newCoords.reset();
+    return ret;
+}
+
+std::unique_ptr<LineString>
+GeometryFactory::createLineString(CoordinateSequence && newCoords)
+const
+{
+    // Can't use make_unique with protected constructor
     return std::unique_ptr<LineString>(new LineString(std::move(newCoords), *this));
 }
 
@@ -514,7 +537,7 @@ GeometryFactory::createLineString(const CoordinateSequence& fromCoords)
 const
 {
     // Can't use make_unique with protected constructor
-    return std::unique_ptr<LineString>(new LineString(fromCoords.clone(), *this));
+    return std::unique_ptr<LineString>(new LineString(CoordinateSequence(fromCoords), *this));
 }
 
 /*public*/

--- a/src/geom/LinearRing.cpp
+++ b/src/geom/LinearRing.cpp
@@ -35,7 +35,7 @@ namespace geom { // geos::geom
 LinearRing::LinearRing(const LinearRing& lr): LineString(lr) {}
 
 /*public*/
-LinearRing::LinearRing(CoordinateSequence::Ptr && newCoords,
+LinearRing::LinearRing(CoordinateSequence && newCoords,
                        const GeometryFactory& newFactory)
         : LineString(std::move(newCoords), newFactory)
 {
@@ -43,10 +43,10 @@ LinearRing::LinearRing(CoordinateSequence::Ptr && newCoords,
 }
 
 void
-LinearRing::validateConstruction()
+LinearRing::validateConstruction() const
 {
     // Empty ring is valid
-    if(points->isEmpty()) {
+    if(points.isEmpty()) {
         return;
     }
 
@@ -56,10 +56,10 @@ LinearRing::validateConstruction()
         );
     }
 
-    if(points->getSize() < MINIMUM_VALID_SIZE) {
+    if(points.getSize() < MINIMUM_VALID_SIZE) {
         std::ostringstream os;
         os << "Invalid number of points in LinearRing found "
-           << points->getSize() << " - must be 0 or >= 4";
+           << points.getSize() << " - must be 0 or >= 4";
         throw util::IllegalArgumentException(os.str());
     }
 }
@@ -73,7 +73,7 @@ LinearRing::getBoundaryDimension() const
 bool
 LinearRing::isClosed() const
 {
-    if(points->isEmpty()) {
+    if(points.isEmpty()) {
         // empty LinearRings are closed by definition
         return true;
     }
@@ -89,7 +89,7 @@ LinearRing::getGeometryType() const
 void
 LinearRing::setPoints(const CoordinateSequence* cl)
 {
-    points = cl->clone();
+    points = *cl;
 }
 
 GeometryTypeId
@@ -105,11 +105,9 @@ LinearRing::reverseImpl() const
         return clone().release();
     }
 
-    assert(points.get());
-    auto seq = points->clone();
-    seq->reverse();
-    assert(getFactory());
-    return getFactory()->createLinearRing(std::move(seq)).release();
+    CoordinateSequence revPts(points);
+    revPts.reverse();
+    return getFactory()->createLinearRing(std::move(revPts)).release();
 }
 
 } // namespace geos::geom

--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -340,9 +340,9 @@ WKBReader::readPoint()
     auto seq = readCoordinateSequence(1);
 
     // POINT EMPTY
-    const CoordinateXY& coord = seq->getAt<CoordinateXY>(0);
+    const CoordinateXY& coord = seq.getAt<CoordinateXY>(0);
     if (std::isnan(coord.x) && std::isnan(coord.y)) {
-        seq->clear();
+        seq.clear();
     }
 
     return factory.createPoint(std::move(seq));
@@ -370,8 +370,8 @@ WKBReader::readLinearRing()
 #endif
     auto pts = readCoordinateSequence(size);
     // Replace unclosed ring with closed
-    if (fixStructure && !pts->isRing()) {
-        pts->closeRing();
+    if (fixStructure && !pts.isRing()) {
+        pts.closeRing();
     }
     return factory.createLinearRing(std::move(pts));
 }
@@ -476,11 +476,11 @@ WKBReader::readGeometryCollection()
     return factory.createGeometryCollection(std::move(geoms));
 }
 
-std::unique_ptr<CoordinateSequence>
+CoordinateSequence
 WKBReader::readCoordinateSequence(uint32_t size)
 {
     minMemSize(GEOS_LINESTRING, size);
-    auto seq = detail::make_unique<CoordinateSequence>(size, hasZ, hasM, false);
+    CoordinateSequence seq(size, hasZ, hasM, false);
 
     CoordinateXYZM coord(0, 0, DoubleNotANumber, DoubleNotANumber);
     for(uint32_t i = 0; i < size; i++) {
@@ -496,7 +496,7 @@ WKBReader::readCoordinateSequence(uint32_t size)
             coord.m = ordValues[j++];
         }
 
-        seq->setAt(coord, i);
+        seq.setAt(coord, i);
     }
     return seq;
 }

--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -59,24 +59,24 @@ WKTReader::read(const std::string& wellKnownText) const
     return ret;
 }
 
-std::unique_ptr<CoordinateSequence>
+CoordinateSequence
 WKTReader::getCoordinates(StringTokenizer* tokenizer, OrdinateSet& ordinateFlags) const
 {
     std::string nextToken = getNextEmptyOrOpener(tokenizer, ordinateFlags);
     if(nextToken == "EMPTY") {
-        return detail::make_unique<CoordinateSequence>(0u, ordinateFlags.hasZ(), ordinateFlags.hasM());
+        return CoordinateSequence(0u, ordinateFlags.hasZ(), ordinateFlags.hasM());
     }
 
     CoordinateXYZM coord(0, 0, DoubleNotANumber, DoubleNotANumber);
     getPreciseCoordinate(tokenizer, ordinateFlags, coord);
 
-    auto coordinates = detail::make_unique<CoordinateSequence>(0u, ordinateFlags.hasZ(), ordinateFlags.hasM());
-    coordinates->add(coord);
+    CoordinateSequence coordinates(0u, ordinateFlags.hasZ(), ordinateFlags.hasM());
+    coordinates.add(coord);
 
     nextToken = getNextCloserOrComma(tokenizer);
     while(nextToken == ",") {
         getPreciseCoordinate(tokenizer, ordinateFlags, coord);
-        coordinates->add(coord);
+        coordinates.add(coord);
         nextToken = getNextCloserOrComma(tokenizer);
     }
 
@@ -321,8 +321,8 @@ std::unique_ptr<LinearRing>
 WKTReader::readLinearRingText(StringTokenizer* tokenizer, OrdinateSet& ordinateFlags) const
 {
     auto&& coords = getCoordinates(tokenizer, ordinateFlags);
-    if (fixStructure && !coords->isRing()) {
-        coords->closeRing();
+    if (fixStructure && !coords.isRing()) {
+        coords.closeRing();
     }
     return geometryFactory->createLinearRing(std::move(coords));
 }

--- a/tests/unit/geom/LinearRingTest.cpp
+++ b/tests/unit/geom/LinearRingTest.cpp
@@ -46,7 +46,7 @@ struct test_linearring_data {
     test_linearring_data()
         : pm_(1000), factory_(geos::geom::GeometryFactory::create(&pm_, 0))
         , reader_(factory_.get())
-        , empty_ring_(geos::detail::make_unique<geos::geom::CoordinateSequence>(), *factory_)
+        , empty_ring_(geos::geom::CoordinateSequence(), *factory_)
         , ring_(reader_.read<geos::geom::LinearRing>("LINEARRING(0 10, 5 5, 10 5, 15 10, 10 15, 5 15, 0 10)"))
         , ring_size_(7)
     {}
@@ -80,18 +80,17 @@ void object::test<1>
 
     // Non-empty sequence of coordinates
     const std::size_t size7 = 7;
-    auto coords = geos::detail::make_unique<geos::geom::CoordinateSequence>();
-    ensure("sequence is null pointer.", coords != nullptr);
+    geos::geom::CoordinateSequence coords;
 
-    coords->add(Coordinate(0, 10));
-    coords->add(Coordinate(5, 5));
-    coords->add(Coordinate(10, 5));
-    coords->add(Coordinate(15, 10));
-    coords->add(Coordinate(10, 15));
-    coords->add(Coordinate(5, 15));
-    coords->add(Coordinate(0, 10));
+    coords.add(Coordinate(0, 10));
+    coords.add(Coordinate(5, 5));
+    coords.add(Coordinate(10, 5));
+    coords.add(Coordinate(15, 10));
+    coords.add(Coordinate(10, 15));
+    coords.add(Coordinate(5, 15));
+    coords.add(Coordinate(0, 10));
 
-    ensure_equals(coords->size(), size7);
+    ensure_equals(coords.size(), size7);
 
     try {
         // Create non-empty linearring instance

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -82,18 +82,17 @@ void object::test<1>
 
     // Create non-empty Coordinate sequence for Exterior LinearRing
     const std::size_t size = 7;
-    auto coords = geos::detail::make_unique<CoordinateSequence>();
-    ensure("sequence is null pointer.", coords != nullptr);
+    geos::geom::CoordinateSequence coords;
 
-    coords->add(Coordinate(0, 10));
-    coords->add(Coordinate(5, 5));
-    coords->add(Coordinate(10, 5));
-    coords->add(Coordinate(15, 10));
-    coords->add(Coordinate(10, 15));
-    coords->add(Coordinate(5, 15));
-    coords->add(Coordinate(0, 10));
+    coords.add(Coordinate(0, 10));
+    coords.add(Coordinate(5, 5));
+    coords.add(Coordinate(10, 5));
+    coords.add(Coordinate(15, 10));
+    coords.add(Coordinate(10, 15));
+    coords.add(Coordinate(5, 15));
+    coords.add(Coordinate(0, 10));
 
-    ensure_equals(coords->size(), size);
+    ensure_equals(coords.size(), size);
 
     try {
         // Create non-empty LinearRing instance


### PR DESCRIPTION
Now that `CoordinateSequence` is a concrete class, we don't need to be passing it around as a pointer all the time. It's only 32 bytes, so the pattern of `auto cs = detail::make_unique<CoordinateSequence>()` seems like an unnecessary small heap allocation, much like the `std::vector<Coordinate>* vect = new std::vector<Coordinate>()` stuff that we've done a good job eradicating.

As a start, I changed `LineString` to have a `CoordinateSequence` member instead of `std::unique_ptr<CoordinateSequence>`. I then transitioned the triangulation code to avoid heap-allocating the sequences. This should be a worst-case for heap allocation, because we're creating lots of small polygons. I ran into two problems:

- if you have overloaded methods/constructors that take `CoordinateSequence&&` and `const CoordianteSequence&`, it's really easy to forget a `std::move` and introduce an unnecessary copy.
- after fixing the performance regression from these copies, the runtime is exactly where it is in `main`. So either our small heap allocations aren't that bad, or the compiler is somehow optimizing them out.

I don't plan to pursue this further for now. Just trying to avoid publication bias and share all the things that don't work (yet?).