### PR TITLE
Single-precision STRtree

### DIFF
--- a/benchmarks/ClassSizes.cpp
+++ b/benchmarks/ClassSizes.cpp
@@ -20,6 +20,8 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/io/WKTReader.h>
 #include <geos/geom/CoordinateSequence.h>
+#include <geos/index/strtree/TemplateSTRtree.h>
+#include <geos/index/strtree/Interval.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/Point.h>
 #include <geos/geom/LinearRing.h>
@@ -50,7 +52,7 @@
 using namespace geos;
 
 #define check(x) \
-	{ std::cout << "Size of " << #x << " is " << sizeof(x) << std::endl; }
+    { std::cout << "Size of " << #x << " is " << sizeof(x) << std::endl; }
 
 int
 main()
@@ -82,5 +84,15 @@ main()
     check(operation::overlayng::EdgeSourceInfo);
     check(operation::overlayng::OverlayLabel);
     check(int64_t);
+
+    check(index::strtree::Interval);
+    check(index::strtree::FloatInterval);
+    using TreeNodePtrFloatInterval = index::strtree::TemplateSTRNode<void*,index::strtree::IntervalTraits<float>>;
+    using TreeNodePtrDoubleInterval = index::strtree::TemplateSTRNode<void*,index::strtree::IntervalTraits<double>>;
+    using TreeNodePtrDoubleEnvelope = index::strtree::TemplateSTRNode<void*,index::strtree::EnvelopeTraits<double>>;
+    check(TreeNodePtrFloatInterval);
+    check(TreeNodePtrDoubleInterval);
+    check(TreeNodePtrDoubleEnvelope);
+
 }
 

--- a/benchmarks/ClassSizes.cpp
+++ b/benchmarks/ClassSizes.cpp
@@ -87,11 +87,15 @@ main()
 
     check(index::strtree::Interval);
     check(index::strtree::FloatInterval);
+
+    // Templates don't work with the "check" macro. Workaround by defining an alias.
     using TreeNodePtrFloatInterval = index::strtree::TemplateSTRNode<void*,index::strtree::IntervalTraits<float>>;
     using TreeNodePtrDoubleInterval = index::strtree::TemplateSTRNode<void*,index::strtree::IntervalTraits<double>>;
+    using TreeNodePtrFloatEnvelope = index::strtree::TemplateSTRNode<void*,index::strtree::EnvelopeTraits<float>>;
     using TreeNodePtrDoubleEnvelope = index::strtree::TemplateSTRNode<void*,index::strtree::EnvelopeTraits<double>>;
     check(TreeNodePtrFloatInterval);
     check(TreeNodePtrDoubleInterval);
+    check(TreeNodePtrFloatEnvelope);
     check(TreeNodePtrDoubleEnvelope);
 
 }

--- a/benchmarks/index/SpatialIndexPerfTest.cpp
+++ b/benchmarks/index/SpatialIndexPerfTest.cpp
@@ -34,6 +34,7 @@ using geos::index::strtree::ItemDistance;
 using geos::index::strtree::ItemBoundable;
 
 using TemplateIntervalTree = TemplateSTRtree<const Interval*, geos::index::strtree::IntervalTraits<double>>;
+using TemplateFloatEnvelopeTree = TemplateSTRtree<const Envelope*, geos::index::strtree::EnvelopeTraits<float>>;
 
 //////////////////////////
 // Test Data Generation //
@@ -264,13 +265,19 @@ static void BM_STRtree2DQuery(benchmark::State& state) {
     }
 }
 
+template<>
+void BM_STRtree2DQuery<TemplateFloatEnvelopeTree>(benchmark::State& state) {
+}
+
+template<class Tree>
 static void BM_STRtree2DQueryPairs(benchmark::State& state) {
     std::default_random_engine eng(12345);
+    BoundsType
     Envelope extent(0, 1, 0, 1);
     auto envelopes = generate_envelopes(eng, extent, 10000);
     Envelope empty_env;
 
-    TemplateSTRtree<const Envelope*> tree;
+    Tree tree;
     for (auto& e : envelopes) {
         tree.insert(&e, &e);
     }
@@ -353,9 +360,10 @@ BENCHMARK_TEMPLATE(BM_STRtree2DQuery, Quadtree);
 BENCHMARK_TEMPLATE(BM_STRtree2DQuery, STRtree);
 BENCHMARK_TEMPLATE(BM_STRtree2DQuery, SimpleSTRtree);
 BENCHMARK_TEMPLATE(BM_STRtree2DQuery, TemplateSTRtree<const Envelope*>);
-//BENCHMARK_TEMPLATE(BM_STRtree2DQuery, TemplateSTRtree<const Envelope*, geos::index::strtree::EnvelopeTraits<float>>);
+BENCHMARK_TEMPLATE(BM_STRtree2DQuery, TemplateSTRtree<const Envelope*, geos::index::strtree::EnvelopeTraits<float>>);
 
-BENCHMARK(BM_STRtree2DQueryPairs);
+BENCHMARK_TEMPLATE(BM_STRtree2DQueryPairs<TemplateSTRtree<const Envelope*>);
+BENCHMARK_TEMPLATE(BM_STRtree2DQueryPairs, TemplateSTRtree<const Envelope*, geos::index::strtree::EnvelopeTraits<float>>);
 BENCHMARK(BM_STRtree2DQueryPairsNaive);
 
 BENCHMARK_MAIN();

--- a/benchmarks/index/SpatialIndexPerfTest.cpp
+++ b/benchmarks/index/SpatialIndexPerfTest.cpp
@@ -33,7 +33,7 @@ using geos::index::strtree::Interval;
 using geos::index::strtree::ItemDistance;
 using geos::index::strtree::ItemBoundable;
 
-using TemplateIntervalTree = TemplateSTRtree<const Interval*, geos::index::strtree::IntervalTraits>;
+using TemplateIntervalTree = TemplateSTRtree<const Interval*, geos::index::strtree::IntervalTraits<double>>;
 
 //////////////////////////
 // Test Data Generation //
@@ -353,6 +353,7 @@ BENCHMARK_TEMPLATE(BM_STRtree2DQuery, Quadtree);
 BENCHMARK_TEMPLATE(BM_STRtree2DQuery, STRtree);
 BENCHMARK_TEMPLATE(BM_STRtree2DQuery, SimpleSTRtree);
 BENCHMARK_TEMPLATE(BM_STRtree2DQuery, TemplateSTRtree<const Envelope*>);
+//BENCHMARK_TEMPLATE(BM_STRtree2DQuery, TemplateSTRtree<const Envelope*, geos::index::strtree::EnvelopeTraits<float>>);
 
 BENCHMARK(BM_STRtree2DQueryPairs);
 BENCHMARK(BM_STRtree2DQueryPairsNaive);

--- a/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
+++ b/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
@@ -85,7 +85,7 @@ private:
     class IntervalIndexedGeometry {
     private:
 
-        index::strtree::TemplateSTRtree<SegmentView, index::strtree::IntervalTraits> index;
+        index::strtree::TemplateSTRtree<SegmentView, index::strtree::IntervalTraits<float>> index;
 
         void init(const geom::Geometry& g);
         void addLine(const geom::CoordinateSequence* pts);
@@ -95,7 +95,7 @@ private:
 
         template<typename Visitor>
         void query(double min, double max, Visitor&& f) {
-            index.query(index::strtree::Interval(min, max), f);
+            index.query(index::strtree::FloatInterval(min, max), f);
         }
     };
 

--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -103,7 +103,7 @@ public:
      * @param  y1  the first y-value
      * @param  y2  the second y-value
      */
-    void init(double x1, double x2, double y1, double y2)
+    void init(T x1, T x2, T y1, T y2)
     {
         if(x1 < x2) {
             minx = x1;
@@ -206,7 +206,7 @@ public:
      * Returns the Envelope maximum y-value. `min y > max y` indicates
      * that this is a null Envelope.
      */
-    double getMaxY() const
+    T getMaxY() const
     {
         assert(!isNull());
         return maxy;
@@ -216,7 +216,7 @@ public:
      * Returns the Envelope maximum x-value. `min x > max x` indicates
      * that this is a null Envelope.
      */
-    double getMaxX() const
+    T getMaxX() const
     {
         assert(!isNull());
         return maxx;
@@ -226,7 +226,7 @@ public:
      * Returns the Envelope minimum y-value. `min y > max y` indicates
      * that this is a null Envelope.
      */
-    double getMinY() const
+    T getMinY() const
     {
         assert(!isNull());
         return miny;
@@ -236,7 +236,7 @@ public:
      * Returns the Envelope minimum x-value. `min x > max x` indicates
      * that this is a null Envelope.
      */
-    double getMinX() const
+    T getMinX() const
     {
         assert(!isNull());
         return minx;
@@ -457,7 +457,8 @@ public:
     bool
     contains(const CoordinateXY& p) const
     {
-        return covers(p.x, p.y);
+        return covers(static_cast<T>(p.x),
+                      static_cast<T>(p.y));
     }
 
     /** \brief
@@ -910,6 +911,17 @@ private:
 
 class GEOS_DLL FloatEnvelope : public EnvelopeBase<float> {
     using EnvelopeBase<float>::EnvelopeBase;
+
+public:
+
+    FloatEnvelope(const EnvelopeBase<double>& e)
+        : EnvelopeBase<float>(
+              static_cast<float>(e.getMinX()),
+              static_cast<float>(e.getMaxX()),
+              static_cast<float>(e.getMinY()),
+              static_cast<float>(e.getMaxY()))
+    {}
+
 };
 
 

--- a/include/geos/index/strtree/Interval.h
+++ b/include/geos/index/strtree/Interval.h
@@ -16,6 +16,8 @@
 
 #include <geos/export.h>
 #include <algorithm>
+#include <limits>
+#include <cmath>
 #include <cassert>
 #include <cmath>
 
@@ -27,30 +29,49 @@ namespace strtree { // geos::index::strtree
 //
 /// @see SIRtree
 ///
-class GEOS_DLL Interval {
+template<typename T>
+class GEOS_DLL IntervalBase {
 public:
-    Interval(double newMin, double newMax) : imin(newMin), imax(newMax) {
+    IntervalBase(T newMin, T newMax) : imin(newMin), imax(newMax) {
         assert(std::isnan(newMin) || std::isnan(newMax) || imin <= imax);
     }
 
-    double getMin() const { return imin; }
-    double getMax() const { return imax; }
-    double getWidth() const { return imax - imin; }
-    double getCentre() const { return (imin + imax) / 2; }
-    Interval* expandToInclude(const Interval* other) {
+    T getMin() const { return imin; }
+    T getMax() const { return imax; }
+    T getWidth() const { return imax - imin; }
+    T getCentre() const { return (imin + imax) / 2; }
+    IntervalBase<T>* expandToInclude(const IntervalBase<T>* other) {
         imax = std::max(imax, other->imax);
         imin = std::min(imin, other->imin);
         return this;
     }
-    bool intersects(const Interval* other) const {
+    bool intersects(const IntervalBase<T>* other) const {
         return !(other->imin > imax || other->imax < imin);
     }
-    bool equals(const Interval* other) const {
+    bool equals(const IntervalBase<T>* other) const {
         return imin == other->imin && imax == other->imax;
     }
-private:
-    double imin;
-    double imax;
+protected:
+    T imin;
+    T imax;
+};
+
+class GEOS_DLL Interval : public IntervalBase<double> {
+    using IntervalBase<double>::IntervalBase;
+};
+
+class GEOS_DLL FloatInterval : public IntervalBase<float> {
+public:
+    FloatInterval(double min, double max) :
+        IntervalBase<float>(static_cast<float>(min), static_cast<float>(max)) {
+            //if (static_cast<double>(imax) < max) {
+            //    imax = std::nextafter(imax, std::numeric_limits<float>::infinity());
+            //}
+            //if (static_cast<double>(imin) > min) {
+            //    imin = std::nextafter(imin, -std::numeric_limits<float>::infinity());
+            //}
+    }
+
 };
 
 

--- a/include/geos/index/strtree/TemplateSTRtree.h
+++ b/include/geos/index/strtree/TemplateSTRtree.h
@@ -679,8 +679,19 @@ protected:
     }
 };
 
+template<typename T>
+struct EnvelopeType {
+    using type = geom::EnvelopeBase<T>;
+};
+
+template<>
+struct EnvelopeType<double> {
+    using type = geom::Envelope;
+};
+
+template<typename T>
 struct EnvelopeTraits {
-    using BoundsType = geom::Envelope;
+    using BoundsType = typename EnvelopeType<T>::type;
     using TwoDimensional = std::true_type;
 
     static bool intersects(const BoundsType& a, const BoundsType& b) {
@@ -691,11 +702,11 @@ struct EnvelopeTraits {
         return a.getArea();
     }
 
-    static double distance(const BoundsType& a, const BoundsType& b) {
+    static T distance(const BoundsType& a, const BoundsType& b) {
         return a.distance(b);
     }
 
-    static double maxDistance(const BoundsType& a, const BoundsType& b) {
+    static T maxDistance(const BoundsType& a, const BoundsType& b) {
         return a.maxDistance(b);
     }
 
@@ -713,11 +724,11 @@ struct EnvelopeTraits {
         return *(i->getEnvelopeInternal());
     }
 
-    static double getX(const BoundsType& a) {
+    static T getX(const BoundsType& a) {
         return a.getMinX() + a.getMaxX();
     }
 
-    static double getY(const BoundsType& a) {
+    static T getY(const BoundsType& a) {
         return a.getMinY() + a.getMaxY();
     }
 
@@ -730,8 +741,9 @@ struct EnvelopeTraits {
     }
 };
 
+template<typename T>
 struct IntervalTraits {
-    using BoundsType = Interval;
+    using BoundsType = IntervalBase<T>;
     using TwoDimensional = std::false_type;
 
     static bool intersects(const BoundsType& a, const BoundsType& b) {
@@ -761,7 +773,7 @@ struct IntervalTraits {
 };
 
 
-template<typename ItemType, typename BoundsTraits = EnvelopeTraits>
+template<typename ItemType, typename BoundsTraits = EnvelopeTraits<double>>
 class TemplateSTRtree : public TemplateSTRtreeImpl<ItemType, BoundsTraits> {
 public:
     using TemplateSTRtreeImpl<ItemType, BoundsTraits>::TemplateSTRtreeImpl;
@@ -771,12 +783,12 @@ public:
 // the SpatialIndex interface which requires queries via an envelope
 // and items to be representable as void*.
 template<typename ItemType>
-class TemplateSTRtree<ItemType*, EnvelopeTraits> : public TemplateSTRtreeImpl<ItemType*, EnvelopeTraits>, public SpatialIndex {
+class TemplateSTRtree<ItemType*, EnvelopeTraits<double>> : public TemplateSTRtreeImpl<ItemType*, EnvelopeTraits<double>>, public SpatialIndex {
 public:
-    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits>::TemplateSTRtreeImpl;
-    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits>::insert;
-    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits>::query;
-    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits>::remove;
+    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits<double>>::TemplateSTRtreeImpl;
+    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits<double>>::insert;
+    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits<double>>::query;
+    using TemplateSTRtreeImpl<ItemType*, EnvelopeTraits<double>>::remove;
 
     // The SpatialIndex methods only work when we are storing a pointer type.
     void query(const geom::Envelope* queryEnv, std::vector<void*>& results) override {

--- a/include/geos/index/strtree/TemplateSTRtree.h
+++ b/include/geos/index/strtree/TemplateSTRtree.h
@@ -754,11 +754,11 @@ struct IntervalTraits {
         return a.getWidth();
     }
 
-    static double getX(const BoundsType& a) {
+    static T getX(const BoundsType& a) {
         return a.getMin() + a.getMax();
     }
 
-    static double getY(const BoundsType& a) {
+    static T getY(const BoundsType& a) {
         return a.getMin() + a.getMax();
     }
 

--- a/src/algorithm/locate/IndexedPointInAreaLocator.cpp
+++ b/src/algorithm/locate/IndexedPointInAreaLocator.cpp
@@ -78,7 +78,7 @@ IndexedPointInAreaLocator::IntervalIndexedGeometry::addLine(const geom::Coordina
         SegmentView seg(&pts->getAt<CoordinateXY>(i-1), &pts->getAt<CoordinateXY>(i));
         auto r = std::minmax(seg.p0().y, seg.p1().y);
 
-        index.insert(index::strtree::Interval(r.first, r.second), seg);
+        index.insert(index::strtree::FloatInterval(r.first, r.second), seg);
     }
 }
 

--- a/src/geom/Envelope.cpp
+++ b/src/geom/Envelope.cpp
@@ -100,37 +100,6 @@ Envelope::Envelope(const std::string& str)
          strtod(values[3].c_str(), nullptr));
 }
 
-/*public*/
-bool
-Envelope::covers(const Envelope& other) const
-{
-    return
-        std::isgreaterequal(other.minx,  minx) &&
-        std::islessequal(other.maxx,  maxx) &&
-        std::isgreaterequal(other.miny, miny) &&
-        std::islessequal(other.maxy,  maxy);
-}
-
-/*public*/
-bool
-Envelope::equals(const Envelope* other) const
-{
-    if(isNull()) {
-        return other->isNull();
-    }
-    return  other->minx == minx &&
-            other->maxx == maxx &&
-            other->miny == miny &&
-            other->maxy == maxy;
-}
-
-bool
-Envelope::isfinite() const
-{
-    return std::isfinite(minx) && std::isfinite(maxx) &&
-           std::isfinite(miny) && std::isfinite(maxy);
-}
-
 /* public */
 std::ostream&
 operator<< (std::ostream& os, const Envelope& o)
@@ -173,97 +142,6 @@ Envelope::split(const std::string& str, const std::string& delimiters)
 
     return tokens;
 }
-
-/*public*/
-bool
-Envelope::centre(CoordinateXY& p_centre) const
-{
-    if(isNull()) {
-        return false;
-    }
-    p_centre.x = (getMinX() + getMaxX()) / 2.0;
-    p_centre.y = (getMinY() + getMaxY()) / 2.0;
-    return true;
-}
-
-/*public*/
-bool
-Envelope::intersection(const Envelope& env, Envelope& result) const
-{
-    if(isNull() || env.isNull() || ! intersects(env)) {
-        return false;
-    }
-
-    double intMinX = minx > env.minx ? minx : env.minx;
-    double intMinY = miny > env.miny ? miny : env.miny;
-    double intMaxX = maxx < env.maxx ? maxx : env.maxx;
-    double intMaxY = maxy < env.maxy ? maxy : env.maxy;
-    result.init(intMinX, intMaxX, intMinY, intMaxY);
-    return true;
-}
-
-/*public*/
-void
-Envelope::translate(double transX, double transY)
-{
-    if(isNull()) {
-        return;
-    }
-    init(getMinX() + transX, getMaxX() + transX,
-         getMinY() + transY, getMaxY() + transY);
-}
-
-
-/*public*/
-void
-Envelope::expandBy(double deltaX, double deltaY)
-{
-    minx -= deltaX;
-    maxx += deltaX;
-    miny -= deltaY;
-    maxy += deltaY;
-
-    // check for envelope disappearing
-    if(std::isgreater(minx, maxx) || std::isgreater(miny, maxy)) {
-        setToNull();
-    }
-}
-
-
-bool
-operator< (const Envelope& a, const Envelope& b)
-{
-    /*
-    * Compares two envelopes using lexicographic ordering.
-    * The ordering comparison is based on the usual numerical
-    * comparison between the sequence of ordinates.
-    * Null envelopes are less than all non-null envelopes.
-    */
-    if (a.isNull()) {
-        // null == null
-        if (b.isNull())
-            return false;
-        // null < notnull
-        else
-            return true;
-    }
-    // notnull > null
-    if (b.isNull())
-        return false;
-
-    // compare based on numerical ordering of ordinates
-    if (a.getMinX() < b.getMinX()) return true;
-    if (a.getMinX() > b.getMinX()) return false;
-    if (a.getMinY() < b.getMinY()) return true;
-    if (a.getMinY() > b.getMinY()) return false;
-    if (a.getMaxX() < b.getMaxX()) return true;
-    if (a.getMaxX() > b.getMaxX()) return false;
-    if (a.getMaxY() < b.getMaxY()) return true;
-    if (a.getMaxY() > b.getMaxY()) return false;
-    return false; // == is not strictly <
-}
-
-
 
 } // namespace geos::geom
 } // namespace geos

--- a/tests/unit/geom/EnvelopeTest.cpp
+++ b/tests/unit/geom/EnvelopeTest.cpp
@@ -18,6 +18,7 @@ namespace tut {
 
 using geos::geom::CoordinateXY;
 using geos::geom::Envelope;
+using geos::geom::FloatEnvelope;
 
 // dummy data, not used
 struct test_envelope_data {
@@ -653,6 +654,23 @@ void object::test<20>
     set.emplace(2, 0, 2, 1);
 
     ensure_equals(set.size(), 2u);
+}
+
+// Test double containment in FloatEnvelope
+template<>
+template<>
+void object::test<21>
+()
+{
+    FloatEnvelope e(0, 1, 0, 1);
+
+    double xmin = static_cast<double>(e.getMinX());
+    double xmax = static_cast<double>(e.getMaxX());
+    double ymin = static_cast<double>(e.getMinY());
+    double ymax = static_cast<double>(e.getMaxY());
+
+    ensure(e.contains(CoordinateXY(xmax, ymax)));
+    ensure(e.contains(CoordinateXY(xmin, ymin)));
 }
 
 } // namespace tut


### PR DESCRIPTION
This PR generalizes `Envelope` and `Interval` to be constructed from any numeric type, and changes the `IndexedPointInAreaLocator` to use `Interval<float>`. I tested this with `GEOSPreparedContains` because past testing has shown this to be an area where shrinking the size of a tree node has a real benefit. And it does have an impact, but only about 10% in my testing. I'm not sure that's worth it, but maybe there's a more compelling application. Rounding a query envelope from `double` to `float` in a strictly enlarging way seems to pretty expensive.