### PR TITLE
Add Tri invalid index exceptions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,7 @@ xxxx-xx-xx
   - Improve OffsetCurve behaviour and add Joined mode (JTS-956, Martin Davis)
   - GeometryPrecisionReducer preserves input collection types (GH-846, Paul Ramsey)
   - Fix OffsetCurve to handle zero-distance offsets (GH-850, Martin Davis)
+  - Add exceptions for invalid indexes in Tri methods (GH-853, Martin Davis)
 
 ## Changes in 3.11.0
 2022-07-01

--- a/src/triangulate/tri/Tri.cpp
+++ b/src/triangulate/tri/Tri.cpp
@@ -22,6 +22,7 @@
 #include <geos/geom/Triangle.h>
 #include <geos/triangulate/tri/Tri.h>
 #include <geos/util/IllegalArgumentException.h>
+#include <geos/util/IllegalStateException.h>
 #include <geos/util.h>
 
 
@@ -61,7 +62,7 @@ Tri::setTri(TriIndex edgeIndex, Tri* tri)
         case 1: tri1 = tri; return;
         case 2: tri2 = tri; return;
     }
-    assert(false); // never reach here
+    throw util::IllegalArgumentException("Tri::setTri - invalid index");
 }
 
 /* private */
@@ -283,13 +284,12 @@ Tri::hasCoordinate(const Coordinate& v) const
 const Coordinate&
 Tri::getCoordinate(TriIndex i) const
 {
-    if ( i == 0 ) {
-        return p0;
+    switch(i) {
+    case 0: return p0;
+    case 1: return p1;
+    case 2: return p2;
     }
-    if ( i == 1 ) {
-        return p1;
-    }
-    return p2;
+    throw util::IllegalArgumentException("Tri::getCoordinate - invalid index");
 }
 
 /* public */
@@ -327,8 +327,7 @@ Tri::getAdjacent(TriIndex i) const
     case 1: return tri1;
     case 2: return tri2;
     }
-    assert(false); // Never get here
-    return nullptr;
+    throw util::IllegalArgumentException("Tri::getAdjacent - invalid index");
 }
 
 /* public */
@@ -377,6 +376,9 @@ Tri::isInteriorVertex(TriIndex index) const
         const Tri* adj = curr->getAdjacent(currIndex);
         if (adj == nullptr) return false;
         TriIndex adjIndex = adj->getIndex(curr);
+        if (adjIndex < 0) {
+            throw util::IllegalStateException("Inconsistent adjacency - invalid triangulation");
+        }
         curr = adj;
         currIndex = Tri::next(adjIndex);
     }
@@ -510,4 +512,3 @@ operator<<(std::ostream& os, const Tri& tri)
 } // namespace geos.triangulate.tri
 } // namespace geos.triangulate
 } // namespace geos
-


### PR DESCRIPTION
Adds exceptions to `Tri` methods for invalid indexes.

Prevents the infinite looping of #754 (but does not fix the underlying cause).