### PR TITLE
geosop: add option to output GeoJSON

### DIFF
--- a/util/geosop/GeosOp.h
+++ b/util/geosop/GeosOp.h
@@ -31,7 +31,10 @@ class GeosOpArgs {
 
 public:
     enum {
-        fmtNone, fmtText, fmtWKB
+        fmtNone,
+        fmtText,
+        fmtWKB,
+        fmtGeoJSON,
     } format = fmtText;
 
     bool isShowTime = false;


### PR DESCRIPTION
This enhancement adds `-f geojson` (or `-f json`) to output GeoJSON from `geosop`.

```bash
$ ./bin/geosop -a "POINT(1.1 2.2)" -f geojson buffer 10.0
```
> `{"type":"Polygon","coordinates":[[[11.1,2.2],[10.907852804032304,0.2490967798387178],[10.338795325112867,-1.6268343236508978],[9.414696123025452,-3.3557023301960216],[8.171067811865475,-4.871067811865474],[6.655702330196023,-6.114696123025452],[4.9268343236508985,-7.038795325112868],[3.0509032201612833,-7.607852804032304],[1.1000000000000008,-7.8],[-0.8509032201612818,-7.607852804032304],[-2.726834323650897,-7.038795325112868],[-4.45570233019602,-6.114696123025454],[-5.971067811865474,-4.871067811865475],[-7.214696123025453,-3.3557023301960216],[-8.138795325112868,-1.6268343236508986],[-8.707852804032305,0.24909677983871403],[-8.9,2.199999999999999],[-8.707852804032305,4.150903220161284],[-8.138795325112868,6.026834323650897],[-7.214696123025455,7.75570233019602],[-5.971067811865478,9.271067811865475],[-4.455702330196022,10.514696123025452],[-2.726834323650903,11.438795325112864],[-0.8509032201612865,12.007852804032304],[1.0999999999999983,12.2],[3.050903220161283,12.007852804032304],[4.9268343236509,11.438795325112867],[6.655702330196018,10.514696123025455],[8.171067811865473,9.271067811865478],[9.414696123025452,7.755702330196022],[10.338795325112864,6.026834323650904],[10.907852804032302,4.150903220161288],[11.1,2.2]]]}`

Other changes:

- It also accepts `-f json` to enable the same feature
- The `-f fmt` arg is converted to lower-case to enable `-f GeoJSON` or `-f WKT`, etc.

Limitations:

- The `--precision arg` does not "work", since GeoJSONWriter does not have any abilities to set precision (perhaps it could; also it could use ryu to format some numbers more nicely)
- GeoJSONWriter only writes 2D geometries, although it should be enhanced to support 3D XYZ geometries
- This enhancement doesn't consider reading GeoJSON inputs -- just outputs