### PR TITLE
TopologyPreservingSimplifier: Allow ring origin to be removed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ xxxx-xx-xx
   - Use more robust Delaunay Triangulation frame size heuristic (GH-728, Martin Davis)
   - DiscreteFrechetDistance: Fix crash with empty inputs (GH-751, Dan Baston)
   - GEOSSimplify / DouglasPeuckerSimplifier: Allow ring origin to be removed (GH-773, Dan Baston)
+  - GEOSTopologyPreserveSimplify / TopologyPreservingSimplifier: Allow ring origin to be removed (GH-784, Dan Baston)
   - PreparedLineStringIntersects: Fix incorrect result with mixed-dim collection (GH-774, Dan Baston)
 
 

--- a/include/geos/simplify/TaggedLineString.h
+++ b/include/geos/simplify/TaggedLineString.h
@@ -67,11 +67,14 @@ public:
     typedef std::unique_ptr<geom::CoordinateSequence> CoordSeqPtr;
 
     TaggedLineString(const geom::LineString* nParentLine,
-                     std::size_t minimumSize = 2);
+                     std::size_t minimumSize,
+                     bool preserveEndpoint);
 
     ~TaggedLineString();
 
     std::size_t getMinimumSize() const;
+
+    bool getPreserveEndpoint() const;
 
     const geom::LineString* getParent() const;
 
@@ -89,7 +92,11 @@ public:
 
     const std::vector<TaggedLineSegment*>& getSegments() const;
 
+    const std::vector<TaggedLineSegment*>& getResultSegments() const;
+
     void addToResult(std::unique_ptr<TaggedLineSegment> seg);
+
+    void removeRingEndpoint();
 
     std::unique_ptr<geom::Geometry> asLineString() const;
 
@@ -106,6 +113,8 @@ private:
     std::vector<TaggedLineSegment*> resultSegs;
 
     std::size_t minimumSize;
+
+    bool preserveEndpoint;
 
     void init();
 

--- a/include/geos/simplify/TaggedLineStringSimplifier.h
+++ b/include/geos/simplify/TaggedLineStringSimplifier.h
@@ -105,6 +105,8 @@ private:
     void simplifySection(std::size_t i, std::size_t j,
                          std::size_t depth);
 
+    void simplifyRingEndpoint();
+
     static std::size_t findFurthestPoint(
         const geom::CoordinateSequence* pts,
         std::size_t i, std::size_t j,
@@ -129,13 +131,13 @@ private:
     /** \brief
      * Tests whether a segment is in a section of a TaggedLineString
      *
-     * @param parentLine
-     * @param sectionIndex
-     * @param seg
+     * @param line line to be checked for the presence of `seg`
+     * @param sectionIndex start and end indices of the section to check
+     * @param seg segment to look for in `line`
      * @return
      */
     static bool isInLineSection(
-        const TaggedLineString* parentLine,
+        const TaggedLineString* line,
         const std::pair<std::size_t, std::size_t>& sectionIndex,
         const TaggedLineSegment* seg);
 

--- a/src/simplify/TaggedLineString.cpp
+++ b/src/simplify/TaggedLineString.cpp
@@ -44,10 +44,12 @@ namespace simplify { // geos::simplify
 
 /*public*/
 TaggedLineString::TaggedLineString(const geom::LineString* nParentLine,
-                                   std::size_t nMinimumSize)
+                                   std::size_t nMinimumSize,
+                                   bool bPreserveEndpoint)
     :
     parentLine(nParentLine),
-    minimumSize(nMinimumSize)
+    minimumSize(nMinimumSize),
+    preserveEndpoint(bPreserveEndpoint)
 {
     init();
 }
@@ -109,6 +111,13 @@ std::size_t
 TaggedLineString::getMinimumSize() const
 {
     return minimumSize;
+}
+
+/*public*/
+bool
+TaggedLineString::getPreserveEndpoint() const
+{
+    return preserveEndpoint;
 }
 
 /*public*/
@@ -199,7 +208,6 @@ TaggedLineString::getSegment(std::size_t i) const
 std::vector<TaggedLineSegment*>&
 TaggedLineString::getSegments()
 {
-    assert(0);
     return segs;
 }
 
@@ -208,6 +216,13 @@ const std::vector<TaggedLineSegment*>&
 TaggedLineString::getSegments() const
 {
     return segs;
+}
+
+/*public*/
+const std::vector<TaggedLineSegment*>&
+TaggedLineString::getResultSegments() const
+{
+    return resultSegs;
 }
 
 /*public*/
@@ -241,6 +256,17 @@ TaggedLineString::addToResult(std::unique_ptr<TaggedLineSegment> seg)
          << " seg " << seg.get() << " to result"
          << std::endl;
 #endif
+}
+
+void
+TaggedLineString::removeRingEndpoint()
+{
+    auto* firstSeg = resultSegs.front();
+    auto* lastSeg = resultSegs.back();
+
+    firstSeg->p0 = lastSeg->p0;
+    delete lastSeg;
+    resultSegs.pop_back();
 }
 
 } // namespace geos::simplify

--- a/src/simplify/TopologyPreservingSimplifier.cpp
+++ b/src/simplify/TopologyPreservingSimplifier.cpp
@@ -134,9 +134,6 @@ class LineStringMapBuilderFilter: public geom::GeometryComponentFilter {
 
 public:
 
-    // no more needed
-    //friend class TopologyPreservingSimplifier;
-
     /**
      * Filters linear geometries.
      *
@@ -172,16 +169,19 @@ LineStringMapBuilderFilter::LineStringMapBuilderFilter(LinesMap& nMap, std::vect
 void
 LineStringMapBuilderFilter::filter_ro(const Geometry* geom)
 {
-    TaggedLineString* taggedLine;
+    auto typ = geom->getGeometryTypeId();
+    bool preserveEndpoint = true;
 
-    if(const LineString* ls =
-                dynamic_cast<const LineString*>(geom)) {
-        std::size_t minSize = ls->isClosed() ? 4 : 2;
-        taggedLine = new TaggedLineString(ls, minSize);
-    }
-    else {
+    if (typ == GEOS_LINEARRING) {
+        preserveEndpoint = false;
+    } else if (typ != GEOS_LINESTRING) {
         return;
     }
+
+
+    auto ls = static_cast<const LineString*>(geom);
+    std::size_t minSize = ls->isClosed() ? 4 : 2;
+    TaggedLineString* taggedLine = new TaggedLineString(ls, minSize, preserveEndpoint);
 
     // Duplicated Geometry pointers shouldn't happen
     if(! linestringMap.insert(std::make_pair(geom, taggedLine)).second) {

--- a/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
+++ b/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
@@ -238,7 +238,7 @@ void object::test<10>
     std::string wkt("POLYGON ((0 5, 5 5, 5 0, 0 0, 0 1, 0 5))");
     GeomPtr g(wktreader.read(wkt));
 
-    std::string wkt_exp("POLYGON ((0 5, 5 5, 5 0, 0 0, 0 5))");
+    std::string wkt_exp("POLYGON ((0 0, 5 5, 5 0, 0 0))");
     GeomPtr exp(wktreader.read(wkt_exp));
 
     GeomPtr simplified = TopologyPreservingSimplifier::simplify(g.get(), 10.0);
@@ -355,6 +355,29 @@ void object::test<16>
     ensure("Simplified geometry is invalid!", simp->isValid());
     ensure_equals(wktwriter.write(simp.get()),
                   "GEOMETRYCOLLECTION (LINESTRING (0 0, 10 0))");
+}
+
+// Test that start point of a closed LineString is not changed
+template<>
+template<>
+void object::test<17>
+()
+{
+     auto g = wktreader.read("LINESTRING (1 0, 2 0, 2 2, 0 2, 0 0, 1 0)");
+     auto simplified = TopologyPreservingSimplifier::simplify(g.get(), 0);
+     ensure_equals_geometry(simplified.get(), g.get());
+}
+
+// Test that removing starting point of ring does not break topology
+template<>
+template<>
+void object::test<18>
+()
+{
+    auto g = wktreader.read("POLYGON ((0 0, 5 2.05, 10 0, 10 10, 0 10, 0 0),  (5 2.1, 6 2, 6 4, 4 4, 4 2, 5 2.1))");
+    auto simplified = TopologyPreservingSimplifier::simplify(g.get(), 0.1);
+
+    ensure_equals_geometry(simplified.get(), g.get());
 }
 
 } // namespace tut


### PR DESCRIPTION
This PR is the topology-preserving equivalent of #773.

Resolves https://trac.osgeo.org/geos/ticket/1064