### PR TITLE
CoordinateSequence: Add type-detecting forEach (requires C++14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         - cxx_compiler: g++
           c_compiler: gcc
           build_type: Coverage
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: g++
           cmake: 3.15.*
@@ -32,7 +32,7 @@ jobs:
         - cxx_compiler: g++-5
           c_compiler: gcc-5
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'g++-5-multilib gcc-5-multilib'
           cmake: 3.13.*
@@ -41,7 +41,7 @@ jobs:
         - cxx_compiler: g++-5
           c_compiler: gcc-5
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 32
           packages: 'g++-5-multilib gcc-5-multilib g++-multilib gcc-multilib'
           cmake: 3.13.*
@@ -50,7 +50,7 @@ jobs:
         - cxx_compiler: g++-6
           c_compiler: gcc-6
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'g++-6-multilib gcc-6-multilib'
           cmake: 3.13.*
@@ -59,7 +59,7 @@ jobs:
         - cxx_compiler: g++-7
           c_compiler: gcc-7
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'g++-7-multilib gcc-7-multilib'
           cmake: 3.13.*
@@ -68,7 +68,7 @@ jobs:
         - cxx_compiler: g++-8
           c_compiler: gcc-8
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'g++-8-multilib gcc-8-multilib'
           cmake: 3.13.*
@@ -77,7 +77,7 @@ jobs:
         - cxx_compiler: g++-9
           c_compiler: gcc-9
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'g++-9-multilib gcc-9-multilib'
           cmake: 3.13.*
@@ -86,7 +86,7 @@ jobs:
         - cxx_compiler: g++-10
           c_compiler: gcc-10
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'g++-10-multilib gcc-10-multilib'
           cmake: 3.13.*
@@ -113,7 +113,7 @@ jobs:
         - cxx_compiler: clang++-7
           c_compiler: clang-7
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'clang-7'
           cmake: 3.13.*
@@ -122,7 +122,7 @@ jobs:
         - cxx_compiler: clang++-8
           c_compiler: clang-8
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'clang-8'
           cmake: 3.13.*
@@ -131,19 +131,10 @@ jobs:
         - cxx_compiler: clang++-9
           c_compiler: clang-9
           build_type: Release
-          cxxstd: 11
+          cxxstd: 14
           arch: 64
           packages: 'clang-9'
           cmake: 3.13.*
-          os: ubuntu-20.04
-
-        - cxx_compiler: clang++-10
-          c_compiler: clang
-          build_type: Debug
-          cxxstd: 11
-          arch: 64
-          packages: 'clang'
-          cmake: 3.17.*
           os: ubuntu-20.04
 
         - cxx_compiler: clang++-10
@@ -320,12 +311,9 @@ jobs:
     strategy:
       matrix:
         xcode: [11.7, 12.4, 13.2.1]
-        cxxstd: [11]
+        cxxstd: [14]
         build_type: ['Debug']
         include:
-          - xcode: 13.2.1
-            cxxstd: 14
-            build_type: Debug
           - xcode: 13.2.1
             cxxstd: 17
             build_type: Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ include(CMakeDependentOption)
 
 ## CMake global variables
 option(BUILD_SHARED_LIBS "Build GEOS with shared libraries" ON)
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 11)")
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard version to use (default is 11)")
 
 ## GEOS custom variables
 option(BUILD_BENCHMARKS "Build GEOS benchmarks" OFF)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ### Prerequisites
 
-GEOS has no external library dependencies and can be built with any C++11
+GEOS has no external library dependencies and can be built with any C++14
 compiler.
 
 ### Unix

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 xxxx-xx-xx
 
 - New things:
+  - C++14 is now required.
   - Polygonal coverage operations: CoverageValidator, CoveragePolygonValidator,
     CoverageGapFinder, CoverageUnion (JTS-900, Martin Davis & Paul Ramsey)
   - Support reading and writing M values through WKB and WKT readers/writers

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ To build a C++ API program, you must pass a define indicating you're OK with the
 
 ```
 c++ -I/usr/local/include -v \
-    -std=c++11 \
+    -std=c++14 \
     -D USE_UNSTABLE_GEOS_CPP_API \
     cpp_read.cpp \
     -o cpp_read \

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -629,6 +629,16 @@ public:
         }
     }
 
+    template<typename F>
+    void forEach(F&& fun) const {
+        switch(getCoordinateType()) {
+            case CoordinateType::XY:    for (const auto& c : items<CoordinateXY>())   { fun(c); } break;
+            case CoordinateType::XYZ:   for (const auto& c : items<Coordinate>())     { fun(c); } break;
+            case CoordinateType::XYM:   for (const auto& c : items<CoordinateXYM>())  { fun(c); } break;
+            case CoordinateType::XYZM:  for (const auto& c : items<CoordinateXYZM>()) { fun(c); } break;
+        }
+    }
+
     template<typename T, typename F>
     void forEach(F&& fun) const
     {

--- a/include/geos/util.h
+++ b/include/geos/util.h
@@ -35,44 +35,7 @@ void
 ignore_unused_variable_warning(T const &) {}
 
 namespace detail {
-#if __cplusplus >= 201402L
 using std::make_unique;
-#else
-// Backport of std::make_unique to C++11
-// Source: https://stackoverflow.com/a/19472607
-template<class T>
-struct _Unique_if {
-    typedef std::unique_ptr<T> _Single_object;
-};
-
-template<class T>
-struct _Unique_if<T[]> {
-    typedef std::unique_ptr<T[]> _Unknown_bound;
-};
-
-template<class T, std::size_t N>
-struct _Unique_if<T[N]> {
-    typedef void _Known_bound;
-};
-
-template<class T, class... Args>
-typename _Unique_if<T>::_Single_object
-make_unique(Args &&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-template<class T>
-typename _Unique_if<T>::_Unknown_bound
-make_unique(std::size_t n) {
-    typedef typename std::remove_extent<T>::type U;
-    return std::unique_ptr<T>(new U[n]());
-}
-
-template<class T, class... Args>
-typename _Unique_if<T>::_Known_bound
-make_unique(Args &&...) = delete;
-
-#endif
 
 /** Use detail::down_cast<Derived*>(pointer_to_base) as equivalent of
  * static_cast<Derived*>(pointer_to_base) with safe checking in debug

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -566,16 +566,19 @@ std::ostream&
 operator<< (std::ostream& os, const CoordinateSequence& cs)
 {
     os << "(";
-    for(std::size_t i = 0, n = cs.size(); i < n; ++i) {
-        if(i) {
+
+    bool writeComma = false;
+    auto write = [&os, &writeComma](const auto& coord) {
+        if (writeComma) {
             os << ", ";
-        }
-        if (cs.hasZ()) {
-            os << cs.getAt(i);
         } else {
-            os << cs.getAt<CoordinateXY>(i);
+            writeComma = true;
         }
-    }
+
+        os << coord;
+    };
+
+    cs.forEach(write);
     os << ")";
 
     return os;

--- a/tests/unit/geom/CoordinateSequenceTest.cpp
+++ b/tests/unit/geom/CoordinateSequenceTest.cpp
@@ -1392,4 +1392,29 @@ void object::test<52>
     }
 }
 
+// Test type-detecting version of forEach
+template<>
+template<>
+void object::test<53>
+()
+{
+    CoordinateSequence dst(0u, true, true);
+
+    CoordinateSequence src1{{Coordinate{1, 2, 3}, Coordinate{4, 5, 6}}};
+    CoordinateSequence src2{{CoordinateXYM{7, 8, 9}, {10, 11, 12}}};
+
+    auto appendToDst = [&dst](auto& coord) {
+        dst.add(coord);
+    };
+
+    src1.forEach(appendToDst);
+    src2.forEach(appendToDst);
+
+    ensure_equals(dst.size(), 4u);
+    ensure_equals_xyzm(dst.getAt<CoordinateXYZM>(0), CoordinateXYZM{1, 2, 3, DoubleNotANumber});
+    ensure_equals_xyzm(dst.getAt<CoordinateXYZM>(1), CoordinateXYZM{4, 5, 6, DoubleNotANumber});
+    ensure_equals_xyzm(dst.getAt<CoordinateXYZM>(2), CoordinateXYZM{7, 8,    DoubleNotANumber, 9});
+    ensure_equals_xyzm(dst.getAt<CoordinateXYZM>(3), CoordinateXYZM{10, 11,  DoubleNotANumber, 12});
+}
+
 } // namespace tut

--- a/web/content/usage/download.md
+++ b/web/content/usage/download.md
@@ -30,7 +30,7 @@ All *future* **Final Release** dates are subject to change.
 ### Build Requirements
 
 * [CMake](https://cmake.org/download/) 3.13 or later.
-* C++11 compiler. We regularly test GCC, Clang and Microsoft Visual C++.
+* C++14 compiler. We regularly test GCC, Clang and Microsoft Visual C++.
 * [Doxygen](https://www.doxygen.nl/) to build the API documentation.
 
 ### Build


### PR DESCRIPTION
As a follow-on to the introduction of XY, XYM and XYZM Coordinate types to GEOS, I have been exploring the feasibility of supporting these coordinate types in the overlay operations. Consistent with the new `CoordinateSequence` implementation, a design goal is to avoid a penalty for M values in cases where they are not used. (Good news: it's already working for simple cases such as line intersections).

One problem I have come across several times already is the need to perform some operation to each coordinate in a sequence, in type-generic but type-preserving way. For example, `OverlayMixedPoints::findPoints` needs to read a `CoordinateSequence`, find unique coordinates matching a certain condition that only requires use of X and Y, and write them to an output `CoordinateSequence`.

One way do do this is to copy everything into a `CoordinateXYZM` when we read it:

```
set::set<OverlayXY> points;
CoordinateSequence result(0, coords.hasZ(), coords.hasM());
CoordinateXYZM tmp;
for (std::size_t i = 0; i = inputSeq.size(); i++) {
	inputSeq.getAt(i, tmp);
	if (matchesCondition(c) && points.insert(c).second) {
		resultSeq.add(c);
	}
}
```

Of course, the problem here is that we copy the coordinate every time we handle it, which goes against the goal by introducing a new performance penalty for XY and XYZ operations. If we want to avoid the copy, we need to work with references matching the actual backing type of the `CoordianteSequence.` The simplest way to do this is by checking the backing type of the `CoordinateSequence` and providing an implementation for each type, for example:

```
set::set<OverlayXY> points;
CoordinateSequence result(0, coords.hasZ(), coords.hasM());

switch(getCoordinateType(inputSeq)) {
    case CoordinateType::XY:    for (const auto& c : items<CoordinateXY>())   { if (matchesCondition(c) && points.insert(c).second) resultSeq.add(c); } break;
    case CoordinateType::XYZ:   for (const auto& c : items<Coordinate>())     { if (matchesCondition(c) && points.insert(c).second) resultSeq.add(c); } break;
    case CoordinateType::XYM:   for (const auto& c : items<CoordinateXYM>())  { if (matchesCondition(c) && points.insert(c).second) resultSeq.add(c); } break;
    case CoordinateType::XYZM:  for (const auto& c : items<CoordinateXYZM>()) { if (matchesCondition(c) && points.insert(c).second) resultSeq.add(c); } break;
}
```

That's simple and also very repetitive. In https://github.com/libgeos/geos/pull/799, I proposed a `CoordinateInspector` base class that lets you provide a template that hooks into the existing `CoordinateFilter` machinery. So instead of the code above, you could write

```
struct CheckUniqueAndAdd : public CoordinateInspector<CheckUniqueAndAdd> {
public:
	CheckUniqueAndAdd(const OverlayMixedPoints& p_omp, CoordinateSequence& p_result) : omp(p_omp), result(p_result) {}

	template<typename CoordType>
	void filter(const CoordType* c) {
		if (omp.matchesCondition(c) && points.insert(c).second)
 		  result.add(c);
	}

	OverlayMixedPoints omp;
	set::set<OverlayXY> points;
	CoordinateSequence& result;
}

CoordinateSequence result(0, coords.hasZ(), coords.hasM());
CheckUniqueAndAdd filter(*this, resultSeq);
seq.apply_ro(&filter);
```

This avoids repeating the implementation, but is harder to read and requires a lot of tedious plumbing. We can't define the template at the spot where it's used, we need to bring in any variables the implementation requires as member variables, write a contructor, etc. A much cleaner solution is available with auto lambdas:

```
CoordinateSequence result(0, coords.hasZ(), coords.hasM());
set::set<OverlayXY> points;

seq.forEach([this, &points, &result](const auto& c) {
	if (matchesCondition(c) && points.insert(c).second)
	  result.add(c);
});
```

The problem (?) with the above is that it requires C++14. Switching to C++14 may sound like a disruptive change but in practice should have no effect. C++14 is fully supported by all of our CI environments including  gcc 5. C++14 is not supported by gcc 4.8, but GEOS already does not build on gcc 4.8 since #726.

