### PR TITLE
Add LargestEmptyCircle handling of polygon obstacles

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -4129,8 +4129,7 @@ extern GEOSGeometry GEOS_DLL *GEOSMaximumInscribedCircle(
 * Constructs the "largest empty circle" (LEC) for a set of obstacle geometries
 * and within a polygonal boundary,
 * with accuracy to to a specified distance tolerance.
-* The obstacles are point and line geometries.
-* Polygonal obstacles are treated as linear features.
+* The obstacles may be any collection of points, lines and polygons.
 * The LEC is the largest circle whose interior does not intersect with any obstacle.
 * and which has its **center** inside the given boundary.
 * If no boundary is provided, the
@@ -4139,15 +4138,21 @@ extern GEOSGeometry GEOS_DLL *GEOSMaximumInscribedCircle(
 * the obstacles (up to the given distance tolerance).
 * The LEC is determined by the center point and a point indicating the circle radius
 * (which will lie on an obstacle).
+*
+* To compute an LEC which lies **wholly** within a polygonal boundary, 
+* include the boundary of the polygon(s) as a linear obstacle.
+*
 * The implementation uses a successive-approximation technique over a grid of square cells covering the obstacles and boundary.
 * The grid is refined using a branch-and-bound algorithm.  Point containment and distance are computed in a performant
 * way by using spatial indexes.
+*
 * Returns the LEC radius as a two-point linestring, with the start point at the center of the inscribed circle and the end
 * on the boundary of the circle.
+*
 * \param obstacles The geometries that the LEC must not cross
 * \param boundary The area to contain the LEC center (may be null or empty)
 * \param tolerance Stop the algorithm when the search area is smaller than this tolerance
-* \return A newly allocated geometry of the LEC radius. NULL on exception.
+* \return A newly allocated geometry of the LEC radius line. NULL on exception.
 * Caller is responsible for freeing with GEOSGeom_destroy().
 * \see geos::algorithm::construct::LargestEmptyCircle
 *

--- a/include/geos/algorithm/construct/IndexedDistanceToPoint.h
+++ b/include/geos/algorithm/construct/IndexedDistanceToPoint.h
@@ -1,0 +1,88 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2023 Martin Davis <mtnclimb@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: algorithm/construct/IndexedDistanceToPoint.java
+ * https://github.com/locationtech/jts/commit/d92f783163d9440fcc10c729143787bf7b9fe8f9
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/Point.h>
+#include <geos/algorithm/construct/IndexedPointInPolygonsLocator.h>
+#include <geos/operation/distance/IndexedFacetDistance.h>
+
+using geos::geom::Geometry;
+using geos::geom::Point;
+using geos::operation::distance::IndexedFacetDistance;
+
+namespace geos {
+namespace algorithm { // geos::algorithm
+namespace construct { // geos::algorithm::construct
+
+/**
+ * \brief Computes the distance between a point and a geometry
+ * (which may be a collection containing any type of geometry).
+ * 
+ * Also computes the pair of points containing the input
+ * point and the nearest point on the geometry.
+ * 
+ * \author Martin Davis
+ */
+class GEOS_DLL IndexedDistanceToPoint {
+
+public:
+    /** 
+     * \brief Creates an instance to find the distance from points to a geometry.
+     * 
+     * \param geom the geometry to compute distances to
+     */
+    IndexedDistanceToPoint(const Geometry& geom);
+
+    /**
+     * \brief Computes the distance from the base geometry to the given point.
+     *
+     * \param pt the point to compute the distance to
+     *
+     * \return the computed distance
+     */
+    double distance(const Point& pt);
+
+    /**
+     * \brief Computes the nearest point on the geometry to the point.
+     * 
+     * The first location lies on the geometry, 
+     * and the second location is the provided point.
+     *
+     * \param pt the point to compute the nearest point for
+     *
+     * \return the points that are nearest
+     */
+    std::unique_ptr<geom::CoordinateSequence> nearestPoints(const Point& pt);
+
+private:
+    void init();
+
+    bool isInArea(const Point& pt);
+
+    //-- members
+    const Geometry& targetGeometry;
+    std::unique_ptr<operation::distance::IndexedFacetDistance> facetDistance;
+    std::unique_ptr<IndexedPointInPolygonsLocator> ptLocator;
+
+};
+
+}}}

--- a/include/geos/algorithm/construct/IndexedPointInPolygonsLocator.h
+++ b/include/geos/algorithm/construct/IndexedPointInPolygonsLocator.h
@@ -1,0 +1,79 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2023 Martin Davis <mtnclimb@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: algorithm/construct/IndexedDistanceToPoint.java
+ * https://github.com/locationtech/jts/commit/d92f783163d9440fcc10c729143787bf7b9fe8f9
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/Location.h>
+#include <geos/index/strtree/TemplateSTRtree.h>
+#include <geos/algorithm/locate/IndexedPointInAreaLocator.h>
+
+using geos::geom::Geometry;
+using geos::geom::CoordinateXY;
+using geos::geom::Location;
+using geos::index::strtree::TemplateSTRtree;
+using geos::algorithm::locate::IndexedPointInAreaLocator;
+
+namespace geos {
+namespace algorithm { // geos::algorithm
+namespace construct { // geos::algorithm::construct
+
+/**
+ * \brief Determines the location of a point in the polygonal elements of a geometry.
+ * 
+ * Uses spatial indexing to provide efficient performance.
+ * 
+ * \author Martin Davis
+ */
+class GEOS_DLL IndexedPointInPolygonsLocator {
+
+public:
+    /** 
+     * \brief Creates an instance to locate a point in polygonal elements.
+     * 
+     * \param geom the geometry to locate in
+     */
+    IndexedPointInPolygonsLocator(const Geometry& geom);
+
+    /** \brief
+     * Determines the [Location](@ref geom::Location) of a point in 
+     * the polygonal elements of a
+     * [Geometry](@ref geom::Geometry).
+     *
+     * @param p the point to test
+     * @return the location of the point in the geometry
+     */
+    Location locate(const CoordinateXY* /*const*/ p);
+
+private:
+    void init();
+
+    // Declare type as noncopyable
+    IndexedPointInPolygonsLocator(const IndexedPointInPolygonsLocator& other) = delete;
+    IndexedPointInPolygonsLocator& operator=(const IndexedPointInPolygonsLocator& rhs) = delete;
+
+    //-- members
+    const Geometry& geom;
+    bool isInitialized;
+    TemplateSTRtree<IndexedPointInAreaLocator*> index;
+    std::vector<std::unique_ptr<IndexedPointInAreaLocator>> locators;
+};
+
+}}}

--- a/include/geos/geom/util/PolygonalExtracter.h
+++ b/include/geos/geom/util/PolygonalExtracter.h
@@ -1,0 +1,54 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2001-2002 Vivid Solutions Inc.
+ * Copyright (C) 2006 Refractions Research Inc.
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/export.h>
+#include <geos/geom/Geometry.h>
+#include <vector>
+
+namespace geos {
+namespace geom { // geos.geom
+namespace util { // geos.geom.util
+
+/**
+ * \brief Extracts the polygonal (Polygon and MultiPolygon) elements from a Geometry.
+ */
+class GEOS_DLL PolygonalExtracter {
+
+public:
+
+    /**
+     * Pushes the polygonal (Polygon and MultiPolygon) elements from a geometry into
+     * the provided vector.
+     * 
+     * @param geom the geometry to extract from
+     * @param polys the vector to add the polygonal elements to
+     */
+    static void getPolygonals(const Geometry& geom, std::vector<const Geometry*>& polys);
+
+private:
+
+    static void getPolygonals(const Geometry* geom, std::vector<const Geometry*>& polys);
+
+    // Declare type as noncopyable
+    PolygonalExtracter(const PolygonalExtracter& other) = delete;
+    PolygonalExtracter& operator=(const PolygonalExtracter& rhs) = delete;
+};
+
+} // namespace geos.geom.util
+} // namespace geos.geom
+} // namespace geos
+

--- a/src/algorithm/construct/IndexedDistanceToPoint.cpp
+++ b/src/algorithm/construct/IndexedDistanceToPoint.cpp
@@ -1,0 +1,68 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2023 Martin Davis <mtnclimb@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: algorithm/construct/IndexedDistanceToPoint.java
+ * https://github.com/locationtech/jts/commit/d92f783163d9440fcc10c729143787bf7b9fe8f9
+ *
+ **********************************************************************/
+
+#include <geos/algorithm/construct/IndexedDistanceToPoint.h>
+#include <geos/geom/Location.h>
+
+//using namespace geos::geom;
+using geos::geom::Location;
+
+namespace geos {
+namespace algorithm { // geos.algorithm
+namespace construct { // geos.algorithm.construct
+
+IndexedDistanceToPoint::IndexedDistanceToPoint(const Geometry& geom)
+    : targetGeometry(geom)
+{
+}
+
+/* private */
+void IndexedDistanceToPoint::init()
+{
+    if (facetDistance != nullptr)
+      return;
+    ptLocator.reset(new IndexedPointInPolygonsLocator(targetGeometry));
+    facetDistance.reset(new IndexedFacetDistance(&targetGeometry));
+}
+
+/* public */
+double IndexedDistanceToPoint::distance(const Point& pt)
+{
+    init();
+    //-- distance is 0 if point is inside a target polygon
+    if (isInArea(pt)) {
+        return 0;
+    }
+    return facetDistance->distance(&pt);
+}
+
+/* private */
+bool IndexedDistanceToPoint::isInArea(const Point& pt)
+{
+    return Location::EXTERIOR != ptLocator->locate(pt.getCoordinate());
+}
+
+/* public */
+std::unique_ptr<geom::CoordinateSequence> 
+IndexedDistanceToPoint::nearestPoints(const Point& pt)
+{
+    return facetDistance->nearestPoints(&pt);
+}
+
+}}}

--- a/src/algorithm/construct/IndexedPointInPolygonsLocator.cpp
+++ b/src/algorithm/construct/IndexedPointInPolygonsLocator.cpp
@@ -1,0 +1,70 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2023 Martin Davis <mtnclimb@gmail.com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: algorithm/construct/IndexedDistanceToPoint.java
+ * https://github.com/locationtech/jts/commit/d92f783163d9440fcc10c729143787bf7b9fe8f9
+ *
+ **********************************************************************/
+
+#include <geos/algorithm/construct/IndexedPointInPolygonsLocator.h>
+#include <geos/geom/Envelope.h>
+#include <geos/geom/util/PolygonalExtracter.h>
+#include <vector>
+
+using geos::algorithm::locate::IndexedPointInAreaLocator;
+using geos::geom::Envelope;
+using geos::geom::util::PolygonalExtracter;
+
+namespace geos {
+namespace algorithm { // geos.algorithm
+namespace construct { // geos.algorithm.construct
+
+/* public */
+IndexedPointInPolygonsLocator::IndexedPointInPolygonsLocator(const Geometry& g)
+    : geom(g), isInitialized(false)
+{   
+}
+
+/* private */
+void IndexedPointInPolygonsLocator::init()
+{
+    if (isInitialized) {
+        return;
+    }
+    isInitialized = true;
+    std::vector<const Geometry*> polys;
+    PolygonalExtracter::getPolygonals(geom, polys);
+    for (const Geometry* poly : polys) {
+        IndexedPointInAreaLocator* ptLocator = new IndexedPointInAreaLocator(*poly);
+        locators.emplace_back(ptLocator);
+        index.insert(poly->getEnvelopeInternal(), ptLocator);
+    }
+}
+
+/* public */
+Location IndexedPointInPolygonsLocator::locate(const CoordinateXY* /*const*/ pt)
+{
+    init();
+    Envelope queryEnv(*pt);
+    std::vector<IndexedPointInAreaLocator*> result;
+    index.query(queryEnv, result);
+    for (IndexedPointInAreaLocator* ptLocater : result) {
+      Location loc = ptLocater->locate(pt);
+      if (loc != Location::EXTERIOR)
+        return loc;
+    }
+    return Location::EXTERIOR;
+}
+
+}}}

--- a/src/geom/util/PolygonalExtracter.cpp
+++ b/src/geom/util/PolygonalExtracter.cpp
@@ -1,0 +1,49 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2001-2002 Vivid Solutions Inc.
+ * Copyright (C) 2006 Refractions Research Inc.
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/export.h>
+#include <geos/geom/Polygon.h>
+#include <geos/geom/MultiPolygon.h>
+#include <vector>
+
+#include <geos/geom/util/PolygonalExtracter.h>
+
+namespace geos {
+namespace geom { // geos.geom
+namespace util { // geos.geom.util
+
+void
+PolygonalExtracter::getPolygonals(const Geometry& geom, std::vector<const Geometry*>& polys)
+{
+    getPolygonals(&geom, polys);
+}
+
+void
+PolygonalExtracter::getPolygonals(const Geometry* geom, std::vector<const Geometry*>& polys)
+{
+   if (dynamic_cast<const Polygon*>(geom) != nullptr
+         || dynamic_cast<const MultiPolygon*>(geom) != nullptr ) {
+  		polys.push_back(geom);
+  	}
+  	else if (dynamic_cast<const GeometryCollection*>(geom) != nullptr) {
+  	  for (std::size_t i = 0; i < geom->getNumGeometries(); i++) {
+  	    getPolygonals(geom->getGeometryN(i), polys);
+  	  }
+  	}
+}
+
+}
+}
+}

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -19,9 +19,7 @@
 #include <string>
 #include <memory>
 
-using namespace geos;
 using namespace geos::geom;
-
 using geos::algorithm::construct::LargestEmptyCircle;
 
 namespace tut {
@@ -31,12 +29,12 @@ namespace tut {
 
 // dummy data, not used
 struct test_data_LargestEmptyCircle {
-    geos::geom::PrecisionModel pm_;
-    geos::geom::GeometryFactory::Ptr factory_;
+    PrecisionModel pm_;
+    GeometryFactory::Ptr factory_;
     geos::io::WKTReader reader_;
 
     test_data_LargestEmptyCircle():
-        pm_(geos::geom::PrecisionModel::FLOATING),
+        pm_(PrecisionModel::FLOATING),
         factory_(GeometryFactory::create(&pm_, 0)),
         reader_(factory_.get())
     {}
@@ -46,8 +44,8 @@ struct test_data_LargestEmptyCircle {
     }
 
     void
-    ensure_equals_coordinate(const geos::geom::Coordinate &lhs,
-                             const geos::geom::Coordinate &rhs, double tolerance)
+    ensure_equals_coordinate(const Coordinate &lhs,
+                             const Coordinate &rhs, double tolerance)
     {
         ensure_equals("x coordinate does not match", lhs.x, rhs.x, tolerance);
         ensure_equals("y coordinate does not match", lhs.y, rhs.y, tolerance);

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -1,7 +1,6 @@
 //
 // Test Suite for geos::algorithm::construct::LargestEmptyCircle
 
-
 #include <tut/tut.hpp>
 // geos
 #include <geos/operation/distance/IndexedFacetDistance.h>
@@ -19,8 +18,6 @@
 #include <sstream>
 #include <string>
 #include <memory>
-
-
 
 using namespace geos;
 using namespace geos::geom;
@@ -150,112 +147,83 @@ typedef group::object object;
 
 group test_lec_group("geos::algorithm::construct::LargestEmptyCircle");
 
-//
 // testPointsSquare
-//
+template<>  
 template<>
-template<>
-void object::test<1>
-()
+void object::test<1>()
 {
-
     checkCircle("MULTIPOINT ((100 100), (100 200), (200 200), (200 100))",
-       0.01, 150, 150, 70.71 );}
+       0.01, 150, 150, 70.71 );
+}
 
-//
 // testPointsTriangleOnHull
-//
 template<>
 template<>
-void object::test<2>
-()
+void object::test<2>()
 {
     checkCircle("MULTIPOINT ((100 100), (300 100), (150 50))",
        0.01, 216.66, 99.99, 83.33 );
 }
 
-//
 // testPointsTriangleInterior
-//
 template<>
 template<>
-void object::test<3>
-()
+void object::test<3>()
 {
  checkCircle("MULTIPOINT ((100 100), (300 100), (200 250))",
        0.01, 200.00, 141.66, 108.33 );
 }
 
-//
 // testLinesOpenDiamond
-//
 template<>
 template<>
-void object::test<4>
-()
+void object::test<4>()
 {
 
     checkCircle("MULTILINESTRING ((50 100, 150 50), (250 50, 350 100), (350 150, 250 200), (50 150, 150 200))",
-       0.01, 200, 125, 90.13 );}
+       0.01, 200, 125, 90.13 );
+}
 
-//
 //    testLinesCrossed
-//
 template<>
 template<>
-void object::test<5>
-()
+void object::test<5>()
 {
   checkCircle("MULTILINESTRING ((100 100, 300 300), (100 200, 300 0))",
        0.01, 299.99, 150.00, 106.05 );
 }
 
-
-//
 // testLinesZigzag
-//
 template<>
 template<>
-void object::test<6>
-()
+void object::test<6>()
 {
-
     checkCircle("MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (70 380, 0 350, 50 300, 0 250, 50 200, 0 150, 50 120))",
        0.01, 77.52, 249.99, 54.81 );
 }
 
-//
 // testPointsLinesTriangle
-//
 template<>
 template<>
-void object::test<7>
-()
+void object::test<7>()
 {
 checkCircle("GEOMETRYCOLLECTION (LINESTRING (100 100, 300 100), POINT (250 200))",
        0.01, 196.49, 164.31, 64.31 );
 }
 
-
-//
 // testPointsLinesTriangle
-//
 template<>
 template<>
-void object::test<8>
-()
+void object::test<8>()
 {
 checkCircleZeroRadius("POINT (100 100)",
        0.01 );
 }
 
-//
 // testLineFlat
-//
 template<>
 template<>
-void object::test<9>
-()
+void object::test<9>()
 {
  checkCircleZeroRadius("LINESTRING (0 0, 50 50)",
        0.01 );
@@ -264,18 +232,47 @@ void object::test<9>
 // testThinExtent
 template<>
 template<>
-void object::test<10>
-()
+void object::test<10>()
 {
     checkCircle("MULTIPOINT ((100 100), (300 100), (200 100.1))",
        0.01 );
 }
 
+//------------ Polygon Obstacles -----------------
+
+// testPolygonConcave
+template<>
+template<>
+void object::test<11>()
+{
+    checkCircle("POLYGON ((1 9, 9 6, 6 5, 5 3, 8 3, 9 4, 9 1, 1 1, 1 9))", 
+        0.01, 7.495, 4.216, 1.21);
+} 
+
+// testPolygonsBoxes
+template<>
+template<>
+void object::test<12>()
+{
+    checkCircle("MULTIPOLYGON (((1 6, 6 6, 6 1, 1 1, 1 6)), ((6 7, 4 7, 4 9, 6 9, 6 7)))", 
+        0.01, 2.50, 7.50, 1.50);
+} 
+
+// testPolygonLines
+template<>
+template<>
+void object::test<13>()
+{
+    checkCircle("GEOMETRYCOLLECTION (POLYGON ((1 6, 6 6, 6 1, 1 1, 1 6)), LINESTRING (6 7, 3 9), LINESTRING (1 7, 3 8))", 
+        0.01, 3.74, 7.14, 1.14);
+} 
+
+//----------  Obstacles and Boundary  --------------
+
 // testBoundaryEmpty
 template<>
 template<>
-void object::test<11>
-()
+void object::test<14>()
 {
  checkCircle("MULTIPOINT ((2 2), (8 8), (7 5))",
         "POLYGON EMPTY",
@@ -285,8 +282,7 @@ void object::test<11>
 // testBoundarySquare
 template<>
 template<>
-void object::test<12>
-()
+void object::test<15>()
 {
     checkCircle("MULTIPOINT ((2 2), (6 4), (8 8))",
         "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
@@ -296,8 +292,7 @@ void object::test<12>
 //testBoundarySquareObstaclesOutside
 template<>
 template<>
-void object::test<13>
-()
+void object::test<16>()
 {
     checkCircle("MULTIPOINT ((10 10), (10 0))",
         "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
@@ -307,8 +302,7 @@ void object::test<13>
 // testBoundaryMultiSquares
 template<>
 template<>
-void object::test<14>
-()
+void object::test<17>()
 {
     checkCircle("MULTIPOINT ((10 10), (10 0), (5 5))",
         "MULTIPOLYGON (((1 9, 9 9, 9 1, 1 1, 1 9)), ((15 20, 20 20, 20 15, 15 15, 15 20)))",
@@ -318,12 +312,20 @@ void object::test<14>
 // testBoundaryAsObstacle
 template<>
 template<>
-void object::test<15>
-()
+void object::test<18>()
 {
-    checkCircle("GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9)), POINT (4 3), POINT (7 6))",
+    checkCircle("GEOMETRYCOLLECTION (LINESTRING (1 9, 9 9, 9 1, 1 1, 1 9), POINT (4 3), POINT (7 6))",
         "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
         0.01, 4, 6, 3 );
+}
+
+// testObstacleEmptyElement
+template<>
+template<>
+void object::test<19>()
+{
+    checkCircle("GEOMETRYCOLLECTION (LINESTRING EMPTY, POINT (4 3), POINT (7 6), POINT (4 6))", 
+        0.01, 5.5, 4.5, 2.12 );
 }
 
 } // namespace tut

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -5,13 +5,10 @@
 // geos
 #include <geos/algorithm/construct/LargestEmptyCircle.h>
 #include <geos/geom/Coordinate.h>
-#include <geos/geom/Dimension.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryFactory.h>
-#include <geos/geom/LineString.h>
 #include <geos/geom/PrecisionModel.h>
 #include <geos/io/WKTReader.h>
-#include <geos/io/WKTWriter.h>
 #include <geos/constants.h>
 // std
 #include <sstream>

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -30,24 +30,19 @@ namespace tut {
 //
 
 // dummy data, not used
-struct test_lec_data {
-    geos::geom::Geometry* geom_;
+struct test_data_LargestEmptyCircle {
     geos::geom::PrecisionModel pm_;
     geos::geom::GeometryFactory::Ptr factory_;
     geos::io::WKTReader reader_;
-    geos::io::WKTWriter writer_;
 
-    test_lec_data():
-        geom_(nullptr),
+    test_data_LargestEmptyCircle():
         pm_(geos::geom::PrecisionModel::FLOATING),
         factory_(GeometryFactory::create(&pm_, 0)),
         reader_(factory_.get())
     {}
 
-    ~test_lec_data()
+    ~test_data_LargestEmptyCircle()
     {
-        factory_->destroyGeometry(geom_);
-        geom_ = nullptr;
     }
 
     void
@@ -142,10 +137,10 @@ struct test_lec_data {
 
 };
 
-typedef test_group<test_lec_data> group;
+typedef test_group<test_data_LargestEmptyCircle> group;
 typedef group::object object;
 
-group test_lec_group("geos::algorithm::construct::LargestEmptyCircle");
+group test_group_LargestEmptyCircle("geos::algorithm::construct::LargestEmptyCircle");
 
 // testPointsSquare
 template<>  

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -23,7 +23,6 @@ namespace tut {
 // Test Group
 //
 
-// dummy data, not used
 struct test_data_LargestEmptyCircle {
     PrecisionModel pm_;
     GeometryFactory::Ptr factory_;

--- a/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
+++ b/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp
@@ -3,7 +3,6 @@
 
 #include <tut/tut.hpp>
 // geos
-#include <geos/operation/distance/IndexedFacetDistance.h>
 #include <geos/algorithm/construct/LargestEmptyCircle.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/Dimension.h>

--- a/tests/unit/capi/GEOSLargestEmptyCircleTest.cpp
+++ b/tests/unit/capi/GEOSLargestEmptyCircleTest.cpp
@@ -1,0 +1,71 @@
+// $Id$
+//
+// Test Suite for C-API GEOSLargestEmptyCircle
+
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+// std
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_data_GEOSLargestEmptyCircle : public capitest::utility {
+
+    test_data_GEOSLargestEmptyCircle()
+    {
+    }
+
+    ~test_data_GEOSLargestEmptyCircle()
+    {
+    }
+
+};
+
+typedef test_group<test_data_GEOSLargestEmptyCircle> group;
+typedef group::object object;
+
+group test_capi_largestemptycircle_group("capi::GEOSLargestEmptyCircle");
+
+//
+// Test Cases
+//
+
+// Points of a square
+template<>
+template<>
+void object::test<1>
+()
+{
+    input_ = GEOSGeomFromWKT("MULTIPOINT ((100 100), (100 200), (200 200), (200 100))");
+    result_ = GEOSLargestEmptyCircle(input_, nullptr, 0.001);
+    ensure(nullptr != result_);
+    expected_ = GEOSGeomFromWKT("LINESTRING (150 150, 100 100)");
+    ensure(GEOSEqualsExact(result_, expected_, 0.0001) == 1);
+}
+
+// Line obstacles with square boundary
+template<>
+template<>
+void object::test<2>
+()
+{
+    input_ = GEOSGeomFromWKT("MULTILINESTRING ((40 90, 90 60), (90 40, 40 10))");
+    geom2_ = GEOSGeomFromWKT("POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))");
+    result_ = GEOSLargestEmptyCircle(input_, geom2_, 0.001);
+    ensure(nullptr != result_);
+    expected_ = GEOSGeomFromWKT("LINESTRING (0.00038147 49.99961853, 40 10)");
+    ensure(GEOSEqualsExact(result_, expected_, 0.0001) == 1);
+}
+
+} // namespace tut
+

--- a/tests/unit/capi/GEOSLargestEmptyCircleTest.cpp
+++ b/tests/unit/capi/GEOSLargestEmptyCircleTest.cpp
@@ -48,9 +48,8 @@ void object::test<1>
 {
     input_ = GEOSGeomFromWKT("MULTIPOINT ((100 100), (100 200), (200 200), (200 100))");
     result_ = GEOSLargestEmptyCircle(input_, nullptr, 0.001);
-    ensure(nullptr != result_);
     expected_ = GEOSGeomFromWKT("LINESTRING (150 150, 100 100)");
-    ensure(GEOSEqualsExact(result_, expected_, 0.0001) == 1);
+    ensure_geometry_equals_exact(result_, expected_, 0.0001);
 }
 
 // Line obstacles with square boundary
@@ -62,9 +61,8 @@ void object::test<2>
     input_ = GEOSGeomFromWKT("MULTILINESTRING ((40 90, 90 60), (90 40, 40 10))");
     geom2_ = GEOSGeomFromWKT("POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))");
     result_ = GEOSLargestEmptyCircle(input_, geom2_, 0.001);
-    ensure(nullptr != result_);
     expected_ = GEOSGeomFromWKT("LINESTRING (0.00038147 49.99961853, 40 10)");
-    ensure(GEOSEqualsExact(result_, expected_, 0.0001) == 1);
+    ensure_geometry_equals_exact(result_, expected_, 0.0001);
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSMaximumInscribedCircleTest.cpp
+++ b/tests/unit/capi/GEOSMaximumInscribedCircleTest.cpp
@@ -1,6 +1,6 @@
 // $Id$
 //
-// Test Suite for C-API GEOSGetCentroid
+// Test Suite for C-API GEOSMaximumInscribedCircle
 
 #include <tut/tut.hpp>
 // geos
@@ -44,7 +44,7 @@ group test_capimaximuminscribedcircle_group("capi::GEOSMaximumInscribedCircle");
 // Test Cases
 //
 
-// Single point
+// Square
 template<>
 template<>
 void object::test<1>
@@ -60,28 +60,11 @@ void object::test<1>
     ensure_equals(std::string(wkt_), std::string("LINESTRING (150 150, 150 200)"));
 }
 
-// Single point
-template<>
-template<>
-void object::test<2>
-()
-{
-    geom1_ = GEOSGeomFromWKT("MULTIPOINT ((100 100), (100 200), (200 200), (200 100))");
-    ensure(nullptr != geom1_);
-    geom2_ = GEOSLargestEmptyCircle(geom1_, nullptr, 0.001);
-    ensure(nullptr != geom2_);
-
-    wkt_ = GEOSWKTWriter_write(wktw_, geom2_);
-
-    ensure_equals(std::string(wkt_), std::string("LINESTRING (150 150, 100 100)"));
-}
-
-
 // Crash with Inf coords
 // https://github.com/libgeos/geos/issues/821
 template<>
 template<>
-void object::test<3>
+void object::test<2>
 ()
 {
     std::string wkb("0106000020E61000000100000001030000000100000005000000000000000000F07F000000000000F07F000000000000F07F000000000000F07F000000000000F07F000000000000F07F000000000000F07F000000000000F07F000000000000F07F000000000000F07F");

--- a/tests/unit/capi/capi_test_utils.h
+++ b/tests/unit/capi/capi_test_utils.h
@@ -161,8 +161,8 @@ namespace capitest {
             const char* val1 = (g1 == nullptr) ? "null" : wkt1;
             const char* val2 = (g2 == nullptr) ? "null" : wkt2;
             std::fprintf(stdout, "\n%s : %s != %s (tol = %f)\n", tag, val1, val2, tolerance);
-            if (wkt1 != nullptr) GEOSFree(wkt1);
-            if (wkt2 != nullptr) GEOSFree(wkt2);
+            GEOSFree(wkt1);
+            GEOSFree(wkt2);
         }
 
     };

--- a/tests/unit/capi/capi_test_utils.h
+++ b/tests/unit/capi/capi_test_utils.h
@@ -93,17 +93,30 @@ namespace capitest {
         void
         ensure_geometry_equals(GEOSGeometry* g1, GEOSGeometry* g2, double tolerance)
         {
-            GEOSNormalize(g1);
-            GEOSNormalize(g2);
-            char rslt = GEOSEqualsExact(g1, g2, tolerance);
-            if (rslt != 1)
-            {
-                char* wkt1 = GEOSWKTWriter_write(wktw_, g1);
-                char* wkt2 = GEOSGeomToWKT(g2);
-                std::fprintf(stdout, "\n%s != %s\n", wkt1, wkt2);
-                GEOSFree(wkt1);
-                GEOSFree(wkt2);
+            char rslt;
+            if (g1 == nullptr || g2 == nullptr) {
+                rslt = (g1 == nullptr && g2 == nullptr) ? 1 : 0;
+            } 
+            else {
+                GEOSNormalize(g1);
+                GEOSNormalize(g2);
+                rslt = GEOSEqualsExact(g1, g2, tolerance);
             }
+            report_not_equal("ensure_equals_norm", g1, g2, tolerance, rslt);
+            tut::ensure_equals("GEOSEqualsExact(g1, g2, tolerance)", rslt, 1);
+        }
+
+        void
+        ensure_geometry_equals_exact(GEOSGeometry* g1, GEOSGeometry* g2, double tolerance)
+        {
+            char rslt;
+            if (g1 == nullptr || g2 == nullptr) {
+                rslt = (g1 == nullptr && g2 == nullptr) ? 1 : 0;
+            } 
+            else {
+                rslt = GEOSEqualsExact(g1, g2, tolerance);
+            }
+            report_not_equal("ensure_equals_exact", g1, g2, tolerance, rslt);
             tut::ensure_equals("GEOSEqualsExact(g1, g2, tolerance)", rslt, 1);
         }
 
@@ -133,7 +146,24 @@ namespace capitest {
             tut::ensure_equals("GEOSEqualsExact(g1, g2, 1e-12)", rslt, 1);
         }
 
+        void
+        report_not_equal(const char* tag, GEOSGeometry* g1, GEOSGeometry* g2, double tolerance, char rslt)
+        {
+            if (rslt == 1) return;
+            //TODO: handle rslt exception value
 
+            char* wkt1;
+            char* wkt2;
+            if (g1 != nullptr)
+                wkt1 = GEOSWKTWriter_write(wktw_, g1);
+            if (g2 != nullptr)
+                wkt2 = GEOSWKTWriter_write(wktw_, g2);
+            const char* val1 = (g1 == nullptr) ? "null" : wkt1;
+            const char* val2 = (g2 == nullptr) ? "null" : wkt2;
+            std::fprintf(stdout, "\n%s : %s != %s (tol = %f)\n", tag, val1, val2, tolerance);
+            if (g1 != nullptr) GEOSFree(wkt1);
+            if (g2 != nullptr) GEOSFree(wkt2);
+        }
 
     };
 

--- a/tests/unit/capi/capi_test_utils.h
+++ b/tests/unit/capi/capi_test_utils.h
@@ -152,8 +152,8 @@ namespace capitest {
             if (rslt == 1) return;
             //TODO: handle rslt exception value
 
-            char* wkt1;
-            char* wkt2;
+            char* wkt1 = nullptr;
+            char* wkt2 = nullptr;
             if (g1 != nullptr)
                 wkt1 = GEOSWKTWriter_write(wktw_, g1);
             if (g2 != nullptr)
@@ -161,8 +161,8 @@ namespace capitest {
             const char* val1 = (g1 == nullptr) ? "null" : wkt1;
             const char* val2 = (g2 == nullptr) ? "null" : wkt2;
             std::fprintf(stdout, "\n%s : %s != %s (tol = %f)\n", tag, val1, val2, tolerance);
-            if (g1 != nullptr) GEOSFree(wkt1);
-            if (g2 != nullptr) GEOSFree(wkt2);
+            if (wkt1 != nullptr) GEOSFree(wkt1);
+            if (wkt2 != nullptr) GEOSFree(wkt2);
         }
 
     };


### PR DESCRIPTION
Fixes LargestEmptyCircle to handle polygonal obstacles. The centre of the LEC is constrained to be outside of any polygonal obstacles. Previously polygonal obstacles were only handled as linear constraints, which allowed the LEC centre to lie inside polygons.

Port of https://github.com/locationtech/jts/pull/988