### PR TITLE
Change WKTWriter Old3D option to only add "M" for XYM

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -5407,8 +5407,9 @@ extern int  GEOS_DLL GEOSWKTWriter_getOutputDimension(GEOSWKTWriter *writer);
 
 /**
 * Sets the format for 3D outputs. The "old 3D" format does not
-* include a dimensionality tag, eg. "POINT(1 2 3)" while the new (ISO)
-* format does includes a tag, eg "POINT Z (1 2 3)".
+* include a Z dimension tag, e.g. "POINT (1 2 3)", except for XYM,
+* e.g. "POINT M (1 2 3)". Geometries with XYZM coordinates do not add
+* any dimensionality tags, e.g. "POINT (1 2 3 4)".
 * \param writer A \ref GEOSWKTWriter.
 * \param useOld3D True to use the old format, false is the default.
 *

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -252,7 +252,10 @@ WKTWriter::appendGeometryTaggedText(const Geometry& geometry,
 void
 WKTWriter::appendOrdinateText(OrdinateSet outputOrdinates, Writer& writer) const
 {
-    if (old3D && !outputOrdinates.hasM()) {
+    if (old3D) {
+        if (!outputOrdinates.hasZ() && outputOrdinates.hasM()) {
+            writer.write("M ");
+        }
         return;
     }
 

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -260,11 +260,21 @@ void object::test<9>
     ensure_equals(wktwriter.write(*ls),
                   std::string("LINESTRING ZM (1 2 3 4, 5 6 7 8)"));
 
+    wktwriter.setOld3D(true);
+    ensure_equals(wktwriter.write(*ls),
+                  std::string("LINESTRING (1 2 3 4, 5 6 7 8)"));
+
+
     // If only 3 dimensions are allowed we pick Z instead of M
+    wktwriter.setOld3D(false);
     wktwriter.setOutputDimension(3);
 
     ensure_equals(wktwriter.write(*ls),
                   std::string("LINESTRING Z (1 2 3, 5 6 7)"));
+
+    wktwriter.setOld3D(true);
+    ensure_equals(wktwriter.write(*ls),
+                  std::string("LINESTRING (1 2 3, 5 6 7)"));
 }
 
 // Test writing XYM
@@ -284,6 +294,11 @@ void object::test<10>
 
     ensure_equals(wktwriter.write(*ls),
                   std::string("LINESTRING M (1 2 3, 4 5 6)"));
+
+    // Same output
+    wktwriter.setOld3D(true);
+    ensure_equals(wktwriter.write(*ls),
+                  std::string("LINESTRING M (1 2 3, 4 5 6)"));
 }
 
 // Test writing XY
@@ -300,6 +315,11 @@ void object::test<11>
 
     wktwriter.setTrim(true);
 
+    ensure_equals(wktwriter.write(*ls),
+                  std::string("LINESTRING (1 2, 3 4)"));
+
+    // Same output
+    wktwriter.setOld3D(true);
     ensure_equals(wktwriter.write(*ls),
                   std::string("LINESTRING (1 2, 3 4)"));
 }


### PR DESCRIPTION
The WKTWriter Old3D option previously only modified the behaviour of XYZ geometries, rendering "POINT Z (1 2 3)" as "POINT (1 2 3)". This PR changes geometries with M coordinates to also remove dimensionality tag, as I suppose this was the original meaning of the option.

<s>For instance, "POINT M (1 2 4)" would be formatted as "POINT (1 2 4)". I've added a note that 3D XYZ and XYM geometries are indistinguishable.</s>

Furthermore, "POINT ZM (1 2 3 4)" is now formatted as "POINT (1 2 3 4)" with Old3D enabled. Is this the same output as older PostGIS versions?