### PR TITLE
Change WKBWriter default output dimension to 4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,7 @@ xxxx-xx-xx
 - Changes:
   - Remove Orientation.isCCW exception to simplify logic and align with JTS (GH-878, Martin Davis)
   - Change MultiPoint WKT to use parentheses in sub-members (GH-903, Mike Taves)
+  - Change WKBWriter default output dimension to 4 (GH-908, Mike Taves)
 
 ## Changes in 3.11.0
 2022-07-01

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -5584,7 +5584,7 @@ extern int GEOS_DLL GEOSWKBWriter_getOutputDimension(
 
 /**
 * Set the output dimensionality of the writer. Either
-* 2, 3, or 4 dimensions.
+* 2, 3, or 4 dimensions. Default since GEOS 3.12 is 4.
 * \param writer The writer to read from.
 * \param newDimension The dimensionality desired
 * \since 3.0

--- a/include/geos/io/WKBWriter.h
+++ b/include/geos/io/WKBWriter.h
@@ -58,7 +58,7 @@ namespace io {
  *
  * The WKB format is specified in the OGC Simple Features for SQL specification.
  * This implementation supports the extended WKB standard for representing
- * 3-dimensional coordinates.  The presence of 3D coordinates is signified
+ * Z and M coordinates.  The presence of Z and/or M coordinates is signified
  * by setting the high bit of the wkbType word.
  *
  * Empty Points cannot be represented in WKB; an
@@ -80,15 +80,16 @@ public:
      * Initializes writer with target coordinate dimension, endianness
      * flag and SRID value.
      *
-     * @param dims Supported values are 2 or 3.  Note that 3 indicates
-     * up to 3 dimensions will be written but 2D WKB is still produced for 2D geometries.
+     * @param dims Supported values are 2, 3 or 4.  Note that 4 indicates
+     * up to 4 dimensions will be written but (e.g.) 2D WKB is still produced
+     * for 2D geometries. Default since GEOS 3.12 is 4.
      * @param bo output byte order - default to native machine byte order.
      * Legal values include 0 (big endian/xdr) and 1 (little endian/ndr).
      * @param incudeSRID true if SRID should be included in WKB (an
      * extension).
      */
     WKBWriter(
-        uint8_t dims = 2,
+        uint8_t dims = 4,
         int bo = getMachineByteOrder(),
         bool includeSRID = false,
         int flv = WKBConstants::wkbExtended);
@@ -113,9 +114,9 @@ public:
     /*
      * Sets the output dimension used by the <code>WKBWriter</code>.
      *
-     * @param newOutputDimension Supported values are 2 or 3.
-     * Note that 3 indicates up to 3 dimensions will be written but
-     * 2D WKB is still produced for 2D geometries.
+     * @param newOutputDimension Supported values are 2, 3 or 4.
+     * Note that 4 indicates up to 4 dimensions will be written but
+     * (e.g.) 2D WKB is still produced for 2D geometries.
      */
     void setOutputDimension(uint8_t newOutputDimension);
 

--- a/tests/unit/capi/GEOSWKBWriterTest.cpp
+++ b/tests/unit/capi/GEOSWKBWriterTest.cpp
@@ -31,6 +31,7 @@ typedef group::object object;
 
 group test_geoswkbwriter("capi::GEOSWKBWriter");
 
+// WKBWriter defaults
 template<>
 template<>
 void object::test<1>()
@@ -38,7 +39,7 @@ void object::test<1>()
     ensure_equals(GEOSWKBWriter_getIncludeSRID(wkbwriter_), 0);
     ensure_equals(GEOSWKBWriter_getByteOrder(wkbwriter_), getMachineByteOrder());
     ensure_equals(GEOSWKBWriter_getFlavor(wkbwriter_), GEOS_WKB_EXTENDED);
-    ensure_equals(GEOSWKBWriter_getOutputDimension(wkbwriter_), 2);
+    ensure_equals(GEOSWKBWriter_getOutputDimension(wkbwriter_), 4);
 }
 
 template<>
@@ -83,7 +84,6 @@ void object::test<4>()
     GEOSSetSRID(geom1_, 32145);
 
     GEOSWKBWriter_setIncludeSRID(wkbwriter_, 1);
-    GEOSWKBWriter_setOutputDimension(wkbwriter_, 3);
 
     std::size_t hex_size = 0;
     buf_ = GEOSWKBWriter_writeHEX(wkbwriter_, geom1_, &hex_size);
@@ -110,6 +110,77 @@ void object::test<5>()
 
     // SELECT encode(ST_AsBinary('POINT (3 8)'::geometry, 'XDR'), 'hex');
     ensure_equals(hexstr, "000000000140080000000000004020000000000000");
+}
+
+template<>
+template<>
+void object::test<6>()
+{
+    geom1_ = fromWKT("POINT M (3 8 2)");
+
+    GEOSWKBWriter_setOutputDimension(wkbwriter_, 2);
+    ensure_equals(GEOSWKBWriter_getOutputDimension(wkbwriter_), 2);
+
+    std::size_t hex_size = 0;
+    buf_ = GEOSWKBWriter_writeHEX(wkbwriter_, geom1_, &hex_size);
+
+    std::string hexstr = std::string((const char*) buf_, (const char*) buf_ + hex_size);
+
+    // POINT (3 8)
+    ensure_equals(hexstr, "010100000000000000000008400000000000002040");
+}
+
+template<>
+template<>
+void object::test<7>()
+{
+    geom1_ = fromWKT("POINT M (3 8 2)");
+
+    GEOSWKBWriter_setOutputDimension(wkbwriter_, 3);
+    ensure_equals(GEOSWKBWriter_getOutputDimension(wkbwriter_), 3);
+
+    std::size_t hex_size = 0;
+    buf_ = GEOSWKBWriter_writeHEX(wkbwriter_, geom1_, &hex_size);
+
+    std::string hexstr = std::string((const char*) buf_, (const char*) buf_ + hex_size);
+
+    // POINT M (3 8 2)
+    ensure_equals(hexstr, "0101000040000000000000084000000000000020400000000000000040");
+}
+
+template<>
+template<>
+void object::test<8>()
+{
+    geom1_ = fromWKT("POINT ZM (3 8 1 2)");
+
+    GEOSWKBWriter_setOutputDimension(wkbwriter_, 2);
+
+    std::size_t hex_size = 0;
+    buf_ = GEOSWKBWriter_writeHEX(wkbwriter_, geom1_, &hex_size);
+
+    std::string hexstr = std::string((const char*) buf_, (const char*) buf_ + hex_size);
+
+    // POINT (3 8)
+    ensure_equals(hexstr, "010100000000000000000008400000000000002040");
+}
+
+template<>
+template<>
+void object::test<9>()
+{
+    geom1_ = fromWKT("POINT ZM (3 8 1 2)");
+
+    GEOSWKBWriter_setOutputDimension(wkbwriter_, 3);
+    ensure_equals(GEOSWKBWriter_getOutputDimension(wkbwriter_), 3);
+
+    std::size_t hex_size = 0;
+    buf_ = GEOSWKBWriter_writeHEX(wkbwriter_, geom1_, &hex_size);
+
+    std::string hexstr = std::string((const char*) buf_, (const char*) buf_ + hex_size);
+
+    // POINT Z (3 8 1)
+    ensure_equals(hexstr, "010100008000000000000008400000000000002040000000000000F03F");
 }
 
 } // namespace tut

--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -545,7 +545,6 @@ void GeosOp::outputGeometry(const Geometry * geom) {
     if (args.format == GeosOpArgs::fmtWKB ) {
         // output as hex-encoded WKB
         WKBWriter writer;
-        writer.setOutputDimension(4);
         writer.writeHEX(*geom, std::cout);
         std::cout << std::endl;
     }

--- a/web/content/specifications/wkb.md
+++ b/web/content/specifications/wkb.md
@@ -254,8 +254,9 @@ GEOSWKBReader* reader = GEOSWKBReader_create();
 GEOSGeom* geom = GEOSWKTReader_read(reader, linestring);
 GEOSSetSRID(geom, 4326);
 
-/* Write it out as ISO WKB */
+/* Write it out as Extended WKB */
 GEOSWKBWriter* writer = GEOSWKBWriter_create();
+/* Next line only needed before GEOS 3.12 */
 GEOSWKBWriter_setOutputDimension(writer, 3);
 GEOSWKBWriter_setFlavor(writer, GEOS_WKB_EXTENDED);
 GEOSWKBWriter_setIncludeSRID(writer, 1);
@@ -294,6 +295,7 @@ GEOSGeom* geom = GEOSWKTReader_read(reader, linestring);
 
 /* Write it out as ISO WKB */
 GEOSWKBWriter* writer = GEOSWKBWriter_create();
+/* Next line only needed before GEOS 3.12 */
 GEOSWKBWriter_setOutputDimension(writer, 3);
 GEOSWKBWriter_setFlavor(writer, GEOS_WKB_ISO);
 


### PR DESCRIPTION
This potentially breaking change is to use output dimension 4 with the WKBWriter.

For example, `POINT Z (1.1 2.2 3.3)` via writeHEX using defaults:

- Current: `01010000009A9999999999F13F9A99999999990140` or `POINT (1.1 2.2)`
- Proposed: `01010000809A9999999999F13F9A999999999901406666666666660A40` same as input WKT

Also add a few additional tests related to `setOutputDimension` that didn't seem to be covered.