### PR TITLE
Avoid FE_INVALID on operations with empty Envelopes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,9 @@ xxxx-xx-xx
   - GEOSSimplify / DouglasPeuckerSimplifier: Allow ring origin to be removed (GH-773, Dan Baston)
   - GEOSTopologyPreserveSimplify / TopologyPreservingSimplifier: Allow ring origin to be removed (GH-784, Dan Baston)
   - PreparedLineStringIntersects: Fix incorrect result with mixed-dim collection (GH-774, Dan Baston)
+  - GEOSIntersection: Fix FE_INVALID exception on intersection of disjoint geometries
+    (GH-791, Joris Van den Bossche & Dan Baston)
+  - Fix incorrect result from Envelope::disjoint (GH-791, Dan Baston)
 
 
 ## Changes in 3.11.0

--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -454,16 +454,16 @@ public:
             maxy = other->maxy;
         }
         else {
-            if(other->minx < minx) {
+            if(std::isless(other->minx, minx)) {
                 minx = other->minx;
             }
-            if(other->maxx > maxx) {
+            if(std::isgreater(other->maxx, maxx)) {
                 maxx = other->maxx;
             }
-            if(other->miny < miny) {
+            if(std::isless(other->miny, miny)) {
                 miny = other->miny;
             }
-            if(other->maxy > maxy) {
+            if(std::isgreater(other->maxy, maxy)) {
                 maxy = other->maxy;
             }
         }
@@ -535,8 +535,8 @@ public:
      */
     bool intersects(const CoordinateXY& other) const
     {
-        return (other.x <= maxx && other.x >= minx &&
-                other.y <= maxy && other.y >= miny);
+        return (std::islessequal(other.x, maxx) && std::isgreaterequal(other.x, minx) &&
+                std::islessequal(other.y, maxy) && std::isgreaterequal(other.y,  miny));
     }
 
     /** \brief
@@ -548,7 +548,10 @@ public:
      */
     bool intersects(double x, double y) const
     {
-        return (x <= maxx && x >= minx && y <= maxy && y >= miny);
+        return std::islessequal(x, maxx) &&
+               std::isgreaterequal(x, minx) &&
+               std::islessequal(y, maxy) &&
+               std::isgreaterequal(y, miny);
     }
 
     /** \brief
@@ -559,10 +562,10 @@ public:
      */
     bool intersects(const Envelope* other) const
     {
-        return other->minx <= maxx &&
-               other->maxx >= minx &&
-               other->miny <= maxy &&
-               other->maxy >= miny;
+        return std::islessequal(other->minx, maxx) &&
+               std::isgreaterequal(other->maxx, minx) &&
+               std::islessequal(other->miny, maxy) &&
+               std::isgreaterequal(other->maxy, miny);
     }
 
     bool intersects(const Envelope& other) const
@@ -584,10 +587,10 @@ public:
 
     bool disjoint(const Envelope* other) const
     {
-        return !(other->minx <= maxx ||
-                 other->maxx >= minx ||
-                 other->miny <= maxy ||
-                 other->maxy >= miny);
+        return !(std::islessequal(other->minx, maxx) ||
+                 std::isgreaterequal(other->maxx, minx) ||
+                 std::islessequal(other->miny, maxy) ||
+                 std::isgreaterequal(other->maxy,  miny));
     }
 
     /** \brief
@@ -598,10 +601,10 @@ public:
      * @return `true` if `(x, y)` lies in the interior or on the boundary of this Envelope.
      */
     bool covers(double x, double y) const {
-        return x >= minx &&
-               x <= maxx &&
-               y >= miny &&
-               y <= maxy;
+        return std::isgreaterequal(x,  minx) &&
+               std::islessequal(x, maxx) &&
+               std::isgreaterequal(y, miny) &&
+               std::islessequal(y,  maxy);
     }
 
     /** \brief

--- a/include/geos/geom/Envelope.h
+++ b/include/geos/geom/Envelope.h
@@ -582,15 +582,12 @@ public:
     */
     bool disjoint(const Envelope& other) const
     {
-        return disjoint(&other);
+        return !intersects(other);
     }
 
     bool disjoint(const Envelope* other) const
     {
-        return !(std::islessequal(other->minx, maxx) ||
-                 std::isgreaterequal(other->maxx, minx) ||
-                 std::islessequal(other->miny, maxy) ||
-                 std::isgreaterequal(other->maxy,  miny));
+        return !intersects(other);
     }
 
     /** \brief

--- a/src/geom/Envelope.cpp
+++ b/src/geom/Envelope.cpp
@@ -58,22 +58,22 @@ Envelope::intersects(const CoordinateXY& a, const CoordinateXY& b) const
     // std::minmax performs no better and compiles down to more
     // instructions.
     double envminx = (a.x < b.x) ? a.x : b.x;
-    if(!(maxx >= envminx)) { // awkward comparison catches cases where this->isNull()
+    if(!std::isgreaterequal(maxx, envminx)) { // awkward comparison catches cases where this->isNull()
         return false;
     }
 
     double envmaxx = (a.x > b.x) ? a.x : b.x;
-    if(envmaxx < minx) {
+    if(std::isless(envmaxx, minx)) {
         return false;
     }
 
     double envminy = (a.y < b.y) ? a.y : b.y;
-    if(envminy > maxy) {
+    if(std::isgreater(envminy, maxy)) {
         return false;
     }
 
     double envmaxy = (a.y > b.y) ? a.y : b.y;
-    if(envmaxy < miny) {
+    if(std::isless(envmaxy, miny)) {
         return false;
     }
 
@@ -105,10 +105,10 @@ bool
 Envelope::covers(const Envelope& other) const
 {
     return
-        other.minx >= minx &&
-        other.maxx <= maxx &&
-        other.miny >= miny &&
-        other.maxy <= maxy;
+        std::isgreaterequal(other.minx,  minx) &&
+        std::islessequal(other.maxx,  maxx) &&
+        std::isgreaterequal(other.miny, miny) &&
+        std::islessequal(other.maxy,  maxy);
 }
 
 /*public*/
@@ -233,7 +233,7 @@ Envelope::expandBy(double deltaX, double deltaY)
     maxy += deltaY;
 
     // check for envelope disappearing
-    if(minx > maxx || miny > maxy) {
+    if(std::isgreater(minx, maxx) || std::isgreater(miny, maxy)) {
         setToNull();
     }
 }

--- a/tests/unit/capi/GEOSIntersectionTest.cpp
+++ b/tests/unit/capi/GEOSIntersectionTest.cpp
@@ -131,6 +131,20 @@ void object::test<6>
     // No memory leaked
 }
 
+// https://github.com/libgeos/geos/pull/790
+template<>
+template<>
+void object::test<7>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))");
+    geom2_ = GEOSGeomFromWKT("POLYGON ((1 2, 1 3, 0 3, 0 2, 1 2))");
+
+    result_ = GEOSIntersection(geom1_, geom2_);
+
+    ensure(!std::fetestexcept(FE_INVALID));
+}
+
 
 } // namespace tut
 

--- a/tests/unit/capi/capi_test_utils.h
+++ b/tests/unit/capi/capi_test_utils.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cfenv>
 
 
 namespace capitest {
@@ -29,6 +30,8 @@ namespace capitest {
             wktw_ = GEOSWKTWriter_create();
             GEOSWKTWriter_setTrim(wktw_, 1);
             GEOSWKTWriter_setRoundingPrecision(wktw_, 10);
+
+            std::feclearexcept(FE_ALL_EXCEPT);
         }
 
         ~utility()

--- a/tests/unit/geom/EnvelopeTest.cpp
+++ b/tests/unit/geom/EnvelopeTest.cpp
@@ -7,6 +7,7 @@
 #include <geos/geom/Envelope.h>
 #include <geos/geom/Coordinate.h>
 
+#include <array>
 #include <cfenv>
 
 namespace tut {
@@ -14,6 +15,7 @@ namespace tut {
 // Test Group
 //
 
+using geos::geom::CoordinateXY;
 using geos::geom::Envelope;
 
 // dummy data, not used
@@ -23,7 +25,70 @@ struct test_envelope_data {
         std::feclearexcept(FE_ALL_EXCEPT);
     }
 
-    static void ensure_no_fp_except()
+    static std::size_t
+    absdiff(std::size_t a, std::size_t b)
+    {
+        auto x = std::minmax(a, b);
+        return x.second - x.first;
+    }
+
+    static void
+    check_intersects(const Envelope& e1, const Envelope& e2, bool expected)
+    {
+        ensure_equals(e1.intersects(e2), expected);
+        ensure_equals(e1.intersects(&e2), expected);
+        ensure_equals(e1.disjoint(e2), !expected);
+        ensure_equals(e1.disjoint(&e2), !expected);
+
+        ensure_equals(e2.intersects(e1), expected);
+        ensure_equals(e2.intersects(&e1), expected);
+        ensure_equals(e2.disjoint(e1), !expected);
+        ensure_equals(e2.disjoint(&e1), !expected);
+
+        CoordinateXY p0, p1, q0, q1;
+
+        if (!e2.isNull()) {
+            q0 = {e2.getMinX(), e2.getMaxY()};
+            q1 = {e2.getMaxX(), e2.getMinY()};
+            ensure_equals(e1.intersects(q0, q1), expected);
+            ensure_equals(e1.intersects(q1, q0), expected);
+        }
+
+        if (!e1.isNull()) {
+            p0 = {e1.getMinX(), e1.getMinY()};
+            p1 = {e1.getMaxX(), e1.getMaxY()};
+
+            ensure_equals(e2.intersects(p0, p1), expected);
+            ensure_equals(e2.intersects(p1, p0), expected);
+        }
+
+        if (!e1.isNull() && !e2.isNull()) {
+            ensure_equals(Envelope::intersects(p0, p1, q0, q1), expected);
+            ensure_equals(Envelope::intersects(p1, p0, q0, q1), expected);
+            ensure_equals(Envelope::intersects(p1, p0, q1, q0), expected);
+            ensure_equals(Envelope::intersects(p1, p0, q0, q1), expected);
+        }
+    }
+
+    static void
+    check_intersects(const Envelope& e1, const CoordinateXY& q, bool expected)
+    {
+        ensure_equals(e1.intersects(q), expected);
+        ensure_equals(e1.intersects(q.x, q.y), expected);
+        ensure_equals(e1.contains(q), expected);
+        ensure_equals(e1.contains(q.x, q.y), expected);
+        ensure_equals(e1.covers(&q), expected);
+        ensure_equals(e1.covers(q.x, q.y), expected);
+
+        if (!e1.isNull()) {
+            CoordinateXY p0{e1.getMinX(), e1.getMinY()};
+            CoordinateXY p1{e1.getMaxX(), e1.getMaxY()};
+            ensure_equals(Envelope::intersects(p0, p1, q), expected);
+        }
+    }
+
+    static void
+    ensure_no_fp_except()
     {
         ensure("FE_DIVBYZERO raised", !std::fetestexcept(FE_DIVBYZERO));
         //ensure("FE_INEXACT raised", !std::fetestexcept(FE_INEXACT));
@@ -176,18 +241,12 @@ void object::test<6>
     ensure("big envelope contains small envelope", big.contains(small));
     ensure("non-empty envelope contains itself", big.contains(big));
 
-    // Test raw point
-    ensure(small.contains(0, 0));
-    ensure(small.contains(-1, -1));
-    ensure(!small.contains(5, 5));
+    // Test points
+    check_intersects(small, {0, 0}, true);
+    check_intersects(small, {-1, -1}, true);
+    check_intersects(small, {5, 5}, false);
 
-    // Test coordinate
-    geos::geom::Coordinate origin(0, 0, 0);
-
-    ensure_equals(origin.x, 0);
-    ensure_equals(origin.y, 0);
-    ensure_equals(origin.z, 0);
-    ensure(small.contains(origin));
+    check_intersects(empty, {0, 0}, false);
 
     ensure_no_fp_except();
 }
@@ -198,56 +257,55 @@ template<>
 void object::test<7>
 ()
 {
+    constexpr std::size_t nrow = 3;
+    constexpr std::size_t ncol = 3;
+
+    std::array<std::array<Envelope, ncol>, nrow> envelopes;
+
+    double xmin = 0.0;
+    double xmax = 1.0;
+    double ymin = 0.0;
+    double ymax = 2.0;
+    double dx = (xmax - xmin) / static_cast<double>(ncol);
+    double dy = (ymax - ymin) / static_cast<double>(nrow);
+    for (std::size_t i = 0; i < ncol; i++) {
+        for (std::size_t j = 0; j < nrow; j++) {
+            double x0 = xmin + static_cast<double>(i)*dx;
+            double x1 = xmin + static_cast<double>(i + 1)*dx;
+            double y0 = ymax - static_cast<double>(j + 1)*dy;
+            double y1 =	ymax - static_cast<double>(j)*dy;
+
+            envelopes[i][j] = Envelope(x0, x1, y0, y1);
+        }
+    }
+
     geos::geom::Envelope empty;
-    geos::geom::Envelope with_origin(-100, 100, -100, 100);
-    geos::geom::Envelope moved(50, 150, 50, 150);
 
-    ensure(empty.isNull());
-    ensure(!with_origin.isNull());
-    ensure(!moved.isNull());
+    // check intersection against empty
+    for (std::size_t ia = 0; ia < ncol; ia++) {
+        for (std::size_t ja = 0; ja < nrow; ja++) {
+            check_intersects(envelopes[ia][ja], empty, false);
+        }
+    }
 
-    // Test empty envelope by reference
-    ensure("empty envelope does not intersect non-empty envelope", !empty.intersects(with_origin));
-    ensure("non-empty envelope does not intersect empty envelope", !with_origin.intersects(empty));
-    ensure("empty envelope is disjoint with non-empty envelope", empty.disjoint(with_origin));
-    ensure("non-empty envelope is disjoint with empty envelope", with_origin.disjoint(empty));
+    // check intersection against adjacent
+    for (std::size_t ia = 0; ia < ncol; ia++) {
+        for (std::size_t ja = 0; ja < nrow; ja++) {
+            for (std::size_t ib = 0; ib < ncol; ib++) {
+                for (std::size_t jb = 0; jb < nrow; jb++) {
+                    bool should_intersect = absdiff(ia, ib) <= 1 && absdiff(ja, jb) <= 1;
 
-    // Test empty envelope by pointer
-    ensure("empty envelope does not intersect non-empty envelope", !empty.intersects(&with_origin));
-    ensure("non-empty envelope does not intersect empty envelope", !with_origin.intersects(&empty));
-    ensure("empty envelope is disjoint with non-empty envelope", empty.disjoint(&with_origin));
-    ensure("non-empty envelope is disjoint with empty envelope", with_origin.disjoint(&empty));
+                    check_intersects(envelopes[ia][ja], envelopes[ib][jb], should_intersect);
+                }
+            }
+        }
+    }
 
-    // Test empty envelope does not intersect self
-    ensure("empty envelope does not intersect self", !empty.intersects(empty));
-    ensure("empty envelope is disjoint with self", empty.disjoint(empty));
-
-    // Test non-empty envelope by reference
-    ensure(with_origin.intersects(moved));
-    ensure(!with_origin.disjoint(moved));
-
-    ensure(moved.intersects(with_origin));
-    ensure(!moved.disjoint(with_origin));
-
-    // Test intersection with raw point
-    ensure(with_origin.intersects(0, 0));
-    ensure(with_origin.intersects(-100, 100));
-    ensure(!with_origin.intersects(-200, 200));
-
-    // Test intersection with coordinate
-    geos::geom::Coordinate origin(0, 0, 0);
-
-    ensure_equals(origin.x, 0);
-    ensure_equals(origin.y, 0);
-    ensure_equals(origin.z, 0);
-    ensure(with_origin.intersects(origin));
-
-    ensure("empty envelope does not intersect coordinate", !empty.intersects(origin));
 
     ensure_no_fp_except();
 }
 
-// Test of expand()
+// Test of expandToInclude()
 template<>
 template<>
 void object::test<8>
@@ -274,7 +332,7 @@ void object::test<8>
     ensure_no_fp_except();
 }
 
-// Second test of expand()
+// Second test of expandToInclude()
 template<>
 template<>
 void object::test<9>
@@ -438,6 +496,146 @@ void object::test<13>
     ensure_no_fp_except();
 }
 
+// Test of expandBy
+template<>
+template<>
+void object::test<14>
+()
+{
+    // expanding null envelope is still null
+    Envelope empty;
+    empty.expandBy(10, 10);
+    ensure(empty.isNull());
+
+    // expanding a regular envelope gives expected result
+    Envelope e(0, 1, -2, 2);
+    e.expandBy(2, 1);
+    ensure_equals(e.getMinX(), -2);
+    ensure_equals(e.getMaxX(), 3);
+    ensure_equals(e.getMinY(), -3);
+    ensure_equals(e.getMaxY(), 3);
+
+    // expanding envelope by negative amount shrinks it
+    e.expandBy(-2, -1);
+    ensure_equals(e, Envelope(0, 1, -2, 2));
+
+    // shrinking it until it disappears makes it null
+    e.expandBy(-100, -100);
+    ensure(e.isNull());
+
+    ensure_no_fp_except();
+}
+
+// Test of intersection
+template<>
+template<>
+void object::test<15>
+()
+{
+    Envelope a(0, 1, 0, 1);
+    Envelope b(1, 2, 1, 1);
+    Envelope c;
+    Envelope d(100, 200, 100, 200);
+
+    // A - B
+    Envelope ab_intersection;
+    bool ab_intersect = a.intersection(b, ab_intersection);
+    ensure(ab_intersect);
+    ensure_equals(ab_intersection, Envelope(1, 1, 1, 1));
+
+    // A - C
+    Envelope ac_intersection;
+    bool ac_intersect = a.intersection(c, ac_intersection);
+    ensure(!ac_intersect);
+    ensure(ac_intersection.isNull());
+
+    // A - D
+    Envelope ad_intersection;
+    bool ad_intersect = a.intersection(c, ad_intersection);
+    ensure(!ad_intersect);
+    ensure(ad_intersection.isNull());
+
+    // B - C
+    Envelope bc_intersection;
+    bool bc_intersect = a.intersection(c, bc_intersection);
+    ensure(!bc_intersect);
+    ensure(bc_intersection.isNull());
+
+    ensure_no_fp_except();
+}
+
+// Test of centre
+template<>
+template<>
+void object::test<16>
+()
+{
+    // regular envelope
+    Envelope e(0, 1, 2, 4);
+    CoordinateXY c;
+
+    bool success = e.centre(c);
+    ensure(success);
+    ensure_equals(c, CoordinateXY{0.5, 3});
+
+    // null envelope
+    Envelope empty;
+    success = empty.centre(c);
+    ensure(!success);
+    ensure_equals(c, CoordinateXY{0.5, 3});
+
+    ensure_no_fp_except();
+}
+
+// Test of translate
+template<>
+template<>
+void object::test<17>
+()
+{
+    // regular envelope
+    Envelope e(0, 1, 2, 4);
+    e.translate(1, 2);
+    ensure_equals(e, Envelope(1, 2, 4, 6));
+
+    // null envelope
+    Envelope empty;
+    empty.translate(1, 2);
+    ensure(empty.isNull());
+
+    ensure_no_fp_except();
+}
+
+// Test of hashCode
+template<>
+template<>
+void object::test<18>
+()
+{
+    Envelope a(0, 1, 2, 3);
+    Envelope b;
+
+    ensure(a.hashCode() != b.hashCode());
+
+    ensure_no_fp_except();
+}
+
+// Test of expandToInclude(Coordinate)
+template<>
+template<>
+void object::test<19>
+()
+{
+    Envelope e;
+    e.expandToInclude({6, 7});
+
+    ensure_equals(e, Envelope(6, 6, 7, 7));
+
+    e.expandToInclude(0, 1);
+    ensure_equals(e, Envelope(0, 6, 1, 7));
+
+    ensure_no_fp_except();
+}
 
 } // namespace tut
 


### PR DESCRIPTION
This PR is an alternative approach to #790 that replaces comparison operators in `Envelope` with the C99 comparison functions that provide an equivalent result but do not set `FE_INVALID`.

@jorisvandenbossche 
In the process of putting this together I noticed that `Envelope::distance` sets `FE_INEXACT` in some of the test cases. I am guessing that one is not a problem for you?