### PR TITLE
handle MSVC flag warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,10 @@
 # See the COPYING file for more information.
 ##############################################################################
 
-# Require CMake 3.13+ with support for meta-features that request compiler
-# modes for specific C/C++ language standard levels, and object libraries.
-cmake_minimum_required(VERSION 3.13)
+# Require CMake 3.15+ with support for handling MSVC warning flags, meta-features 
+# that request compiler modes for specific C/C++ language standard levels, and 
+# object libraries.
+cmake_minimum_required(VERSION 3.15)
 
 #-----------------------------------------------------------------------------
 # Version


### PR DESCRIPTION
- increases `cmake_minimum_required` to version 3.15, as the related MSVC flag policy was added in 3.15
  - see https://cmake.org/cmake/help/latest/policy/CMP0092.html
- this solves 707 repeated warnings with MSVC of `Command line warning D9025 : overriding '/W3' with '/W4'` such as:
```
[ 16%] Building CXX object CMakeFiles/geos.dir/src/geomgraph/Depth.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
Depth.cpp
[ 16%] Building CXX object CMakeFiles/geos.dir/src/geomgraph/DirectedEdge.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
DirectedEdge.cpp
[ 16%] Building CXX object CMakeFiles/geos.dir/src/geomgraph/DirectedEdgeStar.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
DirectedEdgeStar.cpp
[ 16%] Building CXX object CMakeFiles/geos.dir/src/geomgraph/Edge.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
Edge.cpp
[ 16%] Building CXX object CMakeFiles/geos.dir/src/geomgraph/EdgeEnd.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
EdgeEnd.cpp
```