### PR TITLE
DOC: Update docstring of GEOSSnap / GeometrySnapper to clarify behavior

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -4079,7 +4079,20 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXY(
     void* userdata);
 
 /**
-* Snap first geometry onto second within the given tolerance.
+* Snaps the vertices and segments of the first geometry to vertices of the
+* second geometry within the given tolerance.
+*
+* Snapping one geometry to another can improve robustness for overlay operations
+* by eliminating nearly-coincident edges (which cause problems during noding and
+* intersection calculation). Because too much snapping can result in invalid
+* topology being created, heuristics are used to determine the number and
+* location of snapped vertices that are likely safe to snap. These heuristics
+* may omit some potential snaps that are otherwise within the tolerance.
+*
+* Where possible, this operation tries to avoid creating invalid geometries;
+* however, it does not guarantee that output geometries will be valid.  It is
+* the responsibility of the caller to check for and handle invalid geometries.
+*
 * \param input An input geometry
 * \param snap_target A geometry to snap the input to
 * \param tolerance Snapping tolerance

--- a/include/geos/operation/overlay/snap/GeometrySnapper.h
+++ b/include/geos/operation/overlay/snap/GeometrySnapper.h
@@ -43,16 +43,16 @@ namespace snap { // geos::operation::overlay::snap
  * Snaps the vertices and segments of a {@link geom::Geometry}
  * to another Geometry's vertices.
  *
- * A snap distance tolerance is used to control where snapping is performed.
- * Snapping one geometry to another can improve
- * robustness for overlay operations by eliminating
- * nearly-coincident edges
- * (which cause problems during noding and intersection calculation).
- * Too much snapping can result in invalid topology
- * being created, so the number and location of snapped vertices
- * is decided using heuristics to determine when it
- * is safe to snap.
- * This can result in some potential snaps being omitted, however.
+ * Snapping one geometry to another can improve robustness for overlay operations
+ * by eliminating nearly-coincident edges (which cause problems during noding and
+ * intersection calculation). Because too much snapping can result in invalid
+ * topology being created, heuristics are used to determine the number and
+ * location of snapped vertices that are likely safe to snap. These heuristics
+ * may omit some potential snaps that are otherwise within the tolerance.
+ *
+ * Where possible, this operation tries to avoid creating invalid geometries;
+ * however, it does not guarantee that output geometries will be valid.  It is
+ * the responsibility of the caller to check for and handle invalid geometries.
  */
 class GEOS_DLL GeometrySnapper {
 


### PR DESCRIPTION
resolves #814 

This updates the docstrings of `GEOSSnap` and `GeometrySnapper` to better clarify behavior, especially regarding creation of invalid geometries.