### PR TITLE
Clarify thread safety requirements for C API

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -87,19 +87,18 @@ extern "C" {
 
 
 /**
-* Type returned by GEOS_init_r(), for use in multi-threaded
-* applications.
+* Type returned by GEOS_init_r(), for use with the functions ending in `_r`
+* (the reentrant API).
 *
-* There should be only one GEOSContextHandle_t per thread.
+* Contexts must only be used from a single thread at a time.
 */
 typedef struct GEOSContextHandle_HS *GEOSContextHandle_t;
 
 /**
 * Callback function for passing GEOS error messages to parent process.
 *
-* Set the \ref GEOSMessageHandler function for error and notice messages in \ref initGEOS
-* for single-threaded programs, or using \ref initGEOS_r for threaded
-* programs
+* Set the \ref GEOSMessageHandler function for error and notice messages using
+* \ref initGEOS or \ref initGEOS_r.
 *
 * \param fmt the message format template
 */
@@ -331,9 +330,10 @@ extern void GEOS_DLL GEOS_interruptCancel(void);
 /* ========== Initialization and Cleanup ========== */
 
 /**
-* Initialize a context for this thread. Pass this context into
-* your other calls of `*_r` functions.
-* \return a GEOS context for this thread
+* Allocate and initialize a context. Pass this context as the first argument
+* when calling other `*_r` functions. Contexts must only be used from a single
+* thread at a time.
+* \return a new GEOS context.
 *
 * \since 3.5
 */


### PR DESCRIPTION
The response to #876 suggests that it's safe to create multiple contexts in a single thread. As such, I'm proposing some updates to the C API header docs to remove the stated one-context-per-thread limitation and to avoid implying that contexts must be thread-confined. This change is useful when using geos within higher-level concurrency abstractions that guarantee serial access but do not guarantee a specific thread (e.g. a serial task queue served by a thread pool).