### PR TITLE
Add functions to interrupt processing in a specific thread/context

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -123,6 +123,12 @@ extern "C" {
     }
 
     void
+    GEOS_interruptThread()
+    {
+        geos::util::Interrupt::requestForCurrentThread();
+    }
+
+    void
     GEOS_interruptCancel()
     {
         geos::util::Interrupt::cancel();

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -296,8 +296,8 @@ typedef int (*GEOSTransformXYCallback)(
 /* ========== Interruption ========== */
 
 /**
-* Callback function for use in interruption. The callback will be invoked _before_ checking for
-* interruption, so can be used to request it.
+* Callback function for use in interruption. The callback will be invoked at each
+* possible interruption point and can be used to request interruption.
 *
 * \see GEOS_interruptRegisterCallback
 * \see GEOS_interruptRequest
@@ -306,18 +306,55 @@ typedef int (*GEOSTransformXYCallback)(
 typedef void (GEOSInterruptCallback)(void);
 
 /**
-* Register a function to be called when processing is interrupted.
+* Callback function for use in interruption. The callback will be invoked at each
+* possible interruption point and can be used to request interruption.
+*
+* \see GEOS_interruptRegisterThreadCallback
+* \see GEOS_interruptThread
+*/
+typedef void (GEOSInterruptThreadCallback)(void*);
+
+/**
+* Register a function to be called when a possible interruption point is reached
+* on any thread. The function may be used to request interruption.
+*
 * \param cb Callback function to invoke
-* \return the previously configured callback
+* \return the previously registered callback, or NULL
 * \see GEOSInterruptCallback
+* \see GEOSContext_setInterruptCallback_r
 */
 extern GEOSInterruptCallback GEOS_DLL *GEOS_interruptRegisterCallback(
     GEOSInterruptCallback* cb);
 
 /**
-* Request safe interruption of operations
+* Register a function to be called when a possible interruption point is reached
+* in code executed in the specified context. The function can interrupt the
+* thread if desired by calling GEOS_interruptThread.
+*
+* \param extHandle the context returned by \ref GEOS_init_r.
+* \param cb Callback function to invoke
+* \param userData optional data to be pe provided as argument to callback
+* \return the previously registered callback, or NULL
+* \see GEOSInterruptThreadCallback
+*/
+extern GEOSInterruptThreadCallback GEOS_DLL *GEOSContext_setInterruptCallback_r(
+        GEOSContextHandle_t extHandle,
+        GEOSInterruptThreadCallback* cb,
+        void* userData);
+
+/**
+* Request safe interruption of operations. The next thread to check for an
+* interrupt will be interrupted. To request interruption of a specific thread,
+* instead call GEOS_interruptThread() from a callback executed by that thread.
 */
 extern void GEOS_DLL GEOS_interruptRequest(void);
+
+/**
+* Request safe interruption of operations in the current thread. This function
+* should be called from a callback registered by GEOS_interruptRegisterThreadCallback()
+* or GEOS_interruptRegisterCallback().
+*/
+extern void GEOS_DLL GEOS_interruptThread(void);
 
 /**
 * Cancel a pending interruption request

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -204,6 +204,8 @@ typedef struct GEOSContextHandle_HS {
     void* noticeData;
     GEOSMessageHandler errorMessageOld;
     GEOSMessageHandler_r errorMessageNew;
+    GEOSInterruptThreadCallback* interrupt_cb;
+    void* interrupt_cb_data;
     void* errorData;
     uint8_t WKBOutputDims;
     int WKBByteOrder;
@@ -218,6 +220,8 @@ typedef struct GEOSContextHandle_HS {
         noticeData(nullptr),
         errorMessageOld(nullptr),
         errorMessageNew(nullptr),
+        interrupt_cb(nullptr),
+        interrupt_cb_data(nullptr),
         errorData(nullptr),
         point2d(nullptr)
     {
@@ -273,6 +277,15 @@ typedef struct GEOSContextHandle_HS {
         errorData = userData;
 
         return f;
+    }
+
+    GEOSInterruptThreadCallback*
+    setInterruptHandler(GEOSInterruptThreadCallback* cb, void* userData)
+    {
+        auto old = interrupt_cb;
+        interrupt_cb = cb;
+        interrupt_cb_data = userData;
+        return old;
     }
 
     void
@@ -375,12 +388,37 @@ gstrdup(std::string const& str)
     return gstrdup_s(str.c_str(), str.size());
 }
 
+struct InterruptManager {
+    InterruptManager(GEOSContextHandle_t handle) :
+        cb(handle->interrupt_cb),
+        cb_data(handle->interrupt_cb_data) {
+        if (cb) {
+            geos::util::Interrupt::registerThreadCallback(cb, cb_data);
+        }
+    }
+
+    ~InterruptManager() {
+        if (cb != nullptr) {
+            geos::util::Interrupt::registerThreadCallback(nullptr, nullptr);
+        }
+    }
+
+    GEOSInterruptThreadCallback* cb;
+    void* cb_data;
+};
+
+struct NotInterruptible {
+    NotInterruptible(GEOSContextHandle_t handle) {
+        (void) handle;
+    }
+};
+
 } // namespace anonymous
 
 // Execute a lambda, using the given context handle to process errors.
 // Return errval on error.
 // Errval should be of the type returned by f, unless f returns a bool in which case we promote to char.
-template<typename F>
+template<typename InterruptManagerType=InterruptManager, typename F>
 inline auto execute(
         GEOSContextHandle_t extHandle,
         typename std::conditional<std::is_same<decltype(std::declval<F>()()),bool>::value,
@@ -396,6 +434,8 @@ inline auto execute(
         return errval;
     }
 
+    InterruptManagerType ic(handle);
+
     try {
         return f();
     } catch (const std::exception& e) {
@@ -409,7 +449,7 @@ inline auto execute(
 
 // Execute a lambda, using the given context handle to process errors.
 // Return nullptr on error.
-template<typename F, typename std::enable_if<!std::is_void<decltype(std::declval<F>()())>::value, std::nullptr_t>::type = nullptr>
+template<typename InterruptManagerType=InterruptManager, typename F, typename std::enable_if<!std::is_void<decltype(std::declval<F>()())>::value, std::nullptr_t>::type = nullptr>
 inline auto execute(GEOSContextHandle_t extHandle, F&& f) -> decltype(f()) {
     if (extHandle == nullptr) {
         return nullptr;
@@ -419,6 +459,8 @@ inline auto execute(GEOSContextHandle_t extHandle, F&& f) -> decltype(f()) {
     if (!handle->initialized) {
         return nullptr;
     }
+
+    InterruptManagerType ic(handle);
 
     try {
         return f();
@@ -433,9 +475,14 @@ inline auto execute(GEOSContextHandle_t extHandle, F&& f) -> decltype(f()) {
 
 // Execute a lambda, using the given context handle to process errors.
 // No return value.
-template<typename F, typename std::enable_if<std::is_void<decltype(std::declval<F>()())>::value, std::nullptr_t>::type = nullptr>
+template<typename InterruptManagerType=InterruptManager, typename F, typename std::enable_if<std::is_void<decltype(std::declval<F>()())>::value, std::nullptr_t>::type = nullptr>
 inline void execute(GEOSContextHandle_t extHandle, F&& f) {
     GEOSContextHandleInternal_t* handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+
+    if (handle != nullptr) {
+        InterruptManagerType ic(handle);
+    }
+
     try {
         f();
     } catch (const std::exception& e) {
@@ -512,6 +559,17 @@ extern "C" {
         }
 
         return handle->setErrorHandler(ef, userData);
+    }
+
+    GEOSInterruptThreadCallback*
+    GEOSContext_setInterruptCallback_r(GEOSContextHandle_t extHandle, GEOSInterruptThreadCallback* cb, void* userData)
+    {
+        GEOSContextHandleInternal_t* handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+        if(0 == handle->initialized) {
+            return nullptr;
+        }
+
+        return handle->setInterruptHandler(cb, userData);
     }
 
     void
@@ -879,7 +937,7 @@ extern "C" {
     int
     GEOSArea_r(GEOSContextHandle_t extHandle, const Geometry* g, double* area)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             *area = g->getArea();
             return 1;
         });
@@ -888,7 +946,7 @@ extern "C" {
     int
     GEOSLength_r(GEOSContextHandle_t extHandle, const Geometry* g, double* length)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             *length = g->getLength();
             return 1;
         });
@@ -1640,7 +1698,7 @@ extern "C" {
     int
     GEOSGetNumInteriorRings_r(GEOSContextHandle_t extHandle, const Geometry* g1)
     {
-        return execute(extHandle, -1, [&]() {
+        return execute<NotInterruptible>(extHandle, -1, [&]() {
             const Polygon* p = dynamic_cast<const Polygon*>(g1);
             if(!p) {
                 throw IllegalArgumentException("Argument is not a Polygon");
@@ -1654,7 +1712,7 @@ extern "C" {
     int
     GEOSGetNumGeometries_r(GEOSContextHandle_t extHandle, const Geometry* g1)
     {
-        return execute(extHandle, -1, [&]() {
+        return execute<NotInterruptible>(extHandle, -1, [&]() {
             return static_cast<int>(g1->getNumGeometries());
         });
     }
@@ -1667,7 +1725,7 @@ extern "C" {
     const Geometry*
     GEOSGetGeometryN_r(GEOSContextHandle_t extHandle, const Geometry* g1, int n)
     {
-        return execute(extHandle, [&]() {
+        return execute<NotInterruptible>(extHandle, [&]() {
             if(n < 0) {
                 throw IllegalArgumentException("Index must be non-negative.");
             }
@@ -1856,7 +1914,7 @@ extern "C" {
     const Geometry*
     GEOSGetExteriorRing_r(GEOSContextHandle_t extHandle, const Geometry* g1)
     {
-        return execute(extHandle, [&]() {
+        return execute<NotInterruptible>(extHandle, [&]() {
             const Polygon* p = dynamic_cast<const Polygon*>(g1);
             if(!p) {
                 throw IllegalArgumentException("Invalid argument (must be a Polygon)");
@@ -1872,7 +1930,7 @@ extern "C" {
     const Geometry*
     GEOSGetInteriorRingN_r(GEOSContextHandle_t extHandle, const Geometry* g1, int n)
     {
-        return execute(extHandle, [&]() {
+        return execute<NotInterruptible>(extHandle, [&]() {
             const Polygon* p = dynamic_cast<const Polygon*>(g1);
             if(!p) {
                 throw IllegalArgumentException("Invalid argument (must be a Polygon)");
@@ -2573,7 +2631,7 @@ extern "C" {
     GEOSCoordSeq_setOrdinate_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs,
                                unsigned int idx, unsigned int dim, double val)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             cs->setOrdinate(idx, dim, val);
             return 1;
         });
@@ -2600,7 +2658,7 @@ extern "C" {
     int
     GEOSCoordSeq_setXY_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs, unsigned int idx, double x, double y)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             cs->setAt(CoordinateXY{x, y}, idx);
             return 1;
         });
@@ -2609,7 +2667,7 @@ extern "C" {
     int
     GEOSCoordSeq_setXYZ_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs, unsigned int idx, double x, double y, double z)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             cs->setAt(Coordinate{x, y, z}, idx);
             return 1;
         });
@@ -2627,7 +2685,7 @@ extern "C" {
     GEOSCoordSeq_getOrdinate_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs,
                                unsigned int idx, unsigned int dim, double* val)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             *val = cs->getOrdinate(idx, dim);
             return 1;
         });
@@ -2654,7 +2712,7 @@ extern "C" {
     int
     GEOSCoordSeq_getXY_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs, unsigned int idx, double* x, double* y)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             auto& c = cs->getAt(idx);
             *x = c.x;
             *y = c.y;
@@ -2665,7 +2723,7 @@ extern "C" {
     int
     GEOSCoordSeq_getXYZ_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs, unsigned int idx, double* x, double* y, double* z)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             auto& c = cs->getAt(idx);
             *x = c.x;
             *y = c.y;
@@ -2677,7 +2735,7 @@ extern "C" {
     int
     GEOSCoordSeq_getSize_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs, unsigned int* size)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             const std::size_t sz = cs->getSize();
             *size = static_cast<unsigned int>(sz);
             return 1;
@@ -2687,7 +2745,7 @@ extern "C" {
     int
     GEOSCoordSeq_getDimensions_r(GEOSContextHandle_t extHandle, const CoordinateSequence* cs, unsigned int* dims)
     {
-        return execute(extHandle, 0, [&]() {
+        return execute<NotInterruptible>(extHandle, 0, [&]() {
             const std::size_t dim = cs->getDimension();
             *dims = static_cast<unsigned int>(dim);
 

--- a/include/geos/util/Interrupt.h
+++ b/include/geos/util/Interrupt.h
@@ -27,14 +27,24 @@ class GEOS_DLL Interrupt {
 public:
 
     typedef void (Callback)(void);
+    typedef void (ThreadCallback)(void*);
 
     /**
      * Request interruption of operations
      *
      * Operations will be terminated by a GEOSInterrupt
-     * exception at first occasion.
+     * exception at first occasion, by the first thread
+     * to check for an interrupt request.
      */
     static void request();
+
+    /**
+     * Request interruption of operations in the current thread
+     *
+     * Operations in the current thread will be terminated by
+     * a GEOSInterrupt at first occasion.
+     */
+    static void requestForCurrentThread();
 
     /** Cancel a pending interruption request */
     static void cancel();
@@ -43,16 +53,28 @@ public:
     static bool check();
 
     /** \brief
-     * Register a callback that will be invoked
+     * Register a callback that will be invoked by all threads
      * before checking for interruption requests.
      *
      * NOTE that interruption request checking may happen
-     * frequently so any callback would better be quick.
+     * frequently so the callback should execute quickly.
      *
      * The callback can be used to call Interrupt::request()
-     *
+     * or Interrupt::requestForCurrentThread().
      */
     static Callback* registerCallback(Callback* cb);
+
+    /** \brief
+     * Register a callback that will be invoked the current thread
+     * before checking for interruption requests.
+     *
+     * NOTE that interruption request checking may happen
+     * frequently so the callback should execute quickly.
+     *
+     * The callback can be used to call Interrupt::request()
+     * or Interrupt::requestForCurrentThread().
+     */
+    static ThreadCallback* registerThreadCallback(ThreadCallback* cb, void* data);
 
     /**
      * Invoke the callback, if any. Process pending interruption, if any.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -44,6 +44,7 @@ foreach(_testfile ${_testfiles})
       string(CONCAT _testname "geos::" ${_testname})
     endif()
     add_test(NAME unit-${_cmake_testname} COMMAND test_geos_unit ${_testname})
+    set_tests_properties(unit-${_cmake_testname} PROPERTIES TIMEOUT 30)
 endforeach()
 
 # Run all the unit tests in one go, for faster memory checking

--- a/tests/unit/util/InterruptTest.cpp
+++ b/tests/unit/util/InterruptTest.cpp
@@ -1,0 +1,140 @@
+// tut
+#include <tut/tut.hpp>
+// geos
+#include <geos/util/Interrupt.h>
+// std
+#include <chrono>
+#include <functional>
+#include <thread>
+
+using geos::util::Interrupt;
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_interrupt_data {
+    static void workForever() {
+        try {
+            std::cerr << "Started " << std::this_thread::get_id() << "." << std::endl;
+            while (true) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                GEOS_CHECK_FOR_INTERRUPTS();
+            }
+        } catch (const std::exception&) {
+            std::cerr << "Interrupted " << std::this_thread::get_id() << "." << std::endl;
+            return;
+        }
+    }
+
+    static void interruptNow() {
+        Interrupt::request();
+    }
+
+    static std::map<std::thread::id, bool>* toInterrupt;
+
+    static void interruptIfRequested() {
+        if (toInterrupt == nullptr) {
+            return;
+        }
+
+        auto it = toInterrupt->find(std::this_thread::get_id());
+        if (it != toInterrupt->end() && it->second) {
+            it->second = false;
+            Interrupt::requestForCurrentThread();
+        }
+    }
+};
+
+std::map<std::thread::id, bool>* test_interrupt_data::toInterrupt = nullptr;
+
+typedef test_group<test_interrupt_data> group;
+typedef group::object object;
+
+group test_interrupt_group("geos::util::Interrupt");
+
+//
+// Test Cases
+//
+
+
+// Interrupt worker thread via global request from from main thead
+template<>
+template<>
+void object::test<1>
+()
+{
+    std::thread t(workForever);
+    Interrupt::request();
+
+    t.join();
+}
+
+// Interrupt worker thread via thread-specific request from worker thread using a callback
+template<>
+template<>
+void object::test<2>
+()
+{
+    Interrupt::registerCallback(interruptIfRequested);
+
+    std::thread t1(workForever);
+    std::thread t2(workForever);
+
+    // Create map and add entries before exposing it to the interrupt
+    // callback that will be acessed from multiple threads. It's OK
+    // for multiple threads to modify entries in the map but not for
+    // multiple threads to create entries.
+    std::map<std::thread::id, bool> shouldInterrupt;
+    shouldInterrupt[t1.get_id()] = false;
+    shouldInterrupt[t2.get_id()] = false;
+    toInterrupt = &shouldInterrupt;
+
+    shouldInterrupt[t2.get_id()] = true;
+    t2.join();
+
+    shouldInterrupt[t1.get_id()] = true;
+    t1.join();
+}
+
+// Register separate callbacks for each thread. Each callback will
+// request interruption of itself only.
+template<>
+template<>
+void object::test<3>
+()
+{
+    bool interrupt1 = false;
+    int numCalls2 = 0;
+
+    auto cb1 = ([](void* data) {
+        if (*static_cast<bool*>(data)) {
+            Interrupt::requestForCurrentThread();
+        }
+    });
+
+    auto cb2 = ([](void* data) {
+        if (++*static_cast<int*>(data) > 5) {
+            Interrupt::requestForCurrentThread();
+        }
+    });
+
+
+    std::thread t1([&cb1, &interrupt1]() {
+        Interrupt::registerThreadCallback(cb1, &interrupt1);
+    });
+
+    std::thread t2([&cb2, &numCalls2]() {
+        Interrupt::registerThreadCallback(cb2, &numCalls2);
+    });
+
+    t2.join();
+
+    interrupt1 = true;
+    t1.join();
+}
+
+} // namespace tut
+


### PR DESCRIPTION
This PR is an alternative API to #761. Instead of registering an interrupt handler for the calling thread -- which is a bit awkward, the handler is registered with the context handle. Since the C++ library has no notion of a context handle, the C API registers and unregisters the interrupt handler with every C API call. To avoid a significant performance penalty for very short C API functions, the C API `execute` error handler is modified so that functions can be tagged as noninterruptible so the interrupt handler will not be registered when they are called. 