### PR TITLE
Construction of XYZ points with NaN coordinates

### DIFF
--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -197,6 +197,20 @@ public:
         return m_vect.empty();
     }
 
+    /// Returns <code>true</code> if there is 1 coordinate and if it is null.
+    bool isNullPoint() const {
+        if (size() != 1) {
+            return false;
+        }
+        switch(getCoordinateType()) {
+            case CoordinateType::XY: return getAt<CoordinateXY>(0).isNull();
+            case CoordinateType::XYZ: return getAt<Coordinate>(0).isNull();
+            case CoordinateType::XYZM: return getAt<CoordinateXYZM>(0).isNull();
+            case CoordinateType::XYM: return getAt<CoordinateXYM>(0).isNull();
+            default: return false;
+        }
+    }
+
     /** \brief
     * Tests whether an a {@link CoordinateSequence} forms a ring,
     * by checking length and closure. Self-intersection is not checked.

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -224,16 +224,19 @@ GeometryFactory::createPoint(std::size_t coordinateDimension) const
 std::unique_ptr<Point>
 GeometryFactory::createPoint(std::unique_ptr<CoordinateSequence>&& coords) const
 {
-    return std::unique_ptr<Point>(new Point(
-                                      coords ? std::move(*coords) : CoordinateSequence(),
-                                      this));
+    if (!coords) {
+        return createPoint();
+    } else if ((*coords).isNullPoint()) {
+        return createPoint((*coords).getDimension());
+    }
+    return std::unique_ptr<Point>(new Point(std::move(*coords), this));
 }
 
 std::unique_ptr<Point>
 GeometryFactory::createPoint(const CoordinateXY& coordinate) const
 {
     if(coordinate.isNull()) {
-        return createPoint();
+        return createPoint(2);
     }
     else {
         return std::unique_ptr<Point>(new Point(coordinate, this));
@@ -245,7 +248,7 @@ std::unique_ptr<Point>
 GeometryFactory::createPoint(const Coordinate& coordinate) const
 {
     if(coordinate.isNull()) {
-        return createPoint();
+        return createPoint(3);
     }
     else {
         return std::unique_ptr<Point>(new Point(coordinate, this));
@@ -256,7 +259,7 @@ std::unique_ptr<Point>
 GeometryFactory::createPoint(const CoordinateXYM& coordinate) const
 {
     if(coordinate.isNull()) {
-        return createPoint();
+        return createPoint(4);  // can't do XYM!
     }
     else {
         return std::unique_ptr<Point>(new Point(coordinate, this));
@@ -267,7 +270,7 @@ std::unique_ptr<Point>
 GeometryFactory::createPoint(const CoordinateXYZM& coordinate) const
 {
     if(coordinate.isNull()) {
-        return createPoint();
+        return createPoint(4);
     }
     else {
         return std::unique_ptr<Point>(new Point(coordinate, this));
@@ -278,6 +281,9 @@ GeometryFactory::createPoint(const CoordinateXYZM& coordinate) const
 std::unique_ptr<Point>
 GeometryFactory::createPoint(const CoordinateSequence& fromCoords) const
 {
+    if (fromCoords.isNullPoint()) {
+        return createPoint(fromCoords.getDimension());
+    }
     CoordinateSequence newCoords(fromCoords);
     return std::unique_ptr<Point>(new Point(std::move(newCoords), this));
 

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -49,18 +49,6 @@ Point::Point(CoordinateSequence&& newCoords, const GeometryFactory* factory)
 {
     if (coordinates.getSize() > 1) {
         throw util::IllegalArgumentException("Point coordinate list must contain a single element");
-    } else if (coordinates.getSize() == 1) {
-        // Replace all-NaN point with empty point
-        bool isnull = false;
-        switch(coordinates.getCoordinateType()) {
-            case CoordinateType::XY: isnull = coordinates.getAt<CoordinateXY>(0).isNull(); break;
-            case CoordinateType::XYZ: isnull = coordinates.getAt<Coordinate>(0).isNull(); break;
-            case CoordinateType::XYZM: isnull = coordinates.getAt<CoordinateXYZM>(0).isNull(); break;
-            case CoordinateType::XYM: isnull = coordinates.getAt<CoordinateXYM>(0).isNull(); break;
-        }
-        if (isnull) {
-            coordinates.clear();
-        }
     }
 }
 
@@ -69,9 +57,6 @@ Point::Point(const Coordinate & c, const GeometryFactory* factory)
     , coordinates{c}
     , envelope(c)
 {
-    if (c.isNull()) {
-        coordinates.clear();
-    }
 }
 
 Point::Point(const CoordinateXY & c, const GeometryFactory* factory)
@@ -79,9 +64,6 @@ Point::Point(const CoordinateXY & c, const GeometryFactory* factory)
     , coordinates{c}
     , envelope(c)
 {
-    if (c.isNull()) {
-        coordinates.clear();
-    }
 }
 
 Point::Point(const CoordinateXYM & c, const GeometryFactory* factory)
@@ -89,9 +71,6 @@ Point::Point(const CoordinateXYM & c, const GeometryFactory* factory)
     , coordinates{c}
     , envelope(c)
 {
-    if (c.isNull()) {
-        coordinates.clear();
-    }
 }
 
 Point::Point(const CoordinateXYZM & c, const GeometryFactory* factory)
@@ -101,9 +80,7 @@ Point::Point(const CoordinateXYZM & c, const GeometryFactory* factory)
     , coordinates{1u, !std::isnan(c.z), !std::isnan(c.m), false}
     , envelope(c)
 {
-    if (c.isNull()) {
-        coordinates.clear();
-    }
+    coordinates.setAt(c, 0);
 }
 
 /*protected*/

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -59,7 +59,7 @@ Point::Point(CoordinateSequence&& newCoords, const GeometryFactory* factory)
             case CoordinateType::XYM: isnull = coordinates.getAt<CoordinateXYM>(0).isNull(); break;
         }
         if (isnull) {
-            coordinates = CoordinateSequence(0, coordinates.hasZ(), coordinates.hasM(), false);
+            coordinates.clear();
         }
     }
 }
@@ -70,7 +70,7 @@ Point::Point(const Coordinate & c, const GeometryFactory* factory)
     , envelope(c)
 {
     if (c.isNull()) {
-        coordinates = CoordinateSequence(0u, true, false, false);
+        coordinates.clear();
     }
 }
 
@@ -80,7 +80,7 @@ Point::Point(const CoordinateXY & c, const GeometryFactory* factory)
     , envelope(c)
 {
     if (c.isNull()) {
-        coordinates = CoordinateSequence(0u, false, false, false);
+        coordinates.clear();
     }
 }
 
@@ -90,7 +90,7 @@ Point::Point(const CoordinateXYM & c, const GeometryFactory* factory)
     , envelope(c)
 {
     if (c.isNull()) {
-        coordinates = CoordinateSequence(0u, false, true, false);
+        coordinates.clear();
     }
 }
 
@@ -102,9 +102,7 @@ Point::Point(const CoordinateXYZM & c, const GeometryFactory* factory)
     , envelope(c)
 {
     if (c.isNull()) {
-        coordinates = CoordinateSequence(0u, true, true, false);
-    } else {
-        coordinates.setAt(c, 0);
+        coordinates.clear();
     }
 }
 

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -281,7 +281,7 @@ WKTWriter::appendPointTaggedText(const Point& point, OrdinateSet outputOrdinates
     appendOrdinateText(outputOrdinates, writer);
 
     const CoordinateXY* coord = point.getCoordinate();
-    if (coord == nullptr || (std::isnan(coord->x) && std::isnan(coord->y))) {
+    if (coord == nullptr) {
         writer.write("EMPTY");
     } else {
         appendSequenceText(*point.getCoordinatesRO(), outputOrdinates, p_level, false, writer);


### PR DESCRIPTION
While making a more strict approach to NaN coordinate handling in shapely, I noticed that the NaN handling (and coordseq dimensionality) has improved a great deal in GEOS (which is great!)

However I bumped into an inconsistency in the interpretation of XYZ points with NaN coordinates. When constructing a point from `NaN, NaN`, you get an empty point. I personally think that is good because it is consistent with the limitations of WKB. I guess the rule is "a point with an all-NaN coordinate is an empty point".

However, the logic in GEOS considers only X and Y at two points yielding surprising behaviour on 3D points:

```
>>> Point(nan, nan nan)
<POINT Z EMPTY>
>>> Point(nan, 1, nan)
<POINT Z (NaN 1 NaN)
>>> Point(nan, nan, 1)
<POINT Z EMPTY>
```

This PR addresses that issue by constructing an empty point if its first coordinate is all-NaN.
This allowed me to cleanup some logic in the Point::isEmpty and in the WKTWriter.

Ref. https://github.com/shapely/shapely/pull/1811