### PR TITLE
Delegate Geometry::intersects to PreparedGeometry::intersects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ xxxx-xx-xx
   - WKTReader: Throw exception on inconsistent geometry dimension (#1080, Dan Baston)
   - WKTReader: Throw exception if WKT contains extra text after end of geometry (#1095, Dan Baston)
   - GEOSIntersects: Fix crash with empty point inputs (#1110, Dan Baston)
+  - GEOSIntersects: Improve performance/robustness by using PreparedGeometry algorithm (GH-775, Dan Baston)
   - LineMerger: Recursively collect all components from GeometryCollections (#401, Dan Baston)
   - GeometryPrecisionReducer: Return correct dimensionality for empty results (GH-684, Dan Baston)
   - Improve performance of coverage union (GH-681, Dan Baston)

--- a/include/geos/index/strtree/Interval.h
+++ b/include/geos/index/strtree/Interval.h
@@ -17,6 +17,7 @@
 #include <geos/export.h>
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 
 namespace geos {
 namespace index { // geos::index
@@ -29,7 +30,7 @@ namespace strtree { // geos::index::strtree
 class GEOS_DLL Interval {
 public:
     Interval(double newMin, double newMax) : imin(newMin), imax(newMax) {
-        assert(imin <= imax);
+        assert(std::isnan(newMin) || std::isnan(newMax) || imin <= imax);
     }
 
     double getMin() const { return imin; }

--- a/tests/unit/capi/GEOSIntersectsTest.cpp
+++ b/tests/unit/capi/GEOSIntersectsTest.cpp
@@ -113,8 +113,11 @@ void object::test<4>
 
     char const r1 = GEOSIntersects(geom1_, geom1_);
 
-    ensure_equals(int(r1), 2);
+    (void) r1;
 
+    // The specific result here is not important -- the point is that
+    // we shouldn't crash or enter an infinite loop.
+    // ensure_equals(int(r1), 2);
 }
 
 // This is a test for bug #357 (GEOSIntersects with inf coords)
@@ -132,8 +135,11 @@ void object::test<5>
 
     char const r1 = GEOSIntersects(geom1_, geom1_);
 
-    ensure_equals(int(r1), 2);
+    (void) r1;
 
+    // The specific result here is not important -- the point is that
+    // we shouldn't crash or enter an infinite loop.
+    // ensure_equals(int(r1), 2);
 }
 
 // Test for #782 (collection with empty components)
@@ -181,6 +187,37 @@ void object::test<8>
     char r1 = GEOSIntersects(geom1_, geom2_);
 
     ensure_equals(r1, 1);
+}
+
+template<>
+template<>
+void object::test<9>
+()
+{
+    geom1_ = GEOSGeomFromWKT("GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POINT (2 2))");
+    geom2_ = GEOSGeomFromWKT("LINESTRING (2 2, 3 3)");
+
+    char r1 = GEOSIntersects(geom1_, geom2_);
+    ensure_equals(r1, 1);
+
+    char r2 = GEOSIntersects(geom2_, geom1_);
+    ensure_equals(r2, 1);
+}
+
+// https://github.com/libgeos/geos/issues/766
+template<>
+template<>
+void object::test<10>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON ((26639.240191093646 6039.3615818717535, 26639.240191093646 5889.361620883223,28000.000095100608 5889.362081553552, 28000.000095100608 6039.361620882992, 28700.00019021402 6039.361620882992, 28700.00019021402 5889.361822800367, 29899.538842431968 5889.362160452064,32465.59665091549 5889.362882757903, 32969.2837182586 -1313.697771558439, 31715.832811969216 -1489.87008918589, 31681.039836323587 -1242.3030298361555, 32279.3890331618 -1158.210534269224, 32237.63710287376 -861.1301136466199, 32682.89764107368 -802.0828534499739, 32247.445200905553 5439.292852892075, 31797.06861513178 5439.292852892075, 31797.06861513178 5639.36178850523, 29899.538849750803 5639.361268079038, 26167.69458275995 5639.3602445643955, 26379.03654594742 2617.0293071870683, 26778.062167926924 2644.9318977193907, 26792.01346261031 2445.419086759444, 26193.472956813417 2403.5650586598513, 25939.238114175267 6039.361685403233, 26639.240191093646 6039.3615818717535), (32682.89764107368 -802.0828534499738, 32682.89764107378 -802.0828534499669, 32247.445200905655 5439.292852892082, 32247.445200905553 5439.292852892075, 32682.89764107368 -802.0828534499738))");
+    geom2_ = GEOSGeomFromWKT("POLYGON ((32450.100392347143 5889.362314133216, 32050.1049555691 5891.272957209961, 32100.021071878822 16341.272221116333, 32500.016508656867 16339.361578039587, 32450.100392347143 5889.362314133216))");
+
+    char r1 = GEOSIntersects(geom1_, geom2_);
+    ensure_equals(r1, 1);
+
+    char r2 = GEOSIntersects(geom2_, geom1_);
+    ensure_equals(r2, 1);
 }
 
 } // namespace tut


### PR DESCRIPTION
This PR changes `Geometry::intersects` and `Geometry::disjoint` to use `PreparedGeometry` instead of `RelateOp`. Relative to the `RelateOp` implementation, the prepared intersection is more robust (e.g., https://github.com/libgeos/geos/issues/766) and is faster for both complex and simple polygons, even if the object is only used a single time.

A quick benchmark shows the performance difference in cases of relatively complex polygons (left) and triangles (right), using the GEOS `perf_intersection`, which combines index querying, intersects testing, and intersection overlay.

![image](https://user-images.githubusercontent.com/6318931/207198344-c23ab47e-734a-4ae7-a000-4c6ad2bfd445.png)
