### PR TITLE
CoordinateFilter: Support multiple CoordinateSequence dimensions

### DIFF
--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -152,7 +152,7 @@ public:
         {}
 
         void
-        filter_ro(const geom::Coordinate* pt) override
+        filter_ro(const geom::CoordinateXY* pt) override
         {
             minPtDist.initialize();
             DistanceToPoint::computeDistance(geom, *pt,

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -608,8 +608,26 @@ public:
     /// \defgroup iterate Iteration
     /// @{
 
-    void apply_rw(const CoordinateFilter* filter);
-    void apply_ro(CoordinateFilter* filter) const;
+    template<typename Filter>
+    void apply_rw(const Filter* filter) {
+        switch(getCoordinateType()) {
+            case CoordinateType::XY:    for (auto& c : items<CoordinateXY>())   { filter->filter_rw(&c); } break;
+            case CoordinateType::XYZ:   for (auto& c : items<Coordinate>())     { filter->filter_rw(&c); } break;
+            case CoordinateType::XYM:   for (auto& c : items<CoordinateXYM>())  { filter->filter_rw(&c); } break;
+            case CoordinateType::XYZM:  for (auto& c : items<CoordinateXYZM>()) { filter->filter_rw(&c); } break;
+        }
+        m_hasdim = m_hasz = false; // re-check (see http://trac.osgeo.org/geos/ticket/435)
+    }
+
+    template<typename Filter>
+    void apply_ro(Filter* filter) const {
+        switch(getCoordinateType()) {
+            case CoordinateType::XY:    for (const auto& c : items<CoordinateXY>())   { filter->filter_ro(&c); } break;
+            case CoordinateType::XYZ:   for (const auto& c : items<Coordinate>())     { filter->filter_ro(&c); } break;
+            case CoordinateType::XYM:   for (const auto& c : items<CoordinateXYM>())  { filter->filter_ro(&c); } break;
+            case CoordinateType::XYZM:  for (const auto& c : items<CoordinateXYZM>()) { filter->filter_ro(&c); } break;
+        }
+    }
 
     template<typename T, typename F>
     void forEach(F&& fun) const

--- a/include/geos/geom/Quadrant.h
+++ b/include/geos/geom/Quadrant.h
@@ -95,7 +95,7 @@ public:
      *
      * @throws IllegalArgumentException if the points are equal
      */
-    static int quadrant(const geom::Coordinate& p0, const geom::Coordinate& p1)
+    static int quadrant(const geom::CoordinateXY& p0, const geom::CoordinateXY& p1)
     {
         if(p1.x == p0.x && p1.y == p0.y) {
             throw util::IllegalArgumentException("Cannot compute the quadrant for two identical points " + p0.toString());

--- a/include/geos/util/UniqueCoordinateArrayFilter.h
+++ b/include/geos/util/UniqueCoordinateArrayFilter.h
@@ -38,14 +38,14 @@ namespace util { // geos::util
  *
  *  Last port: util/UniqueCoordinateArrayFilter.java rev. 1.17
  */
-class GEOS_DLL UniqueCoordinateArrayFilter: public geom::CoordinateFilter {
+class GEOS_DLL UniqueCoordinateArrayFilter : public geom::CoordinateInspector<UniqueCoordinateArrayFilter> {
 public:
     /**
      * Constructs a CoordinateArrayFilter.
      *
      * @param target The destination set.
      */
-    UniqueCoordinateArrayFilter(geom::Coordinate::ConstVect& target)
+    UniqueCoordinateArrayFilter(std::vector<const geom::Coordinate*>& target)
         : pts(target)
     {}
 
@@ -62,17 +62,27 @@ public:
      * @param coord The "read-only" Coordinate to which
      * 				the filter is applied.
      */
-    void
-    filter_ro(const geom::Coordinate* coord) override
+    template<typename CoordType>
+    void filter(const CoordType* coord)
     {
         if(uniqPts.insert(coord).second) {
+            // TODO make `pts` a CoordinateSequence rather than coercing the type
             pts.push_back(coord);
         }
     }
 
+    void filter(const geom::CoordinateXY*) {
+        assert(0); // not supported
+    }
+
+
+    void filter(const geom::CoordinateXYM*) {
+        assert(0); // not supported
+    }
+
 private:
-    geom::Coordinate::ConstVect& pts;	// target set reference
-    geom::Coordinate::ConstSet uniqPts; 	// unique points set
+    std::vector<const geom::Coordinate*>& pts;	// target set reference
+    std::set<const geom::CoordinateXY*, geom::CoordinateLessThen> uniqPts; 	// unique points set
 
     // Declare type as noncopyable
     UniqueCoordinateArrayFilter(const UniqueCoordinateArrayFilter& other) = delete;

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -239,25 +239,6 @@ CoordinateSequence::add(const CoordinateSequence& cl, bool allowRepeated, bool f
 
 /*public*/
 
-void
-CoordinateSequence::apply_rw(const CoordinateFilter* filter)
-{
-    // FIXME dispatch on dimension?
-    for(auto& c : items<Coordinate>()) {
-        filter->filter_rw(&c);
-    }
-    m_hasdim = m_hasz = false; // re-check (see http://trac.osgeo.org/geos/ticket/435)
-}
-
-void
-CoordinateSequence::apply_ro(CoordinateFilter* filter) const
-{
-    // FIXME dispatch on dimension?
-    for(const auto& c : items<Coordinate>()) {
-        filter->filter_ro(&c);
-    };
-}
-
 std::unique_ptr<CoordinateSequence>
 CoordinateSequence::clone() const
 {

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -57,7 +57,7 @@ public:
      m_context(context),
      m_list(list) {}
 
-    void filter_ro(const Coordinate* c) override final {
+    void filter_ro(const CoordinateXY* c) override {
         process(c);
 
         m_prev = c;
@@ -76,7 +76,7 @@ private:
         m_start = chainEnd;
     }
 
-    void process(const Coordinate* curr) {
+    void process(const CoordinateXY* curr) {
         if (m_prev == nullptr || curr->equals2D(*m_prev)) {
             return;
         }
@@ -93,7 +93,7 @@ private:
         }
     }
 
-    const Coordinate* m_prev;
+    const CoordinateXY* m_prev;
     std::size_t m_i;
     int m_quadrant;
     std::size_t m_start;

--- a/src/noding/ScaledNoder.cpp
+++ b/src/noding/ScaledNoder.cpp
@@ -89,7 +89,7 @@ public:
     //void filter_ro(const geom::Coordinate* c) { assert(0); }
 
     void
-    filter_rw(geom::Coordinate* c) const override
+    filter_rw(geom::CoordinateXY* c) const override
     {
         c->x = util::round((c->x - sn.offsetX) * sn.scaleFactor);
         c->y = util::round((c->y - sn.offsetY) * sn.scaleFactor);
@@ -114,14 +114,14 @@ public:
     }
 
     void
-    filter_ro(const geom::Coordinate* c) override
+    filter_ro(const geom::CoordinateXY* c) override
     {
         ::geos::ignore_unused_variable_warning(c);
         assert(0);
     }
 
     void
-    filter_rw(geom::Coordinate* c) const override
+    filter_rw(geom::CoordinateXY* c) const override
     {
         c->x = c->x / sn.scaleFactor + sn.offsetX;
         c->y = c->y / sn.scaleFactor + sn.offsetY;

--- a/tests/unit/operation/valid/RepeatedPointRemoverTest.cpp
+++ b/tests/unit/operation/valid/RepeatedPointRemoverTest.cpp
@@ -148,6 +148,7 @@ void object::test<6>()
 {
     checkSequence("LINESTRING M EMPTY", "LINESTRING M EMPTY", 0.0);
     checkSequence("LINESTRING M (1 1 1, 2 2 2, 2 2 3, 3 3 3)", "LINESTRING M (1 1 1, 2 2 2, 3 3 3)", 0.0);
+    checkSequence("LINESTRING ZM (1 2 3 4, 5 6 7 8, 5 6 9 9, 10 11 12 13)", "LINESTRING ZM (1 2 3 4, 5 6 7 8, 10 11 12 13)", 0.5);
 }
 
 


### PR DESCRIPTION
The interface of CoordinateFilter is changed so that a filter should support operations on CoordinateXY* rather than Coordinate*. By default, higher-dimension coordinates will default to base-class implementations (e.g., a CoordinateXYZM will be processed as a CoordinateXY if no implementation is available for Coordiante or CoordinateXYZM.)

To avoid the case where the filter implementation does not need to consider Z or M but must preserve them (e.g., repeated point removal), the CoordinateInspector and CoordinateMutator base classes are provided. These allow a filter class to inherit from the base using CRTP and provide a template for the filter method rather than an implementation for each coordinate type.