### PR TITLE
HotPixelIndex: Use STRtree instead of KdTree

### DIFF
--- a/include/geos/noding/snapround/HotPixelIndex.h
+++ b/include/geos/noding/snapround/HotPixelIndex.h
@@ -24,6 +24,7 @@
 #include <geos/io/WKTWriter.h>
 #include <geos/index/kdtree/KdTree.h>
 #include <geos/index/kdtree/KdNodeVisitor.h>
+#include <geos/index/strtree/TemplateSTRtree.h>
 
 #include <array>
 #include <map>
@@ -63,8 +64,10 @@ private:
     /* members */
     const geom::PrecisionModel* pm;
     double scaleFactor;
-    std::unique_ptr<geos::index::kdtree::KdTree> index;
+    //std::unique_ptr<geos::index::kdtree::KdTree> index;
+    index::strtree::TemplateSTRtree<HotPixel*> index;
     std::deque<HotPixel> hotPixelQue;
+    std::map<geom::Coordinate, HotPixel*> hotPixelMap;
 
     /* methods */
     geom::Coordinate round(const geom::Coordinate& c);
@@ -84,8 +87,15 @@ public:
     * The visitor must determine whether each hot pixel actually intersects
     * the segment.
     */
+    template<typename Visitor>
     void query(const geom::Coordinate& p0, const geom::Coordinate& p1,
-               index::kdtree::KdNodeVisitor& visitor);
+               Visitor&& visitor) {
+        geom::Envelope queryEnv(p0, p1);
+        queryEnv.expandBy(1.0 / scaleFactor);
+
+        index.query(queryEnv, visitor);
+    }
+
 
 };
 

--- a/src/index/kdtree/KdTree.cpp
+++ b/src/index/kdtree/KdTree.cpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <iostream>
 #include <stack>
 
 using namespace geos::geom;

--- a/src/noding/snapround/HotPixelIndex.cpp
+++ b/src/noding/snapround/HotPixelIndex.cpp
@@ -35,8 +35,7 @@ namespace snapround { // geos.noding.snapround
 HotPixelIndex::HotPixelIndex(const PrecisionModel* p_pm)
     :
     pm(p_pm),
-    scaleFactor(p_pm->getScale()),
-    index(new KdTree())
+    scaleFactor(p_pm->getScale())
 {
 }
 
@@ -72,8 +71,9 @@ HotPixelIndex::add(const Coordinate& p)
     // Pick up a pointer to the most recently added
     // HotPixel.
     hp = &(hotPixelQue.back());
+    hotPixelMap[hp->getCoordinate()] = hp;
 
-    index->insert(hp->getCoordinate(), hp);
+    index.insert(Envelope(hp->getCoordinate()), hp);
     return hp;
 }
 
@@ -140,11 +140,18 @@ HotPixelIndex::addNodes(const std::vector<geom::Coordinate>& pts)
 HotPixel*
 HotPixelIndex::find(const geom::Coordinate& pixelPt)
 {
-    index::kdtree::KdNode *kdNode = index->query(pixelPt);
-    if (kdNode == nullptr) {
+    auto it = hotPixelMap.find(pixelPt);
+    if (it != hotPixelMap.end()) {
+        return it->second;
+    } else {
         return nullptr;
     }
-    return (HotPixel*)(kdNode->getData());
+    //HotPixel* ret = nullptr;
+    //index.query(Envelope(pixelPt, pixelPt), [&ret](HotPixel* hit) {
+    //    ret = hit;
+    //    return false;
+    //});
+    //return ret;
 }
 
 /*private*/
@@ -156,15 +163,6 @@ HotPixelIndex::round(const Coordinate& pt)
     return p2;
 }
 
-
-/*public*/
-void
-HotPixelIndex::query(const Coordinate& p0, const Coordinate& p1, index::kdtree::KdNodeVisitor& visitor)
-{
-    Envelope queryEnv(p0, p1);
-    queryEnv.expandBy(1.0 / scaleFactor);
-    index->query(queryEnv, visitor);
-}
 
 
 } // namespace geos.noding.snapround

--- a/src/noding/snapround/SnapRoundingNoder.cpp
+++ b/src/noding/snapround/SnapRoundingNoder.cpp
@@ -208,6 +208,10 @@ SnapRoundingNoder::snapSegment(Coordinate& p0, Coordinate& p1, NodedSegmentStrin
 
         void visit(KdNode* node) override {
             HotPixel* hp = static_cast<HotPixel*>(node->getData());
+            (*this)(hp);
+        }
+
+        void operator()(HotPixel* hp) {
             /**
             * If the hot pixel is not a node, and it contains one of the segment vertices,
             * then that vertex is the source for the hot pixel.
@@ -265,7 +269,10 @@ SnapRoundingNoder::snapVertexNode(const Coordinate& p0, NodedSegmentString* ss, 
 
         void visit(KdNode* node) override {
             HotPixel* hp = static_cast<HotPixel*>(node->getData());
+            (*this)(hp);
+        }
 
+        void operator()(const HotPixel* hp) {
             /**
             * If vertex pixel is a node, add it.
             */


### PR DESCRIPTION
This PR modifies `HotPixelIndex` to back it with an STRtree instead of a KdTree. It provides about a 15% performance gain in a buffer benchmark that heavily uses the HotPixelIndex. I don't know if that's worth the change. Peak memory usage increases by about 10%. There may be room for more tuning.

[gps_tracks.txt](https://github.com/libgeos/geos/files/10198955/gps_tracks.txt)

`bin/geosop -t -q -a ~/data/gps_tracks.txt buffer 20`

(test case is from https://github.com/r-spatial/sf/issues/2039)