### PR TITLE
PreparedPolygonIntersects: Use SimplePointInAreaLocator for first test

### DIFF
--- a/include/geos/geom/prep/PreparedPolygon.h
+++ b/include/geos/geom/prep/PreparedPolygon.h
@@ -53,6 +53,7 @@ private:
     bool isRectangle;
     mutable std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;
     mutable std::unique_ptr<algorithm::locate::PointOnGeometryLocator> ptOnGeomLoc;
+    mutable std::unique_ptr<algorithm::locate::PointOnGeometryLocator> indexedPtOnGeomLoc;
     mutable noding::SegmentString::ConstVect segStrings;
     mutable std::unique_ptr<operation::distance::IndexedFacetDistance> indexedDistance;
 


### PR DESCRIPTION
This provides better performance in cases where the prepared polygon is only used for one test.

I think it would be possible to take this a bit further and tell the `PreparedPolygonFactory` how many times the prepared geometry is expected to be queried. This hint could then be used for some more sophisticated algorithm selection. But this is a good improvement for now.

With this PR, the single-use prepared geometry used by `Geometry::intersects` outperforms `RelateOp` for all scenarios in the JTS benchmark.

![image](https://user-images.githubusercontent.com/6318931/207944583-31677f5d-8813-48a0-93b1-77a39203ba12.png)


