### PR TITLE
Avoid FE_INVALID floating point errors in HausdorffDistance and VoronoiDiagram

### DIFF
--- a/src/algorithm/CGAlgorithmsDD.cpp
+++ b/src/algorithm/CGAlgorithmsDD.cpp
@@ -158,6 +158,9 @@ CGAlgorithmsDD::intersection(const CoordinateXY& p1, const CoordinateXY& p2,
 CoordinateXY
 CGAlgorithmsDD::circumcentreDD(const CoordinateXY& a, const CoordinateXY& b, const CoordinateXY& c)
 {
+    if((a == b) && (a == c)){
+        return a;
+    }
     DD ax = DD(a.x) - DD(c.x);
     DD ay = DD(a.y) - DD(c.y);
     DD bx = DD(b.x) - DD(c.x);

--- a/src/geom/LineSegment.cpp
+++ b/src/geom/LineSegment.cpp
@@ -55,6 +55,9 @@ LineSegment::projectionFactor(const CoordinateXY& p) const
     if(p == p1) {
         return 1.0;
     }
+    if(p0 == p1) {
+        return 0.0;
+    }
     // Otherwise, use comp.graphics.algorithms Frequently Asked Questions method
     /*(1)     	      AC dot AB
                    r = ---------

--- a/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <string>
 #include <memory>
+#include <cfenv>
 
 namespace geos {
 namespace geom {
@@ -181,6 +182,24 @@ void object::test<5>
     ensure(std::isnan(distance));
 }
 
+
+// https://github.com/libgeos/geos/issues/515
+//
+// Avoid FE_INVALID floating point errors being raised
+//
+template<>
+template<>
+void object::test<6>
+()
+{
+    std::feclearexcept(FE_ALL_EXCEPT);
+
+    runTest(
+        "LINESTRING (0 0, 100 0, 10 100, 10 100)",
+        "LINESTRING (0 100, 0 10, 80 10)", 0.001, 47.89);
+
+    ensure("FE_INVALID raised", !std::fetestexcept(FE_INVALID));
+}
 
 } // namespace tut
 

--- a/tests/unit/capi/GEOSVoronoiDiagramTest.cpp
+++ b/tests/unit/capi/GEOSVoronoiDiagramTest.cpp
@@ -5,6 +5,7 @@
 // geos
 #include <geos_c.h>
 // std
+#include <cfenv>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -61,6 +62,8 @@ template<>
 void object::test<1>
 ()
 {
+    std::feclearexcept(FE_ALL_EXCEPT);
+
     geom1_ = GEOSGeomFromWKT("POINT(10 20)");
 
     geom2_ = GEOSVoronoiDiagram(geom1_, nullptr, 0, 0);
@@ -70,6 +73,8 @@ void object::test<1>
     GEOSGeom_destroy(geom2_);
     geom2_ = GEOSVoronoiDiagram(geom1_, nullptr, 0, 1);
     ensure_geometry_equals(geom2_, "MULTILINESTRING EMPTY");
+
+    ensure("FE_INVALID raised", !std::fetestexcept(FE_INVALID));
 }
 
 //More points:


### PR DESCRIPTION
Similarly as https://github.com/libgeos/geos/pull/790 / https://github.com/libgeos/geos/pull/791 and fixes the remaining cases originally reported in https://github.com/libgeos/geos/issues/515