### PR TITLE
Voronoi: Add option to reorder diagram to match order of input points

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ xxxx-xx-xx
   - Geometry clustering: DBSCAN, geometry intersection/distance, envelope
     intersection/distance (GH-688, Dan Baston)
   - CAPI: GEOSLineSubstring (GH-706, Dan Baston)
+  - Voronoi: Add option to create diagram in order consistent with inputs (GH-781, Dan Baston)
 
 - Fixes/Improvements:
   - WKTReader: Fix parsing of Z and M flags in WKTReader (#676 and GH-669, Dan Baston)

--- a/benchmarks/algorithm/VoronoiPerfTest.cpp
+++ b/benchmarks/algorithm/VoronoiPerfTest.cpp
@@ -98,9 +98,28 @@ static void BM_VoronoiFromGeom(benchmark::State& state) {
     }
 }
 
+static void BM_OrderedVoronoiFromGeom(benchmark::State& state) {
+    Envelope e(0, 100, 0, 100);
+    auto gfact = geos::geom::GeometryFactory::getDefaultInstance();
+
+    std::size_t i = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto nPts = static_cast<std::size_t>(state.range(0));
+        auto sites = gfact->createLineString(geos::benchmark::createRandomCoords(e, nPts, i++));
+        state.ResumeTiming();
+
+        geos::triangulate::VoronoiDiagramBuilder vdb;
+        vdb.setOrdered(true);
+        vdb.setSites(*sites);
+        auto result = vdb.getDiagram(*gfact);
+    }
+}
+
 BENCHMARK(BM_DelaunayFromSeq)->Range(10, 1e6);
 BENCHMARK(BM_DelaunayFromGeom)->Range(10, 1e6);
 BENCHMARK(BM_VoronoiFromSeq)->Range(10, 1e6);
 BENCHMARK(BM_VoronoiFromGeom)->Range(10, 1e6);
+BENCHMARK(BM_OrderedVoronoiFromGeom)->Range(10, 1e6);
 
 BENCHMARK_MAIN();

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1751,9 +1751,9 @@ extern "C" {
     }
 
     Geometry*
-    GEOSVoronoiDiagram(const Geometry* g, const Geometry* env, double tolerance, int onlyEdges)
+    GEOSVoronoiDiagram(const Geometry* g, const Geometry* env, double tolerance, int flags)
     {
-        return GEOSVoronoiDiagram_r(handle, g, env, tolerance, onlyEdges);
+        return GEOSVoronoiDiagram_r(handle, g, env, tolerance, flags);
     }
 
     int

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1020,7 +1020,7 @@ extern GEOSGeometry GEOS_DLL * GEOSVoronoiDiagram_r(
     const GEOSGeometry *g,
     const GEOSGeometry *env,
     double tolerance,
-    int onlyEdges);
+    int flags);
 
 /** \see GEOSSegmentIntersection */
 extern int GEOS_DLL GEOSSegmentIntersection_r(
@@ -3768,6 +3768,17 @@ extern GEOSGeometry GEOS_DLL * GEOSDelaunayTriangulation(
 extern GEOSGeometry GEOS_DLL * GEOSConstrainedDelaunayTriangulation(
     const GEOSGeometry *g);
 
+/** Change behaviour of \ref GEOSVoronoiDiagram */
+enum GEOSVoronoiFlags
+{
+    /** Return only edges of the Voronoi cells, as a MultiLineString **/
+    GEOS_VORONOI_ONLY_EDGES = 1,
+    /** Preserve order of inputs, such that the nth cell in the result corresponds
+     *  to the nth vertex in the input. If this cannot be done, such as for inputs
+     *  that contain repeated points, \ref GEOSVoronoiDiagram will return NULL. **/
+    GEOS_VORONOI_PRESERVE_ORDER = 2
+};
+
 /**
 * Returns the Voronoi polygons or edges of the vertices of the given geometry.
 *
@@ -3777,9 +3788,7 @@ extern GEOSGeometry GEOS_DLL * GEOSConstrainedDelaunayTriangulation(
                    place. This argument can be finicky and is known to cause
                    the algorithm to fail in several cases. If you're using
                    tolerance and getting a failure, try setting it to 0.0.
-* \param onlyEdges whether to return only edges of the voronoi cells.
-*                  If non-zero, the result will be a MultiLineString, otherwise
-*                  it will be a GeometryCollection of Polygons.
+* \param flags A value from the \ref GEOSVoronoiFlags enum
 * \param env clipping envelope for the returned diagram, automatically
 *            determined if env is NULL.
 *            The diagram will be clipped to the larger
@@ -3792,7 +3801,7 @@ extern GEOSGeometry GEOS_DLL * GEOSVoronoiDiagram(
     const GEOSGeometry *g,
     const GEOSGeometry *env,
     double tolerance,
-    int onlyEdges);
+    int flags);
 
 ///@}
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -3998,7 +3998,7 @@ extern "C" {
 
     Geometry*
     GEOSVoronoiDiagram_r(GEOSContextHandle_t extHandle, const Geometry* g1, const Geometry* env, double tolerance,
-                         int onlyEdges)
+                         int flags)
     {
         using geos::triangulate::VoronoiDiagramBuilder;
 
@@ -4006,19 +4006,20 @@ extern "C" {
             VoronoiDiagramBuilder builder;
             builder.setSites(*g1);
             builder.setTolerance(tolerance);
+            builder.setOrdered(flags & GEOS_VORONOI_PRESERVE_ORDER);
+            std::unique_ptr<Geometry> out;
             if(env) {
                 builder.setClipEnvelope(env->getEnvelopeInternal());
             }
-            if(onlyEdges) {
-                Geometry* out = builder.getDiagramEdges(*g1->getFactory()).release();
-                out->setSRID(g1->getSRID());
-                return out;
+            if(flags & GEOS_VORONOI_ONLY_EDGES) {
+                out = builder.getDiagramEdges(*g1->getFactory());
             }
             else {
-                Geometry* out = builder.getDiagram(*g1->getFactory()).release();
-                out->setSRID(g1->getSRID());
-                return out;
+                out = builder.getDiagram(*g1->getFactory());
             }
+
+            out->setSRID(g1->getSRID());
+            return out.release();
         });
     }
 

--- a/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
+++ b/src/triangulate/quadedge/QuadEdgeSubdivision.cpp
@@ -545,13 +545,10 @@ QuadEdgeSubdivision::getVoronoiCellPolygon(const QuadEdge* qe, const geom::Geome
 
     std::unique_ptr<Geometry> cellPoly = geomFact.createPolygon(geomFact.createLinearRing(std::move(cellPts)));
 
-    /*
-    //-- attach cell centroid coordinate
-    // MD - disable this since memory handling is problematic
-    Vertex v = startQE->orig();
-    c = v.getCoordinate();
-    cellPoly->setUserData(reinterpret_cast<void*>(&c));
-    */
+    const Vertex& v = startQE->orig();
+    const Coordinate& c = v.getCoordinate();
+    cellPoly->setUserData(const_cast<Coordinate*>(&c));
+
     return cellPoly;
 }
 
@@ -579,11 +576,6 @@ QuadEdgeSubdivision::getVoronoiCellEdge(const QuadEdge* qe, const geom::Geometry
     std::unique_ptr<geom::Geometry> cellEdge(
         geomFact.createLineString(std::move(cellPts)));
 
-    // FIXME why is this returning a pointer to a local variable?
-    //Vertex v = startQE->orig();
-    //Coordinate c(0, 0);
-    //c = v.getCoordinate();
-    //cellEdge->setUserData(reinterpret_cast<void*>(&c));
     return cellEdge;
 }
 
@@ -618,4 +610,5 @@ QuadEdgeSubdivision::getVertexUniqueEdges(bool includeFrame)
 
 } //namespace geos.triangulate.quadedge
 } //namespace geos.triangulate
+
 } //namespace goes


### PR DESCRIPTION
This may slow down the Voronoi creation process by a significant amount (50% for a diagram of 1 million random points), so it needs to be explicitly turned on through `VoronoiDiagramBuilder::setOrdered` or `GEOS_VORONOI_PRESERVE_ORDER`.

(This PR is an update of #320)