### PR TITLE
python-software-properties has been deprecated

### DIFF
--- a/web/content/usage/install.md
+++ b/web/content/usage/install.md
@@ -25,7 +25,7 @@ The [Ubuntu GIS](https://wiki.ubuntu.com/UbuntuGIS) project maintains a collecti
 
 ```bash
 # Add the Ubuntu GIS PPA
-sudo apt-get install python-software-properties
+sudo apt-get install software-properties-common
 sudo add-apt-repository ppa:ubuntugis/ppa
 
 # Install the packages


### PR DESCRIPTION
I suggest it is replaced with https://packages.ubuntu.com/kinetic/software-properties-common

python3-software-properties may be preferrable (less to download) but I've not tested it.

https://packages.ubuntu.com/kinetic/python3-software-properties