### PR TITLE
Polygonizer: Fix duplicate results from getInvalidRingLines()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ xxxx-xx-xx
   - GEOSIntersection: Fix FE_INVALID exception on intersection of disjoint geometries
     (GH-791, Joris Van den Bossche & Dan Baston)
   - Fix incorrect result from Envelope::disjoint (GH-791, Dan Baston)
+  - Polygonizer: Fix duplicate lines return by getInvalidRingLines (GH-782, Martin Davis & Dan Baston)
 
 
 ## Changes in 3.11.0

--- a/include/geos/operation/polygonize/EdgeRing.h
+++ b/include/geos/operation/polygonize/EdgeRing.h
@@ -72,6 +72,7 @@ private:
 
     EdgeRing* shell = nullptr;
     bool is_hole;
+    bool is_valid = false;
     bool is_processed = false;
     bool is_included_set = false;
     bool is_included = false;
@@ -168,6 +169,10 @@ public:
     void build(PolygonizeDirectedEdge* startDE);
 
     void computeHole();
+
+    const DeList& getEdges() const {
+        return deList;
+    }
 
     /** \brief
      * Tests whether this ring is a hole.
@@ -298,7 +303,9 @@ public:
      * Tests if the LinearRing ring formed by this edge ring
      * is topologically valid.
      */
-    bool isValid();
+    bool isValid() const;
+
+    void computeValid();
 
     /** \brief
      * Gets the coordinates for this ring as a LineString.

--- a/include/geos/operation/polygonize/Polygonizer.h
+++ b/include/geos/operation/polygonize/Polygonizer.h
@@ -109,7 +109,32 @@ private:
 
     static void findValidRings(const std::vector<EdgeRing*>& edgeRingList,
                                std::vector<EdgeRing*>& validEdgeRingList,
-                               std::vector<std::unique_ptr<geom::LineString>>& invalidRingList);
+                               std::vector<EdgeRing*>& invalidRingList);
+
+    /**
+     * Extracts unique lines for invalid rings,
+     * discarding rings which correspond to outer rings and hence contain
+     * duplicate linework.
+     */
+    std::vector<std::unique_ptr<geom::LineString>> extractInvalidLines(
+            std::vector<EdgeRing*>& invalidRings);
+
+    /**
+     * Tests if a invalid ring should be included in
+     * the list of reported invalid rings.
+     *
+     * Rings are included only if they contain
+     * linework which is not already in a valid ring,
+     * or in an already-included ring.
+     *
+     * Because the invalid rings list is sorted by extent area,
+     * this results in outer rings being discarded,
+     * since all their linework is reported in the rings they contain.
+     *
+     * @param invalidRing the ring to test
+     * @return true if the ring should be included
+     */
+    bool isIncludedInvalid(EdgeRing* invalidRing);
 
     void findShellsAndHoles(const std::vector<EdgeRing*>& edgeRingList);
 

--- a/src/operation/polygonize/EdgeRing.cpp
+++ b/src/operation/polygonize/EdgeRing.cpp
@@ -197,12 +197,21 @@ EdgeRing::getPolygon()
 
 /*public*/
 bool
-EdgeRing::isValid()
+EdgeRing::isValid() const
 {
-    if(! getRingInternal()) {
-        return false;    // computes cached ring
+    return is_valid;
+}
+
+void
+EdgeRing::computeValid()
+{
+    getCoordinates();
+    if (ringPts->size() <= 3) {
+        is_valid = false;
+        return;
     }
-    return ring->isValid();
+    getRingInternal();
+    is_valid = ring->isValid();
 }
 
 /*private*/

--- a/tests/unit/capi/GEOSPolygonizeTest.cpp
+++ b/tests/unit/capi/GEOSPolygonizeTest.cpp
@@ -154,5 +154,38 @@ void object::test<5>
     }
 }
 
+// Test GEOSPolygonize_full
+template<>
+template<>
+void object::test<6>
+()
+{
+    geom1_ = GEOSGeomFromWKT("MULTILINESTRING ((0 0, 1 0, 1 1, 0 1, 0 0),  (0 0, 0.5 0.5),  (1 1, 2 2, 1 2, 2 1, 1 1))");
+
+    GEOSGeometry* cuts;
+    GEOSGeometry* dangles;
+    GEOSGeometry* invalidRings;
+
+    result_ = GEOSPolygonize_full(geom1_, &cuts, &dangles, &invalidRings);
+
+    expected_ = GEOSGeomFromWKT("GEOMETRYCOLLECTION(POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))");
+    GEOSGeometry* expected_cuts = GEOSGeomFromWKT("GEOMETRYCOLLECTION EMPTY");
+    GEOSGeometry* expected_dangles = GEOSGeomFromWKT("GEOMETRYCOLLECTION(LINESTRING (0 0, 0.5 0.5))");
+    GEOSGeometry* expected_invalidRings = GEOSGeomFromWKT("GEOMETRYCOLLECTION(LINESTRING (1 1, 2 2, 1 2, 2 1, 1 1))");
+
+    ensure_geometry_equals(result_, expected_);
+    ensure_geometry_equals(cuts, expected_cuts);
+    ensure_geometry_equals(dangles, expected_dangles);
+    ensure_geometry_equals(invalidRings, expected_invalidRings);
+
+    GEOSGeom_destroy(cuts);
+    GEOSGeom_destroy(dangles);
+    GEOSGeom_destroy(invalidRings);
+
+    GEOSGeom_destroy(expected_cuts);
+    GEOSGeom_destroy(expected_dangles);
+    GEOSGeom_destroy(expected_invalidRings);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fix from https://github.com/locationtech/jts/pull/949
Resolves https://github.com/libgeos/geos/issues/782