### PR TITLE
WKTWriter: Disable removal of empty dimensions

### DIFF
--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -147,6 +147,18 @@ public:
     void setTrim(bool p0);
 
     /**
+     * Enables/disables removal of Z/M dimensions that have
+     * no non-NaN values in a geometry.
+     *
+     * @brief setRemoveEmptyDimensions
+     * @param remove
+     */
+    void setRemoveEmptyDimensions(bool remove)
+    {
+        removeEmptyDimensions = remove;
+    }
+
+    /**
      * Enable old style 3D/4D WKT generation.
      *
      * By default the WKBWriter produces new style 3D/4D WKT
@@ -290,6 +302,8 @@ private:
     int roundingPrecision;
 
     bool trim;
+
+    bool removeEmptyDimensions = false;
 
     int level;
 

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -212,7 +212,7 @@ WKTWriter::appendGeometryTaggedText(const Geometry& geometry,
                                     Writer& writer) const
 {
     OrdinateSet outputOrdinates = OrdinateSet::createXY();
-    if (geometry.isEmpty()) {
+    if (geometry.isEmpty() || !removeEmptyDimensions) {
         // for an empty geometry, use the declared dimensionality
         outputOrdinates.setZ(geometry.hasZ());
         outputOrdinates.setM(geometry.hasM());

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -191,7 +191,7 @@ BufferBuilder::bufferLineSingleSided(const Geometry* g, double distance,
         CoordinateSequence* seq = lineList[i];
 
         // SegmentString takes ownership of CoordinateSequence
-        SegmentString* ss = new NodedSegmentString(seq, false, false, nullptr);
+        SegmentString* ss = new NodedSegmentString(seq, seq->hasZ(), seq->hasM(), nullptr);
         curveList.push_back(ss);
     }
     lineList.clear();

--- a/src/operation/buffer/BufferCurveSetBuilder.cpp
+++ b/src/operation/buffer/BufferCurveSetBuilder.cpp
@@ -113,9 +113,7 @@ BufferCurveSetBuilder::addCurve(CoordinateSequence* coord,
     Label* newlabel = new Label(0, Location::BOUNDARY, leftLoc, rightLoc);
 
     // coord ownership transferred to SegmentString
-    constexpr bool hasZ = false;
-    constexpr bool hasM = false;
-    SegmentString* e = new NodedSegmentString(coord, hasZ, hasM, newlabel);
+    SegmentString* e = new NodedSegmentString(coord, coord->hasZ(), coord->hasM(), newlabel);
 
     // SegmentString doesnt own the sequence, so we need to delete in
     // the destructor

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -346,5 +346,44 @@ void object::test<12>
     ensure_equals(wktwriter.write(*poly_xyzm), std::string("POLYGON ZM EMPTY"));
 }
 
+// Test writing an explicitly-created XYZ geometry where Z is NaN
+// https://github.com/libgeos/geos/issues/808
+template<>
+template<>
+void object::test<13>
+()
+{
+    wktwriter.setOutputDimension(3);
+    wktwriter.setTrim(true);
+
+    CoordinateSequence xyz(1, true, false);
+    xyz.setAt(Coordinate(1, 2, std::numeric_limits<double>::quiet_NaN()), 0);
+    auto pt = gf->createPoint(std::move(xyz));
+
+    ensure_equals(wktwriter.write(*pt), std::string("POINT Z (1 2 NaN)"));
+
+    wktwriter.setRemoveEmptyDimensions(true);
+
+    ensure_equals(wktwriter.write(*pt), std::string("POINT (1 2)"));
+}
+
+// Test removal of empty dimensions
+template<>
+template<>
+void object::test<14>
+()
+{
+    wktwriter.setOutputDimension(4);
+    wktwriter.setTrim(true);
+
+    auto g = wktreader.read("LINESTRING ZM (1 2 NaN 3, 4 5 NaN NaN)");
+
+    ensure_equals(wktwriter.write(*g), "LINESTRING ZM (1 2 NaN 3, 4 5 NaN NaN)");
+
+    wktwriter.setRemoveEmptyDimensions(true);
+
+    ensure_equals(wktwriter.write(*g), "LINESTRING M (1 2 3, 4 5 NaN)");
+}
+
 } // namespace tut
 


### PR DESCRIPTION
The removal of empty dimensions (JTS behavior) is still available by a flag that defaults to off.

Also fix a case in `BufferBuilder` where a geometry declared to be 2D was storing 3D coordinates. Correct output of this case depended on `WKTWriter` ignoring the declared dimensionality.

Resolves https://github.com/libgeos/geos/issues/808