### PR TITLE
Change WKTWriter default output dimension to 4 and trim to 'on'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,7 @@ xxxx-xx-xx
   - Remove Orientation.isCCW exception to simplify logic and align with JTS (GH-878, Martin Davis)
   - Change MultiPoint WKT to use parentheses in sub-members (GH-903, Mike Taves)
   - Change WKBWriter default output dimension to 4 (GH-908, Mike Taves)
+  - Change WKTWriter defaults output dimension to 4 and trim to 'on' (GH-915, Mike Taves)
 
 ## Changes in 3.11.0
 2022-07-01

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -5412,8 +5412,9 @@ extern char GEOS_DLL *GEOSWKTWriter_write(
 * With trim set to 1, the writer will strip trailing 0's from
 * the output coordinates. With 0, all coordinates will be
 * padded with 0's out to the rounding precision.
+* Default since GEOS 3.12 is with trim set to 1 for 'on'.
 * \param writer A \ref GEOSWKTWriter.
-* \param trim The trimming behaviour to set, 1 for 'on', 0 for 'off', default 'off'
+* \param trim The trimming behaviour to set, 1 for 'on', 0 for 'off'
 *
 * \since 3.3
 */
@@ -5434,10 +5435,10 @@ extern void GEOS_DLL GEOSWKTWriter_setRoundingPrecision(
     int precision);
 
 /**
-* Sets whether or not to write out XY or XYZ coordinates.
-* Legal values are 2 or 3.
+* Set the output dimensionality of the writer. Either
+* 2, 3, or 4 dimensions. Default since GEOS 3.12 is 4.
 * \param writer A \ref GEOSWKTWriter.
-* \param dim The desired dimension, default 2.
+* \param dim The dimensionality desired.
 *
 * \since 3.3
 */

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -935,7 +935,11 @@ extern "C" {
     GEOSGeomToWKT_r(GEOSContextHandle_t extHandle, const Geometry* g1)
     {
         return execute(extHandle, [&]() {
-            char* result = gstrdup(g1->toString());
+            // Deprecated, show untrimmed 2D output
+            geos::io::WKTWriter writer;
+            writer.setTrim(false);
+            writer.setOutputDimension(2);
+            char* result = gstrdup(writer.write(g1));
             return result;
         });
     }

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -161,7 +161,7 @@ public:
     /**
      * Enable old style 3D/4D WKT generation.
      *
-     * By default the WKBWriter produces new style 3D/4D WKT
+     * By default the WKTWriter produces new style 3D/4D WKT
      * (ie. "POINT Z (10 20 30)") but if this method is used
      * to turn on old style WKT production then the WKT will
      * be formatted in the style "POINT (10 20 30)".
@@ -177,7 +177,7 @@ public:
     /*
      * \brief
      * Returns the output dimension used by the
-     * <code>WKBWriter</code>.
+     * <code>WKTWriter</code>.
      */
     int
     getOutputDimension() const
@@ -186,11 +186,12 @@ public:
     }
 
     /*
-     * Sets the output dimension used by the <code>WKBWriter</code>.
+     * Sets the output dimension used by the <code>WKTWriter</code>.
      *
-     * @param newOutputDimension Supported values are 2 or 3.
+     * @param newOutputDimension Supported values are 2, 3 or 4.
+     *        Default since GEOS 3.12 is 4.
      *        Note that 3 indicates up to 3 dimensions will be
-     *        written but 2D WKB is still produced for 2D geometries.
+     *        written but 2D WKT is still produced for 2D geometries.
      */
     void setOutputDimension(uint8_t newOutputDimension);
 

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -454,6 +454,9 @@ std::string
 Geometry::toText() const
 {
     io::WKTWriter writer;
+    // To enable "GEOS<3.12" outputs, uncomment the following:
+    // writer.setTrim(false);
+    // writer.setOutputDimension(2);
     return writer.write(this);
 }
 

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -57,9 +57,9 @@ WKTWriter::WKTWriter():
     decimalPlaces(6),
     isFormatted(false),
     roundingPrecision(-1),
-    trim(false),
+    trim(true),
     level(0),
-    defaultOutputDimension(2),
+    defaultOutputDimension(4),
     old3D(false)
 {
 }

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -620,7 +620,6 @@ BufferBuilder::computeNodedEdges(SegmentString::NonConstVect& bufferSegStrList,
 
 #if JTS_DEBUG
     geos::io::WKTWriter wktWriter;
-    wktWriter.setTrim(true);
     std::cerr << "before noding: "
               << wktWriter.write(
                   convertSegStrings(geomFact, bufferSegStrList.begin(),

--- a/src/operation/overlayng/OverlayNG.cpp
+++ b/src/operation/overlayng/OverlayNG.cpp
@@ -184,8 +184,6 @@ OverlayNG::getResult()
 
 #if GEOS_DEBUG
     io::WKTWriter w;
-    w.setOutputDimension(3);
-    w.setTrim(true);
 
     std::cerr << "Before populatingZ: " << w.write(result.get()) << std::endl;
 #endif

--- a/tests/unit/capi/GEOSBufferTest.cpp
+++ b/tests/unit/capi/GEOSBufferTest.cpp
@@ -25,7 +25,6 @@ struct test_capigeosbuffer_data : public capitest::utility {
     test_capigeosbuffer_data()
         : bp_(nullptr)
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 
     ~test_capigeosbuffer_data()

--- a/tests/unit/capi/GEOSBuildAreaTest.cpp
+++ b/tests/unit/capi/GEOSBuildAreaTest.cpp
@@ -20,8 +20,6 @@ namespace tut {
 struct test_capi_buildarea_data : public capitest::utility {
     test_capi_buildarea_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 };
 

--- a/tests/unit/capi/GEOSClipByRectTest.cpp
+++ b/tests/unit/capi/GEOSClipByRectTest.cpp
@@ -36,7 +36,6 @@ struct test_capigeosclipbyrect_data : public capitest::utility {
 
     test_capigeosclipbyrect_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
     }
 };

--- a/tests/unit/capi/GEOSConstrainedDelaunayTriangulationTest.cpp
+++ b/tests/unit/capi/GEOSConstrainedDelaunayTriangulationTest.cpp
@@ -20,7 +20,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capiconstrainedgeosdelaunaytriangulation_data : public capitest::utility {
     test_capiconstrainedgeosdelaunaytriangulation_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 

--- a/tests/unit/capi/GEOSDelaunayTriangulationTest.cpp
+++ b/tests/unit/capi/GEOSDelaunayTriangulationTest.cpp
@@ -20,7 +20,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosdelaunaytriangulation_data : public capitest::utility {
     test_capigeosdelaunaytriangulation_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 

--- a/tests/unit/capi/GEOSDistanceTest.cpp
+++ b/tests/unit/capi/GEOSDistanceTest.cpp
@@ -23,7 +23,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosdistance_data : public capitest::utility {
     test_capigeosdistance_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 

--- a/tests/unit/capi/GEOSFrechetDistanceTest.cpp
+++ b/tests/unit/capi/GEOSFrechetDistanceTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosfrechetdistance_data : public capitest::utility {
     test_capigeosfrechetdistance_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 

--- a/tests/unit/capi/GEOSGeomToWKBTest.cpp
+++ b/tests/unit/capi/GEOSGeomToWKBTest.cpp
@@ -41,7 +41,6 @@ struct test_capigeosgeomtowkb_data : public capitest::utility {
 
         GEOSWKTWriter* wktwriter = GEOSWKTWriter_create();
         GEOSWKTWriter_setRoundingPrecision(wktwriter, 3);
-        GEOSWKTWriter_setTrim(wktwriter, 1);
         GEOSWKTWriter_setOutputDimension(wktwriter, 3);
         char* wkt_c = GEOSWKTWriter_write(wktwriter, geom2_);
         GEOSWKTWriter_destroy(wktwriter);

--- a/tests/unit/capi/GEOSGeomToWKTTest.cpp
+++ b/tests/unit/capi/GEOSGeomToWKTTest.cpp
@@ -23,12 +23,13 @@ struct test_capigeosgeomtowkt_data : public capitest::utility {
     void
     test_wkt(std::string const& wkt)
     {
-        geom1_ = GEOSGeomFromWKT(wkt.c_str());
-        ensure(nullptr != geom1_);
+        GEOSGeometry* geom1 = GEOSGeomFromWKT(wkt.c_str());
+        ensure(nullptr != geom1);
 
-        char* wkt_c = GEOSGeomToWKT(geom1_);
+        char* wkt_c = GEOSGeomToWKT(geom1);
         std::string out(wkt_c);
         free(wkt_c);
+        GEOSGeom_destroy(geom1);
 
         ensure_equals(out, wkt);
     }
@@ -36,12 +37,13 @@ struct test_capigeosgeomtowkt_data : public capitest::utility {
     void
     test_wkt(std::string const& wkt, std::string::size_type n)
     {
-        geom1_ = GEOSGeomFromWKT(wkt.c_str());
-        ensure(nullptr != geom1_);
+        GEOSGeometry* geom1 = GEOSGeomFromWKT(wkt.c_str());
+        ensure(nullptr != geom1);
 
-        char* wkt_c = GEOSGeomToWKT(geom1_);
+        char* wkt_c = GEOSGeomToWKT(geom1);
         std::string out(wkt_c);
         free(wkt_c);
+        GEOSGeom_destroy(geom1);
 
         ensure_equals(out.substr(0, n), wkt.substr(0, n));
     }
@@ -105,14 +107,18 @@ void object::test<6>
 }
 
 // Comparing string based on float-point numbers does not make sense,
-// so make poor-man comparison of WKT type tag.
+// so make poor-man comparison of WKT type tag and first few numbers
 
 template<>
 template<>
 void object::test<7>
 ()
 {
-    test_wkt("POINT (1.234 5.678)", 7);
+    test_wkt("POINT (1.234000 5.678)", 15);
+
+    // check default OutputDimension(2) with higher dimension points
+    test_wkt("POINT (1.234000 5.678 9)", 15); // POINT Z
+    test_wkt("POINT (1.234000 5.678 9 10)", 15); // POINT ZM
 }
 
 template<>
@@ -120,7 +126,7 @@ template<>
 void object::test<8>
 ()
 {
-    test_wkt("LINESTRING (0 0, 5 5, 10 5, 10 10)", 13);
+    test_wkt("LINESTRING (0.000 0, 5 5, 10 5, 10 10)", 17);
 }
 
 template<>
@@ -128,7 +134,7 @@ template<>
 void object::test<9>
 ()
 {
-    test_wkt("POLYGON ((0 10, 5 5, 10 5, 15 10, 10 15, 5 15, 0 10))", 11);
+    test_wkt("POLYGON ((0.000 10, 5 5, 10 5, 15 10, 10 15, 5 15, 0 10))", 15);
 }
 
 template<>
@@ -136,7 +142,7 @@ template<>
 void object::test<10>
 ()
 {
-    test_wkt("MULTIPOINT ((0 0), (5 5), (10 10), (15 15), (20 20))", 13);
+    test_wkt("MULTIPOINT ((0.000 0), (5 5), (10 10), (15 15), (20 20))", 17);
 }
 
 template<>
@@ -144,7 +150,7 @@ template<>
 void object::test<11>
 ()
 {
-    test_wkt("MULTILINESTRING ((0 0, 10 0, 10 10, 0 10, 10 20),(2 2, 2 6, 6 4, 20 2))", 19);
+    test_wkt("MULTILINESTRING ((0.000 0, 10 0, 10 10, 0 10, 10 20),(2 2, 2 6, 6 4, 20 2))", 23);
 }
 
 template<>
@@ -152,7 +158,7 @@ template<>
 void object::test<12>
 ()
 {
-    test_wkt("MULTIPOLYGON (((0 0, 10 0, 10 10, 0 10, 0 0),(2 2, 2 6, 6 4, 2 2)),((60 60, 60 50, 70 40, 60 60)))", 17);
+    test_wkt("MULTIPOLYGON (((0.000 0, 10 0, 10 10, 0 10, 0 0),(2 2, 2 6, 6 4, 2 2)),((60 60, 60 50, 70 40, 60 60)))", 21);
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSGetCentroidTest.cpp
+++ b/tests/unit/capi/GEOSGetCentroidTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capicentroid_data : public capitest::utility {
     test_capicentroid_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 6);
     }
 };

--- a/tests/unit/capi/GEOSHausdorffDistanceTest.cpp
+++ b/tests/unit/capi/GEOSHausdorffDistanceTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeoshausdorffdistance_data : public capitest::utility {
     test_capigeoshausdorffdistance_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 

--- a/tests/unit/capi/GEOSIntersectionPrecTest.cpp
+++ b/tests/unit/capi/GEOSIntersectionPrecTest.cpp
@@ -20,8 +20,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosintersectionprec_data : public capitest::utility {
     test_capigeosintersectionprec_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 
     static int

--- a/tests/unit/capi/GEOSIntersectionTest.cpp
+++ b/tests/unit/capi/GEOSIntersectionTest.cpp
@@ -13,8 +13,6 @@ namespace tut {
 struct test_capigeosintersection_data : public capitest::utility
 {
     test_capigeosintersection_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 };
 

--- a/tests/unit/capi/GEOSMakeValidTest.cpp
+++ b/tests/unit/capi/GEOSMakeValidTest.cpp
@@ -21,8 +21,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capimakevalid_data : public capitest::utility {
     test_capimakevalid_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 };
 

--- a/tests/unit/capi/GEOSMaximumInscribedCircleTest.cpp
+++ b/tests/unit/capi/GEOSMaximumInscribedCircleTest.cpp
@@ -25,7 +25,6 @@ struct test_capimaximuminscribedcircle_data : public capitest::utility {
     test_capimaximuminscribedcircle_data()
         : wkt_(nullptr)
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
     }
 

--- a/tests/unit/capi/GEOSMinimumBoundingCircleTest.cpp
+++ b/tests/unit/capi/GEOSMinimumBoundingCircleTest.cpp
@@ -22,7 +22,6 @@ namespace tut {
 struct test_capiminimumboundingcircle_data : public capitest::utility {
     test_capiminimumboundingcircle_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
     }
 };

--- a/tests/unit/capi/GEOSMinimumRotatedRectangleTest.cpp
+++ b/tests/unit/capi/GEOSMinimumRotatedRectangleTest.cpp
@@ -19,7 +19,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_minimumrotatedrectangle_data : public capitest::utility {
     test_minimumrotatedrectangle_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
     }
 

--- a/tests/unit/capi/GEOSMinimumWidthTest.cpp
+++ b/tests/unit/capi/GEOSMinimumWidthTest.cpp
@@ -19,7 +19,6 @@ namespace tut {
 struct test_capigeosminimumwidth_data : public capitest::utility {
     test_capigeosminimumwidth_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
     }
 };

--- a/tests/unit/capi/GEOSNodeTest.cpp
+++ b/tests/unit/capi/GEOSNodeTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 struct test_capigeosnode_data : public capitest::utility {
     test_capigeosnode_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 
@@ -140,7 +139,6 @@ void object::test<6>
 
     GEOSNormalize(result_);
     GEOSNormalize(expected_);
-    GEOSWKTWriter_setOutputDimension(wktw_, 3);
 
     auto wkt_result = GEOSWKTWriter_write(wktw_, result_);
     auto wkt_expected = GEOSWKTWriter_write(wktw_, expected_);
@@ -167,7 +165,6 @@ void object::test<7>
 
     GEOSNormalize(result_);
     GEOSNormalize(expected_);
-    GEOSWKTWriter_setOutputDimension(wktw_, 3);
 
     auto wkt_result = GEOSWKTWriter_write(wktw_, result_);
     auto wkt_expected = GEOSWKTWriter_write(wktw_, expected_);
@@ -194,7 +191,6 @@ void object::test<8>
 
     GEOSNormalize(result_);
     GEOSNormalize(expected_);
-    GEOSWKTWriter_setOutputDimension(wktw_, 4);
 
     auto wkt_result = GEOSWKTWriter_write(wktw_, result_);
     auto wkt_expected = GEOSWKTWriter_write(wktw_, expected_);

--- a/tests/unit/capi/GEOSOffsetCurveTest.cpp
+++ b/tests/unit/capi/GEOSOffsetCurveTest.cpp
@@ -20,7 +20,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capioffsetcurve_data : public capitest::utility {
     test_capioffsetcurve_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 
     void debugOutput (const char* label, GEOSGeometry* geom)

--- a/tests/unit/capi/GEOSPointOnSurfaceTest.cpp
+++ b/tests/unit/capi/GEOSPointOnSurfaceTest.cpp
@@ -22,7 +22,6 @@ namespace tut {
 struct test_capipointonsurface_data : public capitest::utility {
     test_capipointonsurface_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 4);
     }
 };

--- a/tests/unit/capi/GEOSRemoveRepeatedPointsTest.cpp
+++ b/tests/unit/capi/GEOSRemoveRepeatedPointsTest.cpp
@@ -20,8 +20,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capiremoverepeatedpoints_data : public capitest::utility {
     test_capiremoverepeatedpoints_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 };
 

--- a/tests/unit/capi/GEOSSharedPathsTest.cpp
+++ b/tests/unit/capi/GEOSSharedPathsTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 struct test_capigeossharedpaths_data : public capitest::utility {
     test_capigeossharedpaths_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 };
 

--- a/tests/unit/capi/GEOSSnapTest.cpp
+++ b/tests/unit/capi/GEOSSnapTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 struct test_capigeossnap_data : public capitest::utility {
     test_capigeossnap_data()
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
         GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
     }
 };

--- a/tests/unit/capi/GEOSUnaryUnionPrecTest.cpp
+++ b/tests/unit/capi/GEOSUnaryUnionPrecTest.cpp
@@ -21,8 +21,6 @@ namespace tut {
 struct test_capiunaryunionprec_data : public capitest::utility {
 
     test_capiunaryunionprec_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 
 };

--- a/tests/unit/capi/GEOSUnaryUnionTest.cpp
+++ b/tests/unit/capi/GEOSUnaryUnionTest.cpp
@@ -21,8 +21,6 @@ namespace tut {
 struct test_capiunaryunion_data : public capitest::utility {
 
     test_capiunaryunion_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 
 };

--- a/tests/unit/capi/GEOSVoronoiDiagramTest.cpp
+++ b/tests/unit/capi/GEOSVoronoiDiagramTest.cpp
@@ -21,7 +21,6 @@ namespace tut {
 // Common data used in test cases.
 struct test_capigeosvoronoidiagram_data : public capitest::utility {
     test_capigeosvoronoidiagram_data() {
-        GEOSWKTWriter_setTrim(wktw_, 1);
     }
 
 

--- a/tests/unit/capi/GEOSWKTWriterTest.cpp
+++ b/tests/unit/capi/GEOSWKTWriterTest.cpp
@@ -24,13 +24,29 @@ struct test_geoswktwriter_data : public capitest::utility {
     void
     test_writer_wkt(std::string const& wkt)
     {
-        geom1_ = GEOSGeomFromWKT(wkt.c_str());
-        ensure(nullptr != geom1_);
+        GEOSGeometry* geom1 = GEOSGeomFromWKT(wkt.c_str());
+        ensure(nullptr != geom1);
 
-        wkt_ = GEOSWKTWriter_write(wktwriter_, geom1_);
-        std::string out(wkt_);
+        char* wkt_c = GEOSWKTWriter_write(wktwriter_, geom1);
+        std::string out(wkt_c);
+        free(wkt_c);
+        GEOSGeom_destroy(geom1);
 
         ensure_equals(out, wkt);
+    }
+
+    void
+    test_writer_wkt(std::string const& wkt, std::string const& expected)
+    {
+        GEOSGeometry* geom1 = GEOSGeomFromWKT(wkt.c_str());
+        ensure(nullptr != geom1);
+
+        char* wkt_c = GEOSWKTWriter_write(wktwriter_, geom1);
+        std::string out(wkt_c);
+        free(wkt_c);
+        GEOSGeom_destroy(geom1);
+
+        ensure_equals(out, expected);
     }
 
     GEOSWKTWriter* wktwriter_;
@@ -42,33 +58,108 @@ typedef group::object object;
 
 group test_geoswktwriter("capi::GEOSWKTWriter");
 
+// Check default output dimension 4
 template<>
 template<>
 void object::test<1>()
 {
-    ensure_equals(GEOSWKTWriter_getOutputDimension(wktwriter_), 2);
+    ensure_equals(GEOSWKTWriter_getOutputDimension(wktwriter_), 4);
+
+    test_writer_wkt("POINT (10 13)");
+    test_writer_wkt("POINT Z (10 13 3)");
+    test_writer_wkt("POINT M (10 13 5)");
+    test_writer_wkt("POINT ZM (10 13 3 5)");
 }
 
+// Check writer with output dimension 2
 template<>
 template<>
 void object::test<2>()
 {
-    GEOSWKTWriter_setTrim(wktwriter_, 1);
-    GEOSWKTWriter_setOutputDimension(wktwriter_, 3);
-    ensure_equals("getOutputDimension_2", GEOSWKTWriter_getOutputDimension(wktwriter_), 3);
+    GEOSWKTWriter_setOutputDimension(wktwriter_, 2);
+    ensure_equals("getOutputDimension_2", GEOSWKTWriter_getOutputDimension(wktwriter_), 2);
 
-    test_writer_wkt("POINT Z (10 13 3)");
+    test_writer_wkt("POINT (10 13)");
+    test_writer_wkt("POINT Z (10 13 3)", "POINT (10 13)");
+    test_writer_wkt("POINT M (10 13 5)", "POINT (10 13)");
+    test_writer_wkt("POINT ZM (10 13 3 5)", "POINT (10 13)");
 }
 
+// Check writer with output dimension 3
 template<>
 template<>
 void object::test<3>()
 {
-    GEOSWKTWriter_setTrim(wktwriter_, 1);
+    GEOSWKTWriter_setTrim(wktwriter_, 1);  // redundant, but keep to ensure it stays trim
     GEOSWKTWriter_setOutputDimension(wktwriter_, 3);
-    GEOSWKTWriter_setOld3D(wktwriter_, 1);
+    ensure_equals("getOutputDimension_3", GEOSWKTWriter_getOutputDimension(wktwriter_), 3);
 
+    test_writer_wkt("POINT (10 13)");
+    test_writer_wkt("POINT Z (10 13 3)");
+    test_writer_wkt("POINT M (10 13 3)");
+    test_writer_wkt("POINT ZM (10 13 3 5)", "POINT Z (10 13 3)");
+}
+
+// Check Old3D with output dimension 3
+template<>
+template<>
+void object::test<4>()
+{
+    GEOSWKTWriter_setOld3D(wktwriter_, 1);
+    GEOSWKTWriter_setOutputDimension(wktwriter_, 3);
+
+    test_writer_wkt("POINT (10 13)");
     test_writer_wkt("POINT (10 13 3)");
+    test_writer_wkt("POINT M (10 13 5)");
+    test_writer_wkt("POINT ZM (10 13 3 5)", "POINT (10 13 3)");
+
+}
+
+// Check Old3D with default output dimension 4
+template<>
+template<>
+void object::test<5>()
+{
+    GEOSWKTWriter_setOld3D(wktwriter_, 1);
+    ensure_equals(GEOSWKTWriter_getOutputDimension(wktwriter_), 4);
+
+    test_writer_wkt("POINT (10 13)");
+    test_writer_wkt("POINT (10 13 3)");
+    test_writer_wkt("POINT M (10 13 5)");
+    test_writer_wkt("POINT (10 13 3 5)");
+
+}
+
+// Check to get legacy default output before GEOS 3.12, showing untrimmed 2D WKT
+template<>
+template<>
+void object::test<6>()
+{
+    GEOSWKTWriter_setTrim(wktwriter_, 0);
+    GEOSWKTWriter_setOutputDimension(wktwriter_, 2);
+
+    std::string expected("POINT (10.0000000000000000 13.0000000000000000)");
+
+    test_writer_wkt("POINT (10 13)", expected);
+    test_writer_wkt("POINT Z (10 13 3)", expected);
+    test_writer_wkt("POINT M (10 13 5)", expected);
+    test_writer_wkt("POINT ZM (10 13 3 5)", expected);
+
+}
+
+// Check untrimmed WKT with a fixed precision
+template<>
+template<>
+void object::test<7>()
+{
+    GEOSWKTWriter_setTrim(wktwriter_, 0);
+    GEOSWKTWriter_setRoundingPrecision(wktwriter_, 2);
+
+    test_writer_wkt("POINT (10 13)", "POINT (10.00 13.00)");
+    test_writer_wkt("POINT Z (10 13 3)", "POINT Z (10.00 13.00 3.00)");
+    test_writer_wkt("POINT M (10 13 5)", "POINT M (10.00 13.00 5.00)");
+    test_writer_wkt("POINT ZM (10 13 3 5)", "POINT ZM (10.00 13.00 3.00 5.00)");
+
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSisValidDetailTest.cpp
+++ b/tests/unit/capi/GEOSisValidDetailTest.cpp
@@ -25,8 +25,6 @@ struct test_capiisvaliddetail_data : public capitest::utility {
 
     test_capiisvaliddetail_data() : loc_(nullptr), reason_(nullptr)
     {
-        GEOSWKTWriter_setTrim(wktw_, 1);
-        GEOSWKTWriter_setOutputDimension(wktw_, 3);
     }
 
     void

--- a/tests/unit/capi/capi_test_utils.h
+++ b/tests/unit/capi/capi_test_utils.h
@@ -28,7 +28,6 @@ namespace capitest {
         {
             initGEOS(notice, notice);
             wktw_ = GEOSWKTWriter_create();
-            GEOSWKTWriter_setTrim(wktw_, 1);
             GEOSWKTWriter_setRoundingPrecision(wktw_, 10);
 
             std::feclearexcept(FE_ALL_EXCEPT);

--- a/tests/unit/coverage/CoverageRingEdgesTest.cpp
+++ b/tests/unit/coverage/CoverageRingEdgesTest.cpp
@@ -25,7 +25,6 @@ struct test_coverageringedges_data
     WKTWriter w;
 
     test_coverageringedges_data() {
-        w.setTrim(true);
     }
 
     void

--- a/tests/unit/coverage/CoverageSimplifierTest.cpp
+++ b/tests/unit/coverage/CoverageSimplifierTest.cpp
@@ -22,7 +22,6 @@ struct test_coveragesimplifier_data {
     std::vector<std::unique_ptr<Geometry>> geomArray;
 
     test_coveragesimplifier_data() {
-        w.setTrim(true);
     }
 
     void checkNoop(

--- a/tests/unit/coverage/TPVWSimplifierTest.cpp
+++ b/tests/unit/coverage/TPVWSimplifierTest.cpp
@@ -21,7 +21,6 @@ struct test_tpvwsimplifier_data {
     WKTWriter w;
 
     test_tpvwsimplifier_data() {
-        w.setTrim(true);
     }
 
     void

--- a/tests/unit/geom/Geometry/normalizeTest.cpp
+++ b/tests/unit/geom/Geometry/normalizeTest.cpp
@@ -27,7 +27,6 @@ struct test_geometry_normalize_data {
     test_geometry_normalize_data()
         : reader(), writer()
     {
-        writer.setTrim(true);
     }
 
     void

--- a/tests/unit/geom/Geometry/toTextTest.cpp
+++ b/tests/unit/geom/Geometry/toTextTest.cpp
@@ -1,0 +1,60 @@
+//
+// Test Suite for Geometry's toText() function
+
+// tut
+#include <tut/tut.hpp>
+// geos
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/Geometry.h>
+#include <geos/io/WKTReader.h>
+// std
+#include <memory>
+#include <string>
+
+namespace tut {
+
+//
+// Test Group
+//
+
+struct test_totext_data {
+    typedef std::unique_ptr<geos::geom::Geometry> GeomPtr;
+    geos::io::WKTReader reader;
+
+    test_totext_data()
+        : reader()
+    {}
+};
+
+typedef test_group<test_totext_data> group;
+typedef group::object object;
+
+group test_totext_data("geos::geom::Geometry::toText");
+
+//
+// Test Cases
+//
+
+// Input WKT is the same as output from toText()
+template<> template<> void object::test<1>
+()
+{
+
+    std::vector<std::string> variants{
+        "POINT (1 2)",
+        "POINT Z (1 2 3)",
+        "POINT M (1 2 4)",
+        "POINT ZM (1 2 3 4)",
+        "POINT EMPTY",
+        "POINT Z EMPTY",
+        "GEOMETRYCOLLECTION EMPTY",
+    };
+    for (const auto& wkt : variants) {
+      GeomPtr g1(reader.read(wkt));
+      ensure_equals(g1->toText(), wkt);
+    }
+
+}
+
+} // namespace tut
+

--- a/tests/unit/geom/util/GeometryFixerTest.cpp
+++ b/tests/unit/geom/util/GeometryFixerTest.cpp
@@ -36,8 +36,6 @@ struct test_geometryfixer_data {
 
     test_geometryfixer_data()
     {
-        wktwriter_.setTrim(true);
-        wktwriter_.setOutputDimension(3);
     }
 
     void checkFix(const std::string& wkt, const std::string& wktExpected) {

--- a/tests/unit/io/GeoJSONFeatureTest.cpp
+++ b/tests/unit/io/GeoJSONFeatureTest.cpp
@@ -51,12 +51,12 @@ void object::test<1>
         {"id",   geos::io::GeoJSONValue(1.0)     },
         {"name", geos::io::GeoJSONValue(std::string{"One"}) },
     }};
-    ensure_equals(feature.getGeometry()->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(feature.getGeometry()->toText(), "POINT (-117 33)");
     ensure_equals(feature.getProperties().at("id").getNumber(), 1.0);
     ensure_equals(feature.getProperties().at("name").getString(), "One");
 
     const geos::io::GeoJSONFeature feature2 = feature;
-    ensure_equals(feature2.getGeometry()->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(feature2.getGeometry()->toText(), "POINT (-117 33)");
     ensure_equals(feature2.getProperties().at("id").getNumber(), 1.0);
     ensure_equals(feature2.getProperties().at("name").getString(), "One");
 }
@@ -78,10 +78,10 @@ void object::test<2>
         }}
     }};
     ensure_equals(static_cast<size_t>(2), features.getFeatures().size());
-    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POINT (-117 33)");
     ensure_equals(features.getFeatures()[0].getProperties().at("id").getNumber(), 1.0);
     ensure_equals(features.getFeatures()[0].getProperties().at("name").getString(), "One");
-    ensure_equals(features.getFeatures()[1].getGeometry()->toText(), "POINT (-127.000 53.000)");
+    ensure_equals(features.getFeatures()[1].getGeometry()->toText(), "POINT (-127 53)");
     ensure_equals(features.getFeatures()[1].getProperties().at("id").getNumber(), 2.0);
     ensure_equals(features.getFeatures()[1].getProperties().at("name").getString(), "Two");
 }

--- a/tests/unit/io/GeoJSONReaderTest.cpp
+++ b/tests/unit/io/GeoJSONReaderTest.cpp
@@ -52,7 +52,7 @@ void object::test<1>
 {
     std::string geojson { "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(geom->toText(), "POINT (-117 33)");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -64,7 +64,7 @@ void object::test<2>
 {
     std::string geojson { "{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "LINESTRING (102.000 0.000, 103.000 1.000, 104.000 0.000, 105.000 1.000)");
+    ensure_equals(geom->toText(), "LINESTRING (102 0, 103 1, 104 0, 105 1)");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -76,7 +76,7 @@ void object::test<3>
 {
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[[[30,10],[40,40],[20,40],[10,20],[30,10]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "POLYGON ((30.000 10.000, 40.000 40.000, 20.000 40.000, 10.000 20.000, 30.000 10.000))");
+    ensure_equals(geom->toText(), "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -88,7 +88,7 @@ void object::test<4>
 {
     std::string geojson { "{\"type\":\"Polygon\",\"coordinates\":[[[35,10],[45,45],[15,40],[10,20],[35,10]],[[20,30],[35,35],[30,20],[20,30]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "POLYGON ((35.000 10.000, 45.000 45.000, 15.000 40.000, 10.000 20.000, 35.000 10.000), (20.000 30.000, 35.000 35.000, 30.000 20.000, 20.000 30.000))");
+    ensure_equals(geom->toText(), "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -100,7 +100,7 @@ void object::test<5>
 {
     std::string geojson { "{\"type\":\"MultiPoint\",\"coordinates\":[[10, 40], [40, 30], [20, 20], [30, 10]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "MULTIPOINT ((10.000 40.000), (40.000 30.000), (20.000 20.000), (30.000 10.000))");
+    ensure_equals(geom->toText(), "MULTIPOINT ((10 40), (40 30), (20 20), (30 10))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -112,7 +112,7 @@ void object::test<6>
 {
     std::string geojson { "{\"type\":\"MultiLineString\",\"coordinates\":[[[10, 10], [20, 20], [10, 40]],[[40, 40], [30, 30], [40, 20], [30, 10]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "MULTILINESTRING ((10.000 10.000, 20.000 20.000, 10.000 40.000), (40.000 40.000, 30.000 30.000, 40.000 20.000, 30.000 10.000))");
+    ensure_equals(geom->toText(), "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -124,7 +124,7 @@ void object::test<7>
 {
     std::string geojson { "{\"type\": \"MultiPolygon\", \"coordinates\": [[[[40, 40], [20, 45], [45, 30], [40, 40]]], [[[20, 35], [10, 30], [10, 10], [30, 5], [45, 20], [20, 35]], [[30, 20], [20, 15], [20, 25], [30, 20]]]]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "MULTIPOLYGON (((40.000 40.000, 20.000 45.000, 45.000 30.000, 40.000 40.000)), ((20.000 35.000, 10.000 30.000, 10.000 10.000, 30.000 5.000, 45.000 20.000, 20.000 35.000), (30.000 20.000, 20.000 15.000, 20.000 25.000, 30.000 20.000)))");
+    ensure_equals(geom->toText(), "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -136,7 +136,7 @@ void object::test<8>
 {
     std::string geojson { "{\"type\": \"GeometryCollection\",\"geometries\": [{\"type\": \"Point\",\"coordinates\": [40, 10]},{\"type\": \"LineString\",\"coordinates\": [[10, 10], [20, 20], [10, 40]]},{\"type\": \"Polygon\",\"coordinates\": [[[40, 40], [20, 45], [45, 30], [40, 40]]]}]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "GEOMETRYCOLLECTION (POINT (40.000 10.000), LINESTRING (10.000 10.000, 20.000 20.000, 10.000 40.000), POLYGON ((40.000 40.000, 20.000 45.000, 45.000 30.000, 40.000 40.000)))");
+    ensure_equals(geom->toText(), "GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), POLYGON ((40 40, 20 45, 45 30, 40 40)))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -148,7 +148,7 @@ void object::test<9>
 {
     std::string geojson { "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(geom->toText(), "POINT (-117 33)");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -160,7 +160,7 @@ void object::test<10>
 {
     std::string geojson { "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-122.0,45.0]}}]}" };
     GeomPtr geom(geojsonreader.read(geojson));
-    ensure_equals(geom->toText(), "GEOMETRYCOLLECTION (POINT (-117.000 33.000), POINT (-122.000 45.000))");
+    ensure_equals(geom->toText(), "GEOMETRYCOLLECTION (POINT (-117 33), POINT (-122 45))");
     ensure_equals(static_cast<size_t>(geom->getCoordinateDimension()), 2u);
 }
 
@@ -258,7 +258,7 @@ void object::test<18>
     geos::io::GeoJSONFeatureCollection features(geojsonreader.readFeatures(geojson));
     ensure_equals(features.getFeatures().size(), static_cast<size_t>(1));
     ensure_equals(static_cast<size_t>(features.getFeatures()[0].getGeometry()->getCoordinateDimension()), 2u);
-    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POINT (-117 33)");
     ensure_equals(features.getFeatures()[0].getProperties().at("id").getNumber(), 1.0);
     ensure_equals(features.getFeatures()[0].getProperties().at("name").getString(), "one");
     ensure_equals(features.getFeatures()[0].getProperties().at("required").getBoolean(), true);
@@ -274,7 +274,7 @@ void object::test<19>
     geos::io::GeoJSONFeatureCollection features(geojsonreader.readFeatures(geojson));
     ensure_equals(features.getFeatures().size(), static_cast<size_t>(1));
     ensure_equals(static_cast<size_t>(features.getFeatures()[0].getGeometry()->getCoordinateDimension()), 2u);
-    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POINT (-117.000 33.000)");
+    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POINT (-117 33)");
     ensure_equals(features.getFeatures()[0].getProperties().at("id").getNumber(), 1.0);
     ensure_equals(features.getFeatures()[0].getProperties().at("name").getString(), "one");
     std::vector<geos::io::GeoJSONValue> values = features.getFeatures()[0].getProperties().at("items").getArray();
@@ -299,9 +299,9 @@ void object::test<20>
     geos::io::GeoJSONFeatureCollection features(geojsonreader.readFeatures(geojson));
     ensure_equals(features.getFeatures().size(), static_cast<size_t>(3));
     ensure_equals(static_cast<size_t>(features.getFeatures()[0].getGeometry()->getCoordinateDimension()), 2u);
-    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POLYGON ((87.890 64.923, 76.992 55.178, 102.656 46.558, 115.312 60.413, 94.570 58.447, 87.890 64.923))");
+    ensure_equals(features.getFeatures()[0].getGeometry()->toText(), "POLYGON ((87.89 64.923, 76.992 55.178, 102.656 46.558, 115.312 60.413, 94.57 58.447, 87.89 64.923))");
     ensure_equals(features.getFeatures()[0].getProperties().at("id").getNumber(), 1.0);
-    ensure_equals(features.getFeatures()[1].getGeometry()->toText(), "LINESTRING (1.406 48.690, 41.835 34.016, 22.500 13.923)");
+    ensure_equals(features.getFeatures()[1].getGeometry()->toText(), "LINESTRING (1.406 48.69, 41.835 34.016, 22.5 13.923)");
     ensure_equals(features.getFeatures()[1].getProperties().at("id").getNumber(), 2.0);
     ensure_equals(features.getFeatures()[2].getGeometry()->toText(), "POINT (-28.125 39.095)");
     ensure_equals(features.getFeatures()[2].getProperties().at("id").getNumber(), 3.0);

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -36,7 +36,6 @@ struct test_lengthindexedline_data {
     test_lengthindexedline_data()
         : reader(), writer()
     {
-        writer.setTrim(true);
     }
 
     geos::io::WKTReader reader;

--- a/tests/unit/noding/snapround/SnapRoundingNoderTest.cpp
+++ b/tests/unit/noding/snapround/SnapRoundingNoderTest.cpp
@@ -53,7 +53,6 @@ struct test_snaproundingnoder_data {
 
         std::unique_ptr<Geometry> expected = r.read(expected_wkt);
 
-        // w.setOutputDimension(4);
         // std::cout << std::endl << "result" << std::endl;
         // std::cout << std::endl << w.write(result.get()) << std::endl;
         // std::cout << std::endl << "expected" << std::endl;

--- a/tests/unit/operation/geounion/UnaryUnionOpTest.cpp
+++ b/tests/unit/operation/geounion/UnaryUnionOpTest.cpp
@@ -37,7 +37,6 @@ struct test_unaryuniontest_data {
         : gf(GeometryFactory::create()),
           wktreader(gf.get())
     {
-        wktwriter.setTrim(true);
     }
 
     void

--- a/tests/unit/operation/intersection/RectangleIntersectionTest.cpp
+++ b/tests/unit/operation/intersection/RectangleIntersectionTest.cpp
@@ -35,7 +35,6 @@ struct test_rectangleintersectiontest_data {
     test_rectangleintersectiontest_data()
         : wktreader()
     {
-        wktwriter.setTrim(true);
         // wktwriter.setRoundingPrecision(30);
     }
 

--- a/tests/unit/operation/linemerge/LineMergerTest.cpp
+++ b/tests/unit/operation/linemerge/LineMergerTest.cpp
@@ -40,7 +40,6 @@ struct test_linemerger_data {
     test_linemerger_data()
         : wktreader(), wktwriter()
     {
-        wktwriter.setTrim(true);
     }
 
     ~test_linemerger_data()

--- a/tests/unit/operation/linemerge/LineSequencerTest.cpp
+++ b/tests/unit/operation/linemerge/LineSequencerTest.cpp
@@ -39,7 +39,6 @@ struct test_linesequencer_data {
     test_linesequencer_data()
         : wktreader(), wktwriter()
     {
-        wktwriter.setTrim(true);
     }
 
     ~test_linesequencer_data()

--- a/tests/unit/operation/overlayng/CoverageUnionNGTest.cpp
+++ b/tests/unit/operation/overlayng/CoverageUnionNGTest.cpp
@@ -36,7 +36,6 @@ struct test_coverageunionng_data {
         try {
             ensure_equals_geometry_xyzm(result.get(), expected.get());
         } catch (const std::exception& e) {
-            w.setOutputDimension(4);
             std::string wkt_result = w.write(result.get());
             std::cerr << std::endl << wkt_result << std::endl;
             throw;

--- a/tests/unit/operation/overlayng/ElevationModelTest.cpp
+++ b/tests/unit/operation/overlayng/ElevationModelTest.cpp
@@ -37,8 +37,6 @@ struct test_overlayng_elevationmodel_data {
 
     test_overlayng_elevationmodel_data()
     {
-        w.setTrim(true);
-        w.setOutputDimension(3);
     }
 
     void checkElevation(const std::string& wkt1, const std::string& wkt2, std::initializer_list<double> ords)

--- a/tests/unit/operation/overlayng/OverlayNGZTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayNGZTest.cpp
@@ -36,8 +36,6 @@ struct test_overlayngz_data {
 
     test_overlayngz_data()
     {
-        w.setTrim(true);
-        w.setOutputDimension(3);
     }
 
     void checkOverlay(int opCode, const std::string& wktA, const std::string& wktB, const std::string& wktExpected)

--- a/tests/unit/operation/polygonize/PolygonizeTest.cpp
+++ b/tests/unit/operation/polygonize/PolygonizeTest.cpp
@@ -47,7 +47,6 @@ struct test_polygonizetest_data {
     test_polygonizetest_data()
         : wktreader()
     {
-        wktwriter.setTrim(true);
     }
 
     template <class T>

--- a/tests/unit/operation/sharedpaths/SharedPathsOpTest.cpp
+++ b/tests/unit/operation/sharedpaths/SharedPathsOpTest.cpp
@@ -37,7 +37,6 @@ struct test_shpathop_data {
     test_shpathop_data()
         : wktreader(), wktwriter()
     {
-        wktwriter.setTrim(true);
     }
 
 private:

--- a/tests/unit/operation/valid/RepeatedPointRemoverTest.cpp
+++ b/tests/unit/operation/valid/RepeatedPointRemoverTest.cpp
@@ -41,7 +41,6 @@ struct test_repeated_point_remover_test_data
     std::string
     wkt(const Geometry& geom)
     {
-        writer.setTrim(true);
         return writer.write(&geom);
     }
 

--- a/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
+++ b/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
@@ -33,7 +33,6 @@ struct test_tpsimp_data {
         , wktreader(gf.get())
         , wktwriter()
     {
-        //wktwriter.setTrim(1);
     }
 };
 

--- a/tests/unit/triangulate/VoronoiTest.cpp
+++ b/tests/unit/triangulate/VoronoiTest.cpp
@@ -104,7 +104,6 @@ runVoronoi(const char* sitesWkt, const char* expectedWkt, const double tolerance
                   static_cast<std::size_t>(expected->getCoordinateDimension()));
     bool eq = results->equalsExact(expected.get(), 1e-7);
     if(! eq) {
-        writer.setTrim(true);
         std::cout << std::endl;
         std::cout << " Expected: " << writer.write(expected.get()) << std::endl;
         std::cout << " Obtained: " << writer.write(results.get()) << std::endl;

--- a/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
+++ b/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
@@ -43,7 +43,6 @@ struct test_quadedgesub_data {
         reader(),
         writer()
     {
-        writer.setTrim(true);
     }
 };
 

--- a/tests/unit/utility.h
+++ b/tests/unit/utility.h
@@ -219,7 +219,6 @@ ensure_equals_geometry(T const* lhs_in, T const* rhs_in, double tolerance = 0.0)
 
     if(! (areCoordsEqual && areaNumPointsEqual)) {
         WKTWriter writer;
-        writer.setTrim(true);
         std::cout << std::endl
             << writer.write(*rhs) << std::endl
             << writer.write(*lhs) << std::endl;

--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -557,13 +557,9 @@ void GeosOp::outputGeometry(const Geometry * geom) {
     else {
         // output as text/WKT
         WKTWriter writer;
-        writer.setOutputDimension(4);
         if (args.precision >= 0) {
-             writer.setRoundingPrecision(args.precision);
-        }
-        else {
-            // turn off stoopid fixed precision
-            writer.setTrim(true);
+            writer.setRoundingPrecision(args.precision);
+            writer.setTrim(false);
         }
         std::cout << writer.write(geom) << std::endl;
     }

--- a/web/content/specifications/geojson.md
+++ b/web/content/specifications/geojson.md
@@ -70,7 +70,7 @@ void main(void)
 
     // Prepare WKT writer
     WKTWriter writer;
-    writer.setTrim(true);
+    writer.setTrim(true); // Only needed before GEOS 3.12
     writer.setRoundingPrecision(2);
 
     // Print out the features

--- a/web/content/specifications/wkt.md
+++ b/web/content/specifications/wkt.md
@@ -107,10 +107,10 @@ const char* linestring = "LINESTRING(0 0 1, 1 1 1, 2 1 2)";
 GEOSWKTReader* reader = GEOSWKTReader_create();
 GEOSGeom* geom = GEOSWKTReader_read(reader, linestring);
 
-/* Get a WKT  writer*/
+/* Get a WKT writer */
 GEOSWKTWriter* writer = GEOSWKTWriter_create();
 
-/* Preserve the Z dimension. */
+/* Preserve the Z dimension -- only needed before GEOS 3.12 */
 GEOSWKTWriter_setOutputDimension(writer, 3);
 
 /* Sets the number places after the decimal to output in WKT. Default 16. */
@@ -121,6 +121,7 @@ GEOSWKTWriter_setRoundingPrecision(writer, 4);
  * With trim set to 1, the writer will strip trailing 0's from
  * the output coordinates. With 0, all coordinates will be
  * padded with 0's out to the rounding precision.
+ * This is generally only needed before GEOS 3.12.
  */
 GEOSWKTWriter_setTrim(writer, 1);
 

--- a/web/content/usage/c_api.md
+++ b/web/content/usage/c_api.md
@@ -291,7 +291,7 @@ GEOSGeometry* geom = GEOSWKTReader_read(reader, wkt_in);
 
 /* Convert geometry back to WKT */
 GEOSWKTWriter* writer = GEOSWKTWriter_create();
-/* Trim trailing zeros off output */
+/* Trim trailing zeros off output; only needed before GEOS 3.12 */
 GEOSWKTWriter_setTrim(writer, 1);
 char* wkt_out = GEOSWKTWriter_write(writer, geom);
 

--- a/web/content/usage/cpp_api.md
+++ b/web/content/usage/cpp_api.md
@@ -79,7 +79,7 @@ int main()
 
     /* Convert Geometry to WKT */
     WKTWriter writer;
-    writer.setTrim(true);
+    writer.setTrim(true); /* Only needed before GEOS 3.12 */
     std::string inter_wkt = writer.write(inter.get());
 
     /* Print out results */


### PR DESCRIPTION
This potentially breaking change with the WKTWriter is to use output dimension 4 and trim 'on'.

For example, `POINT Z (1.1 2.2 3.3)` output using defaults are:

- Current: `POINT (1.1000000000000001 2.2000000000000002)`
- Proposed: `POINT Z (1.1 2.2 3.3)`

Other details:

- From the C++ API, both `toText()` and `toString()` will also use the new defaults; add `tests/unit/geom/Geometry/toTextTest.cpp` for this coverage
- Deprecated `GEOSGeomToWKT` (and `GEOSGeomToWKT_r`) should keep the previous defaults showing untrimmed 2D outputs, which is checked with `tests/unit/capi/GEOSGeomToWKTTest.cpp`