### PR TITLE
Add possiblity to read coordinates with 3 values from geojson file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,11 @@ set(CMAKE_CXX_FLAGS_ASAN "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-
 set(CMAKE_EXE_LINKER_FLAGS_ASAN "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address")
 set(CMAKE_SHARED_LINKER_FLAGS_ASAN "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address")
 
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "ASAN")
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Debug' as none was specified.")
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "ASAN")
+endif()
 
 #-----------------------------------------------------------------------------
 # Install directories

--- a/src/io/GeoJSONReader.cpp
+++ b/src/io/GeoJSONReader.cpp
@@ -203,13 +203,16 @@ geom::Coordinate GeoJSONReader::readCoordinate(
     const std::vector<double>& coords) const
 {
     if (coords.size() == 1) {
-        throw  ParseException("Expected two coordinates found one");
+        throw  ParseException("Expected two or three coordinates found one");
     }
-    else if (coords.size() > 2) {
-        throw  ParseException("Expected two coordinates found more than two");
+    else if (coords.size() > 3) {
+        throw  ParseException("Expected two or three coordinates found more than three");
+    }
+    else if (coords.size() == 2) {
+        return geom::Coordinate { coords[0], coords[1] };
     }
     else {
-        return geom::Coordinate {coords[0], coords[1]};
+        return geom::Coordinate { coords[0], coords[1], coords[2] };
     }
 }
 


### PR DESCRIPTION
Change to allow reading coordinates with three values from geoJson files; an optional height as well as just latitude and longitude

(Suppotred as per the GeoJson specification: https://www.rfc-editor.org/rfc/rfc7946#page-7)