### PR TITLE
Fix Coverage ops to handle empty and collapsed cases

### DIFF
--- a/include/geos/coverage/CoverageEdge.h
+++ b/include/geos/coverage/CoverageEdge.h
@@ -63,12 +63,12 @@ private:
     // Methods
 
     static std::unique_ptr<CoordinateSequence>
-    extractEdgePoints(const LinearRing* ring,
+    extractEdgePoints(const CoordinateSequence& ring,
         std::size_t start, std::size_t end);
 
     static const Coordinate&
     findDistinctPoint(
-        const CoordinateSequence* pts,
+        const CoordinateSequence& pts,
         std::size_t index,
         bool isForward,
         const Coordinate& pt);
@@ -91,7 +91,7 @@ public:
     * @return a LineSegment representing the key
     */
     static LineSegment key(
-        const LinearRing* ring);
+        const CoordinateSequence& ring);
 
     /**
     * Computes a distinct key for a section of a linear ring.
@@ -102,15 +102,15 @@ public:
     * @return a LineSegment representing the key
     */
     static LineSegment key(
-        const LinearRing* ring,
+        const CoordinateSequence& ring,
         std::size_t start,
         std::size_t end);
 
     static std::unique_ptr<CoverageEdge> createEdge(
-        const LinearRing* ring);
+        const CoordinateSequence& ring);
 
     static std::unique_ptr<CoverageEdge> createEdge(
-        const LinearRing* ring,
+        const CoordinateSequence& ring,
         std::size_t start,
         std::size_t end);
 
@@ -169,8 +169,3 @@ public:
 
 } // namespace geos.coverage
 } // namespace geos
-
-
-
-
-

--- a/include/geos/coverage/CoveragePolygonValidator.h
+++ b/include/geos/coverage/CoveragePolygonValidator.h
@@ -372,6 +372,11 @@ private:
 
     void createRings(const Polygon* poly, std::vector<CoverageRing*>& rings);
 
+    void addRing(
+        const LinearRing* ring,
+        bool isShell,
+        std::vector<CoverageRing*>& rings);
+
     CoverageRing* createRing(const LinearRing* ring, bool isShell);
 
 
@@ -380,11 +385,3 @@ private:
 
 } // namespace geos::coverage
 } // namespace geos
-
-
-
-
-
-
-
-

--- a/include/geos/coverage/CoverageRingEdges.h
+++ b/include/geos/coverage/CoverageRingEdges.h
@@ -121,7 +121,7 @@ private:
         LineSegment::UnorderedSet& boundarySegs,
         std::map<LineSegment, CoverageEdge*>& uniqueEdgeMap);
 
-    void addBoundaryNodes(
+    void addBoundaryInnerNodes(
         const LinearRing* ring,
         LineSegment::UnorderedSet& boundarySegs,
         Coordinate::UnorderedSet& nodes);
@@ -132,24 +132,24 @@ private:
         Coordinate::UnorderedSet& nodes);
 
     CoverageEdge* createEdge(
-        const LinearRing* ring,
+        const CoordinateSequence& ring,
         std::map<LineSegment, CoverageEdge*>& uniqueEdgeMap);
 
     CoverageEdge* createEdge(
-        const LinearRing* ring,
+        const CoordinateSequence& ring,
         std::size_t start, std::size_t end,
         std::map<LineSegment, CoverageEdge*>& uniqueEdgeMap);
 
     std::size_t findNextNodeIndex(
-        const LinearRing* ring,
+        const CoordinateSequence& ring,
         std::size_t start,
         Coordinate::UnorderedSet& nodes) const;
 
     static std::size_t next(
         std::size_t index,
-        const LinearRing* ring);
+        const CoordinateSequence& ring);
 
-    Coordinate::UnorderedSet findNodes(
+    Coordinate::UnorderedSet findMultiRingNodes(
         std::vector<const Geometry*>& coverage);
 
     Coordinate::UnorderedSet findBoundaryNodes(
@@ -177,8 +177,3 @@ private:
 
 } // namespace geos.coverage
 } // namespace geos
-
-
-
-
-

--- a/include/geos/coverage/VertexRingCounter.h
+++ b/include/geos/coverage/VertexRingCounter.h
@@ -36,12 +36,12 @@ using geos::geom::Geometry;
 namespace geos {
 namespace coverage { // geos::coverage
 
-class VertexCounter : public CoordinateSequenceFilter
+class VertexRingCounter : public CoordinateSequenceFilter
 {
 
 public:
 
-    VertexCounter(std::map<Coordinate, std::size_t>& counts)
+    VertexRingCounter(std::map<Coordinate, std::size_t>& counts)
         : vertexCounts(counts)
         {};
 
@@ -63,7 +63,7 @@ private:
 
     std::map<Coordinate, std::size_t>& vertexCounts;
 
-}; // VertexCounter
+}; // VertexRingCounter
 
 
 

--- a/src/coverage/CoverageBoundarySegmentFinder.cpp
+++ b/src/coverage/CoverageBoundarySegmentFinder.cpp
@@ -85,5 +85,3 @@ CoverageBoundarySegmentFinder::isBoundarySegment(
 
 } // namespace geos.coverage
 } // namespace geos
-
-

--- a/src/coverage/CoveragePolygonValidator.cpp
+++ b/src/coverage/CoveragePolygonValidator.cpp
@@ -373,12 +373,24 @@ CoveragePolygonValidator::createRings(
     std::vector<CoverageRing*>& rings)
 {
     // Create exterior shell ring
-    rings.push_back(createRing(poly->getExteriorRing(), true));
+    addRing( poly->getExteriorRing(), true, rings);
 
     // Create hole rings
     for (std::size_t i = 0; i < poly->getNumInteriorRing(); i++) {
-        rings.push_back(createRing(poly->getInteriorRingN(i), false));
+        addRing( poly->getInteriorRingN(i), false, rings);
     }
+}
+
+/* private */
+void
+CoveragePolygonValidator::addRing(
+    const LinearRing* ring,
+    bool isShell,
+    std::vector<CoverageRing*>& rings)
+{
+    if (ring->isEmpty())
+        return;
+    rings.push_back(createRing(ring, isShell));
 }
 
 /* private */
@@ -403,5 +415,3 @@ CoveragePolygonValidator::createRing(const LinearRing* ring, bool isShell)
 
 } // namespace geos.coverage
 } // namespace geos
-
-

--- a/src/coverage/CoverageRingEdges.cpp
+++ b/src/coverage/CoverageRingEdges.cpp
@@ -72,12 +72,20 @@ CoverageRingEdges::build()
     for (const Geometry* geom : m_coverage) {
         for (std::size_t ipoly = 0; ipoly < geom->getNumGeometries(); ipoly++) {
             const Polygon* poly = static_cast<const Polygon*>(geom->getGeometryN(ipoly));
+
+            //-- skip empty elements. Missing elements are copied in result
+            if (poly->isEmpty())
+                continue;
+
             //-- extract shell
             const LinearRing* shell = poly->getExteriorRing();
             addRingEdges(shell, nodes, boundarySegs, uniqueEdgeMap);
             //-- extract holes
             for (std::size_t ihole = 0; ihole < poly->getNumInteriorRing(); ihole++) {
                 const LinearRing* hole = poly->getInteriorRingN(ihole);
+                //-- skip empty rings. Missing rings are copied in result
+                if (hole->isEmpty())
+                    continue;
                 addRingEdges(hole, nodes, boundarySegs, uniqueEdgeMap);
             }
         }

--- a/src/coverage/CoverageSimplifier.cpp
+++ b/src/coverage/CoverageSimplifier.cpp
@@ -17,7 +17,6 @@
 #include <geos/coverage/CoverageEdge.h>
 #include <geos/coverage/CoverageRingEdges.h>
 #include <geos/coverage/TPVWSimplifier.h>
-#include <geos/coverage/VertexCounter.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/MultiLineString.h>

--- a/src/coverage/VertexRingCounter.cpp
+++ b/src/coverage/VertexRingCounter.cpp
@@ -13,7 +13,7 @@
  *
  **********************************************************************/
 
-#include <geos/coverage/VertexCounter.h>
+#include <geos/coverage/VertexRingCounter.h>
 
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateSequence.h>
@@ -32,11 +32,11 @@ namespace coverage { // geos.coverage
 
 /* public static  */
 void
-VertexCounter::count(
+VertexRingCounter::count(
     std::vector<const Geometry*>& geoms,
     std::map<Coordinate, std::size_t>& counts)
 {
-    VertexCounter vertextCounter(counts);
+    VertexRingCounter vertextCounter(counts);
     for (const Geometry* geom : geoms) {
         geom->apply_ro(vertextCounter);
     }
@@ -45,7 +45,7 @@ VertexCounter::count(
 
 /* public */
 void
-VertexCounter::filter_ro(const CoordinateSequence& seq, std::size_t i)
+VertexRingCounter::filter_ro(const CoordinateSequence& seq, std::size_t i)
 {
     //-- for rings don't double-count duplicate endpoint
     if (seq.isRing() && i == 0)

--- a/tests/unit/coverage/CoverageRingEdgesTest.cpp
+++ b/tests/unit/coverage/CoverageRingEdgesTest.cpp
@@ -137,5 +137,15 @@ void object::test<5> ()
         "MULTILINESTRING ((1 2, 2 2), (2 1, 2 2), (2 2, 2 3), (2 2, 3 2))");
 }
 
+// testMultiPolygons
+template<>
+template<>
+void object::test<6> ()
+{
+    checkEdges(
+        "GEOMETRYCOLLECTION (MULTIPOLYGON (((5 9, 2.5 7.5, 1 5, 5 5, 5 9)), ((5 5, 9 5, 7.5 2.5, 5 1, 5 5))), MULTIPOLYGON (((5 9, 6.5 6.5, 9 5, 5 5, 5 9)), ((1 5, 5 5, 5 1, 3.5 3.5, 1 5))))",
+        "MULTILINESTRING ((1 5, 2.5 7.5, 5 9), (1 5, 3.5 3.5, 5 1), (1 5, 5 5), (5 1, 5 5), (5 1, 7.5 2.5, 9 5), (5 5, 5 9), (5 5, 9 5), (5 9, 6.5 6.5, 9 5))"
+    );
+}
 
 } // namespace tut

--- a/tests/unit/coverage/CoverageSimplifierTest.cpp
+++ b/tests/unit/coverage/CoverageSimplifierTest.cpp
@@ -367,6 +367,58 @@ void object::test<19> ()
 
 }
 
+// testRepeatedPointRemoved
+template<>
+template<>
+void object::test<20> ()
+{
+    checkResult(readArray({
+        "POLYGON ((5 9, 6.5 6.5, 9 5, 5 5, 5 5, 5 9))" }),
+        2,
+        readArray({
+            "POLYGON ((5 5, 5 9, 9 5, 5 5))" })
+    );
+}
+
+// testRepeatedPointCollapseToLine
+template<>
+template<>
+void object::test<21> ()
+{
+checkResult(readArray({
+    "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((10 20, 20 19, 20 19, 10 20)))" }),
+    5,
+    readArray({
+        "MULTIPOLYGON (((10 20, 20 19, 30 20, 30 10, 10 10, 10 20)), ((30 20, 20 19, 10 20, 10 30, 30 30, 30 20)), ((10 20, 20 19, 10 20)))" })
+);
+}
+
+// testRepeatedPointCollapseToPoint()
+template<>
+template<>
+void object::test<22> ()
+{
+    checkResult(readArray({
+        "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((20 19, 20 19, 20 19)))" }),
+        5,
+        readArray({
+            "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 20, 10 30, 30 30, 30 20, 20 19, 10 20)), ((20 19, 20 19, 20 19)))" })
+    );
+}
+
+// testRepeatedPointCollapseToPoint2
+template<>
+template<>
+void object::test<23> ()
+{
+    checkResult(readArray({
+        "MULTIPOLYGON (((100 200, 150 195, 200 200, 200 100, 100 100, 100 200)), ((150 195, 150 195, 150 195, 150 195)))" }),
+        40,
+        readArray({
+            "MULTIPOLYGON (((150 195, 200 200, 200 100, 100 100, 100 200, 150 195)), ((150 195, 150 195, 150 195, 150 195)))" })
+    );
+}
+
 //---------------------------------
 // all inputs empty
 // template<>

--- a/tests/unit/coverage/CoverageSimplifierTest.cpp
+++ b/tests/unit/coverage/CoverageSimplifierTest.cpp
@@ -419,21 +419,49 @@ void object::test<23> ()
     );
 }
 
-//---------------------------------
-// all inputs empty
-// template<>
-// template<>
-// void object::test<20> ()
-// {
-//     checkResult(readArray({
-//             "POLYGON EMPTY",
-//             "POLYGON EMPTY" }),
-//         1.5,
-//         readArray({
-//             "POLYGON EMPTY",
-//             "POLYGON EMPTY" })
-//     );
-// }
+// testAllEmpty()
+template<>
+template<>
+void object::test<24> ()
+{
+    checkResult(readArray({
+        "POLYGON EMPTY",
+        "POLYGON EMPTY" }),
+        1,
+        readArray({
+            "POLYGON EMPTY",
+            "POLYGON EMPTY" })
+    );
+  }
 
+// testOneEmpty
+template<>
+template<>
+void object::test<25> ()
+{
+    checkResult(readArray({
+        "POLYGON ((1 9, 5 9.1, 9 9, 9 1, 1 1, 1 9))",
+        "POLYGON EMPTY" }),
+        1,
+        readArray({
+            "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+            "POLYGON EMPTY" })
+    );
+  }
+
+// testEmptyHole()
+template<>
+template<>
+void object::test<26> ()
+{
+    checkResult(readArray({
+        "POLYGON ((1 9, 5 9.1, 9 9, 9 1, 1 1, 1 9), EMPTY)",
+        "POLYGON EMPTY"  }),
+        1,
+        readArray({
+            "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), EMPTY)",
+            "POLYGON EMPTY" })
+    );
+  }
 
 } // namespace tut

--- a/tests/unit/coverage/CoverageValidatorTest.cpp
+++ b/tests/unit/coverage/CoverageValidatorTest.cpp
@@ -282,6 +282,73 @@ void object::test<10> ()
     checkValid(coverage);
 }
 
+// testMultiPolygon
+template<>
+template<>
+void object::test<11> ()
+{
+    std::vector<std::string> coverage{
+        "MULTIPOLYGON (((1 9, 5 9, 5 5, 1 5, 1 9)), ((9 1, 5 1, 5 5, 9 5, 9 1)))",
+        "MULTIPOLYGON (((1 1, 1 5, 5 5, 5 1, 1 1)), ((9 9, 9 5, 5 5, 5 9, 9 9)))"
+    };
+    checkValid(coverage);
+}
+
+// testValidDuplicatePoints
+template<>
+template<>
+void object::test<12> ()
+{
+    std::vector<std::string> coverage{
+        "POLYGON ((1 9, 5 9, 5 5, 1 5, 1 5, 1 5, 1 9))",
+        "POLYGON ((9 9, 9 5, 5 5, 5 9, 9 9))",
+        "POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1))",
+        "POLYGON ((9 1, 5 1, 5 5, 9 5, 9 1))"
+    };
+    checkValid(coverage);
+}
+
+// testRingCollapse
+template<>
+template<>
+void object::test<13> ()
+{
+    std::vector<std::string> coverage{
+        "POLYGON ((1 9, 5 9, 1 9))",
+        "POLYGON ((9 9, 9 5, 5 5, 5 9, 9 9))",
+        "POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1))",
+        "POLYGON ((9 1, 5 1, 5 5, 9 5, 9 1))"
+    };
+    checkValid(coverage);
+}
+
+  //========  Valid cases with EMPTY  =============================
+
+// testPolygonEmpty
+template<>
+template<>
+void object::test<14> ()
+{
+    std::vector<std::string> coverage{
+        "POLYGON ((1 9, 5 9, 5 5, 1 5, 1 9))",
+        "POLYGON ((9 9, 9 5, 5 5, 5 9, 9 9))",
+        "POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1))",
+        "POLYGON EMPTY"
+    };
+    checkValid(coverage);
+}
+
+// testMultiPolygonWithEmptyRing
+template<>
+template<>
+void object::test<15> ()
+{
+    std::vector<std::string> coverage{
+        "MULTIPOLYGON (((9 9, 9 1, 1 1, 2 4, 7 7, 9 9)), EMPTY)"
+    };
+    checkValid(coverage);
+}
+
 
 
 


### PR DESCRIPTION
Fixes `CoverageValidator` and `CoverageSimplifier` to handle cases with collapsed and empty components.