### PR TITLE
Improve scale handling for GEOS_setPrecision

### DIFF
--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2980,12 +2980,14 @@ extern "C" {
         return execute(extHandle, [&]() {
             PrecisionModel newpm;
             if (gridSize != 0) {
-                //-- check for an integral scale
                 double scale = 1.0 / gridSize;
-                double scaleInt = std::round(scale);
-                //-- if scale factor is essentially integral, use the exact integer value
-                if (std::abs(scale - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
-                    scale = scaleInt;
+                //-- check if the gridsize corresponds to an integral scale
+                if (gridSize < 1) {
+                    double scaleInt = std::round(scale);
+                    //-- if scale factor is essentially integral, use the exact integer value
+                    if (std::abs(scale - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
+                        scale = scaleInt;
+                    }
                 }
                 newpm = PrecisionModel(scale);
             }

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2982,8 +2982,7 @@ extern "C" {
             if (gridSize != 0) {
                 //-- check for an integral scale
                 double scale = 1.0 / gridSize;
-                //-- add a small "bump" to ensure flooring works
-                double scaleInt = std::floor(scale + 2 * GRIDSIZE_INTEGER_TOLERANCE);
+                double scaleInt = std::round(scale);
                 //-- if scale factor is essentially integral, use the exact integer value
                 if (std::abs(scale - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
                     scale = scaleInt;

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2978,9 +2978,16 @@ extern "C" {
         return execute(extHandle, [&]() {
             PrecisionModel newpm;
             if(gridSize != 0) {
-                // Use negative scale to indicate you actually want a gridSize
-                double scale = -1.0 * std::abs(gridSize);
-                newpm = PrecisionModel(scale);
+                double scaleNom = 1.0 / gridSize;
+                double scaleInt = std::floor(scaleNom);
+                if (std::abs(scaleNom - scaleInt) < 1e-5) {
+                    //-- if scale factor is nearly integral, use an exact integer value
+                    newpm = PrecisionModel(scaleInt);
+                }
+                else {
+                    //-- otherwise, just use the reciprocal of the grid size
+                    newpm = PrecisionModel(scaleNom);
+                }
             }
 
             const PrecisionModel* pm = g->getPrecisionModel();

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2979,17 +2979,16 @@ extern "C" {
 
         return execute(extHandle, [&]() {
             PrecisionModel newpm;
-            if(gridSize != 0) {
-                double scaleNom = 1.0 / gridSize;
-                double scaleInt = std::floor(scaleNom);
-                if (std::abs(scaleNom - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
-                    //-- if scale factor is nearly integral, use an exact integer value
-                    newpm = PrecisionModel(scaleInt);
+            if (gridSize != 0) {
+                //-- check for an integral scale
+                double scale = 1.0 / gridSize;
+                //-- add a small "bump" to ensure flooring works
+                double scaleInt = std::floor(scale + 0.1);
+                //-- if scale factor is essentially integral, use the exact integer value
+                if (std::abs(scale - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
+                    scale = scaleInt;
                 }
-                else {
-                    //-- otherwise, just use the reciprocal of the grid size
-                    newpm = PrecisionModel(scaleNom);
-                }
+                newpm = PrecisionModel(scale);
             }
 
             const PrecisionModel* pm = g->getPrecisionModel();

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2983,7 +2983,7 @@ extern "C" {
                 //-- check for an integral scale
                 double scale = 1.0 / gridSize;
                 //-- add a small "bump" to ensure flooring works
-                double scaleInt = std::floor(scale + 0.1);
+                double scaleInt = std::floor(scale + 2 * GRIDSIZE_INTEGER_TOLERANCE);
                 //-- if scale factor is essentially integral, use the exact integer value
                 if (std::abs(scale - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
                     scale = scaleInt;

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2980,8 +2980,8 @@ extern "C" {
         return execute(extHandle, [&]() {
             PrecisionModel newpm;
             if(gridSize != 0) {
-                // Use negative scale to indicate argument is gridSize
-                double scale = -1.0 * std::abs(gridSize);
+                // Convert gridSize to scale factor
+                double scale = 1.0 / std::abs(gridSize);
                 newpm = PrecisionModel(scale);
             }
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2969,7 +2969,7 @@ extern "C" {
         });
     }
 
-    const double GRIDSIZE_INTEGER_TOLERANCE = 1e-5;
+    //const double GRIDSIZE_INTEGER_TOLERANCE = 1e-5;
 
     Geometry*
     GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry* g,
@@ -2979,16 +2979,9 @@ extern "C" {
 
         return execute(extHandle, [&]() {
             PrecisionModel newpm;
-            if (gridSize != 0) {
-                double scale = 1.0 / gridSize;
-                //-- check if the gridsize corresponds to an integral scale
-                if (gridSize < 1) {
-                    double scaleInt = std::round(scale);
-                    //-- if scale factor is essentially integral, use the exact integer value
-                    if (std::abs(scale - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
-                        scale = scaleInt;
-                    }
-                }
+            if(gridSize != 0) {
+                // Use negative scale to indicate argument is gridSize
+                double scale = -1.0 * std::abs(gridSize);
                 newpm = PrecisionModel(scale);
             }
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2969,8 +2969,6 @@ extern "C" {
         });
     }
 
-    //const double GRIDSIZE_INTEGER_TOLERANCE = 1e-5;
-
     Geometry*
     GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry* g,
                             double gridSize, int flags)

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2969,6 +2969,8 @@ extern "C" {
         });
     }
 
+    const double GRIDSIZE_INTEGER_TOLERANCE = 1e-5;
+
     Geometry*
     GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry* g,
                             double gridSize, int flags)
@@ -2980,7 +2982,7 @@ extern "C" {
             if(gridSize != 0) {
                 double scaleNom = 1.0 / gridSize;
                 double scaleInt = std::floor(scaleNom);
-                if (std::abs(scaleNom - scaleInt) < 1e-5) {
+                if (std::abs(scaleNom - scaleInt) < GRIDSIZE_INTEGER_TOLERANCE) {
                     //-- if scale factor is nearly integral, use an exact integer value
                     newpm = PrecisionModel(scaleInt);
                 }

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -77,8 +77,6 @@ namespace geom { // geos::geom
  *
  * It is also supported to specify a precise grid size
  * by providing it as a negative scale factor.
- * This allows setting a precise grid size rather than using a fractional scale,
- * which provides more accurate and robust rounding.
  * For example, to specify rounding to the nearest 1000 use a scale factor of -1000.
  *
  * Coordinates are represented internally as Java double-precision values.

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -348,6 +348,11 @@ private:
     void setScale(double newScale);
     // throw IllegalArgumentException
 
+    /** \brief
+     * Snaps a value to nearest integer, if within tolerance.
+     */
+    static double snapToInt(double val, double tolerance);
+
     Type modelType;
 
     /**

--- a/src/geom/PrecisionModel.cpp
+++ b/src/geom/PrecisionModel.cpp
@@ -62,7 +62,9 @@ PrecisionModel::makePrecise(double val) const
 //std::cout << std::setprecision(16) << "GS[" << gridSize << "] " << val << " -> "  << v2 << std::endl;
             return util::round(val / gridSize) * gridSize;
         }
-        else {
+        //-- since grid size is <= 1, scale must be >= 1 OR 0
+        //-- if scale == 0, this is a no-op (should never happen)
+        else if (scale != 0.0) {
 //double v2 = util::round(val * scale) / scale;
 //std::cout << std::setprecision(16) << "SC[" << scale << "] " << val << " -> " << "SC " << v2 << std::endl;
             return util::round(val * scale) / scale;
@@ -166,6 +168,11 @@ const double GRIDSIZE_INTEGER_TOLERANCE = 1e-5;
 void
 PrecisionModel::setScale(double newScale)
 {
+    //-- should never happen, but make this a no-op in case
+    if (newScale == 0) {
+        scale = 0.0;
+        gridSize = 0.0;
+    }
     /**
     * A negative scale indicates the grid size is being set.
     * The scale is set as well, as the reciprocal.

--- a/src/geom/PrecisionModel.cpp
+++ b/src/geom/PrecisionModel.cpp
@@ -169,6 +169,7 @@ PrecisionModel::setScale(double newScale)
     /**
     * A negative scale indicates the grid size is being set.
     * The scale is set as well, as the reciprocal.
+    * NOTE: may not need to support negative grid size now due to robust arithmetic
     */
     if (newScale < 0) {
         scale = 1.0 / std::fabs(newScale);

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -291,5 +291,26 @@ void object::test<21>()
         "LINESTRING(334729.13 4103548.88,334729.12 4103548.53)");
 }
 
+// Test multiple grid sizes
+template<>
+template<>
+void object::test<22>()
+{
+    const char* wkt = "LINESTRING(674169.89 198051.619820510769063, 674197.71234 1448065.55674200)";
+
+    checkPrecision(wkt, 0.1,   "LINESTRING (674169.9  198051.6,  674197.7   1448065.6)");
+    checkPrecision(wkt, 0.01,  "LINESTRING (674169.89 198051.62, 674197.71  1448065.56)");
+    checkPrecision(wkt, 0.001, "LINESTRING (674169.89 198051.62, 674197.712 1448065.557)");
+
+    checkPrecision(wkt,       1, "LINESTRING ( 674170 198052,  674198 1448066)");
+    checkPrecision(wkt,      10, "LINESTRING ( 674170 198050,  674200 1448070)");
+    checkPrecision(wkt,     100, "LINESTRING ( 674200 198100,  674200 1448100)");
+    checkPrecision(wkt,    1000, "LINESTRING ( 674000 198000,  674000 1448000)");
+    checkPrecision(wkt,   10000, "LINESTRING ( 670000 200000,  670000 1450000)");
+    // this fails for some reason although WKT looks identical
+    //checkPrecision(wkt,  100000, "LINESTRING (700000 200000, 700000 1400000)");
+    checkPrecision(wkt, 1000000, "LINESTRING (1000000      0, 1000000 1000000)");
+
+}
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -13,10 +13,12 @@ struct test_capigeosgeomsetprecision_data : public capitest::utility {
     void
     checkPrecision(const char* wktInput, double gridSize, const char* wktExpected)
     {
-        geom1_ = fromWKT(wktInput);
-        geom2_ = GEOSGeom_setPrecision(geom1_, gridSize, 0);
-        ensure(geom2_ != nullptr);
-        ensure_geometry_equals(geom2_, wktExpected);
+        GEOSGeometry* input = fromWKT(wktInput);
+        GEOSGeometry* result = GEOSGeom_setPrecision(input, gridSize, 0);
+        ensure(result != nullptr);
+        ensure_geometry_equals(result, wktExpected);
+        GEOSGeom_destroy(input);
+        GEOSGeom_destroy(result);
     }
 };
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -214,5 +214,17 @@ void object::test<13>()
         "LINESTRING (657035.913 6475590.114, 657075.57 6475500)");
 }
 
+//-- test that a large gridsize works
+template<>
+template<>
+void object::test<14>()
+{
+    geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, 100, 0);
+//std::cout << toWKT(geom2_) << std::endl;
+    ensure_geometry_equals(geom2_,
+        "LINESTRING (657000 6475600, 657100 6475500)");
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -298,19 +298,23 @@ void object::test<22>()
 {
     const char* wkt = "LINESTRING(674169.89 198051.619820510769063, 674197.71234 1448065.55674200)";
 
-    checkPrecision(wkt, 0.1,   "LINESTRING (674169.9  198051.6,  674197.7   1448065.6)");
-    checkPrecision(wkt, 0.01,  "LINESTRING (674169.89 198051.62, 674197.71  1448065.56)");
-    checkPrecision(wkt, 0.001, "LINESTRING (674169.89 198051.62, 674197.712 1448065.557)");
+    checkPrecision(wkt, 0.1,       "LINESTRING (674169.9  198051.6,       674197.7     1448065.6 )");
+    checkPrecision(wkt, 0.01,      "LINESTRING (674169.89 198051.62,      674197.71    1448065.56 )");
+    checkPrecision(wkt, 0.001,     "LINESTRING (674169.89 198051.62,      674197.712   1448065.557 )");
+    checkPrecision(wkt, 0.0001,    "LINESTRING (674169.89 198051.6198,    674197.7123  1448065.5567 )");
+    checkPrecision(wkt, 0.00001,   "LINESTRING (674169.89 198051.61982,   674197.71234 1448065.55674 )");
+    checkPrecision(wkt, 0.000001,  "LINESTRING (674169.89 198051.619821,  674197.71234 1448065.556742 )");
+    checkPrecision(wkt, 0.0000001, "LINESTRING (674169.89 198051.6198205, 674197.71234 1448065.556742 )");
 
     checkPrecision(wkt,       1, "LINESTRING ( 674170 198052,  674198 1448066)");
     checkPrecision(wkt,      10, "LINESTRING ( 674170 198050,  674200 1448070)");
     checkPrecision(wkt,     100, "LINESTRING ( 674200 198100,  674200 1448100)");
     checkPrecision(wkt,    1000, "LINESTRING ( 674000 198000,  674000 1448000)");
     checkPrecision(wkt,   10000, "LINESTRING ( 670000 200000,  670000 1450000)");
-    // this fails for some reason although WKT looks identical
-    //checkPrecision(wkt,  100000, "LINESTRING (700000 200000, 700000 1400000)");
+    // this fails due to rounding error if computed directly with scale factor
+    checkPrecision(wkt,  100000, "LINESTRING ( 700000 200000,  700000 1400000)");
     checkPrecision(wkt, 1000000, "LINESTRING (1000000      0, 1000000 1000000)");
-
 }
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -238,7 +238,17 @@ void object::test<15>()
         "LINESTRING (674169.89 198051.38, 674197.7 198065.55, 674200.36 198052.38)");
 }
 
-
+// see https://trac.osgeo.org/postgis/ticket/3929
+template<>
+template<>
+void object::test<16>()
+{
+    geom1_ = fromWKT("POINT(311.4 0)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .1, 0);
+//std::cout << toWKT(geom2_) << std::endl;
+    ensure_geometry_equals(geom2_,
+        "POINT(311.4 0)");
+}
 
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -201,11 +201,23 @@ void object::test<12>()
     ensure_equals(GEOSGeom_getCoordinateDimension(geom2_), 2);
 }
 
+//-- test that a large gridsize works
+template<>
+template<>
+void object::test<13>()
+{
+    geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, 100, 0);
+//std::cout << toWKT(geom2_) << std::endl;
+    ensure_geometry_equals(geom2_,
+        "LINESTRING (657000 6475600, 657100 6475500)");
+}
+
 // Test more exact rounding for integral scale factors
 // see https://trac.osgeo.org/postgis/ticket/5520
 template<>
 template<>
-void object::test<13>()
+void object::test<14>()
 {
     geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
     geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
@@ -214,17 +226,19 @@ void object::test<13>()
         "LINESTRING (657035.913 6475590.114, 657075.57 6475500)");
 }
 
-//-- test that a large gridsize works
+// see https://trac.osgeo.org/postgis/ticket/5425
 template<>
 template<>
-void object::test<14>()
+void object::test<15>()
 {
-    geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, 100, 0);
+    geom1_ = fromWKT("LINESTRING(674169.89 198051.38,674197.7 198065.55,674200.36 198052.38)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
 //std::cout << toWKT(geom2_) << std::endl;
     ensure_geometry_equals(geom2_,
-        "LINESTRING (657000 6475600, 657100 6475500)");
+        "LINESTRING (674169.89 198051.38, 674197.7 198065.55, 674200.36 198052.38)");
 }
+
+
 
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -1,3 +1,5 @@
+//
+// Test Suite for capi::GEOSGeom_setPrecision
 
 #include "capi_test_utils.h"
 
@@ -6,8 +8,17 @@ namespace tut {
 // Test Group
 //
 
-// Common data used in test cases.
-struct test_capigeosgeomsetprecision_data : public capitest::utility {};
+// Common code used in test cases.
+struct test_capigeosgeomsetprecision_data : public capitest::utility {
+    void
+    checkPrecision(const char* wktInput, double gridSize, const char* wktExpected)
+    {
+        geom1_ = fromWKT(wktInput);
+        geom2_ = GEOSGeom_setPrecision(geom1_, gridSize, 0);
+        ensure(geom2_ != nullptr);
+        ensure_geometry_equals(geom2_, wktExpected);
+    }
+};
 
 typedef test_group<test_capigeosgeomsetprecision_data> group;
 typedef group::object object;
@@ -37,10 +48,9 @@ template<>
 void object::test<2>
 ()
 {
-    geom1_ = fromWKT("LINESTRING(-3 6, 9 1)");
-    geom3_ = GEOSGeom_setPrecision(geom1_, 2.0, 0);
-    ensure(geom3_ != 0);
-    ensure_geometry_equals(geom3_, "LINESTRING (-2 6, 10 2)");
+    checkPrecision("LINESTRING(-3 6, 9 1)",
+        2.0,
+        "LINESTRING (-2 6, 10 2)");
 }
 
 // See effects of precision reduction on intersection operation
@@ -123,9 +133,9 @@ template<>
 template<>
 void object::test<6> ()
 {
-    geom1_ = fromWKT("LINESTRING (0 0, 0.1 0.1)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, 1.0, 0);
-    ensure_geometry_equals(geom2_, "LINESTRING EMPTY");
+    checkPrecision("LINESTRING (0 0, 0.1 0.1)",
+        1.0,
+        "LINESTRING EMPTY");
 }
 
 // Retain (or not) collapsed elements
@@ -164,9 +174,9 @@ template<>
 template<>
 void object::test<10> ()
 {
-    geom1_ = fromWKT("LINEARRING (0 0, 0.1 0, 0.1 0.1, 0 0.1, 0 0)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, 1.0, 0);
-    ensure_geometry_equals(geom2_, "LINEARRING EMPTY");
+    checkPrecision("LINEARRING (0 0, 0.1 0, 0.1 0.1, 0 0.1, 0 0)",
+        1.0,
+        "LINEARRING EMPTY");
 }
 
 // Reduce polygon precision, corner case / Trac #1127
@@ -174,31 +184,18 @@ template<>
 template<>
 void object::test<11> ()
 {
-    // POLYGON((
-    //   100 49.5, (1)
-    //   100 300,  (2)
-    //   320 60,   (3)
-    //   340 49.9, (4)
-    //   360 50.1, (5)
-    //   380 49.5, (6)
-    //   100 49.5  (7)
-    // ))
-    // * points 4 and 5 are close (less than 100.0/100) to segment (6, 7);
-    // * Y coordinates of points 4 and 5 are rounded to different values, 0 and 100 respectively;
-    // * point 4 belongs to monotone chain of size > 1 -- segments (2, 3) and (3, 4)
-    geom1_ = fromWKT("POLYGON((100 49.5, 100 300, 320 60, 340 49.9, 360 50.1, 380 49.5, 100 49.5))");
-    geom2_ = GEOSGeom_setPrecision(geom1_, 100.0, 0);
-    ensure(geom2_ != nullptr); // just check that valid geometry is constructed
+    checkPrecision("POLYGON((100 49.5, 100 300, 320 60, 340 49.9, 360 50.1, 380 49.5, 100 49.5))",
+        100.0,
+        "POLYGON ((100 300, 300 100, 300 0, 100 0, 100 300))"); 
 }
 
 template<>
 template<>
 void object::test<12>()
 {
-    geom1_ = fromWKT("POLYGON ((0 0, 0.1 0, 0.1 0.1, 0 0.1, 0 0))");
-    geom2_ = GEOSGeom_setPrecision(geom1_, 1.0, 0);
-
-    ensure_equals(GEOSGeom_getCoordinateDimension(geom2_), 2);
+    checkPrecision("POLYGON ((0 0, 0.1 0, 0.1 0.1, 0 0.1, 0 0))",
+        1.0,
+        "POLYGON EMPTY");
 }
 
 //-- test that a large gridsize works
@@ -206,9 +203,8 @@ template<>
 template<>
 void object::test<13>()
 {
-    geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, 100, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("LINESTRING (657035.913 6475590.114,657075.57 6475500)",
+        100,
         "LINESTRING (657000 6475600, 657100 6475500)");
 }
 
@@ -218,9 +214,8 @@ template<>
 template<>
 void object::test<14>()
 {
-    geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("LINESTRING (657035.913 6475590.114,657075.57 6475500)",
+        0.001,
         "LINESTRING (657035.913 6475590.114, 657075.57 6475500)");
 }
 
@@ -229,9 +224,8 @@ template<>
 template<>
 void object::test<15>()
 {
-    geom1_ = fromWKT("LINESTRING(674169.89 198051.38,674197.7 198065.55,674200.36 198052.38)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("LINESTRING(674169.89 198051.38,674197.7 198065.55,674200.36 198052.38)",
+        0.001,
         "LINESTRING (674169.89 198051.38, 674197.7 198065.55, 674200.36 198052.38)");
 }
 
@@ -240,9 +234,8 @@ template<>
 template<>
 void object::test<16>()
 {
-    geom1_ = fromWKT("POINT(311.4 0)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .1, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("POINT(311.4 0)",
+        0.1,
         "POINT(311.4 0)");
 }
 
@@ -251,9 +244,8 @@ template<>
 template<>
 void object::test<17>()
 {
-    geom1_ = fromWKT("LINESTRING (16.418792399944802 54.24801559999939, 16.4176588 54.248003)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .0000001, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("LINESTRING (16.418792399944802 54.24801559999939, 16.4176588 54.248003)",
+        0.0000001,
         "LINESTRING (16.4187924 54.2480156, 16.4176588 54.248003)");
 }
 
@@ -262,9 +254,8 @@ template<>
 template<>
 void object::test<18>()
 {
-    geom1_ = fromWKT("POINT (21.619820510769063 41.94186153740355)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .0000001, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("POINT (21.619820510769063 41.94186153740355)",
+        0.0000001,
         "POINT (21.6198205 41.9418615)");
 }
 
@@ -273,9 +264,8 @@ template<>
 template<>
 void object::test<19>()
 {
-    geom1_ = fromWKT("POINT (22.49594094391644 41.20357506925623)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .0000001, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("POINT (22.49594094391644 41.20357506925623)",
+        0.0000001, 
         "POINT (22.4959409 41.2035751)");
 }
 
@@ -296,9 +286,8 @@ template<>
 template<>
 void object::test<21>()
 {
-    geom1_ = fromWKT("LINESTRING(334729.13 4103548.88, 334729.12 4103548.53)");
-    geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
-    ensure_geometry_equals(geom2_,
+    checkPrecision("LINESTRING(334729.13 4103548.88, 334729.12 4103548.53)",
+        0.001,
         "LINESTRING(334729.13 4103548.88,334729.12 4103548.53)");
 }
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -201,5 +201,18 @@ void object::test<12>()
     ensure_equals(GEOSGeom_getCoordinateDimension(geom2_), 2);
 }
 
+// Test more exact rounding for integral scale factors
+// see https://trac.osgeo.org/postgis/ticket/5520
+template<>
+template<>
+void object::test<13>()
+{
+    geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
+//std::cout << toWKT(geom2_) << std::endl;
+    ensure_geometry_equals(geom2_,
+        "LINESTRING (657035.913 6475590.114, 657075.57 6475500)");
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -291,5 +291,16 @@ void object::test<20>()
         "POINT(1.235 9.877)");
 }
 
+// see https://lists.osgeo.org/pipermail/postgis-users/2023-September/046107.html
+template<>
+template<>
+void object::test<21>()
+{
+    geom1_ = fromWKT("LINESTRING(334729.13 4103548.88, 334729.12 4103548.53)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
+    ensure_geometry_equals(geom2_,
+        "LINESTRING(334729.13 4103548.88,334729.12 4103548.53)");
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -313,9 +313,17 @@ void object::test<22>()
     checkPrecision(wkt,     100, "LINESTRING ( 674200 198100,  674200 1448100)");
     checkPrecision(wkt,    1000, "LINESTRING ( 674000 198000,  674000 1448000)");
     checkPrecision(wkt,   10000, "LINESTRING ( 670000 200000,  670000 1450000)");
-    // this fails due to rounding error if computed directly with scale factor
     checkPrecision(wkt,  100000, "LINESTRING ( 700000 200000,  700000 1400000)");
     checkPrecision(wkt, 1000000, "LINESTRING (1000000      0, 1000000 1000000)");
+}
+
+// This case with a large scale factor produced inexact rounding before code update 
+template<>
+template<>
+void object::test<23>()
+{
+    const char* wkt = "LINESTRING(674169.89 198051.619820510769063, 674197.71234 1448065.55674200)";
+    checkPrecision(wkt,  100000, "LINESTRING ( 700000 200000,  700000 1400000)");
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -208,7 +208,6 @@ void object::test<13>()
 {
     geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
     geom2_ = GEOSGeom_setPrecision(geom1_, 100, 0);
-//std::cout << toWKT(geom2_) << std::endl;
     ensure_geometry_equals(geom2_,
         "LINESTRING (657000 6475600, 657100 6475500)");
 }
@@ -221,7 +220,6 @@ void object::test<14>()
 {
     geom1_ = fromWKT("LINESTRING (657035.913 6475590.114,657075.57 6475500)");
     geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
-//std::cout << toWKT(geom2_) << std::endl;
     ensure_geometry_equals(geom2_,
         "LINESTRING (657035.913 6475590.114, 657075.57 6475500)");
 }
@@ -233,7 +231,6 @@ void object::test<15>()
 {
     geom1_ = fromWKT("LINESTRING(674169.89 198051.38,674197.7 198065.55,674200.36 198052.38)");
     geom2_ = GEOSGeom_setPrecision(geom1_, .001, 0);
-//std::cout << toWKT(geom2_) << std::endl;
     ensure_geometry_equals(geom2_,
         "LINESTRING (674169.89 198051.38, 674197.7 198065.55, 674200.36 198052.38)");
 }
@@ -245,9 +242,53 @@ void object::test<16>()
 {
     geom1_ = fromWKT("POINT(311.4 0)");
     geom2_ = GEOSGeom_setPrecision(geom1_, .1, 0);
-//std::cout << toWKT(geom2_) << std::endl;
     ensure_geometry_equals(geom2_,
         "POINT(311.4 0)");
+}
+
+// see https://gis.stackexchange.com/questions/465485/postgis-reduce-precision-in-linestring
+template<>
+template<>
+void object::test<17>()
+{
+    geom1_ = fromWKT("LINESTRING (16.418792399944802 54.24801559999939, 16.4176588 54.248003)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .0000001, 0);
+    ensure_geometry_equals(geom2_,
+        "LINESTRING (16.4187924 54.2480156, 16.4176588 54.248003)");
+}
+
+// see https://gis.stackexchange.com/questions/321814/st-snaptogrid-doesnt-work-properly-e-g-41-94186153740355-41-94186149999999
+template<>
+template<>
+void object::test<18>()
+{
+    geom1_ = fromWKT("POINT (21.619820510769063 41.94186153740355)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .0000001, 0);
+    ensure_geometry_equals(geom2_,
+        "POINT (21.6198205 41.9418615)");
+}
+
+// see https://gis.stackexchange.com/questions/321814/st-snaptogrid-doesnt-work-properly-e-g-41-94186153740355-41-94186149999999
+template<>
+template<>
+void object::test<19>()
+{
+    geom1_ = fromWKT("POINT (22.49594094391644 41.20357506925623)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .0000001, 0);
+    ensure_geometry_equals(geom2_,
+        "POINT (22.4959409 41.2035751)");
+}
+
+// see https://lists.osgeo.org/pipermail/postgis-users/2006-January/010861.html
+template<>
+template<>
+void object::test<20>()
+{
+    geom1_ = fromWKT("POINT(1.23456789 9.87654321)");
+    geom2_ = GEOSGeom_setPrecision(geom1_, .000001, 0);
+    geom3_ = GEOSGeom_setPrecision(geom2_, .001, 0);
+    ensure_geometry_equals(geom3_,
+        "POINT(1.235 9.877)");
 }
 
 } // namespace tut


### PR DESCRIPTION
## Problem

`GEOS_setPrecision` accepts a parameter specifying the **grid size** of the desired precision.  The most common usage is to reduce the number of decimal places in a geometry (e.g. to 3 decimal places).  In this case, the grid size is a negative power of 10 (e.g. 0.001).  However, this can result in inexact rounding of ordinate values.

For example, this `geosop` command reproduces this [PostGIS issue](https://trac.osgeo.org/postgis/ticket/5520#comment:2) and shows how reducing the precision of a geometry using grid size 0.001 produces unwanted "extra decimals" (note that in `geosop` the `reducePrecision` operation parameter is negative to indicate the value is a grid size):
```
bin/geosop -a "LINESTRING (657035.913 6475590.114,657075.57 6475500)" reducePrecision N-0.001

LINESTRING (657035.9130000001 6475590.114, 657075.5700000001 6475500)
```
The same issue can happen when using a **scale factor** that is a negative power of 10:
```
bin/geosop -a "POINT (674169.89 198051.619820510769063)" reducePrecision .00001
LINESTRING (700000 199999.99999999997, 700000 1400000)
```

## Cause

There are two causes of this problem:
* computing the scale factor as the reciprocal of the grid size may be inexact for some values (i.e. the reciprocal of a fractional power of 10 may not be an exact integral value)
* the [arithmetic](https://github.com/libgeos/geos/blob/main/src/geom/PrecisionModel.cpp#L62) used to scale values is subject to rounding issues when non-integral values are used:
```
return util::round(val / gridSize) * gridSize;
```
Because negative powers of 10 [cannot be represented exactly in binary FP numbers](https://stackoverflow.com/questions/1089018/why-cant-decimal-numbers-be-represented-exactly-in-binary)  this can cause the resulting "rounded" ordinate values to be inexact.

In contrast, if an integral scale factor is used directly, the [rounding arithmetic](https://github.com/libgeos/geos/blob/main/src/geom/PrecisionModel.cpp#L59) is:
```
return util::round(val * scale) / scale;
```
This produces the desired result:
```
bin/geosop -a "LINESTRING (657035.913 6475590.114,657075.57 6475500)" reducePrecision 1000   

LINESTRING (657035.913 6475590.114, 657075.57 6475500)
```

> It appears that in FP arithmetic multiplying by an integer value is more accurate than dividing by an (approximately equal) fractional value

## Proposed Fix
This PR proposes a fix which has **no impact** on the GEOS API or semantics (and hence on downstream usage).  

The fix does two things:
* It detects when the PrecisionModel scale factor OR the equivalent grid size is "essentially integral" (i.e. very close to an integer).  If one of these is the case, then the exact integer value of grid size or scale factor is used. 
* The arithmetic to adjust ordinate values uses the larger of the scale factor and grid size.  This ensures that an integral grid size or scale factor is used if present (which is almost always the case).  This produces a more exact scaled value (thanks to the magic voodoo of FP arithmetic).

Almost all (or all?) uses of `GEOS_setPrecision` use either grid sizes equivalent to integral scale factors OR grid sizes which are obviously NOT integral (e.g. say `0.5`),  so the heuristic of deciding "close" is fine for practical purposes.

In the very rare cases where both grid size and scale factor are fractional, the original values are used for scaling.  Since they are fractional already, the output won't be exact in any case.

As a nice side effect, this fix allows dropping support for negative scale factors, which was introduced solely to accommodate the use of grid size rather than scale factor.  (This PR will be extended to delete this code if that is agreed to).




