### PR TITLE
Fix PreparedLineStringDistance for lines within envelope and polygons

### DIFF
--- a/src/geom/prep/PreparedLineStringDistance.cpp
+++ b/src/geom/prep/PreparedLineStringDistance.cpp
@@ -32,12 +32,18 @@ PreparedLineStringDistance::distance(const geom::Geometry* g) const
         return DoubleInfinity;
     }
 
-    // TODO: test if this shortcut be any useful
-    //if ( prepLine.intersects(g) ) return 0.0;
-
-    /* Not intersecting, compute distance from facets */
+    /* Compute potential distance from facets */
     operation::distance::IndexedFacetDistance *idf = prepLine.getIndexedFacetDistance();
-    return idf->distance(g);
+    double dist = idf->distance(g);
+
+    // If any point from prepLine is contained by g, the distance is zero
+    // Do this last because this PIP test is not indexed.
+    if ( g->getDimension() == 2 
+            && dist > 0 
+            && prepLine.isAnyTargetComponentInTest(g)) {
+        return 0.0;
+    }
+    return dist;
 }
 
 bool

--- a/src/geom/prep/PreparedLineStringDistance.cpp
+++ b/src/geom/prep/PreparedLineStringDistance.cpp
@@ -49,7 +49,15 @@ PreparedLineStringDistance::isWithinDistance(const geom::Geometry* g, double d) 
     }
 
     operation::distance::IndexedFacetDistance *idf = prepLine.getIndexedFacetDistance();
-    return idf->isWithinDistance(g, d);
+    bool withinDistance = idf->isWithinDistance(g, d);
+
+    // If any point from prepLine is contained by g, the distance is zero
+    // Do this last because this PIP test is not indexed.
+    if ( g->getDimension() == 2 && ! withinDistance) {
+        return prepLine.isAnyTargetComponentInTest(g);
+    }
+
+    return withinDistance;
 }
 
 

--- a/src/geom/prep/PreparedLineStringDistance.cpp
+++ b/src/geom/prep/PreparedLineStringDistance.cpp
@@ -35,11 +35,12 @@ PreparedLineStringDistance::distance(const geom::Geometry* g) const
     /* Compute potential distance from facets */
     operation::distance::IndexedFacetDistance *idf = prepLine.getIndexedFacetDistance();
     double dist = idf->distance(g);
+    if (dist == 0.0)
+        return 0.0;
 
     // If any point from prepLine is contained by g, the distance is zero
     // Do this last because this PIP test is not indexed.
     if ( g->getDimension() == 2 
-            && dist > 0 
             && prepLine.isAnyTargetComponentInTest(g)) {
         return 0.0;
     }
@@ -55,15 +56,15 @@ PreparedLineStringDistance::isWithinDistance(const geom::Geometry* g, double d) 
     }
 
     operation::distance::IndexedFacetDistance *idf = prepLine.getIndexedFacetDistance();
-    bool withinDistance = idf->isWithinDistance(g, d);
+    if (idf->isWithinDistance(g, d))
+        return true;
 
     // If any point from prepLine is contained by g, the distance is zero
     // Do this last because this PIP test is not indexed.
-    if ( g->getDimension() == 2 && ! withinDistance) {
+    if ( g->getDimension() == 2 ) {
         return prepLine.isAnyTargetComponentInTest(g);
     }
-
-    return withinDistance;
+    return false;
 }
 
 

--- a/src/operation/distance/IndexedFacetDistance.cpp
+++ b/src/operation/distance/IndexedFacetDistance.cpp
@@ -65,11 +65,6 @@ IndexedFacetDistance::isWithinDistance(const Geometry* g, double maxDistance) co
         return false;
     }
 
-    auto env2 = g->getEnvelope();
-    if (distance(env2.get()) > maxDistance) {
-        return false;
-    }
-
     auto tree2 = FacetSequenceTreeBuilder::build(g);
     return cachedTree->isWithinDistance<FacetDistance>(*tree2, maxDistance);
 }

--- a/src/operation/distance/IndexedFacetDistance.cpp
+++ b/src/operation/distance/IndexedFacetDistance.cpp
@@ -59,12 +59,26 @@ IndexedFacetDistance::distance(const Geometry* g) const
 bool
 IndexedFacetDistance::isWithinDistance(const Geometry* g, double maxDistance) const
 {
+    std::cout << "geom dist = " << distance(g) << std::endl;
+
     // short-circuit check
     double envDist = baseGeometry.getEnvelopeInternal()->distance(*g->getEnvelopeInternal());
     if (envDist > maxDistance) {
         return false;
     }
-
+//*
+    //-- heuristic: for atomic indexed geom, test distance to envelope of test geom
+    if (baseGeometry.getNumGeometries() == 1
+        && ! g->getEnvelopeInternal()->contains(baseGeometry.getEnvelopeInternal()))
+    {
+        auto env2 = g->getEnvelope();
+std::cout << "env dist = " << distance(env2.get()) << std::endl;
+        if (distance(env2.get()) > maxDistance) {
+std::cout << "env dist > maxdistance of " << maxDistance << std::endl;
+            return false;
+        }
+    }
+//*/
     auto tree2 = FacetSequenceTreeBuilder::build(g);
     return cachedTree->isWithinDistance<FacetDistance>(*tree2, maxDistance);
 }

--- a/tests/unit/capi/GEOSPreparedDistanceTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceTest.cpp
@@ -178,5 +178,44 @@ void object::test<9>
     );
 }
 
+// Prepared line within envelope of test line
+template<>
+template<>
+void object::test<12>
+()
+{
+    checkDistance(
+        "LINESTRING (1 4, 4 7)",
+        "LINESTRING (1 1, 5 5, 5 9)",
+        1
+    );
+}
+
+// Prepared line within polygon
+template<>
+template<>
+void object::test<13>
+()
+{
+    checkDistance(
+        "LINESTRING (30 30, 70 70)",
+        "POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))",
+        0
+    );
+}
+
+// Prepared multiline with one element within polygon
+template<>
+template<>
+void object::test<14>
+()
+{
+    checkDistance(
+        "MULTILINESTRING ((30 30, 70 70), (170 200, 200 170))",
+        "POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))",
+        0
+    );
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -271,5 +271,18 @@ void object::test<15>
     );
 }
 
+// Indexed multiline with one element within line envelope.
+template<>
+template<>
+void object::test<16>()
+{
+    checkDistanceWithin(
+        "MULTILINESTRING ((1 6, 1 1), (11 14, 11 11))",
+        "LINESTRING (10 10, 10 20, 30 20)",
+        2,
+        1
+    );
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -213,6 +213,7 @@ void object::test<11>
     );
 }
 
+// see https://github.com/libgeos/geos/issues/958
 template<>
 template<>
 void object::test<12>

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -213,6 +213,7 @@ void object::test<11>
     );
 }
 
+// Prepared line within envelope of test line
 // see https://github.com/libgeos/geos/issues/958
 template<>
 template<>
@@ -222,6 +223,35 @@ void object::test<12>
     checkDistanceWithin(
         "LINESTRING (2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
         "LINESTRING (0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9)",
+        1,
+        1
+    );
+}
+
+// Prepared line within test geometry
+// see https://github.com/libgeos/geos/issues/960
+template<>
+template<>
+void object::test<13>
+()
+{
+    checkDistanceWithin(
+        "LINESTRING (30 30, 70 70)",
+        "POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))",
+        1,
+        1
+    );
+}
+
+// Prepared multiline with one element within test geometry
+template<>
+template<>
+void object::test<14>
+()
+{
+    checkDistanceWithin(
+        "MULTILINESTRING ((30 30, 70 70), (170 200, 200 170))",
+        "POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))",
         1,
         1
     );

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -264,7 +264,7 @@ void object::test<15>
 ()
 {
     checkDistanceWithin(
-        "MULTILINESTRING ((1 6, 1 1), (14 16, 16 14))",
+        "MULTILINESTRING ((1 6, 1 1), (15 16, 15 14))",
         "MULTIPOLYGON (((10 20, 20 20, 20 10, 10 10, 10 20)), ((30 20, 40 20, 40 10, 30 10, 30 20)))",
         1,
         1

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -1,5 +1,5 @@
 //
-// Test Suite for C-API GEOSPreparedDistance
+// Test Suite for C-API GEOSPreparedDistanceWithin
 
 #include <tut/tut.hpp>
 // geos
@@ -243,7 +243,7 @@ void object::test<13>
     );
 }
 
-// Prepared multiline with one element within test geometry
+// Prepared multiline with one element within Polygon
 template<>
 template<>
 void object::test<14>
@@ -252,6 +252,20 @@ void object::test<14>
     checkDistanceWithin(
         "MULTILINESTRING ((30 30, 70 70), (170 200, 200 170))",
         "POLYGON ((0 100, 100 100, 100 0, 0 0, 0 100))",
+        1,
+        1
+    );
+}
+
+// Prepared multiline with one element within MultiPolygon.
+template<>
+template<>
+void object::test<15>
+()
+{
+    checkDistanceWithin(
+        "MULTILINESTRING ((1 6, 1 1), (14 16, 16 14))",
+        "MULTIPOLYGON (((10 20, 20 20, 20 10, 10 10, 10 20)), ((30 20, 40 20, 40 10, 30 10, 30 20)))",
         1,
         1
     );

--- a/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
+++ b/tests/unit/capi/GEOSPreparedDistanceWithinTest.cpp
@@ -213,5 +213,18 @@ void object::test<11>
     );
 }
 
+template<>
+template<>
+void object::test<12>
+()
+{
+    checkDistanceWithin(
+        "LINESTRING (2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+        "LINESTRING (0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9)",
+        1,
+        1
+    );
+}
+
 } // namespace tut
 

--- a/tests/unit/utility.h
+++ b/tests/unit/utility.h
@@ -97,6 +97,23 @@ instanceOf(InstanceType const* instance)
 }
 
 inline void
+ensure_equals_xy(geos::geom::Coordinate const& actual,
+                  geos::geom::Coordinate const& expected)
+{
+    ensure_equals("Coordinate X", actual.x, expected.x );
+    ensure_equals("Coordinate Y", actual.y, expected.y );
+}
+
+inline void
+ensure_equals_xy(geos::geom::Coordinate const& actual,
+                  geos::geom::Coordinate const& expected,
+                  double tol)
+{
+    ensure_equals("Coordinate X", actual.x, expected.x, tol );
+    ensure_equals("Coordinate Y", actual.y, expected.y, tol );
+}
+
+inline void
 ensure_equals_xyz(geos::geom::Coordinate const& actual,
                   geos::geom::Coordinate const& expected)
 {


### PR DESCRIPTION
This PR fixes `PreparedLineStringDistance` to handle the cases:

1. the prepared line is contained within the envelope of the test geometry
2. the prepared line is contained within a polygonal geometry

Fixing the first situation requires removing an invalid heuristic check from `IndexedFacetDistance.isWithinDistance` [code](https://github.com/libgeos/geos/blob/main/src/operation/distance/IndexedFacetDistance.cpp#L69):
```
    auto env2 = g->getEnvelope();
    if (distance(env2.get()) > maxDistance) {
        return false;
    }
```
The check attempts to short-circuit the withinDistance test by checking the distance to the envelope polygon of the tested geometry. However, `IndexedFacetDistance` only computes distances to linework, not to polygonal geometries. So the test is incorrect in some cases (such as #958).

This heuristic is not in the JTS [code](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/operation/distance/IndexedFacetDistance.java#L183).

Fixing the second situation requires an additional point-in-polygon check in 
`PreparedLineStringDistance.distance` and `PreparedLineStringDistance.isWithinDistance` to test for the prepared line (or element of) lying within a test polygonal geometry.

Fixes #958.
Fixes #960.