### PR TITLE
GEOSClipByRect: Fix case with POINT EMPTY, add more tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,7 @@ xxxx-xx-xx
   - OffsetCurve: fix EndCap parameter handling (GH-899, Martin Davis)
   - Reduce artifacts in single-sided Buffers: (GH-665 #810 and #712, Sandro Santilli)
   - GeoJSONReader: Fix 2D empty geometry creation (GH-909, Mike Taves)
+  - GEOSClipByRect: Fix case with POINT EMPTY (GH-913, Mike Taves)
 
 - Changes:
   - Remove Orientation.isCCW exception to simplify logic and align with JTS (GH-878, Martin Davis)

--- a/src/operation/intersection/RectangleIntersection.cpp
+++ b/src/operation/intersection/RectangleIntersection.cpp
@@ -117,7 +117,7 @@ RectangleIntersection::clip_point(const geom::Point* g,
                                   RectangleIntersectionBuilder& parts,
                                   const Rectangle& rect)
 {
-    if(g == nullptr) {
+    if(g == nullptr || g->isEmpty()) {
         return;
     }
 

--- a/src/operation/intersection/RectangleIntersection.cpp
+++ b/src/operation/intersection/RectangleIntersection.cpp
@@ -534,6 +534,10 @@ RectangleIntersection::clip_polygon(const geom::Polygon* g,
                                     const Rectangle& rect,
                                     bool keep_polygons)
 {
+    if(g == nullptr || g->isEmpty()) {
+        return;
+    }
+
     if(keep_polygons) {
         clip_polygon_to_polygons(g, parts, rect);
     }

--- a/tests/unit/capi/GEOSClipByRectTest.cpp
+++ b/tests/unit/capi/GEOSClipByRectTest.cpp
@@ -204,11 +204,11 @@ template<> template<> void object::test<15>
     isEqual(geom2_, "POLYGON ((2 2, 2 5, 5 5, 5 2, 2 2))");
 }
 
-/// Empty combinations
+/// Empty combinations - always return GEOMETRYCOLLECTION EMPTY
 template<> template<> void object::test<16>
 ()
 {
-    std::vector<std::string> variants{
+    std::vector<const char*> variants{
         "POINT EMPTY",
         "LINESTRING EMPTY",
         "POLYGON EMPTY",
@@ -219,9 +219,14 @@ template<> template<> void object::test<16>
         "LINEARRING EMPTY",
     };
     for (const auto& wkt : variants) {
-        geom1_ = GEOSGeomFromWKT(wkt.c_str());
-        geom2_ = GEOSClipByRect(geom1_, 0, 0, 1, 1);
-        isEqual(geom2_, wkt.c_str());
+        GEOSGeom geom1 = GEOSGeomFromWKT(wkt);
+        GEOSGeom geom2 = GEOSClipByRect(geom1, 0, 0, 1, 1);
+        char* obt_wkt = GEOSWKTWriter_write(wktw_, geom2);
+        std::string obt_wkt2(obt_wkt);
+        GEOSFree(obt_wkt);
+        GEOSGeom_destroy(geom1);
+        GEOSGeom_destroy(geom2);
+        ensure_equals(obt_wkt2, "GEOMETRYCOLLECTION EMPTY");
     }
 }
 

--- a/tests/unit/capi/GEOSClipByRectTest.cpp
+++ b/tests/unit/capi/GEOSClipByRectTest.cpp
@@ -204,6 +204,26 @@ template<> template<> void object::test<15>
     isEqual(geom2_, "POLYGON ((2 2, 2 5, 5 5, 5 2, 2 2))");
 }
 
+/// Empty combinations
+template<> template<> void object::test<16>
+()
+{
+    std::vector<std::string> variants{
+        "POINT EMPTY",
+        "LINESTRING EMPTY",
+        "POLYGON EMPTY",
+        "MULTIPOINT EMPTY",
+        "MULTILINESTRING EMPTY",
+        "MULTIPOLYGON EMPTY",
+        "GEOMETRYCOLLECTION EMPTY",
+        "LINEARRING EMPTY",
+    };
+    for (const auto& wkt : variants) {
+        geom1_ = GEOSGeomFromWKT(wkt.c_str());
+        geom2_ = GEOSClipByRect(geom1_, 0, 0, 1, 1);
+        isEqual(geom2_, wkt.c_str());
+    }
+}
 
 
 } // namespace tut

--- a/tests/unit/operation/intersection/RectangleIntersectionTest.cpp
+++ b/tests/unit/operation/intersection/RectangleIntersectionTest.cpp
@@ -1679,4 +1679,27 @@ template<> template<> void object::test<208>
 
     doClipTest(inp, exp, r, 1e-10);
 }
+
+/// Empty combinations - always return GEOMETRYCOLLECTION EMPTY
+template<> template<> void object::test<209>
+()
+{
+    std::vector<const char*> variants{
+        "POINT EMPTY",
+        "LINESTRING EMPTY",
+        "POLYGON EMPTY",
+        "MULTIPOINT EMPTY",
+        "MULTILINESTRING EMPTY",
+        "MULTIPOLYGON EMPTY",
+        "GEOMETRYCOLLECTION EMPTY",
+        "LINEARRING EMPTY",
+    };
+    for (const auto& inp : variants) {
+        doClipTest(
+            inp,
+            "GEOMETRYCOLLECTION EMPTY",
+            Rectangle(0, 0, 1, 1)
+        );
+    }
+}
 }


### PR DESCRIPTION
This seems to be an old bug, where `GEOSClipByRect("POINT EMPTY", ...)` raises:
> GEOSException: UnsupportedOperationException: getX called on empty Point"

Other empty combinations work fine (they only return `GEOMETRYCOLLECTION EMPTY`), so add each empty combination to the tests.