### PR TITLE
Remove Orientation.isCCW exception

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -2320,8 +2320,7 @@ extern int GEOS_DLL GEOSCoordSeq_getDimensions(
 
 /**
 * Check orientation of a coordinate sequence. Closure of the sequence is
-* assumed. Invalid (collapsed) sequences will return false. Short (less
-* than 4 points) sequences will return exception.
+* assumed. Invalid (collapsed) or short (fewer than 4 points) sequences return false.
 * \param s the coordinate sequence
 * \param is_ccw pointer for ccw value, 1 if counter-clockwise orientation, 0 otherwise
 * \return 0 on exception, 1 on success

--- a/src/algorithm/Orientation.cpp
+++ b/src/algorithm/Orientation.cpp
@@ -50,8 +50,7 @@ Orientation::isCCW(const geom::CoordinateSequence* ring)
     int inPts = static_cast<int>(ring->size()) - 1;
     // sanity check
     if (inPts < 3)
-        throw util::IllegalArgumentException(
-            "Ring has fewer than 4 points, so orientation cannot be determined");
+        return false;
 
     uint32_t nPts = static_cast<uint32_t>(inPts);
     /**
@@ -146,4 +145,3 @@ Orientation::isCCWArea(const geom::CoordinateSequence* ring)
 
 } // namespace geos.algorithm
 } //namespace geos
-

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -319,7 +319,8 @@ void object::test<9>
     GEOSCoordSeq_setX(cs_, 2, 1);
     GEOSCoordSeq_setY(cs_, 2, 0);
 
-    ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 0);
+    ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 1);
+    ensure(!ccw);
 }
 
 template<>
@@ -331,7 +332,8 @@ void object::test<10>
     cs_ = GEOSCoordSeq_create(0, 0);
     char ccw;
 
-    ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 0);
+    ensure_equals(GEOSCoordSeq_isCCW(cs_, &ccw), 1);
+    ensure(!ccw);
 }
 
 template<>
@@ -765,4 +767,3 @@ void object::test<21>()
 }
 
 } // namespace tut
-


### PR DESCRIPTION
Change behaviour of `Orientation.isCCW` and `GEOSCoordSeq_isCCW` to avoid throwing an exception when the input sequence is short (< 4 vertices).  This aligns with JTS semantics, and simplifies logic in internal routines.  In particular, `normalize` now works on invalid (short) rings without additional checks.