### PR TITLE
GeoJSONReader: Fix 2D empty geometry creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,7 @@ xxxx-xx-xx
   - GEOSHasZ: Fix handling with empty geometries (GH-887, Mike Taves)
   - OffsetCurve: fix EndCap parameter handling (GH-899, Martin Davis)
   - Reduce artifacts in single-sided Buffers: (GH-665 #810 and #712, Sandro Santilli)
+  - GeoJSONReader: Fix 2D empty geometry creation (GH-909, Mike Taves)
 
 - Changes:
   - Remove Orientation.isCCW exception to simplify logic and align with JTS (GH-878, Martin Davis)

--- a/src/io/GeoJSONReader.cpp
+++ b/src/io/GeoJSONReader.cpp
@@ -233,7 +233,7 @@ std::unique_ptr<geom::LineString> GeoJSONReader::readLineString(
     const geos_nlohmann::json& j) const
 {
     const auto& coords = j.at("coordinates").get<std::vector<std::vector<double>>>();
-    auto coordinates = detail::make_unique<CoordinateSequence>();
+    auto coordinates = detail::make_unique<CoordinateSequence>(0u, 2u);
     coordinates->reserve(coords.size());
     for (const auto& coord : coords) {
         const geom::Coordinate& c = readCoordinate(coord);
@@ -256,7 +256,7 @@ std::unique_ptr<geom::Polygon> GeoJSONReader::readPolygon(
     std::vector<std::unique_ptr<geom::LinearRing>> rings;
     rings.reserve(polygonCoords.size());
     for (const auto& ring : polygonCoords) {
-    auto coordinates = detail::make_unique<CoordinateSequence>();
+    auto coordinates = detail::make_unique<CoordinateSequence>(0u, 2u);
         coordinates->reserve(ring.size());
         for (const auto& coord : ring) {
             const geom::Coordinate& c = readCoordinate(coord);
@@ -300,7 +300,7 @@ std::unique_ptr<geom::MultiLineString> GeoJSONReader::readMultiLineString(
     std::vector<std::unique_ptr<geom::LineString>> lines;
     lines.reserve(listOfCoords.size());
     for (const auto& coords :  listOfCoords) {
-        auto coordinates = detail::make_unique<geom::CoordinateSequence>();
+        auto coordinates = detail::make_unique<geom::CoordinateSequence>(0u, 2u);
         coordinates->reserve(coords.size());
         for (const auto& coord : coords) {
             const geom::Coordinate& c = readCoordinate(coord);

--- a/tests/unit/io/GeoJSONReaderTest.cpp
+++ b/tests/unit/io/GeoJSONReaderTest.cpp
@@ -53,6 +53,7 @@ void object::test<1>
     std::string geojson { "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POINT (-117.000 33.000)", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON LineString
@@ -64,6 +65,7 @@ void object::test<2>
     std::string geojson { "{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("LINESTRING (102.000 0.000, 103.000 1.000, 104.000 0.000, 105.000 1.000)", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON Polygon with only an outer ring
@@ -75,6 +77,7 @@ void object::test<3>
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[[[30,10],[40,40],[20,40],[10,20],[30,10]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POLYGON ((30.000 10.000, 40.000 40.000, 20.000 40.000, 10.000 20.000, 30.000 10.000))", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON Point with an outer ring and an inner ring
@@ -86,6 +89,7 @@ void object::test<4>
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[[[35,10],[45,45],[15,40],[10,20],[35,10]],[[20,30],[35,35],[30,20],[20,30]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POLYGON ((35.000 10.000, 45.000 45.000, 15.000 40.000, 10.000 20.000, 35.000 10.000), (20.000 30.000, 35.000 35.000, 30.000 20.000, 20.000 30.000))", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON MultiPoint
@@ -97,6 +101,7 @@ void object::test<5>
     std::string geojson { "{\"type\":\"MultiPoint\",\"coordinates\":[[10, 40], [40, 30], [20, 20], [30, 10]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTIPOINT (10.000 40.000, 40.000 30.000, 20.000 20.000, 30.000 10.000)", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON MultiLineString
@@ -108,6 +113,7 @@ void object::test<6>
     std::string geojson { "{\"type\":\"MultiLineString\",\"coordinates\":[[[10, 10], [20, 20], [10, 40]],[[40, 40], [30, 30], [40, 20], [30, 10]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTILINESTRING ((10.000 10.000, 20.000 20.000, 10.000 40.000), (40.000 40.000, 30.000 30.000, 40.000 20.000, 30.000 10.000))", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON MultiPolygon
@@ -119,6 +125,7 @@ void object::test<7>
     std::string geojson { "{\"type\": \"MultiPolygon\", \"coordinates\": [[[[40, 40], [20, 45], [45, 30], [40, 40]]], [[[20, 35], [10, 30], [10, 10], [30, 5], [45, 20], [20, 35]], [[30, 20], [20, 15], [20, 25], [30, 20]]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTIPOLYGON (((40.000 40.000, 20.000 45.000, 45.000 30.000, 40.000 40.000)), ((20.000 35.000, 10.000 30.000, 10.000 10.000, 30.000 5.000, 45.000 20.000, 20.000 35.000), (30.000 20.000, 20.000 15.000, 20.000 25.000, 30.000 20.000)))", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON GeometryCollection
@@ -130,6 +137,7 @@ void object::test<8>
     std::string geojson { "{\"type\": \"GeometryCollection\",\"geometries\": [{\"type\": \"Point\",\"coordinates\": [40, 10]},{\"type\": \"LineString\",\"coordinates\": [[10, 10], [20, 20], [10, 40]]},{\"type\": \"Polygon\",\"coordinates\": [[[40, 40], [20, 45], [45, 30], [40, 40]]]}]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("GEOMETRYCOLLECTION (POINT (40.000 10.000), LINESTRING (10.000 10.000, 20.000 20.000, 10.000 40.000), POLYGON ((40.000 40.000, 20.000 45.000, 45.000 30.000, 40.000 40.000)))", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON Feature with a Point and no properties
@@ -141,7 +149,7 @@ void object::test<9>
     std::string geojson { "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POINT (-117.000 33.000)", geom->toText());
-
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON FeatureCollection with two Feature with Points and no properties
@@ -153,7 +161,7 @@ void object::test<10>
     std::string geojson { "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-122.0,45.0]}}]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("GEOMETRYCOLLECTION (POINT (-117.000 33.000), POINT (-122.000 45.000))", geom->toText());
-
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty Point
@@ -165,6 +173,7 @@ void object::test<11>
     std::string geojson { "{\"type\":\"Point\",\"coordinates\":[]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POINT EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty LineString
@@ -176,6 +185,7 @@ void object::test<12>
     std::string geojson { "{\"type\":\"LineString\",\"coordinates\":[]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("LINESTRING EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty Polygon
@@ -187,6 +197,7 @@ void object::test<13>
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POLYGON EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty MultiPoint
@@ -198,6 +209,7 @@ void object::test<14>
     std::string geojson { "{\"type\":\"MultiPoint\",\"coordinates\":[]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTIPOINT EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty MultiLineString
@@ -209,6 +221,7 @@ void object::test<15>
     std::string geojson { "{\"type\":\"MultiLineString\",\"coordinates\":[]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTILINESTRING EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty MultiPolygon
@@ -220,6 +233,7 @@ void object::test<16>
     std::string geojson { "{\"type\": \"MultiPolygon\", \"coordinates\": []}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTIPOLYGON EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read an empty GeometryCollection
@@ -231,6 +245,7 @@ void object::test<17>
     std::string geojson { "{\"type\": \"GeometryCollection\",\"geometries\": []}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("GEOMETRYCOLLECTION EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a Simple Feature
@@ -242,6 +257,7 @@ void object::test<18>
     std::string geojson { "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}, \"properties\": {\"id\": 1, \"name\": \"one\", \"required\": true} }" };
     geos::io::GeoJSONFeatureCollection features(geojsonreader.readFeatures(geojson));
     ensure_equals(static_cast<size_t>(1), features.getFeatures().size());
+    ensure_equals(static_cast<size_t>(features.getFeatures()[0].getGeometry()->getCoordinateDimension()), 2u);
     ensure_equals("POINT (-117.000 33.000)", features.getFeatures()[0].getGeometry()->toText());
     ensure_equals(1.0, features.getFeatures()[0].getProperties().at("id").getNumber());
     ensure_equals("one", features.getFeatures()[0].getProperties().at("name").getString());
@@ -257,6 +273,7 @@ void object::test<19>
     std::string geojson { "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}, \"properties\": {\"id\": 1, \"name\": \"one\", \"items\": [1,2,3,4], \"nested\": {\"id\":2, \"name\":\"two\"}}}" };
     geos::io::GeoJSONFeatureCollection features(geojsonreader.readFeatures(geojson));
     ensure_equals(static_cast<size_t>(1), features.getFeatures().size());
+    ensure_equals(static_cast<size_t>(features.getFeatures()[0].getGeometry()->getCoordinateDimension()), 2u);
     ensure_equals("POINT (-117.000 33.000)", features.getFeatures()[0].getGeometry()->toText());
     ensure_equals(1.0, features.getFeatures()[0].getProperties().at("id").getNumber());
     ensure_equals("one", features.getFeatures()[0].getProperties().at("name").getString());
@@ -281,6 +298,7 @@ void object::test<20>
      "]}" };
     geos::io::GeoJSONFeatureCollection features(geojsonreader.readFeatures(geojson));
     ensure_equals(static_cast<size_t>(3), features.getFeatures().size());
+    ensure_equals(static_cast<size_t>(features.getFeatures()[0].getGeometry()->getCoordinateDimension()), 2u);
     ensure_equals("POLYGON ((87.890 64.923, 76.992 55.178, 102.656 46.558, 115.312 60.413, 94.570 58.447, 87.890 64.923))", features.getFeatures()[0].getGeometry()->toText());
     ensure_equals(1.0, features.getFeatures()[0].getProperties().at("id").getNumber());
     ensure_equals("LINESTRING (1.406 48.690, 41.835 34.016, 22.500 13.923)", features.getFeatures()[1].getGeometry()->toText());
@@ -298,6 +316,7 @@ void object::test<21>
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[[]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POLYGON EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON Point with only one coordinate
@@ -404,6 +423,7 @@ void object::test<27>
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[[],[]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("POLYGON EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON empty MultiLineString with empty LineStrings
@@ -415,6 +435,7 @@ void object::test<28>
     std::string geojson { "{\"type\":\"MultiLineString\",\"coordinates\":[[],[],[]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
     ensure_equals("MULTILINESTRING EMPTY", geom->toText());
+    ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
 // Read a GeoJSON Point with too many coordinates


### PR DESCRIPTION
Closes #906

Notes:

- This fixes `main` only. To patch earlier releases see #910
- To enable 3D support, a great deal of GeoJSONReader would need to be re-written.