### PR TITLE
RepeatedPointRemover: Allow creating LinearRing of length 3

### DIFF
--- a/src/operation/valid/RepeatedPointRemover.cpp
+++ b/src/operation/valid/RepeatedPointRemover.cpp
@@ -190,7 +190,7 @@ public:
             minLength = 2;
         }
         if(geom->getGeometryTypeId() == geom::GEOS_LINEARRING) {
-            minLength = 4;
+            minLength = geom::LinearRing::MINIMUM_VALID_SIZE;
         }
 
         // No way to filter short sequences.


### PR DESCRIPTION
`LinearRing` was somewhat recently changed to allow construction from a `CoordinateSequence` with length 3. I don't think the `RepeatedPointRemover` was intended to be inconsistent with this.