### PR TITLE
Expose geos ryu fork

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -25,6 +25,8 @@
 #include <geos/io/GeoJSONWriter.h>
 #include <geos/util/Interrupt.h>
 
+#include <ryu/ryu.h>
+
 #include <stdexcept>
 #include <new>
 
@@ -1441,6 +1443,11 @@ extern "C" {
     GEOSWKBWriter_setIncludeSRID(GEOSWKBWriter* writer, const char newIncludeSRID)
     {
         GEOSWKBWriter_setIncludeSRID_r(handle, writer, newIncludeSRID);
+    }
+
+    int
+    GEOS_d2sfixed_buffered_n(double d, unsigned int precision, char *result) {
+        return geos_d2sfixed_buffered_n(d, precision, result);
     }
 
     /* GeoJSON Reader */

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -25,8 +25,6 @@
 #include <geos/io/GeoJSONWriter.h>
 #include <geos/util/Interrupt.h>
 
-#include <ryu/ryu.h>
-
 #include <stdexcept>
 #include <new>
 
@@ -1446,8 +1444,8 @@ extern "C" {
     }
 
     int
-    GEOS_d2sfixed_buffered_n(double d, unsigned int precision, char *result) {
-        return geos_d2sfixed_buffered_n(d, precision, result);
+    GEOS_printDouble(double d, unsigned int precision, char *result) {
+        return WKTWriter::writeTrimmedNumber(d, precision, result);
     }
 
     /* GeoJSON Reader */

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1905,7 +1905,7 @@ extern void GEOS_DLL GEOSWKTWriter_setOld3D_r(
  * \param result The buffer to write the result to.
  * \return the length of the written string.
  */
-extern int GEOS_DLL GEOS_d2sfixed_buffered_n(
+extern int GEOS_DLL GEOS_printDouble(
     double d,
     unsigned int precision,
     char *result

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1898,6 +1898,19 @@ extern void GEOS_DLL GEOSWKTWriter_setOld3D_r(
     GEOSWKTWriter *writer,
     int useOld3D);
 
+/** Print the shortest representation of a double using fixed notation.
+ * Only works for numbers smaller than 1e17 (absolute value).
+ * \param d The number to format.
+ * \param precision The desired precision. (max digits after decimal point)
+ * \param result The buffer to write the result to.
+ * \return the length of the written string.
+ */
+extern int GEOS_DLL GEOS_d2sfixed_buffered_n(
+    double d,
+    unsigned int precision,
+    char *result
+);
+
 /* ========== WKB Reader ========== */
 
 /** \see GEOSWKBReader_create */

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -195,6 +195,7 @@ public:
     void setOutputDimension(uint8_t newOutputDimension);
 
     static std::string writeNumber(double d, bool trim, uint32_t precision);
+    static int writeTrimmedNumber(double d, uint32_t precision, char* buf);
 
 protected:
 

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -194,6 +194,8 @@ public:
      */
     void setOutputDimension(uint8_t newOutputDimension);
 
+    static std::string writeNumber(double d, bool trim, uint32_t precision);
+
 protected:
 
     int decimalPlaces;

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -404,6 +404,12 @@ WKTWriter::appendSequenceText(const CoordinateSequence& seq,
     }
 }
 
+int 
+WKTWriter::writeTrimmedNumber(double d, uint32_t precision, char* buf)
+{
+    return geos_d2sfixed_buffered_n(d, precision, buf);
+}
+
 std::string
 WKTWriter::writeNumber(double d, bool trim, uint32_t precision) {
     /*
@@ -412,7 +418,7 @@ WKTWriter::writeNumber(double d, bool trim, uint32_t precision) {
     */
     if (trim) {
         char buf[128];
-        int len = geos_d2sfixed_buffered_n(d, precision, buf);
+        int len = writeTrimmedNumber(d, precision, buf);
         buf[len] = '\0';
         std::string s(buf);
         return s;

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -404,11 +404,8 @@ WKTWriter::appendSequenceText(const CoordinateSequence& seq,
     }
 }
 
-/* protected */
 std::string
-WKTWriter::writeNumber(double d) const
-{
-    uint32_t precision = decimalPlaces >= 0 ? static_cast<std::uint32_t>(decimalPlaces) : 0;
+WKTWriter::writeNumber(double d, bool trim, uint32_t precision) {
     /*
     * For a "trimmed" result, with no trailing zeros we use
     * the ryu library.
@@ -431,6 +428,14 @@ WKTWriter::writeNumber(double d) const
         ss << d;
         return ss.str();
     }
+}
+
+/* protected */
+std::string
+WKTWriter::writeNumber(double d) const
+{
+    uint32_t precision = decimalPlaces >= 0 ? static_cast<std::uint32_t>(decimalPlaces) : 0;
+    return writeNumber(d, trim, precision);
 }
 
 void


### PR DESCRIPTION
This PR exposes the modified GEOS ryu-based double formatting functionality in the c-api, as well as as a static function on the WKTWriter. The change itself is pretty small, but I also ran the bundled `astyle` on the modified files which seems to have formatted lots of other lines. Let me know if you want me to undo it.