### PR TITLE
Fix reading MultiPoint Z/M WKT

### DIFF
--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -338,9 +338,8 @@ WKTReader::readMultiPointText(StringTokenizer* tokenizer, OrdinateSet& ordinateF
     int tok = tokenizer->peekNextToken();
 
     if(tok == StringTokenizer::TT_NUMBER) {
-
-        // Try to parse deprecated form "MULTIPOINT(0 0, 1 1)"
-        auto coords = detail::make_unique<CoordinateSequence>();
+        // Try to parse "MULTIPOINT (0 0, 1 1)"
+        auto coords = detail::make_unique<CoordinateSequence>(0u, ordinateFlags.hasZ(), ordinateFlags.hasM());
 
         CoordinateXYZM coord(0, 0, DoubleNotANumber, DoubleNotANumber);
         do {
@@ -353,8 +352,8 @@ WKTReader::readMultiPointText(StringTokenizer* tokenizer, OrdinateSet& ordinateF
         return std::unique_ptr<MultiPoint>(geometryFactory->createMultiPoint(*coords));
     }
 
-    else if(tok == '(' ||  // Try to parse correct form "MULTIPOINT((0 0), (1 1))"
-            tok == StringTokenizer::TT_WORD)  // EMPTY?
+    else if(tok == '(' ||        // Try to parse "MULTIPOINT ((0 0), (1 1))"
+            tok == StringTokenizer::TT_WORD)  // "MULTIPOINT (EMPTY, (1 1))"
     {
         std::vector<std::unique_ptr<Point>> points;
 

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -49,6 +49,12 @@ struct test_wktreader_data {
                       dim);
     }
 
+    void ensure_dimension(const std::string & wkt, bool has_z, bool has_m) const {
+        auto geom = wktreader.read(wkt);
+        ensure_equals(wkt + " hasZ", geom->hasZ(), has_z);
+        ensure_equals(wkt + " hasM", geom->hasM(), has_m);
+    }
+
     void ensure_parseexception(const std::string & wkt) const {
         try {
             auto geom = wktreader.read(wkt);
@@ -421,6 +427,24 @@ void object::test<21>
         std::string msg(e.what());
         ensure_equals(msg, "ParseException: Unexpected text after end of geometry");
     }
+}
+
+// https://github.com/libgeos/geos/issues/886
+template<>
+template<>
+void object::test<22>
+()
+{
+
+    ensure_dimension("MULTIPOINT (0 0, 1 2)", false, false);
+    ensure_dimension("MULTIPOINT Z (0 0 4, 1 2 4)", true, false);
+    ensure_dimension("MULTIPOINT M (0 0 3, 1 2 5)", false, true);
+    ensure_dimension("MULTIPOINT ZM (0 0 4 3, 1 2 4 5)", true, true);
+
+    ensure_dimension("MULTIPOINT ((0 0), (1 2))", false, false);
+    ensure_dimension("MULTIPOINT Z ((0 0 4), (1 2 4))", true, false);
+    ensure_dimension("MULTIPOINT M ((0 0 3), (1 2 5))", false, true);
+    ensure_dimension("MULTIPOINT ZM ((0 0 4 3), (1 2 4 5))", true, true);
 }
 
 } // namespace tut


### PR DESCRIPTION
Closes #886

Also, re-word some comments around "deprecated" or "correct" forms for multipoint. I can't see any official source for the correct form. Looking at OGC 06-103r4 for [SFA](https://www.ogc.org/standard/sfa) 1.2.1 it has both:

- page 18: `multipoint m(1 0 4, 3 1 4, 5 3 4)`
- page LXI (aka 61): `MultiPoint ((10 10), (20 20))`

The BNF description implies the second form is more "correct". Both GEOS and PostGIS WKTWriters only write the first form, so there is not clear "correct" form.

Also note that this PR does not attempt to fix an outstanding issue with EMPTY described in #902.