### PR TITLE
Add functions to interrupt a single thread

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -116,10 +116,22 @@ extern "C" {
         return geos::util::Interrupt::registerCallback(cb);
     }
 
+    GEOSInterruptThreadCallback*
+    GEOS_interruptRegisterThreadCallback(GEOSInterruptThreadCallback* cb, void* data)
+    {
+        return geos::util::Interrupt::registerThreadCallback(cb, data);
+    }
+
     void
     GEOS_interruptRequest()
     {
         geos::util::Interrupt::request();
+    }
+
+    void
+    GEOS_interruptThread()
+    {
+        geos::util::Interrupt::requestForCurrentThread();
     }
 
     void

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -297,7 +297,7 @@ typedef int (*GEOSTransformXYCallback)(
 
 /**
 * Callback function for use in interruption. The callback will be invoked _before_ checking for
-* interruption, so can be used to request it.
+* an interruption request and can be used to request interruption.
 *
 * \see GEOS_interruptRegisterCallback
 * \see GEOS_interruptRequest
@@ -308,20 +308,23 @@ typedef void (GEOSInterruptCallback)(void);
 typedef void (GEOSInterruptThreadCallback)(void*);
 
 /**
-* Register a function to be called when processing is interrupted on any thread.
+* Register a function to be called when a possible interruption point is reached
+* on any thread. The function may be used to request interruption.
+*
 * \param cb Callback function to invoke
-* \return the previously configured callback
+* \return the previously registered callback, or NULL
 * \see GEOSInterruptCallback
 */
 extern GEOSInterruptCallback GEOS_DLL *GEOS_interruptRegisterCallback(
     GEOSInterruptCallback* cb);
 
 /**
-* Register a function to be called when processing is interrupted on the current thread.
+* Register a function to be called when a possible interruption point is reached
+* on the current thread. The function may be used to request interruption.
 *
 * \param cb Callback function to invoke
 * \param context pointer to a context object that will be passed to `cb`
-* \return the previously configured callback
+* \return the previously registered callback, or NULL
 * \see GEOSInterruptCallback
 */
 extern GEOSInterruptThreadCallback GEOS_DLL *GEOS_interruptRegisterThreadCallback(
@@ -330,13 +333,14 @@ extern GEOSInterruptThreadCallback GEOS_DLL *GEOS_interruptRegisterThreadCallbac
 /**
 * Request safe interruption of operations. The next thread to check for an
 * interrupt will be interrupted. To request interruption of a specific thread,
-* instead call `GEOS_interruptThread` from a callback executed by that thread.
+* instead call GEOS_interruptThread() from a callback executed by that thread.
 */
 extern void GEOS_DLL GEOS_interruptRequest(void);
 
 /**
 * Request safe interruption of operations in the current thread. This function
-* should be called from a callback registered by `GEOS_interruptRegisterThreadCallback`.
+* should be called from a callback registered by GEOS_interruptRegisterThreadCallback()
+* or GEOS_interruptRegisterCallback().
 */
 extern void GEOS_DLL GEOS_interruptThread(void);
 

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -305,8 +305,10 @@ typedef int (*GEOSTransformXYCallback)(
 */
 typedef void (GEOSInterruptCallback)(void);
 
+typedef void (GEOSInterruptThreadCallback)(void*);
+
 /**
-* Register a function to be called when processing is interrupted.
+* Register a function to be called when processing is interrupted on any thread.
 * \param cb Callback function to invoke
 * \return the previously configured callback
 * \see GEOSInterruptCallback
@@ -315,9 +317,28 @@ extern GEOSInterruptCallback GEOS_DLL *GEOS_interruptRegisterCallback(
     GEOSInterruptCallback* cb);
 
 /**
-* Request safe interruption of operations
+* Register a function to be called when processing is interrupted on the current thread.
+*
+* \param cb Callback function to invoke
+* \param context pointer to a context object that will be passed to `cb`
+* \return the previously configured callback
+* \see GEOSInterruptCallback
+*/
+extern GEOSInterruptThreadCallback GEOS_DLL *GEOS_interruptRegisterThreadCallback(
+    GEOSInterruptThreadCallback* cb, void* context);
+
+/**
+* Request safe interruption of operations. The next thread to check for an
+* interrupt will be interrupted. To request interruption of a specific thread,
+* instead call `GEOS_interruptThread` from a callback executed by that thread.
 */
 extern void GEOS_DLL GEOS_interruptRequest(void);
+
+/**
+* Request safe interruption of operations in the current thread. This function
+* should be called from a callback registered by `GEOS_interruptRegisterThreadCallback`.
+*/
+extern void GEOS_DLL GEOS_interruptThread(void);
 
 /**
 * Cancel a pending interruption request

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -296,8 +296,8 @@ typedef int (*GEOSTransformXYCallback)(
 /* ========== Interruption ========== */
 
 /**
-* Callback function for use in interruption. The callback will be invoked _before_ checking for
-* an interruption request and can be used to request interruption.
+* Callback function for use in interruption. The callback will be invoked at each
+* possible interruption point and can be used to request interruption.
 *
 * \see GEOS_interruptRegisterCallback
 * \see GEOS_interruptRequest
@@ -305,6 +305,13 @@ typedef int (*GEOSTransformXYCallback)(
 */
 typedef void (GEOSInterruptCallback)(void);
 
+/**
+* Callback function for use in interruption. The callback will be invoked at each
+* possible interruption point and can be used to request interruption.
+*
+* \see GEOS_interruptRegisterThreadCallback
+* \see GEOS_interruptThread
+*/
 typedef void (GEOSInterruptThreadCallback)(void*);
 
 /**

--- a/include/geos/util/Interrupt.h
+++ b/include/geos/util/Interrupt.h
@@ -69,7 +69,7 @@ public:
      * before checking for interruption requests.
      *
      * NOTE that interruption request checking may happen
-     * frequently so the callback shoudl execute quickly.
+     * frequently so the callback should execute quickly.
      *
      * The callback can be used to call Interrupt::request()
      * or Interrupt::requestForCurrentThread().

--- a/include/geos/util/Interrupt.h
+++ b/include/geos/util/Interrupt.h
@@ -27,14 +27,24 @@ class GEOS_DLL Interrupt {
 public:
 
     typedef void (Callback)(void);
+    typedef void (ThreadCallback)(void*);
 
     /**
      * Request interruption of operations
      *
      * Operations will be terminated by a GEOSInterrupt
-     * exception at first occasion.
+     * exception at first occasion, by the first thread
+     * to check for an interrupt request.
      */
     static void request();
+
+    /**
+     * Request interruption of operations in the current thread
+     *
+     * Operations in the current thread will be terminated by
+     * a GEOSInterrupt at first occasion.
+     */
+    static void requestForCurrentThread();
 
     /** Cancel a pending interruption request */
     static void cancel();
@@ -43,16 +53,28 @@ public:
     static bool check();
 
     /** \brief
-     * Register a callback that will be invoked
+     * Register a callback that will be invoked by all threads
      * before checking for interruption requests.
      *
      * NOTE that interruption request checking may happen
-     * frequently so any callback would better be quick.
+     * frequently so the callback should execute quickly.
      *
      * The callback can be used to call Interrupt::request()
-     *
+     * or Interrupt::requestForCurrentThread().
      */
     static Callback* registerCallback(Callback* cb);
+
+    /** \brief
+     * Register a callback that will be invoked the current thread
+     * before checking for interruption requests.
+     *
+     * NOTE that interruption request checking may happen
+     * frequently so the callback shoudl execute quickly.
+     *
+     * The callback can be used to call Interrupt::request()
+     * or Interrupt::requestForCurrentThread().
+     */
+    static ThreadCallback* registerThreadCallback(ThreadCallback* cb, void* data);
 
     /**
      * Invoke the callback, if any. Process pending interruption, if any.

--- a/src/util/Interrupt.cpp
+++ b/src/util/Interrupt.cpp
@@ -16,10 +16,12 @@
 #include <geos/util/GEOSException.h> // for inheritance
 
 namespace {
-/* Could these be portably stored in thread-specific space ? */
+
+// Callback and request status for interruption of any single thread
 bool requested = false;
 thread_local bool requested_for_thread = false;
 
+// Callback and request status for interruption of a the current thread
 geos::util::Interrupt::Callback* callback = nullptr;
 thread_local geos::util::Interrupt::ThreadCallback* callback_thread = nullptr;
 thread_local void* callback_thread_data = nullptr;

--- a/src/util/Interrupt.cpp
+++ b/src/util/Interrupt.cpp
@@ -18,8 +18,12 @@
 namespace {
 /* Could these be portably stored in thread-specific space ? */
 bool requested = false;
+thread_local bool requested_for_thread = false;
 
 geos::util::Interrupt::Callback* callback = nullptr;
+thread_local geos::util::Interrupt::ThreadCallback* callback_thread = nullptr;
+thread_local void* callback_thread_data = nullptr;
+
 }
 
 namespace geos {
@@ -38,15 +42,22 @@ Interrupt::request()
 }
 
 void
+Interrupt::requestForCurrentThread()
+{
+    requested_for_thread = true;
+}
+
+void
 Interrupt::cancel()
 {
     requested = false;
+    requested_for_thread = false;
 }
 
 bool
 Interrupt::check()
 {
-    return requested;
+    return requested || requested_for_thread;
 }
 
 Interrupt::Callback*
@@ -57,14 +68,25 @@ Interrupt::registerCallback(Interrupt::Callback* cb)
     return prev;
 }
 
+Interrupt::ThreadCallback*
+Interrupt::registerThreadCallback(ThreadCallback* cb, void* data)
+{
+    ThreadCallback* prev = callback_thread;
+    callback_thread = cb;
+    callback_thread_data = data;
+    return prev;
+}
+
 void
 Interrupt::process()
 {
     if(callback) {
         (*callback)();
     }
-    if(requested) {
-        requested = false;
+    if(callback_thread) {
+        (*callback_thread)(callback_thread_data);
+    }
+    if(check()) {
         interrupt();
     }
 }
@@ -74,6 +96,7 @@ void
 Interrupt::interrupt()
 {
     requested = false;
+    requested_for_thread = false;
     throw InterruptedException();
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -44,6 +44,7 @@ foreach(_testfile ${_testfiles})
       string(CONCAT _testname "geos::" ${_testname})
     endif()
     add_test(NAME unit-${_cmake_testname} COMMAND test_geos_unit ${_testname})
+    set_tests_properties(unit-${_cmake_testname} PROPERTIES TIMEOUT 30)
 endforeach()
 
 # Run all the unit tests in one go, for faster memory checking

--- a/tests/unit/util/InterruptTest.cpp
+++ b/tests/unit/util/InterruptTest.cpp
@@ -1,0 +1,137 @@
+// tut
+#include <tut/tut.hpp>
+// geos
+#include <geos/util/Interrupt.h>
+// std
+#include <chrono>
+#include <functional>
+#include <thread>
+
+using geos::util::Interrupt;
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_interrupt_data {
+    static void workForever() {
+        try {
+            std::cerr << "Started " << std::this_thread::get_id() << "." << std::endl;
+            while (true) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                GEOS_CHECK_FOR_INTERRUPTS();
+            }
+        } catch (const std::exception&) {
+            std::cerr << "Interrupted " << std::this_thread::get_id() << "." << std::endl;
+            return;
+        }
+    }
+
+    static void interruptNow() {
+        Interrupt::request();
+    }
+
+    static std::map<std::thread::id, bool>* toInterrupt;
+
+    static void interruptIfRequested() {
+        if (toInterrupt == nullptr) {
+            return;
+        }
+
+        auto it = toInterrupt->find(std::this_thread::get_id());
+        if (it != toInterrupt->end() && it->second) {
+            it->second = false;
+            Interrupt::request();
+        }
+    }
+};
+
+std::map<std::thread::id, bool>* test_interrupt_data::toInterrupt = nullptr;
+
+typedef test_group<test_interrupt_data> group;
+typedef group::object object;
+
+group test_interrupt_group("geos::util::Interrupt");
+
+//
+// Test Cases
+//
+
+
+// Interrupt worker thread via global request from from main thead
+template<>
+template<>
+void object::test<1>
+()
+{
+    std::thread t(workForever);
+    Interrupt::request();
+
+    t.join();
+}
+
+// Interrupt worker thread via global requset from worker thread using a callback
+template<>
+template<>
+void object::test<2>
+()
+{
+    Interrupt::registerCallback(interruptIfRequested);
+
+    std::thread t1(workForever);
+    std::thread t2(workForever);
+
+    std::map<std::thread::id, bool> shouldInterrupt;
+    shouldInterrupt[t1.get_id()] = false;
+    shouldInterrupt[t2.get_id()] = false;
+    toInterrupt = &shouldInterrupt;
+
+    shouldInterrupt[t2.get_id()] = true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    shouldInterrupt[t1.get_id()] = true;
+
+    t1.join();
+    t2.join();
+}
+
+// Register separate callbacks for each thread. Each callback will
+// request interruption of itself only.
+template<>
+template<>
+void object::test<3>
+()
+{
+    bool interrupt1 = false;
+    int numCalls2 = 0;
+
+    auto cb1 = ([](void* data) {
+        if (*static_cast<bool*>(data)) {
+            Interrupt::requestForCurrentThread();
+        }
+    });
+
+    auto cb2 = ([](void* data) {
+        if (++*static_cast<int*>(data) > 5) {
+            Interrupt::requestForCurrentThread();
+        }
+    });
+
+
+    std::thread t1([&cb1, &interrupt1]() {
+        Interrupt::registerThreadCallback(cb1, &interrupt1);
+    });
+
+    std::thread t2([&cb2, &numCalls2]() {
+        Interrupt::registerThreadCallback(cb2, &numCalls2);
+    });
+
+    t2.join();
+
+    interrupt1 = true;
+    t1.join();
+}
+
+} // namespace tut
+

--- a/tests/unit/util/InterruptTest.cpp
+++ b/tests/unit/util/InterruptTest.cpp
@@ -43,7 +43,7 @@ struct test_interrupt_data {
         auto it = toInterrupt->find(std::this_thread::get_id());
         if (it != toInterrupt->end() && it->second) {
             it->second = false;
-            Interrupt::request();
+            Interrupt::requestForCurrentThread();
         }
     }
 };
@@ -72,7 +72,7 @@ void object::test<1>
     t.join();
 }
 
-// Interrupt worker thread via global request from worker thread using a callback
+// Interrupt worker thread via thread-specific request from worker thread using a callback
 template<>
 template<>
 void object::test<2>
@@ -93,14 +93,6 @@ void object::test<2>
     toInterrupt = &shouldInterrupt;
 
     shouldInterrupt[t2.get_id()] = true;
-
-    // We need to wait until t2 has actually been interrupted
-    // before we interrupt t1. Otherwise, t2 may cancel our
-    // request for t1's interrupt. Alternatively, we could
-    // implement `interruptIfRequested` to repeatedly call
-    // Interrupt::request() to avoid the lost request. Or just
-    // use Interrupt::requestForThread() which would also
-    // avoid this possibility.
     t2.join();
 
     shouldInterrupt[t1.get_id()] = true;

--- a/tests/unit/util/InterruptTest.cpp
+++ b/tests/unit/util/InterruptTest.cpp
@@ -89,6 +89,10 @@ void object::test<2>
     toInterrupt = &shouldInterrupt;
 
     shouldInterrupt[t2.get_id()] = true;
+
+    // We need to wait until t2 has actually been interrupted
+    // before we interrupt t1. Otherwise, t2 may cancel our
+    // request for t1's interrupt.
     t2.join();
 
     shouldInterrupt[t1.get_id()] = true;

--- a/tests/unit/util/InterruptTest.cpp
+++ b/tests/unit/util/InterruptTest.cpp
@@ -72,7 +72,7 @@ void object::test<1>
     t.join();
 }
 
-// Interrupt worker thread via global requset from worker thread using a callback
+// Interrupt worker thread via global request from worker thread using a callback
 template<>
 template<>
 void object::test<2>
@@ -89,11 +89,10 @@ void object::test<2>
     toInterrupt = &shouldInterrupt;
 
     shouldInterrupt[t2.get_id()] = true;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    shouldInterrupt[t1.get_id()] = true;
-
-    t1.join();
     t2.join();
+
+    shouldInterrupt[t1.get_id()] = true;
+    t1.join();
 }
 
 // Register separate callbacks for each thread. Each callback will


### PR DESCRIPTION
This PR changes `GEOS_interruptRegisterCallback` to operate on a per-thread basis; the callback will only be registered on the thread from which `GEOS_interruptRegisterCallback` is called. This would break existing expectations of a global callback, so maybe a better solution is to add a new function that registers a thread-local callback.

I'm fuzzy on how this gets used outside of PostGIS which (I think?) would not be affected by this change.

cc @nyalldawson