### PR TITLE
Add GEOSEqualsIdentical C API function for checking binary equivalence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ xxxx-xx-xx
   - Geometry clustering: DBSCAN, geometry intersection/distance, envelope
     intersection/distance (GH-688, Dan Baston)
   - CAPI: GEOSLineSubstring (GH-706, Dan Baston)
+  - CAPI: GEOSEqualsIdentical (GH-810, Dan Baston)
   - Voronoi: Add option to create diagram in order consistent with inputs (GH-781, Dan Baston)
 
 - Fixes/Improvements:

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -267,6 +267,12 @@ extern "C" {
         return GEOSEqualsExact_r(handle, g1, g2, tolerance);
     }
 
+    char
+    GEOSIdentical(const Geometry* g1, const Geometry* g2)
+    {
+        return GEOSIdentical_r(handle, g1, g2);
+    }
+
     int
     GEOSDistance(const Geometry* g1, const Geometry* g2, double* dist)
     {

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -268,9 +268,9 @@ extern "C" {
     }
 
     char
-    GEOSIdentical(const Geometry* g1, const Geometry* g2)
+    GEOSEqualsIdentical(const Geometry* g1, const Geometry* g2)
     {
-        return GEOSIdentical_r(handle, g1, g2);
+        return GEOSEqualsIdentical_r(handle, g1, g2);
     }
 
     int

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1088,6 +1088,12 @@ extern char GEOS_DLL GEOSEqualsExact_r(
     const GEOSGeometry* g2,
     double tolerance);
 
+/** \see GEOSIdentical */
+extern char GEOS_DLL GEOSIdentical_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g1,
+    const GEOSGeometry* g2);
+
 /** \see GEOSCovers */
 extern char GEOS_DLL GEOSCovers_r(
     GEOSContextHandle_t handle,
@@ -4226,6 +4232,8 @@ extern char GEOS_DLL GEOSCoveredBy(const GEOSGeometry* g1, const GEOSGeometry* g
 * checking that they have identical structure
 * and that each vertex of g2 is
 * within the distance tolerance of the corresponding vertex in g1.
+* Z and M values are ignored by GEOSEqualsExact, and this function may return true
+* for inputs with different dimensionality.
 * Unlike GEOSEquals(), geometries that are topologically equivalent but have different
 * representations (e.g., LINESTRING (0 0, 1 1) and MULTILINESTRING ((0 0, 1 1)) ) are not
 * considered equal by GEOSEqualsExact().
@@ -4239,6 +4247,19 @@ extern char GEOS_DLL GEOSEqualsExact(
     const GEOSGeometry* g1,
     const GEOSGeometry* g2,
     double tolerance);
+
+/**
+ * Determine pointwise equivalence of two geometries by checking
+ * that the structure, ordering, and values of all vertices are
+ * identical in all dimensions.
+ *
+* \param g1 Input geometry
+* \param g2 Input geometry
+* \returns 1 on true, 0 on false, 2 on exception
+*/
+extern char GEOS_DLL GEOSIdentical(
+        const GEOSGeometry* g1,
+        const GEOSGeometry* g2);
 
 /**
 * Calculate the DE9IM pattern for this geometry pair

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -4251,7 +4251,8 @@ extern char GEOS_DLL GEOSEqualsExact(
 /**
  * Determine pointwise equivalence of two geometries by checking
  * that the structure, ordering, and values of all vertices are
- * identical in all dimensions.
+ * identical in all dimensions. NaN values are considered to be
+ * equal to other NaN values.
  *
 * \param g1 Input geometry
 * \param g2 Input geometry

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1088,8 +1088,8 @@ extern char GEOS_DLL GEOSEqualsExact_r(
     const GEOSGeometry* g2,
     double tolerance);
 
-/** \see GEOSIdentical */
-extern char GEOS_DLL GEOSIdentical_r(
+/** \see GEOSEqualsIdentical */
+extern char GEOS_DLL GEOSEqualsIdentical_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g1,
     const GEOSGeometry* g2);
@@ -4257,7 +4257,7 @@ extern char GEOS_DLL GEOSEqualsExact(
 * \param g2 Input geometry
 * \returns 1 on true, 0 on false, 2 on exception
 */
-extern char GEOS_DLL GEOSIdentical(
+extern char GEOS_DLL GEOSEqualsIdentical(
         const GEOSGeometry* g1,
         const GEOSGeometry* g2);
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -813,10 +813,10 @@ extern "C" {
     }
 
     char
-    GEOSIdentical_r(GEOSContextHandle_t extHandle, const Geometry* g1, const Geometry* g2)
+    GEOSEqualsIdentical_r(GEOSContextHandle_t extHandle, const Geometry* g1, const Geometry* g2)
     {
         return execute(extHandle, 2, [&]() {
-            return g1->identicalTo(*g2);
+            return g1->equalsIdentical(g2);
         });
     }
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -812,6 +812,14 @@ extern "C" {
         });
     }
 
+    char
+    GEOSIdentical_r(GEOSContextHandle_t extHandle, const Geometry* g1, const Geometry* g2)
+    {
+        return execute(extHandle, 2, [&]() {
+            return g1->identicalTo(*g2);
+        });
+    }
+
     int
     GEOSDistance_r(GEOSContextHandle_t extHandle, const Geometry* g1, const Geometry* g2, double* dist)
     {

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -572,7 +572,7 @@ public:
      * Returns true if the two sequences are identical or pointwise
      * equal in all dimensions.
      */
-    bool identicalTo(const CoordinateSequence& other) const;
+    bool equalsIdentical(const CoordinateSequence& other) const;
 
     /// Scroll given CoordinateSequence so to start with given Coordinate.
     static void scroll(CoordinateSequence* cl, const CoordinateXY* firstCoordinate);

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -569,8 +569,8 @@ public:
 
     /**
      * \brief
-     * Returns true if the two sequences are identical or pointwise
-     * equal in all dimensions.
+     * Returns true if the two sequences are identical (pointwise
+     * equal in all dimensions, with NaN == NaN).
      */
     bool equalsIdentical(const CoordinateSequence& other) const;
 

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -562,10 +562,17 @@ public:
     /**
      * \brief
      * Returns true if the two arrays are identical, both null,
-     * or pointwise equal
+     * or pointwise equal in two dimensions
      */
     static bool equals(const CoordinateSequence* cl1,
                        const CoordinateSequence* cl2);
+
+    /**
+     * \brief
+     * Returns true if the two sequences are identical or pointwise
+     * equal in all dimensions.
+     */
+    bool identicalTo(const CoordinateSequence& other) const;
 
     /// Scroll given CoordinateSequence so to start with given Coordinate.
     static void scroll(CoordinateSequence* cl, const CoordinateXY* firstCoordinate);

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -728,10 +728,18 @@ public:
 
     /** \brief
      * Returns true iff the two Geometrys are of the same type and their
-     * vertices corresponding by index are equal up to a specified tolerance.
+     * vertices corresponding by index are equal up to a specified distance
+     * tolerance. Geometries are not required to have the same dimemsion;
+     * any Z/M values are ignored.
      */
     virtual bool equalsExact(const Geometry* other, double tolerance = 0)
         const = 0; // Abstract
+
+    /** \brief
+     * Returns true if the two geometries are of the same type and their
+     * vertices corresponding by index are equal in all dimensions.
+     */
+    virtual bool identicalTo(const Geometry& other) const = 0;
 
     virtual void apply_rw(const CoordinateFilter* filter) = 0; //Abstract
     virtual void apply_ro(CoordinateFilter* filter) const = 0; //Abstract

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -739,7 +739,7 @@ public:
      * Returns true if the two geometries are of the same type and their
      * vertices corresponding by index are equal in all dimensions.
      */
-    virtual bool identicalTo(const Geometry& other) const = 0;
+    virtual bool equalsIdentical(const Geometry* other) const = 0;
 
     virtual void apply_rw(const CoordinateFilter* filter) = 0; //Abstract
     virtual void apply_ro(CoordinateFilter* filter) const = 0; //Abstract

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -137,7 +137,7 @@ public:
     bool equalsExact(const Geometry* other,
                      double tolerance = 0) const override;
 
-    bool identicalTo(const Geometry& other) const override;
+    bool equalsIdentical(const Geometry* other) const override;
 
     void apply_ro(CoordinateFilter* filter) const override;
 

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -137,6 +137,8 @@ public:
     bool equalsExact(const Geometry* other,
                      double tolerance = 0) const override;
 
+    bool identicalTo(const Geometry& other) const override;
+
     void apply_ro(CoordinateFilter* filter) const override;
 
     void apply_rw(const CoordinateFilter* filter) override;

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -156,6 +156,8 @@ public:
     bool equalsExact(const Geometry* other, double tolerance = 0)
     const override;
 
+    bool identicalTo(const Geometry& other) const override;
+
     void apply_rw(const CoordinateFilter* filter) override;
 
     void apply_ro(CoordinateFilter* filter) const override;

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -156,7 +156,7 @@ public:
     bool equalsExact(const Geometry* other, double tolerance = 0)
     const override;
 
-    bool identicalTo(const Geometry& other) const override;
+    bool equalsIdentical(const Geometry* other) const override;
 
     void apply_rw(const CoordinateFilter* filter) override;
 

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -143,6 +143,8 @@ public:
 
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
 
+    bool identicalTo(const Geometry& other) const override;
+
     void
     normalize(void) override
     {

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -143,7 +143,7 @@ public:
 
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
 
-    bool identicalTo(const Geometry& other) const override;
+    bool equalsIdentical(const Geometry* other) const override;
 
     void
     normalize(void) override

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -138,6 +138,7 @@ public:
     std::string getGeometryType() const override;
     GeometryTypeId getGeometryTypeId() const override;
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
+    bool identicalTo(const Geometry& other) const override;
     void apply_rw(const CoordinateFilter* filter) override;
     void apply_ro(CoordinateFilter* filter) const override;
     void apply_rw(GeometryFilter* filter) override;

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -138,7 +138,7 @@ public:
     std::string getGeometryType() const override;
     GeometryTypeId getGeometryTypeId() const override;
     bool equalsExact(const Geometry* other, double tolerance = 0) const override;
-    bool identicalTo(const Geometry& other) const override;
+    bool equalsIdentical(const Geometry* other) const override;
     void apply_rw(const CoordinateFilter* filter) override;
     void apply_ro(CoordinateFilter* filter) const override;
     void apply_rw(GeometryFilter* filter) override;

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -445,7 +445,7 @@ CoordinateSequence::equals(const CoordinateSequence* cl1,
 }
 
 bool
-CoordinateSequence::identicalTo(const CoordinateSequence& other) const
+CoordinateSequence::equalsIdentical(const CoordinateSequence& other) const
 {
     if (this == &other) {
         return true;

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -465,7 +465,15 @@ CoordinateSequence::equalsIdentical(const CoordinateSequence& other) const
 
     assert(getCoordinateType() == other.getCoordinateType());
 
-    return std::memcmp(data(), other.data(), size() * stride() * sizeof(double)) == 0;
+    for (std::size_t i = 0; i < m_vect.size(); i++) {
+        const double& a = m_vect[i];
+        const double& b = other.m_vect[i];
+        if (a != b && !(std::isnan(a) && std::isnan(b))) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -23,6 +23,7 @@
 #include <geos/util.h>
 
 #include <cstdio>
+#include <cstring>
 #include <algorithm>
 #include <vector>
 #include <cassert>
@@ -441,6 +442,30 @@ CoordinateSequence::equals(const CoordinateSequence* cl1,
         }
     }
     return true;
+}
+
+bool
+CoordinateSequence::identicalTo(const CoordinateSequence& other) const
+{
+    if (this == &other) {
+        return true;
+    }
+
+    if (size() != other.size()) {
+        return false;
+    }
+
+    if (hasZ() != other.hasZ()) {
+        return false;
+    }
+
+    if (hasM() != other.hasM()) {
+        return false;
+    }
+
+    assert(getCoordinateType() == other.getCoordinateType());
+
+    return std::memcmp(data(), other.data(), size() * stride() * sizeof(double)) == 0;
 }
 
 void

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -231,13 +231,13 @@ GeometryCollection::equalsExact(const Geometry* other, double tolerance) const
 }
 
 bool
-GeometryCollection::identicalTo(const Geometry& other_g) const
+GeometryCollection::equalsIdentical(const Geometry* other_g) const
 {
-    if(!isEquivalentClass(&other_g)) {
+    if(!isEquivalentClass(other_g)) {
         return false;
     }
 
-    const auto& other = static_cast<const GeometryCollection&>(other_g);
+    const auto& other = static_cast<const GeometryCollection&>(*other_g);
     if(getNumGeometries() != other.getNumGeometries()) {
         return false;
     }
@@ -247,7 +247,7 @@ GeometryCollection::identicalTo(const Geometry& other_g) const
     }
 
     for(std::size_t i = 0; i < getNumGeometries(); i++) {
-        if(!(getGeometryN(i)->identicalTo(*other.getGeometryN(i)))) {
+        if(!(getGeometryN(i)->equalsIdentical(other.getGeometryN(i)))) {
             return false;
         }
     }

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -230,6 +230,31 @@ GeometryCollection::equalsExact(const Geometry* other, double tolerance) const
     return true;
 }
 
+bool
+GeometryCollection::identicalTo(const Geometry& other_g) const
+{
+    if(!isEquivalentClass(&other_g)) {
+        return false;
+    }
+
+    const auto& other = static_cast<const GeometryCollection&>(other_g);
+    if(getNumGeometries() != other.getNumGeometries()) {
+        return false;
+    }
+
+    if (envelope && other.envelope && *envelope != *other.envelope) {
+        return false;
+    }
+
+    for(std::size_t i = 0; i < getNumGeometries(); i++) {
+        if(!(getGeometryN(i)->identicalTo(*other.getGeometryN(i)))) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void
 GeometryCollection::apply_rw(const CoordinateFilter* filter)
 {

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -270,11 +270,27 @@ LineString::equalsExact(const Geometry* other, double tolerance) const
         return false;
     }
     for(std::size_t i = 0; i < npts; ++i) {
-        if(!equal(points->getAt(i), otherLineString->points->getAt(i), tolerance)) {
+        if(!equal(points->getAt<CoordinateXY>(i), otherLineString->points->getAt<CoordinateXY>(i), tolerance)) {
             return false;
         }
     }
     return true;
+}
+
+bool
+LineString::identicalTo(const Geometry& other_g) const
+{
+    if(!isEquivalentClass(&other_g)) {
+        return false;
+    }
+
+    const auto& other = static_cast<const LineString&>(other_g);
+
+    if (envelope && other.envelope && *envelope != *other.envelope) {
+        return false;
+    }
+
+    return getCoordinatesRO()->identicalTo(*other.getCoordinatesRO());
 }
 
 void

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -278,19 +278,19 @@ LineString::equalsExact(const Geometry* other, double tolerance) const
 }
 
 bool
-LineString::identicalTo(const Geometry& other_g) const
+LineString::equalsIdentical(const Geometry* other_g) const
 {
-    if(!isEquivalentClass(&other_g)) {
+    if(!isEquivalentClass(other_g)) {
         return false;
     }
 
-    const auto& other = static_cast<const LineString&>(other_g);
+    const auto& other = static_cast<const LineString&>(*other_g);
 
     if (envelope && other.envelope && *envelope != *other.envelope) {
         return false;
     }
 
-    return getCoordinatesRO()->identicalTo(*other.getCoordinatesRO());
+    return getCoordinatesRO()->equalsIdentical(*other.getCoordinatesRO());
 }
 
 void

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -283,14 +283,14 @@ Point::equalsExact(const Geometry* other, double tolerance) const
 }
 
 bool
-Point::identicalTo(const Geometry& other) const
+Point::equalsIdentical(const Geometry* other) const
 {
-    if(!isEquivalentClass(&other)) {
+    if(!isEquivalentClass(other)) {
         return false;
     }
 
-    return getCoordinatesRO()->identicalTo(
-                *static_cast<const Point&>(other).getCoordinatesRO());
+    return getCoordinatesRO()->equalsIdentical(
+                *static_cast<const Point*>(other)->getCoordinatesRO());
 }
 
 int

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -282,6 +282,17 @@ Point::equalsExact(const Geometry* other, double tolerance) const
     return equal(*this_coord, *other_coord, tolerance);
 }
 
+bool
+Point::identicalTo(const Geometry& other) const
+{
+    if(!isEquivalentClass(&other)) {
+        return false;
+    }
+
+    return getCoordinatesRO()->identicalTo(
+                *static_cast<const Point&>(other).getCoordinatesRO());
+}
+
 int
 Point::compareToSameClass(const Geometry* g) const
 {

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -302,13 +302,13 @@ Polygon::equalsExact(const Geometry* other, double tolerance) const
 }
 
 bool
-Polygon::identicalTo(const Geometry& other_g) const
+Polygon::equalsIdentical(const Geometry* other_g) const
 {
-    if(!isEquivalentClass(&other_g)) {
+    if(!isEquivalentClass(other_g)) {
         return false;
     }
 
-    const auto& other = static_cast<const Polygon&>(other_g);
+    const auto& other = static_cast<const Polygon&>(*other_g);
 
     if (getNumInteriorRing() != other.getNumInteriorRing()) {
         return false;
@@ -318,12 +318,12 @@ Polygon::identicalTo(const Geometry& other_g) const
         return false;
     }
 
-    if (!getExteriorRing()->identicalTo(*other.getExteriorRing())) {
+    if (!getExteriorRing()->equalsIdentical(other.getExteriorRing())) {
             return false;
     }
 
     for (std::size_t i = 0; i < getNumInteriorRing(); i++) {
-        if (!getInteriorRingN(i)->identicalTo(*other.getInteriorRingN(i))) {
+        if (!getInteriorRingN(i)->equalsIdentical(other.getInteriorRingN(i))) {
             return false;
         }
     }

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -301,6 +301,36 @@ Polygon::equalsExact(const Geometry* other, double tolerance) const
     return true;
 }
 
+bool
+Polygon::identicalTo(const Geometry& other_g) const
+{
+    if(!isEquivalentClass(&other_g)) {
+        return false;
+    }
+
+    const auto& other = static_cast<const Polygon&>(other_g);
+
+    if (getNumInteriorRing() != other.getNumInteriorRing()) {
+        return false;
+    }
+
+    if (envelope && other.envelope && *envelope != *other.envelope) {
+        return false;
+    }
+
+    if (!getExteriorRing()->identicalTo(*other.getExteriorRing())) {
+            return false;
+    }
+
+    for (std::size_t i = 0; i < getNumInteriorRing(); i++) {
+        if (!getInteriorRingN(i)->identicalTo(*other.getInteriorRingN(i))) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void
 Polygon::apply_ro(CoordinateFilter* filter) const
 {

--- a/tests/unit/capi/GEOSEqualsIdenticalTest.cpp
+++ b/tests/unit/capi/GEOSEqualsIdenticalTest.cpp
@@ -113,7 +113,7 @@ void object::test<8>
     geom1_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), 0);
     geom2_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::signaling_NaN(), 0);
 
-    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 1);
 }
 
 // equal lines
@@ -198,6 +198,18 @@ void object::test<15>
     geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((2 2, 3 3), (1 1, 2 2))");
 
     ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
+}
+
+// negative zero and positive zero are equal
+template<>
+template<>
+void object::test<16>
+()
+{
+    geom1_ = GEOSGeom_createPointFromXY(1, 0.0);
+    geom2_ = GEOSGeom_createPointFromXY(1, -0.0);
+
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 1);
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSEqualsIdenticalTest.cpp
+++ b/tests/unit/capi/GEOSEqualsIdenticalTest.cpp
@@ -18,7 +18,7 @@ struct test_geosidentical_data : public capitest::utility {};
 typedef test_group<test_geosidentical_data> group;
 typedef group::object object;
 
-group test_geosidentical_group("capi::GEOSIdentical");
+group test_geosidentical_group("capi::GEOSEqualsIdentical");
 
 // empty inputs of different types
 template<>
@@ -29,7 +29,7 @@ void object::test<1>
     geom1_ = GEOSGeomFromWKT("POINT EMPTY");
     geom2_ = GEOSGeomFromWKT("LINESTRING EMPTY");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // empty inputs of different dimensions
@@ -41,7 +41,7 @@ void object::test<2>
     geom1_ = GEOSGeomFromWKT("POINT EMPTY");
     geom2_ = GEOSGeomFromWKT("POINT Z EMPTY");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // non-empty inputs of different dimensions
@@ -53,7 +53,7 @@ void object::test<3>
     geom1_ = GEOSGeomFromWKT("POINT Z (1 2 3)");
     geom2_ = GEOSGeomFromWKT("POINT M (1 2 3)");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // non-empty inputs of different dimensions
@@ -65,7 +65,7 @@ void object::test<4>
     geom1_ = GEOSGeomFromWKT("POINT ZM (1 2 3 4)");
     geom2_ = GEOSGeomFromWKT("POINT Z (1 2 3)");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // inputs with different structure
@@ -77,7 +77,7 @@ void object::test<5>
     geom1_ = GEOSGeomFromWKT("LINESTRING (1 1, 2 2)");
     geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // inputs with different type
@@ -89,7 +89,7 @@ void object::test<6>
     geom1_ = GEOSGeomFromWKT("GEOMETRYCOLLECTION (LINESTRING (1 1, 2 2))");
     geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // inputs with identical non-finite values
@@ -101,7 +101,7 @@ void object::test<7>
     geom1_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity());
     geom2_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity());
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 1);
 }
 
 // inputs with almost-identical non-finite values
@@ -113,7 +113,7 @@ void object::test<8>
     geom1_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), 0);
     geom2_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::signaling_NaN(), 0);
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // equal lines
@@ -125,7 +125,7 @@ void object::test<9>
     geom1_ = GEOSGeomFromWKT("LINESTRING M (1 1 0, 2 2 1)");
     geom2_ = GEOSGeomFromWKT("LINESTRING M (1 1 0, 2 2 1)");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 1);
 }
 
 // different lines
@@ -137,7 +137,7 @@ void object::test<10>
     geom1_ = GEOSGeomFromWKT("LINESTRING M (1 1 0, 2 2 1)");
     geom2_ = GEOSGeomFromWKT("LINESTRING M (1 1 1, 2 2 1)");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // equal polygons
@@ -149,7 +149,7 @@ void object::test<11>
     geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
     geom2_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 1);
 }
 
 // different polygons (ordering)
@@ -161,7 +161,7 @@ void object::test<12>
     geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
     geom2_ = GEOSGeomFromWKT("POLYGON ((1 0, 1 1, 0 0, 1 0))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // different polygons (number of holes)
@@ -173,7 +173,7 @@ void object::test<13>
     geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1))");
     geom2_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1), (3 3, 4 3, 4 4, 3 3))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 // identical collections
@@ -185,7 +185,7 @@ void object::test<14>
     geom1_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2), (2 2, 3 3))");
     geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2), (2 2, 3 3))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 1);
 }
 
 // different collections (structure)
@@ -197,7 +197,7 @@ void object::test<15>
     geom1_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2), (2 2, 3 3))");
     geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((2 2, 3 3), (1 1, 2 2))");
 
-    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+    ensure_equals(GEOSEqualsIdentical(geom1_, geom2_), 0);
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSIdenticalTest.cpp
+++ b/tests/unit/capi/GEOSIdenticalTest.cpp
@@ -1,0 +1,204 @@
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+
+// std
+#include <limits>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_geosidentical_data : public capitest::utility {};
+
+typedef test_group<test_geosidentical_data> group;
+typedef group::object object;
+
+group test_geosidentical_group("capi::GEOSIdentical");
+
+// empty inputs of different types
+template<>
+template<>
+void object::test<1>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POINT EMPTY");
+    geom2_ = GEOSGeomFromWKT("LINESTRING EMPTY");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// empty inputs of different dimensions
+template<>
+template<>
+void object::test<2>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POINT EMPTY");
+    geom2_ = GEOSGeomFromWKT("POINT Z EMPTY");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// non-empty inputs of different dimensions
+template<>
+template<>
+void object::test<3>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POINT Z (1 2 3)");
+    geom2_ = GEOSGeomFromWKT("POINT M (1 2 3)");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// non-empty inputs of different dimensions
+template<>
+template<>
+void object::test<4>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POINT ZM (1 2 3 4)");
+    geom2_ = GEOSGeomFromWKT("POINT Z (1 2 3)");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// inputs with different structure
+template<>
+template<>
+void object::test<5>
+()
+{
+    geom1_ = GEOSGeomFromWKT("LINESTRING (1 1, 2 2)");
+    geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// inputs with different type
+template<>
+template<>
+void object::test<6>
+()
+{
+    geom1_ = GEOSGeomFromWKT("GEOMETRYCOLLECTION (LINESTRING (1 1, 2 2))");
+    geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// inputs with identical non-finite values
+template<>
+template<>
+void object::test<7>
+()
+{
+    geom1_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity());
+    geom2_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity());
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+}
+
+// inputs with almost-identical non-finite values
+template<>
+template<>
+void object::test<8>
+()
+{
+    geom1_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::quiet_NaN(), 0);
+    geom2_ = GEOSGeom_createPointFromXY(std::numeric_limits<double>::signaling_NaN(), 0);
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// equal lines
+template<>
+template<>
+void object::test<9>
+()
+{
+    geom1_ = GEOSGeomFromWKT("LINESTRING M (1 1 0, 2 2 1)");
+    geom2_ = GEOSGeomFromWKT("LINESTRING M (1 1 0, 2 2 1)");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+}
+
+// different lines
+template<>
+template<>
+void object::test<10>
+()
+{
+    geom1_ = GEOSGeomFromWKT("LINESTRING M (1 1 0, 2 2 1)");
+    geom2_ = GEOSGeomFromWKT("LINESTRING M (1 1 1, 2 2 1)");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// equal polygons
+template<>
+template<>
+void object::test<11>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
+    geom2_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+}
+
+// different polygons (ordering)
+template<>
+template<>
+void object::test<12>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
+    geom2_ = GEOSGeomFromWKT("POLYGON ((1 0, 1 1, 0 0, 1 0))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// different polygons (number of holes)
+template<>
+template<>
+void object::test<13>
+()
+{
+    geom1_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1))");
+    geom2_ = GEOSGeomFromWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 1), (3 3, 4 3, 4 4, 3 3))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+// identical collections
+template<>
+template<>
+void object::test<14>
+()
+{
+    geom1_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2), (2 2, 3 3))");
+    geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2), (2 2, 3 3))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 1);
+}
+
+// different collections (structure)
+template<>
+template<>
+void object::test<15>
+()
+{
+    geom1_ = GEOSGeomFromWKT("MULTILINESTRING ((1 1, 2 2), (2 2, 3 3))");
+    geom2_ = GEOSGeomFromWKT("MULTILINESTRING ((2 2, 3 3), (1 1, 2 2))");
+
+    ensure_equals(GEOSIdentical(geom1_, geom2_), 0);
+}
+
+} // namespace tut
+

--- a/tests/unit/geom/CoordinateSequenceTest.cpp
+++ b/tests/unit/geom/CoordinateSequenceTest.cpp
@@ -1417,7 +1417,7 @@ void object::test<53>
     ensure_equals_xyzm(dst.getAt<CoordinateXYZM>(3), CoordinateXYZM{10, 11,  DoubleNotANumber, 12});
 }
 
-// Test identicalTo()
+// Test equalsIdentical()
 template<>
 template<>
 void object::test<54>
@@ -1441,12 +1441,12 @@ void object::test<54>
     xy3.setAt(Coordinate(4, 5, 6), 1);
     xy3.setAt(Coordinate(7, 8, 9), 2);
 
-    ensure(xy3.identicalTo(xy3));
+    ensure(xy3.equalsIdentical(xy3));
 
-    ensure(!xyz2.identicalTo(xyz3));
-    ensure(!xyz3.identicalTo(xy3));
-    ensure(xyz3.identicalTo(xyz3_2));
-    ensure(xyz3_2.identicalTo(xyz3));
+    ensure(!xyz2.equalsIdentical(xyz3));
+    ensure(!xyz3.equalsIdentical(xy3));
+    ensure(xyz3.equalsIdentical(xyz3_2));
+    ensure(xyz3_2.equalsIdentical(xyz3));
 }
 
 } // namespace tut

--- a/tests/unit/geom/CoordinateSequenceTest.cpp
+++ b/tests/unit/geom/CoordinateSequenceTest.cpp
@@ -1417,4 +1417,36 @@ void object::test<53>
     ensure_equals_xyzm(dst.getAt<CoordinateXYZM>(3), CoordinateXYZM{10, 11,  DoubleNotANumber, 12});
 }
 
+// Test identicalTo()
+template<>
+template<>
+void object::test<54>
+()
+{
+    CoordinateSequence xyz2 = CoordinateSequence::XYZ(2);
+    CoordinateSequence xyz3 = CoordinateSequence::XYZ(3);
+    CoordinateSequence xy3 = CoordinateSequence::XY(3);
+    CoordinateSequence xyz3_2 = CoordinateSequence::XYZ(0);
+
+    xyz2.setAt(Coordinate(1, 2, 3), 0);
+    xyz2.setAt(Coordinate(4, 5, 6), 1);
+
+    xyz3.setAt(Coordinate(1, 2, 3), 0);
+    xyz3.setAt(Coordinate(4, 5, 6), 1);
+    xyz3.setAt(Coordinate(7, 8, 9), 2);
+
+    xyz3_2.add(xyz3);
+
+    xy3.setAt(Coordinate(1, 2, 3), 0);
+    xy3.setAt(Coordinate(4, 5, 6), 1);
+    xy3.setAt(Coordinate(7, 8, 9), 2);
+
+    ensure(xy3.identicalTo(xy3));
+
+    ensure(!xyz2.identicalTo(xyz3));
+    ensure(!xyz3.identicalTo(xy3));
+    ensure(xyz3.identicalTo(xyz3_2));
+    ensure(xyz3_2.identicalTo(xyz3));
+}
+
 } // namespace tut


### PR DESCRIPTION
This PR adds a C API function `GEOSIdentical` that determines if two geometries are ~binary-equivalent~ pointwise-equivalent. It is distinct from other predicates such as `GEOSEquals` (which uses topological equality, returning `true` for different representations of the same structure) and `GEOSEqualsExact` (which uses pointwise equality, but allows for a distance tolerance and ignores Z/M values). This also differs from the above functions in applying a test of binary equivalence (NaN = NaN) rather than numeric equality (NaN != NaN).

I think there may _also_ be a place for some kind of `GEOSEqualsExactDims(int dims, double tol)` function that allows you to specify which dimensions you're interested in, but for the common case of "tol = 0, dims = ALL" it is worthwhile to have a specific function that can use a more efficient implementation.