### PR TITLE
CI: Update Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           arch: 64
           packages: 'g++-5-multilib gcc-5-multilib'
           cmake: 3.13.*
-          os: ubuntu-18.04
+          os: ubuntu-20.04
 
         - cxx_compiler: g++-5
           c_compiler: gcc-5
@@ -45,7 +45,7 @@ jobs:
           arch: 32
           packages: 'g++-5-multilib gcc-5-multilib g++-multilib gcc-multilib'
           cmake: 3.13.*
-          os: ubuntu-18.04
+          os: ubuntu-20.04
 
         - cxx_compiler: g++-6
           c_compiler: gcc-6
@@ -54,7 +54,7 @@ jobs:
           arch: 64
           packages: 'g++-6-multilib gcc-6-multilib'
           cmake: 3.13.*
-          os: ubuntu-18.04
+          os: ubuntu-20.04
 
         - cxx_compiler: g++-7
           c_compiler: gcc-7


### PR DESCRIPTION
Ubuntu 18.04 image will be unsupported beginning April 1, 2023