### PR TITLE
Clarify coverage union behaviour with unmet constraints

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -3762,8 +3762,9 @@ extern GEOSGeometry GEOS_DLL *GEOSOffsetCurve(const GEOSGeometry* g,
 
 /**
 * Optimized union algorithm for polygonal inputs that are correctly
-* noded and do not overlap. It will generate an error (return NULL)
-* for inputs that do not satisfy this constraint.
+* noded and do not overlap. It may generate an error (return NULL)
+* for inputs that do not satisfy this constraint, however this is not
+* guaranteed.
 * \param g The input geometry
 * \return A geometry that covers all the points of the input geometry.
 * Caller is responsible for freeing with GEOSGeom_destroy().


### PR DESCRIPTION
This is an update to clarify in documentation the behaviour of `GEOSCoverageUnion` when the input geometries don't meet the noding/overlap constraints.