### PR TITLE
Add GEOSGeom_releaseCollection to CAPI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ xxxx-xx-xx
   - Voronoi: Add option to create diagram in order consistent with inputs (GH-781, Dan Baston)
   - Polygonal coverages: CoverageSimplifier (JTS-911, Martin Davis)
   - CAPI: GEOSCoverageIsValid, GEOSCoverageSimplifyVW (GH-867, Paul Ramsey)
+  - CAPI: GEOSGeom_releaseCollection (GH-848)
 
 - Fixes/Improvements:
   - WKTReader: Fix parsing of Z and M flags in WKTReader (#676 and GH-669, Dan Baston)

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -849,6 +849,12 @@ extern "C" {
         return GEOSGeom_createCollection_r(handle, type, geoms, ngeoms);
     }
 
+    Geometry**
+    GEOSGeom_releaseCollection(Geometry* collection, unsigned int * ngeoms)
+    {
+        return GEOSGeom_releaseCollection_r(handle, collection, ngeoms);
+    }
+
     Geometry*
     GEOSPolygonize(const Geometry* const* g, unsigned int ngeoms)
     {

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -736,6 +736,12 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_createCollection_r(
     GEOSGeometry* *geoms,
     unsigned int ngeoms);
 
+/** \see GEOSGeom_releaseCollection */
+extern GEOSGeometry GEOS_DLL ** GEOSGeom_releaseCollection_r(
+    GEOSContextHandle_t handle,
+    GEOSGeometry * collection,
+    unsigned int * ngeoms);
+
 /** \see GEOSGeom_createEmptyCollection */
 extern GEOSGeometry GEOS_DLL *GEOSGeom_createEmptyCollection_r(
     GEOSContextHandle_t handle, int type);
@@ -2440,6 +2446,26 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_createCollection(
     int type,
     GEOSGeometry** geoms,
     unsigned int ngeoms);
+
+/**
+* Release the sub-geometries of a collection for management.
+* by the caller. The input collection remains as an empty collection,
+* that the caller is responsible for destroying. The output geometries
+* are also the responsibility of the caller, as is the containing array,
+* which must be freed with GEOSFree().
+* \param geom The collection that will have its components released.
+* \param ngeoms A pointer to a variable that will be filled with the
+*        size of the output array.
+* \return A newly allocated array of GEOSGeometry pointers.
+* \note The caller is responsible for freeing the returned array
+*       with GEOSFree() and all the elements with GEOSGeom_destroy().
+*       If called with an empty collection, null will be returned
+*       and ngeoms set to zero.
+* \since 3.4
+*/
+extern GEOSGeometry GEOS_DLL ** GEOSGeom_releaseCollection(
+    GEOSGeometry * collection,
+    unsigned int * ngeoms);
 
 /**
 * Create an empty geometry collection.

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -2453,7 +2453,7 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_createCollection(
 * that the caller is responsible for destroying. The output geometries
 * are also the responsibility of the caller, as is the containing array,
 * which must be freed with GEOSFree().
-* \param geom The collection that will have its components released.
+* \param collection The collection that will have its components released.
 * \param ngeoms A pointer to a variable that will be filled with the
 *        size of the output array.
 * \return A newly allocated array of GEOSGeometry pointers.

--- a/tests/unit/capi/GEOSGeom_createCollectionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_createCollectionTest.cpp
@@ -126,5 +126,42 @@ void object::test<4>
     ensure(geom_ == nullptr);
 }
 
+// Create collection from dynamic length std::vector of geometries
+template<>
+template<>
+void object::test<5>
+()
+{
+    unsigned int ngeoms;
+    GEOSGeometry ** geoms;
+
+    GEOSWKTReader *reader = GEOSWKTReader_create_r(handle_);
+
+    const char *wkt1 = "MULTIPOLYGON EMPTY";
+    geom_ = GEOSWKTReader_read_r(handle_, reader, wkt1);
+    ensure(geom_ != nullptr);
+
+    geoms = GEOSGeom_releaseCollection_r(handle_, geom_, &ngeoms);
+    ensure(geoms == nullptr);
+    ensure(ngeoms == 0);
+
+    const char *wkt2 = "GEOMETRYCOLLECTION(POINT(0 0), POINT(1 1))";
+    geom_ = GEOSWKTReader_read_r(handle_, reader, wkt2);
+    ensure(geom_ != nullptr);
+
+    geoms = GEOSGeom_releaseCollection_r(handle_, geom_, &ngeoms);
+    ensure(geoms != nullptr);
+    ensure(ngeoms == 2);
+
+    for (size_t i = 0 ; i < ngeoms; i++) {
+        ensure(GEOSGeomTypeId_r(handle_, geoms[i]) == GEOS_POINT);
+        GEOSGeom_destroy_r(handle_, geoms[i]);
+    }
+
+    GEOSFree_r(handle_, geoms);
+    GEOSWKTReader_destroy_r(handle_, reader);
+}
+
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_createCollectionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_createCollectionTest.cpp
@@ -145,7 +145,7 @@ void object::test<4>
     ensure(geom_ == nullptr);
 }
 
-// Create collection from dynamic length std::vector of geometries
+// Release empty collection
 template<>
 template<>
 void object::test<5>
@@ -161,7 +161,7 @@ void object::test<5>
 }
 
 
-// Create collection from dynamic length std::vector of geometries
+// Release generic collection
 template<>
 template<>
 void object::test<6>
@@ -182,7 +182,7 @@ void object::test<6>
 
 }
 
-// Create collection from dynamic length std::vector of geometries
+// Release typed collection
 template<>
 template<>
 void object::test<7>


### PR DESCRIPTION
References #848. This does the opposite of collection creation, taking in a geometry, removing the subgeometries and returning them as a `GEOSGeometry**`. The caller remains on the hook for all the memory management, and the input geometry becomes an empty geometry, since it has lost its sub-geometries.