### PR TITLE
CPack: ignore other files/dirs starting with .; use verbatim option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,24 +454,22 @@ if(PROJECT_IS_TOP_LEVEL)
     set(CPACK_PACKAGE_VERSION_MINOR ${GEOS_VERSION_MINOR})
     set(CPACK_PACKAGE_VERSION_PATCH ${GEOS_VERSION_PATCH})
     set(CPACK_SOURCE_PACKAGE_FILE_NAME "geos-${GEOS_VERSION}")
-
+    set(CPACK_VERBATIM_VARIABLES TRUE)
     set(CPACK_SOURCE_IGNORE_FILES
-      "/\\\\.git"
-      "/autogen\\\\.sh"
-      "/tools/ci"
-      "/HOWTO_RELEASE"
-      "/autom4te\\\\.cache"
-      "\\\\.yml\$"
-      "\\\\.deps"
-      "/debian/"
-      "/php/"
-      "/.*build-.*/"
-      "cmake_install\\\\.cmake\$"
-      "/include/geos/version\\\\.h\$"
-      "/tools/geos-config\$"
-      "/tools/geos\\\\.pc\$"
-      "/bin/"
-      "/web/"
+      /\\..*  # any file/directory starting with .
+      /.*build.*/
+      /autogen\\.sh
+      /autom4te\\.cache
+      /bin/
+      /debian/
+      /HOWTO_RELEASE
+      /include/geos/version\\.h\$
+      /php/
+      /tools/ci
+      /tools/geos-config\$
+      /tools/geos\\.pc\$
+      /web/
+      cmake_install\\.cmake\$
       ${CMAKE_CURRENT_BINARY_DIR}
       )
 

--- a/HOWTO_RELEASE
+++ b/HOWTO_RELEASE
@@ -30,7 +30,7 @@
 
    $ BRANCH_NAME=main
    $ git clone --depth 1 --branch $BRANCH_NAME \
-         https://git.osgeo.org/gitea/geos/geos.git geos-$BRANCH_NAME
+         https://github.com/libgeos/geos.git geos-$BRANCH_NAME
    $ cd geos-$BRANCH_NAME
    $ mkdir _build && cd _build
    $ cmake ..


### PR DESCRIPTION
This PR uses [CPACK_VERBATIM_VARIABLES](https://cmake.org/cmake/help/latest/module/CPack.html#variable:CPACK_VERBATIM_VARIABLES) to simplify the escapes with the `CPACK_SOURCE_IGNORE_FILES` list for CPack. A new entry is added to ignore all files/directories that start with '`.`'. Only a few items that start with '`.`' are removed, otherwise the list is alphasorted.

Looking at results from `cmake --build . --target dist`, the only differences is that `.astylerc`, `.editorconfig` and `.mailmap` are now ignored.

Also fix HOWTO_RELEASE to the current main repo.