### PR TITLE
CAPI: fix GEOSHasZ with empty geometries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,7 @@ xxxx-xx-xx
   - Tri: add exceptions for invalid indexes (GH-853, Martin Davis)
   - LargestEmptyCircle: enhance boundary to allow any polygonal geometry (GH-859, Martin Davis)
   - Fix MaximumInscribedCircle and LargestEmptyCircle performance and memory issues (GH-883, Martin Davis)
+  - GEOSHasZ: Fix handling with empty geometries (GH-887, Mike Taves)
 
 - Changes:
   - Remove Orientation.isCCW exception to simplify logic and align with JTS (GH-878, Martin Davis)

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2378,10 +2378,6 @@ extern "C" {
     GEOSHasZ_r(GEOSContextHandle_t extHandle, const Geometry* g)
     {
         return execute(extHandle, 2, [&]() {
-            if(g->isEmpty()) {
-                return false;
-            }
-
             return g->hasZ();
         });
     }

--- a/tests/unit/capi/GEOSHasZMTest.cpp
+++ b/tests/unit/capi/GEOSHasZMTest.cpp
@@ -46,5 +46,35 @@ void object::test<3>()
     ensure_equals(GEOSHasM(input_), 0);
 }
 
+template<>
+template<>
+void object::test<4>()
+{
+    input_ = GEOSGeomFromWKT("POINT Z EMPTY");
+
+    ensure_equals(GEOSHasZ(input_), 1);
+    ensure_equals(GEOSHasM(input_), 0);
+}
+
+template<>
+template<>
+void object::test<5>()
+{
+    input_ = GEOSGeomFromWKT("POINT M EMPTY");
+
+    ensure_equals(GEOSHasZ(input_), 0);
+    ensure_equals(GEOSHasM(input_), 1);
+}
+
+template<>
+template<>
+void object::test<6>()
+{
+    input_ = GEOSGeomFromWKT("POINT ZM EMPTY");
+
+    ensure_equals(GEOSHasZ(input_), 1);
+    ensure_equals(GEOSHasM(input_), 1);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
This resolves an inconsistency between the C++ and C API versions of HasZ. Here is the correct answer with the C++ API version via geosop:
```bash
$ ./bin/geosop -a "POINT Z EMPTY" -f txt hasZ
true
```
but older CAPI implementations of GEOSHasZ short-circuited to return false if the geometry was empty. This was due to older handling of empty geometries, and possibly the wording "Tests whether the input geometry has Z coordinates" since empty geometries don't have any coordinates. But I think the C++ HasZ has it right.

Note that HasM was already consistent for C++ and C API, which has M with `POINT M EMPTY`. Tests are expanded for different coordinate types.