### PR TITLE
Add PrecisionReducer test for CoordinateSequence.add bug

### DIFF
--- a/tests/unit/operation/overlayng/PrecisionReducerTest.cpp
+++ b/tests/unit/operation/overlayng/PrecisionReducerTest.cpp
@@ -27,11 +27,11 @@ struct test_precisionreducer_data {
     WKTWriter w;
 
     void
-    checkReduce(const std::string& wkt, double gridSize, const std::string& wkt_expected)
+    checkReduce(const std::string& wkt, double scale, const std::string& wkt_expected)
     {
         std::unique_ptr<Geometry> geom = r.read(wkt);
         std::unique_ptr<Geometry> expected = r.read(wkt_expected);
-        PrecisionModel pm(1.0/gridSize);
+        PrecisionModel pm(scale);
         std::unique_ptr<Geometry> result = PrecisionReducer::reducePrecision(geom.get(), &pm);
         ensure_equals_geometry(result.get(), expected.get());
     }
@@ -142,7 +142,7 @@ template<>
 void object::test<11> ()
 {
     checkReduce("LINESTRING(-3 6, 9 1)",
-        2, "LINESTRING (-2 6, 10 2)");
+        0.5, "LINESTRING (-2 6, 10 2)");
 }
 
 // testCollapsedLine
@@ -170,9 +170,18 @@ void object::test<14> ()
 {
     checkReduce("POLYGON ((2 1, 3 1, 3 2, 2 1))",
     // checkReduce("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 1, 1 1), (1 2, 1 3, 2 3, 1 2), (2 3, 3 3, 3 2, 2 3))",
-        1.0/10, "POLYGON ((2 1, 3 1, 3 2, 2 1))");
+        10, "POLYGON ((2 1, 3 1, 3 2, 2 1))");
 }
 
+// see https://github.com/libgeos/geos/issues/811
+template<>
+template<>
+void object::test<15> ()
+{
+    checkReduce("POLYGON ((127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607152 34.562312309, 127.117607012 34.562312359, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117245225 34.562385186, 127.117461568 34.562519572))",
+        100000, 
+        "POLYGON ((127.11775 34.56207, 127.11725 34.56216, 127.11761 34.56231, 127.11775 34.56207))");
+}
 
 
 } // namespace tut


### PR DESCRIPTION
Issue #811 is caused by a bug in a [CoordinateSequence::add](https://github.com/libgeos/geos/blob/main/src/geom/CoordinateSequence.cpp#L178) method, which is called from [SegmentNodeList.addEdgeCoordinates](https://github.com/libgeos/geos/blob/main/src/noding/SegmentNodeList.cpp#L313) during snap-rounding noding.  #963 fixes this issue.  

This PR adds a unit test using the case in #811.

## Demonstration of Bug

If the original code is used with the debug trace statements in [SegmentNodeList.addEdgeCoordinates](https://github.com/libgeos/geos/blob/main/src/noding/SegmentNodeList.cpp#L313), the test:
```
bin/test_geos_unit geos::operation::overlayng::PrecisionReducer 15
```
produces:
```
addEdgeCoordinates: (127.117461568 34.562519572, 127.117461568 34.562519572)
updated coord list: (127.117461568 34.562519572)

addEdgeCoordinates: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359)
updated coord list: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359)

addEdgeCoordinates: (127.117607012 34.562312359, 127.117607152 34.562312309, 127.117607012 34.562312359, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117461568 34.562519572)
updated coord list: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359, 127.117607152 34.562312309, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117461568 34.562519572)

addEdgeCoordinates: (127.117461568 34.562519572, 127.117245225 34.562385186, 127.117461568 34.562519572)
updated coord list: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359, 127.117607152 34.562312309, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117461568 34.562519572, 127.117245225 34.562385186)

geos::operation::overlayng::PrecisionReducer: [15=X]

---> group: geos::operation::overlayng::PrecisionReducer, test: test<15>
     problem: unexpected exception
     exception typeid: N4geos4util17TopologyExceptionE
     message: `TopologyException: Ring edge missing at 127.11745999999999 34.562519999999999`
```

Note that in the final call to `addEdgeCoordinates` the last coordinate `127.117461568 34.562519572` of the added coordinates is not present in the result coordinates.  

Using the new code the trace is:
```
addEdgeCoordinates: (127.117461568 34.562519572, 127.117461568 34.562519572)
updated coord list: (127.117461568 34.562519572)

addEdgeCoordinates: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359)
updated coord list: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359)

addEdgeCoordinates: (127.117607012 34.562312359, 127.117607152 34.562312309, 127.117607012 34.562312359, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117461568 34.562519572)
updated coord list: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359, 127.117607152 34.562312309, 127.117607012 34.562312359, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117461568 34.562519572)

addEdgeCoordinates: (127.117461568 34.562519572, 127.117245225 34.562385186, 127.117461568 34.562519572)
updated coord list: (127.117461568 34.562519572, 127.117483252 34.5624884690001, 127.117603304 34.562319127, 127.117607012 34.562312359, 127.117607152 34.562312309, 127.117607012 34.562312359, 127.117254733 34.5621607510001, 127.117746661 34.5620659730001, 127.117603496 34.5623196400001, 127.117484065 34.562488982, 127.117462315 34.562520066, 127.117461568 34.562519572, 127.117245225 34.562385186, 127.117461568 34.562519572)

geos::operation::overlayng::PrecisionReducer: .

tests summary: ok:1
```

Fixes #811.
