### PR TITLE
fix: null pointer deref on col

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -1184,7 +1184,7 @@ extern "C" {
     {
         return execute(extHandle, [&]() {
             BufferParameters bp;
-            //-- use default cap style ROUND 
+            //-- use default cap style ROUND
             bp.setQuadrantSegments(quadsegs);
 
             if(joinStyle > BufferParameters::JOIN_BEVEL) {
@@ -2069,10 +2069,11 @@ extern "C" {
             GeometryCollection *col = dynamic_cast<GeometryCollection*>(collection);
             if (!col) {
                 handle->ERROR_MESSAGE("Parameter collection of GEOSGeom_releaseCollection_r must not be a collection");
+            } else {
+                *ngeoms = static_cast<unsigned int>(col->getNumGeometries());
             }
 
             // Early exit on empty/null input
-            *ngeoms = static_cast<unsigned int>(col->getNumGeometries());
             if (!col || *ngeoms == 0) {
                 return static_cast<Geometry**>(nullptr);
             }


### PR DESCRIPTION
The defect is detected by coverity scan. The detailed info is following:
```
*** CID 416530:  Null pointer dereferences  (FORWARD_NULL)
/root/pxiao/TDengine/contrib/geos/capi/geos_ts_c.cpp: 2075 in GEOSGeom_releaseCollection_r::[lambda() (instance 1)]::operator ()() const()
2069                 GeometryCollection *col = dynamic_cast<GeometryCollection*>(collection);
2070                 if (!col) {
2071                     handle->ERROR_MESSAGE("Parameter collection of GEOSGeom_releaseCollection_r must not be a collection");
2072                 }
2073     
2074                 // Early exit on empty/null input
>>>     CID 416530:  Null pointer dereferences  (FORWARD_NULL)
>>>     Passing null pointer "col" to "getNumGeometries", which dereferences it. (The dereference happens because this is a virtual function call.)
2075                 *ngeoms = static_cast<unsigned int>(col->getNumGeometries());
2076                 if (!col || *ngeoms == 0) {
2077                     return static_cast<Geometry**>(nullptr);
2078                 }
2079     
2080                 std::vector<std::unique_ptr<Geometry>> subgeoms = col->releaseGeometries();
```