### PR TITLE
Enhance LargestEmptyCircle boundary handling

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -3891,24 +3891,28 @@ extern GEOSGeometry GEOS_DLL *GEOSMaximumInscribedCircle(
     double tolerance);
 
 /**
-* Constructs the "largest empty circle" (LEC) for a set of obstacle geometries, up to a
-* specified tolerance. The obstacles are point and line geometries. Polygonal obstacles willl
-* be treated as linear features.
-* The LEC is the largest circle which  has its **center** inside the boundary,
-* and whose interior does not intersect with any obstacle. If no boundary is provided, the
-* convex hull of the obstacles is used as the boundary.
+* Constructs the "largest empty circle" (LEC) for a set of obstacle geometries
+* and within a polygonal boundary,
+* with accuracy to to a specified distance tolerance.
+* The obstacles are point and line geometries.
+* Polygonal obstacles are treated as linear features.
+* The LEC is the largest circle whose interior does not intersect with any obstacle.
+* and which has its **center** inside the given boundary.
+* If no boundary is provided, the
+* convex hull of the obstacles is used.
 * The LEC center is the point in the interior of the boundary which has the farthest distance from
-* the obstacles (up to tolerance). The LEC is determined by the center point and a point lying on an
-* obstacle indicating the circle radius.
+* the obstacles (up to the given distance tolerance).
+* The LEC is determined by the center point and a point indicating the circle radius
+* (which will lie on an obstacle).
 * The implementation uses a successive-approximation technique over a grid of square cells covering the obstacles and boundary.
 * The grid is refined using a branch-and-bound algorithm.  Point containment and distance are computed in a performant
 * way by using spatial indexes.
-* Returns a two-point linestring, with the start point at the center of the inscribed circle and the end
-* on the boundary of the inscribed circle.
-* \param obstacles The geometries that the LEC must fit within without covering
-* \param boundary The area within which the LEC must reside
+* Returns the LEC radius as a two-point linestring, with the start point at the center of the inscribed circle and the end
+* on the boundary of the circle.
+* \param obstacles The geometries that the LEC must not cross
+* \param boundary The area to contain the LEC center (may be null or empty)
 * \param tolerance Stop the algorithm when the search area is smaller than this tolerance
-* \return A newly allocated geometry of the LEC. NULL on exception.
+* \return A newly allocated geometry of the LEC radius. NULL on exception.
 * Caller is responsible for freeing with GEOSGeom_destroy().
 * \see geos::algorithm::construct::LargestEmptyCircle
 *

--- a/include/geos/algorithm/construct/LargestEmptyCircle.h
+++ b/include/geos/algorithm/construct/LargestEmptyCircle.h
@@ -115,17 +115,15 @@ private:
     /* private members */
     double tolerance;
     const geom::Geometry* obstacles;
+    std::unique_ptr<geom::Geometry> boundary;
     const geom::GeometryFactory* factory;
-    std::unique_ptr<geom::Geometry> boundary; // convexhull(obstacles)
+    geom::Envelope gridEnv;
     operation::distance::IndexedFacetDistance obstacleDistance;
     bool done;
     std::unique_ptr<algorithm::locate::IndexedPointInAreaLocator> ptLocator;
     std::unique_ptr<operation::distance::IndexedFacetDistance> boundaryDistance;
     geom::CoordinateXY centerPt;
     geom::CoordinateXY radiusPt;
-
-    /* private methods */
-    void setBoundary(const geom::Geometry* obstacles);
 
     /**
     * Computes the signed distance from a point to the constraints
@@ -139,6 +137,7 @@ private:
     */
     double distanceToConstraints(const geom::Coordinate& c);
     double distanceToConstraints(double x, double y);
+    void initBoundary();
     void compute();
 
     /* private class */
@@ -218,4 +217,3 @@ private:
 } // geos::algorithm::construct
 } // geos::algorithm
 } // geos
-

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -62,10 +62,10 @@ struct test_lec_data {
     }
 
     void
-    checkCircle(const Geometry *geom, double build_tolerance, double x, double y, double expectedRadius)
+    checkCircle(const Geometry *obstacles, const Geometry *boundary, double build_tolerance, double x, double y, double expectedRadius)
     {
         double tolerance = 2*build_tolerance;
-        LargestEmptyCircle lec(geom, tolerance);
+        LargestEmptyCircle lec(obstacles, boundary, tolerance);
         std::unique_ptr<Point> centerPoint = lec.getCenter();
         Coordinate centerPt(*centerPoint->getCoordinate());
         Coordinate expectedCenter(x, y);
@@ -114,7 +114,15 @@ struct test_lec_data {
     checkCircle(std::string wkt, double tolerance, double x, double y, double expectedRadius)
     {
         std::unique_ptr<Geometry> geom(reader_.read(wkt));
-        checkCircle(geom.get(), tolerance, x, y, expectedRadius);
+        checkCircle(geom.get(), nullptr, tolerance, x, y, expectedRadius);
+    }
+
+    void
+    checkCircle(std::string wktObstacles, std::string wktBoundary, double tolerance, double x, double y, double expectedRadius)
+    {
+        std::unique_ptr<Geometry> obstacles(reader_.read(wktObstacles));
+        std::unique_ptr<Geometry> boundary(reader_.read(wktBoundary));
+        checkCircle(obstacles.get(), boundary.get(), tolerance, x, y, expectedRadius);
     }
 
 };
@@ -235,7 +243,59 @@ void object::test<9>
        0.01 );
 }
 
+// testBoundaryEmpty
+template<>
+template<>
+void object::test<10>
+()
+{
+ checkCircle("MULTIPOINT ((2 2), (8 8), (7 5))",
+        "POLYGON EMPTY",
+        0.01, 4.127, 4.127, 3 );
+}
+
+// testBoundarySquare
+template<>
+template<>
+void object::test<11>
+()
+{
+    checkCircle("MULTIPOINT ((2 2), (6 4), (8 8))",
+        "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+        0.01, 1.00390625, 8.99609375, 7.065 );
+}
+
+//testBoundarySquareObstaclesOutside
+template<>
+template<>
+void object::test<12>
+()
+{
+    checkCircle("MULTIPOINT ((10 10), (10 0))",
+        "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+        0.01, 1.0044, 4.997, 10.29 );
+}
+
+// testBoundaryMultiSquares
+template<>
+template<>
+void object::test<13>
+()
+{
+    checkCircle("MULTIPOINT ((10 10), (10 0), (5 5))",
+        "MULTIPOLYGON (((1 9, 9 9, 9 1, 1 1, 1 9)), ((15 20, 20 20, 20 15, 15 15, 15 20)))",
+        0.01, 19.995, 19.997, 14.137 );
+}
+
+// testBoundaryAsObstacle
+template<>
+template<>
+void object::test<14>
+()
+{
+    checkCircle("GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9)), POINT (4 3), POINT (7 6))",
+        "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+        0.01, 4, 6, 3 );
+}
 
 } // namespace tut
-
-


### PR DESCRIPTION
Enhances `LargestEmptyCircle` to allow boundaries to be any polygonal geometry.  The boundary may have any spatial relationship to the obstacles (containing, intersecting, or disjoint), or may be empty.

Port of part of https://github.com/locationtech/jts/pull/973