### PR TITLE
Make prepared geometry (more?) thread-safe

### DIFF
--- a/benchmarks/index/chain/MonotoneChainBuilderPerfTest.cpp
+++ b/benchmarks/index/chain/MonotoneChainBuilderPerfTest.cpp
@@ -60,7 +60,7 @@ static void BM_MonotoneChainBuilder(benchmark::State& state) {
 
     for (auto _ : state) {
         std::vector<MonotoneChain> chains;
-        MonotoneChainBuilder::getChains(&cs, nullptr, chains);
+        MonotoneChainBuilder::getChains(&cs, nullptr, 0, chains);
     }
 }
 

--- a/benchmarks/index/chain/MonotoneChainPerfTest.cpp
+++ b/benchmarks/index/chain/MonotoneChainPerfTest.cpp
@@ -48,8 +48,8 @@ static void BM_MonotoneChainOverlaps(benchmark::State& state) {
         prev = c;
     }
 
-    MonotoneChain mc1(cs1, 0, cs1.size(), nullptr);
-    MonotoneChain mc2(cs2, 0, cs1.size(), nullptr);
+    MonotoneChain mc1(cs1, 0, cs1.size(), nullptr, 0.0);
+    MonotoneChain mc2(cs2, 0, cs1.size(), nullptr, 0.0);
 
     struct EmptyOverlapAction : public MonotoneChainOverlapAction {
         virtual void

--- a/include/geos/geom/prep/PreparedLineString.h
+++ b/include/geos/geom/prep/PreparedLineString.h
@@ -40,9 +40,12 @@ namespace prep { // geos::geom::prep
  */
 class PreparedLineString : public BasicPreparedGeometry {
 private:
-    std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;
+    mutable std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;
     mutable noding::SegmentString::ConstVect segStrings;
     mutable std::unique_ptr<operation::distance::IndexedFacetDistance> indexedDistance;
+
+    mutable std::once_flag segIntFinderFlag;
+    mutable std::once_flag indexedDistanceFlag;
 
 protected:
 public:
@@ -54,7 +57,7 @@ public:
 
     ~PreparedLineString() override;
 
-    noding::FastSegmentSetIntersectionFinder* getIntersectionFinder();
+    noding::FastSegmentSetIntersectionFinder* getIntersectionFinder() const;
 
     bool intersects(const geom::Geometry* g) const override;
     std::unique_ptr<geom::CoordinateSequence> nearestPoints(const geom::Geometry* g) const override;

--- a/include/geos/geom/prep/PreparedLineStringIntersects.h
+++ b/include/geos/geom/prep/PreparedLineStringIntersects.h
@@ -58,10 +58,7 @@ public:
         return op.intersects(geom);
     }
 
-    /**
-     * \todo FIXME - mloskot: Why not taking linestring through const reference?
-     */
-    PreparedLineStringIntersects(PreparedLineString& prep)
+    PreparedLineStringIntersects(const PreparedLineString& prep)
         : prepLine(prep)
     { }
 
@@ -74,7 +71,7 @@ public:
     bool intersects(const geom::Geometry* g) const;
 
 protected:
-    PreparedLineString& prepLine;
+    const PreparedLineString& prepLine;
 
     /**
      * Tests whether any representative point of the test Geometry intersects

--- a/include/geos/geom/prep/PreparedPolygon.h
+++ b/include/geos/geom/prep/PreparedPolygon.h
@@ -50,12 +50,18 @@ namespace prep { // geos::geom::prep
  */
 class PreparedPolygon : public BasicPreparedGeometry {
 private:
-    bool isRectangle;
     mutable std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;
     mutable std::unique_ptr<algorithm::locate::PointOnGeometryLocator> ptOnGeomLoc;
     mutable std::unique_ptr<algorithm::locate::PointOnGeometryLocator> indexedPtOnGeomLoc;
-    mutable noding::SegmentString::ConstVect segStrings;
     mutable std::unique_ptr<operation::distance::IndexedFacetDistance> indexedDistance;
+
+    mutable noding::SegmentString::ConstVect segStrings;
+
+    mutable std::once_flag segIntFinderFlag;
+    mutable std::once_flag ptOnGeomLocFlag;
+    mutable std::once_flag indexedPtOnGeomLocFlag;
+    mutable std::once_flag indexedDistanceFlag;
+    bool isRectangle;
 
 protected:
 public:

--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -96,13 +96,12 @@ public:
     ///   Ownership left to caller, this class holds a reference.
     ///
     MonotoneChain(const geom::CoordinateSequence& pts,
-                  std::size_t start, std::size_t end, void* context);
+                  std::size_t start, std::size_t end, void* context, double expansionDistance);
 
     ~MonotoneChain() = default;
 
     /// Returned envelope is owned by this class
     const geom::Envelope& getEnvelope() const;
-    const geom::Envelope& getEnvelope(double expansionDistance) const;
 
     size_t
     getStartIndex() const

--- a/include/geos/index/chain/MonotoneChain.h
+++ b/include/geos/index/chain/MonotoneChain.h
@@ -95,6 +95,8 @@ public:
     /// @param context
     ///   Ownership left to caller, this class holds a reference.
     ///
+    /// @param expansionDistance distance by which envelope should be expanded
+    ///
     MonotoneChain(const geom::CoordinateSequence& pts,
                   std::size_t start, std::size_t end, void* context, double expansionDistance);
 

--- a/include/geos/index/chain/MonotoneChainBuilder.h
+++ b/include/geos/index/chain/MonotoneChainBuilder.h
@@ -58,6 +58,7 @@ public:
      */
     static void getChains(const geom::CoordinateSequence* pts,
                           void* context,
+                          double expansionDistance,
                           std::vector<MonotoneChain>& mcList);
 
     /**

--- a/include/geos/math/DD.h
+++ b/include/geos/math/DD.h
@@ -92,6 +92,8 @@
 
 #pragma once
 
+#include <geos/export.h>
+
 #include <cmath>
 
 namespace geos {
@@ -115,36 +117,36 @@ class GEOS_DLL DD {
 
 
     public:
-        DD(double p_hi, double p_lo) : hi(p_hi), lo(p_lo) {};
-        DD(double x) : hi(x), lo(0.0) {};
-        DD() : hi(0.0), lo(0.0) {};
+        constexpr DD(double p_hi, double p_lo) : hi(p_hi), lo(p_lo) {};
+        constexpr DD(double x) : hi(x), lo(0.0) {};
+        constexpr DD() : hi(0.0), lo(0.0) {};
 
-        bool operator==(const DD &rhs) const
+        constexpr bool operator==(const DD &rhs) const
         {
             return hi == rhs.hi && lo == rhs.lo;
         }
 
-        bool operator!=(const DD &rhs) const
+        constexpr bool operator!=(const DD &rhs) const
         {
             return hi != rhs.hi || lo != rhs.lo;
         }
 
-        bool operator<(const DD &rhs) const
+        constexpr bool operator<(const DD &rhs) const
         {
             return (hi < rhs.hi) || (hi == rhs.hi && lo < rhs.lo);
         }
 
-        bool operator<=(const DD &rhs) const
+        constexpr bool operator<=(const DD &rhs) const
         {
             return (hi < rhs.hi) || (hi == rhs.hi && lo <= rhs.lo);
         }
 
-        bool operator>(const DD &rhs) const
+        constexpr bool operator>(const DD &rhs) const
         {
             return (hi > rhs.hi) || (hi == rhs.hi && lo > rhs.lo);
         }
 
-        bool operator>=(const DD &rhs) const
+        constexpr bool operator>=(const DD &rhs) const
         {
             return (hi > rhs.hi) || (hi == rhs.hi && lo >= rhs.lo);
         }

--- a/include/geos/noding/FastSegmentSetIntersectionFinder.h
+++ b/include/geos/noding/FastSegmentSetIntersectionFinder.h
@@ -49,8 +49,7 @@ namespace noding { // geos::noding
  */
 class FastSegmentSetIntersectionFinder {
 private:
-    std::unique_ptr<MCIndexSegmentSetMutualIntersector> segSetMutInt;
-    std::unique_ptr<geos::algorithm::LineIntersector> lineIntersector;
+    MCIndexSegmentSetMutualIntersector segSetMutInt;
 
 protected:
 public:
@@ -67,7 +66,7 @@ public:
     const SegmentSetMutualIntersector*
     getSegmentSetIntersector() const
     {
-        return segSetMutInt.get();
+        return &segSetMutInt;
     }
 
     bool intersects(SegmentString::ConstVect* segStrings);

--- a/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
+++ b/include/geos/noding/MCIndexSegmentSetMutualIntersector.h
@@ -29,8 +29,6 @@ class SegmentIntersector;
 }
 }
 
-//using namespace geos::index::strtree;
-
 namespace geos {
 namespace noding { // geos::noding
 
@@ -45,12 +43,7 @@ class MCIndexSegmentSetMutualIntersector : public SegmentSetMutualIntersector {
 public:
 
     MCIndexSegmentSetMutualIntersector(double p_tolerance)
-        : monoChains()
-        , indexCounter(0)
-        , processCounter(0)
-        , nOverlaps(0)
-        , overlapTolerance(p_tolerance)
-        , indexBuilt(false)
+        : overlapTolerance(p_tolerance)
     {}
 
     MCIndexSegmentSetMutualIntersector()
@@ -68,8 +61,9 @@ public:
 
     void setBaseSegments(SegmentString::ConstVect* segStrings) override;
 
-    // NOTE: re-populates the MonotoneChain vector with newly created chains
     void process(SegmentString::ConstVect* segStrings) override;
+
+    void process(SegmentString::ConstVect* segStrings, SegmentIntersector* si);
 
     class SegmentOverlapAction : public index::chain::MonotoneChainOverlapAction {
     private:
@@ -98,7 +92,6 @@ public:
 private:
 
     typedef std::vector<index::chain::MonotoneChain> MonoChains;
-    MonoChains monoChains;
 
     /*
      * The index::SpatialIndex used should be something that supports
@@ -106,23 +99,18 @@ private:
      * or index::strtree::STRtree).
      */
     index::strtree::TemplateSTRtree<const index::chain::MonotoneChain*> index;
-    int indexCounter;
-    int processCounter;
-    // statistics
-    int nOverlaps;
-    double overlapTolerance;
+
+    const double overlapTolerance;
 
     /* memory management helper, holds MonotoneChain objects used
      * in the SpatialIndex. It's cleared when the SpatialIndex is
      */
-    bool indexBuilt;
+    std::once_flag indexBuilt;
     MonoChains indexChains;
 
-    void addToIndex(SegmentString* segStr);
+    void intersectChains(const MonoChains& chains, SegmentIntersector& segmentIntersector);
 
-    void intersectChains();
-
-    void addToMonoChains(SegmentString* segStr);
+    void addChains(const SegmentString* segStr, MonoChains& chains) const;
 
 };
 

--- a/include/geos/noding/SegmentIntersectionDetector.h
+++ b/include/geos/noding/SegmentIntersectionDetector.h
@@ -40,7 +40,7 @@ namespace noding { // geos::noding
  */
 class SegmentIntersectionDetector : public SegmentIntersector {
 private:
-    algorithm::LineIntersector* li;
+    algorithm::LineIntersector li;
 
     bool findProper;
     bool findAllTypes;
@@ -54,9 +54,8 @@ private:
 
 protected:
 public:
-    SegmentIntersectionDetector(algorithm::LineIntersector* p_li)
+    SegmentIntersectionDetector()
         :
-        li(p_li),
         findProper(false),
         findAllTypes(false),
         _hasIntersection(false),
@@ -68,7 +67,6 @@ public:
 
     ~SegmentIntersectionDetector() override
     {
-        //delete intPt;
         delete intSegments;
     }
 

--- a/src/algorithm/CGAlgorithmsDD.cpp
+++ b/src/algorithm/CGAlgorithmsDD.cpp
@@ -31,7 +31,8 @@ namespace {
 inline int
 OrientationDD(const DD &dd)
 {
-    static DD const zero(0.0);
+    constexpr const DD zero(0.0);
+
     if(dd < zero) {
         return CGAlgorithmsDD::RIGHT;
     }

--- a/src/algorithm/locate/IndexedPointInAreaLocator.cpp
+++ b/src/algorithm/locate/IndexedPointInAreaLocator.cpp
@@ -100,15 +100,12 @@ IndexedPointInAreaLocator::buildIndex(const geom::Geometry& g)
 IndexedPointInAreaLocator::IndexedPointInAreaLocator(const geom::Geometry& g)
     :	areaGeom(g)
 {
+    buildIndex(areaGeom);
 }
 
 geom::Location
 IndexedPointInAreaLocator::locate(const geom::CoordinateXY* /*const*/ p)
 {
-    if (index == nullptr) {
-        buildIndex(areaGeom);
-    }
-
     algorithm::RayCrossingCounter rcc(*p);
 
     index->query(p->y, p->y, [&rcc](const SegmentView& ls) {

--- a/src/geom/prep/AbstractPreparedPolygonContains.cpp
+++ b/src/geom/prep/AbstractPreparedPolygonContains.cpp
@@ -83,9 +83,7 @@ AbstractPreparedPolygonContains::findAndClassifyIntersections(const geom::Geomet
     noding::SegmentString::ConstVect lineSegStr;
     noding::SegmentStringUtil::extractSegmentStrings(geom, lineSegStr);
 
-    algorithm::LineIntersector li;
-
-    noding::SegmentIntersectionDetector intDetector(&li);
+    noding::SegmentIntersectionDetector intDetector;
 
     intDetector.setFindAllIntersectionTypes(true);
     prepPoly->getIntersectionFinder()->intersects(&lineSegStr, &intDetector);

--- a/src/index/chain/MonotoneChain.cpp
+++ b/src/index/chain/MonotoneChain.cpp
@@ -32,29 +32,22 @@ namespace index { // geos.index
 namespace chain { // geos.index.chain
 
 MonotoneChain::MonotoneChain(const geom::CoordinateSequence& newPts,
-                             std::size_t nstart, std::size_t nend, void* nContext)
+                             std::size_t nstart, std::size_t nend, void* nContext,
+                             double expansionDistance)
     : pts(&newPts)
     , context(nContext)
     , start(nstart)
     , end(nend)
-    , env()
-{}
+    , env(pts->getAt<CoordinateXY>(start), pts->getAt<CoordinateXY>(end))
+{
+    if (expansionDistance > 0.0) {
+        env.expandBy(expansionDistance);
+    }
+}
 
 const Envelope&
 MonotoneChain::getEnvelope() const
 {
-    return getEnvelope(0.0);
-}
-
-const Envelope&
-MonotoneChain::getEnvelope(double expansionDistance) const
-{
-    if (env.isNull()) {
-        env.init(pts->getAt<CoordinateXY>(start), pts->getAt<CoordinateXY>(end));
-        if (expansionDistance > 0.0) {
-            env.expandBy(expansionDistance);
-        }
-    }
     return env;
 }
 

--- a/src/index/chain/MonotoneChainBuilder.cpp
+++ b/src/index/chain/MonotoneChainBuilder.cpp
@@ -48,13 +48,14 @@ namespace chain { // geos.index.chain
  */
 class ChainBuilder : public CoordinateFilter {
 public:
-    ChainBuilder(const CoordinateSequence* pts, void* context, std::vector<MonotoneChain> & list) :
+    ChainBuilder(const CoordinateSequence* pts, void* context, double expansionDistance, std::vector<MonotoneChain> & list) :
      m_prev(nullptr),
      m_i(0),
      m_quadrant(-1),
      m_start(0),
      m_seq(pts),
      m_context(context),
+     m_distance(expansionDistance),
      m_list(list) {}
 
     void filter_ro(const CoordinateXY* c) override {
@@ -72,7 +73,7 @@ private:
     void finishChain() {
         if ( m_i == 0 ) return;
         std::size_t chainEnd = m_i - 1;
-        m_list.emplace_back(*m_seq, m_start, chainEnd, m_context);
+        m_list.emplace_back(*m_seq, m_start, chainEnd, m_context, m_distance);
         m_start = chainEnd;
     }
 
@@ -99,6 +100,7 @@ private:
     std::size_t m_start;
     const CoordinateSequence* m_seq;
     void* m_context;
+    double m_distance;
     std::vector<MonotoneChain>& m_list;
 };
 
@@ -106,8 +108,9 @@ private:
 /* static public */
 void
 MonotoneChainBuilder::getChains(const CoordinateSequence* pts, void* context,
+                                double expansionDistance,
                                 std::vector<MonotoneChain>& mcList) {
-    ChainBuilder builder(pts, context, mcList);
+    ChainBuilder builder(pts, context, expansionDistance, mcList);
     pts->apply_ro(&builder);
     builder.finish();
 }

--- a/src/noding/FastSegmentSetIntersectionFinder.cpp
+++ b/src/noding/FastSegmentSetIntersectionFinder.cpp
@@ -39,17 +39,15 @@ namespace noding { // geos::noding
  */
 FastSegmentSetIntersectionFinder::
 FastSegmentSetIntersectionFinder(noding::SegmentString::ConstVect* baseSegStrings)
-    :	segSetMutInt(new MCIndexSegmentSetMutualIntersector()),
-      lineIntersector(new algorithm::LineIntersector())
 {
-    segSetMutInt->setBaseSegments(baseSegStrings);
+    segSetMutInt.setBaseSegments(baseSegStrings);
 }
 
 bool
 FastSegmentSetIntersectionFinder::
 intersects(noding::SegmentString::ConstVect* segStrings)
 {
-    SegmentIntersectionDetector intFinder(lineIntersector.get());
+    SegmentIntersectionDetector intFinder;
 
     return this->intersects(segStrings, &intFinder);
 }
@@ -59,8 +57,7 @@ FastSegmentSetIntersectionFinder::
 intersects(noding::SegmentString::ConstVect* segStrings,
            SegmentIntersectionDetector* intDetector)
 {
-    segSetMutInt->setSegmentIntersector(intDetector);
-    segSetMutInt->process(segStrings);
+    segSetMutInt.process(segStrings, intDetector);
 
     return intDetector->hasIntersection();
 }

--- a/src/noding/MCIndexNoder.cpp
+++ b/src/noding/MCIndexNoder.cpp
@@ -51,7 +51,7 @@ MCIndexNoder::computeNodes(SegmentString::NonConstVect* inputSegStrings)
 
     if (!indexBuilt) {
         for(const auto& mc : monoChains) {
-            index.insert(mc.getEnvelope(overlapTolerance), &mc);
+            index.insert(mc.getEnvelope(), &mc);
         }
         indexBuilt = true;
     }
@@ -84,7 +84,7 @@ MCIndexNoder::add(SegmentString* segStr)
 
     // segChains will contain newly allocated MonotoneChain objects
     MonotoneChainBuilder::getChains(segStr->getCoordinates(),
-                                    segStr, monoChains);
+                                    segStr, overlapTolerance, monoChains);
 
 }
 

--- a/src/noding/SegmentIntersectionDetector.cpp
+++ b/src/noding/SegmentIntersectionDetector.cpp
@@ -43,13 +43,13 @@ processIntersections(
     const CoordinateXY& p10 = e1->getCoordinate<CoordinateXY>( segIndex1 );
     const CoordinateXY& p11 = e1->getCoordinate<CoordinateXY>( segIndex1 + 1 );
 
-    li->computeIntersection(p00, p01, p10, p11);
+    li.computeIntersection(p00, p01, p10, p11);
 
-    if(li->hasIntersection()) {
+    if(li.hasIntersection()) {
         // record intersection info
         _hasIntersection = true;
 
-        bool isProper = li->isProper();
+        bool isProper = li.isProper();
 
         if(isProper) {
             _hasProperIntersection = true;
@@ -69,7 +69,7 @@ processIntersections(
 
         if(!intPt || saveLocation) {
             // record intersection location (approximate)
-            intPt = &li->getIntersection(0);
+            intPt = &li.getIntersection(0);
 
             delete intSegments;
 

--- a/src/operation/buffer/SegmentMCIndex.cpp
+++ b/src/operation/buffer/SegmentMCIndex.cpp
@@ -37,7 +37,7 @@ SegmentMCIndex::SegmentMCIndex(const CoordinateSequence* segs)
 void
 SegmentMCIndex::buildIndex(const CoordinateSequence* segs)
 {
-    chain::MonotoneChainBuilder::getChains(segs, nullptr, segChains);
+    chain::MonotoneChainBuilder::getChains(segs, nullptr, 0.0, segChains);
     for (chain::MonotoneChain& mc : segChains) {
         index.insert(&(mc.getEnvelope()), &mc);
     }

--- a/tests/unit/index/chain/MonotoneChainBuilderTest.cpp
+++ b/tests/unit/index/chain/MonotoneChainBuilderTest.cpp
@@ -40,7 +40,7 @@ void object::test<1>
     std::vector<geos::index::chain::MonotoneChain> chain;
     geos::geom::CoordinateSequence pts;
 
-    geos::index::chain::MonotoneChainBuilder::getChains(&pts, 0, chain);
+    geos::index::chain::MonotoneChainBuilder::getChains(&pts, nullptr, 0, chain);
 
     ensure_equals(chain.size(), 0u);
 }

--- a/tests/unit/operation/relate/RelateOpTest.cpp
+++ b/tests/unit/operation/relate/RelateOpTest.cpp
@@ -111,7 +111,7 @@ void object::test<3>()
     // Launch some threads to check relationships between polygons
     std::vector<std::thread> threads;
     for (std::size_t i = 0; i < numThreads; i++) {
-        threads.emplace_back(runRelate, geoms[i].get(), std::ref(geoms));
+        threads.emplace_back(runRelate, geoms[0].get(), std::ref(geoms));
     }
 
     // Wait for threads to complete


### PR DESCRIPTION
This PR makes prepared geometries thread-safe, or at least more thread safe than they used to be. The clang thread sanitizer reports no errors on the included test. `valgrind --tool=helgrind` reports many, but I'm wondering it isn't correctly understanding the `std::call_once` construct.

This introduces a few number of inconsistencies with JTS. I think they are pretty minor.

- `MonotoneChain::getEnvelope` no longer takes an `expansionDistance` argument. That distance is now provided to `MonotoneChainBuilder`, and the envelopes are eagerly constructed. The previous handling of this parameter was arguably incorrect, in any case.
- `MCIndexSegmentSetMutualIntersector::process` can now accept a `SegmentIntersector` argument so that multiple threads can call `process` with their own `SegmentIntersector`. I did not change the entire `SegmentSetMutualIntersector` interface, just this one class.
- `FastSegmentSetIntersector` no longer shares a `LineIntersector` between calls.
- `IndexedPointInAreaLocator` eagerly builds its index. This should be OK since the locator itself is (usually?) lazily-constructed.

I haven't yet done performance testing to see if there is a penalty for single-threaded uses.
