### PR TITLE
Added illumos macro for int8_t parse_value override. 

### DIFF
--- a/util/geosop/cxxopts.hpp
+++ b/util/geosop/cxxopts.hpp
@@ -677,12 +677,14 @@ namespace cxxopts
       integer_parser(text, value);
     }
 
+    #ifndef __illumos__
     inline
     void
     parse_value(const std::string& text, int8_t& value)
     {
       integer_parser(text, value);
     }
+    #endif
 
     inline
     void


### PR DESCRIPTION
illumos' implementation of stdint.h treats chars as int8_t. So when I was trying to compile this on an illumos distro I was getting the following compilation error:
```
/usr/local/src/geos-3.12.0/util/geosop/cxxopts.hpp:793:10: error: redefinition of 'void cxxopts::values::parse_value(const string&, char&)'
  793 |     void parse_value(const std::string& text, char& c)
      |          ^~~~~~~~~~~
/usr/local/src/geos-3.12.0/util/geosop/cxxopts.hpp:682:5: note: 'void cxxopts::values::parse_value(const string&, int8_t& ' previously defined here
  682 |     parse_value(const std::string& text, int8_t& value)
      |     ^~~~~~~~~~~
```
So this change will only add one of the functions if it's an illumOS system. 