### PR TITLE
geosop: add 'hasZ' and 'hasM' operations; change output to show Z/M

### DIFF
--- a/util/geosop/GeometryOp.cpp
+++ b/util/geosop/GeometryOp.cpp
@@ -110,7 +110,7 @@ struct GeometryOpCreator {
 * Static array of operation definitions.
 * All metadata for an operation is defined here.
 * Operation objects are created on-demand via a
-* lamba, for efficiency.
+* lambda, for efficiency.
 *
 * To add an operation, add an entry to this array.
 *
@@ -132,6 +132,22 @@ std::vector<GeometryOpCreator> opRegistry {
     catGeom, "envelope of geometry",
     [](const std::unique_ptr<Geometry>& geom) {
         return new Result( geom->getEnvelope() );
+    });
+}},
+{"hasZ", [](std::string name) { return GeometryOp::create(name,
+    catGeom,
+    "test if geometry has Z ordinate",
+    Result::typeBool,
+    [](const std::unique_ptr<Geometry>& geom) {
+        return new Result( geom->hasZ() );
+    });
+}},
+{"hasM", [](std::string name) { return GeometryOp::create(name,
+    catGeom,
+    "test if geometry has M ordinate",
+    Result::typeBool,
+    [](const std::unique_ptr<Geometry>& geom) {
+        return new Result( geom->hasM() );
     });
 }},
 {"isEmpty", [](std::string name) { return GeometryOp::create(name,

--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -23,6 +23,7 @@
 #include <geos/io/WKTWriter.h>
 #include <geos/io/WKBReader.h>
 #include <geos/io/WKBStreamReader.h>
+#include <geos/io/WKBWriter.h>
 
 #include <fstream>
 #include <iostream>
@@ -514,15 +515,22 @@ void GeosOp::outputGeometry(const Geometry * geom) {
     }
 
     if (args.format == GeosOpArgs::fmtWKB ) {
-        std::cout << *(geom) << std::endl;
+        // output as hex-encoded WKB
+        WKBWriter writer;
+        writer.setOutputDimension(4);
+        writer.writeHEX(*geom, std::cout);
+        std::cout << std::endl;
     }
     else {
         // output as text/WKT
         WKTWriter writer;
-        // turn off stoopid fixed precision
-        writer.setTrim(true);
+        writer.setOutputDimension(4);
         if (args.precision >= 0) {
              writer.setRoundingPrecision(args.precision);
+        }
+        else {
+            // turn off stoopid fixed precision
+            writer.setTrim(true);
         }
         std::cout << writer.write(geom) << std::endl;
     }


### PR DESCRIPTION
This adds 'hasZ' and 'hasM' operations, e.g.:
```bash
$ ./bin/geosop -a "POINT (1 2 3 4)" -f txt hasZ
true
$ ./bin/geosop -a "POINT M (1 2 4)" -f txt hasZ
false
```
Also, a few output options are improved. Firstly the precision option is fixed (it was effectively ignored):
```bash
$ ./bin/geosop -a "POINT (5.555 7.777)" -f wkt -p 2
POINT (5.55 7.78)
```
The output dimension is increased to 4 to show Z and or M ordinates:
```bash
$ ./bin/geosop -a "LINESTRING Z (0 0 10, 1 0 20)" -f wkt interpolate 0.5
POINT Z (0.5 0 15)
```
similar for hex-encoded WKB:
```bash
$ ./bin/geosop -a "POINT (1 2)" -f wkb
0101000000000000000000F03F0000000000000040
$ ./bin/geosop -a "POINT Z (1 2 3)" -f wkb
0101000080000000000000F03F00000000000000400000000000000840
$ ./bin/geosop -a "POINT M (1 2 4)" -f wkb
0101000040000000000000F03F00000000000000400000000000001040
$ ./bin/geosop -a "POINT ZM (1 2 3 4)" -f wkb
01010000C0000000000000F03F000000000000004000000000000008400000000000001040
```