### PR TITLE
Fix MaximumInscribedCircle and LargestEmptyCircle performance and memory issues

### DIFF
--- a/include/geos/algorithm/construct/MaximumInscribedCircle.h
+++ b/include/geos/algorithm/construct/MaximumInscribedCircle.h
@@ -107,6 +107,22 @@ public:
     */
     static std::unique_ptr<geom::LineString> getRadiusLine(const geom::Geometry* polygonal, double tolerance);
 
+    /**
+     * Computes the maximum number of iterations allowed.
+     * Uses a heuristic based on the area of the input geometry
+     * and the tolerance distance.
+     * The number of tolerance-sized cells that cover the input geometry area
+     * is computed, times a safety factor.
+     * This prevents massive numbers of iterations and created cells
+     * for casees where the input geometry has extremely small area
+     * (e.g. is very thin).
+     *
+     * @param geom the input geometry
+     * @param toleranceDist the tolerance distance
+     * @return the maximum number of iterations allowed
+     */
+    static std::size_t computeMaximumIterations(const geom::Geometry* geom, double toleranceDist);
+
 private:
 
     /* private members */
@@ -170,22 +186,32 @@ private:
         {
             return y;
         }
+
         bool operator< (const Cell& rhs) const
         {
             return maxDist <  rhs.maxDist;
         }
+
         bool operator> (const Cell& rhs) const
         {
             return maxDist >  rhs.maxDist;
         }
+
         bool operator==(const Cell& rhs) const
         {
             return maxDist == rhs.maxDist;
         }
+
+        /**
+         * The Cell priority queue is sorted by the natural order of maxDistance.
+         * std::priority_queue sorts with largest first,
+         * which is what is needed for this algorithm.
+         */
+        using CellQueue = std::priority_queue<Cell>;
     };
 
-    void createInitialGrid(const geom::Envelope* env, std::priority_queue<Cell>& cellQueue);
-    Cell createCentroidCell(const geom::Geometry* geom);
+    void createInitialGrid(const geom::Envelope* env, Cell::CellQueue& cellQueue);
+    Cell createInteriorPointCell(const geom::Geometry* geom);
 
 };
 
@@ -193,4 +219,3 @@ private:
 } // geos::algorithm::construct
 } // geos::algorithm
 } // geos
-

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -61,6 +61,24 @@ struct test_lec_data {
         ensure_equals("y coordinate does not match", lhs.y, rhs.y, tolerance);
     }
 
+    /**
+     * A coarse distance check, mainly testing
+     * that there is not a huge number of iterations.
+     * (This will be revealed by CI taking a very long time!)
+     */
+    void
+    checkCircle(std::string wktObstacles, double tolerance)
+    {
+        std::unique_ptr<Geometry> geom(reader_.read(wktObstacles));
+        LargestEmptyCircle lec(geom.get(), tolerance);
+        std::unique_ptr<Point> centerPoint = lec.getCenter();
+        double dist = geom->distance(centerPoint.get());
+        //std::cout << dist << std::endl;
+        std::unique_ptr<LineString> radiusLine = lec.getRadiusLine();
+        double actualRadius = radiusLine->getLength();
+        ensure(std::abs(actualRadius - dist) < 2 * tolerance);
+    }
+
     void
     checkCircle(const Geometry *obstacles, const Geometry *boundary, double build_tolerance, double x, double y, double expectedRadius)
     {
@@ -202,8 +220,8 @@ void object::test<6>
 ()
 {
 
-    checkCircle("MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (50 400, 0 350, 50 300, 0 250, 50 200, 0 150, 50 100))",
-       0.01, 77.52, 349.99, 54.81 );
+    checkCircle("MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (70 380, 0 350, 50 300, 0 250, 50 200, 0 150, 50 120))",
+       0.01, 77.52, 249.99, 54.81 );
 }
 
 //
@@ -243,10 +261,20 @@ void object::test<9>
        0.01 );
 }
 
-// testBoundaryEmpty
+// testThinExtent
 template<>
 template<>
 void object::test<10>
+()
+{
+    checkCircle("MULTIPOINT ((100 100), (300 100), (200 100.1))",
+       0.01 );
+}
+
+// testBoundaryEmpty
+template<>
+template<>
+void object::test<11>
 ()
 {
  checkCircle("MULTIPOINT ((2 2), (8 8), (7 5))",
@@ -257,7 +285,7 @@ void object::test<10>
 // testBoundarySquare
 template<>
 template<>
-void object::test<11>
+void object::test<12>
 ()
 {
     checkCircle("MULTIPOINT ((2 2), (6 4), (8 8))",
@@ -268,7 +296,7 @@ void object::test<11>
 //testBoundarySquareObstaclesOutside
 template<>
 template<>
-void object::test<12>
+void object::test<13>
 ()
 {
     checkCircle("MULTIPOINT ((10 10), (10 0))",
@@ -279,7 +307,7 @@ void object::test<12>
 // testBoundaryMultiSquares
 template<>
 template<>
-void object::test<13>
+void object::test<14>
 ()
 {
     checkCircle("MULTIPOINT ((10 10), (10 0), (5 5))",
@@ -290,7 +318,7 @@ void object::test<13>
 // testBoundaryAsObstacle
 template<>
 template<>
-void object::test<14>
+void object::test<15>
 ()
 {
     checkCircle("GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9)), POINT (4 3), POINT (7 6))",


### PR DESCRIPTION
This PR adds heuristics to MaximumInscribedCircle and LargestEmptyCircle to prevent long-running (and memory-intensive) processing for nearly flat and very thin inputs.

There are two problems solved:

* if the input extent is very small in one dimension (i.e. almost flat), the cell grid was initialized with cells of very small size, causing a memory explosion.  This is avoided by using a single initial grid cell covering the extent.
* Very thin (low-area) geometries (or LEC boundaries) cause a long search to find a cell with a centre inside the geometry (since very few cells in the search space satisfy this condition). A heuristic is used to determine a maximum number of iterations permitted. This means that the computed result may lie outside the input geometry. This can be mitigated by using a smaller tolerance distance; but there is no way to guarantee the centre will lie inside.

Fixes #875.

Post of https://github.com/locationtech/jts/pull/978 and https://github.com/locationtech/jts/commit/a45d9888a28cdb069a9de7674012a92f204770da