### PR TITLE
Remove warning by changing sprintf to snprintf in geos_ts_c.cpp 

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2332,7 +2332,7 @@ extern "C" {
     const char* GEOSversion()
     {
         static char version[256];
-        sprintf(version, "%s", GEOS_CAPI_VERSION);
+        snprintf(version, 256, "%s", GEOS_CAPI_VERSION);
         return version;
     }
 


### PR DESCRIPTION
On `Apple clang version 14.0.0 (clang-1400.0.29.202)` compiling `geos_ts_c.cpp` with `-Werror,-Wdeprecated-declarations` fails with:
>  'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.

This is the only use of `sprintf` I could find and since the buffer is already constant sized it makes sense to use `snprintf` instead to remove the warning.
