### PR TITLE
Refactor WKTWriter::writeTrimmedNumber for big and small values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
   - Fix PreparedLineStringDistance for lines within envelope and polygons (GH-959, Martin Davis)
   - Improve scale handling for PrecisionModel (GH-956, Martin Davis)
   - Fix error in CoordinateSequence::add when disallowing repeated points (GH-963, Dan Baston)
+  - Fix WKTWriter::writeTrimmedNumber for big and small values (GH-973, Mike Taves)
 
 
 ## Changes in 3.12.0

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1898,11 +1898,13 @@ extern void GEOS_DLL GEOSWKTWriter_setOld3D_r(
     GEOSWKTWriter *writer,
     int useOld3D);
 
-/** Print the shortest representation of a double using fixed notation.
- * Only works for numbers smaller than 1e17 (absolute value).
+/** Print the shortest representation of a double. Non-zero absolute values
+ * that are <1e-4 and >=1e+17 are formatted using scientific notation, and
+ * other values are formatted with positional notation with precision used for
+ * the max digits after decimal point.
  * \param d The number to format.
- * \param precision The desired precision. (max digits after decimal point)
- * \param result The buffer to write the result to.
+ * \param precision The desired precision.
+ * \param result The buffer to write the result to, with a suggested size 28.
  * \return the length of the written string.
  */
 extern int GEOS_DLL GEOS_printDouble(
@@ -5436,7 +5438,10 @@ extern char GEOS_DLL *GEOSWKTWriter_write(
 /**
 * Sets the number trimming option on a \ref GEOSWKTWriter.
 * With trim set to 1, the writer will strip trailing 0's from
-* the output coordinates. With 0, all coordinates will be
+* the output coordinates. With 1 (trimming enabled), big and small
+* absolute coordinates will use scientific notation, otherwise
+* positional notation is used; see \ref GEOS_printDouble for details.
+* With 0 (trimming disabled), all coordinates will be
 * padded with 0's out to the rounding precision.
 * Default since GEOS 3.12 is with trim set to 1 for 'on'.
 * \param writer A \ref GEOSWKTWriter.

--- a/tests/unit/capi/GEOS_printDoubleTest.cpp
+++ b/tests/unit/capi/GEOS_printDoubleTest.cpp
@@ -1,0 +1,84 @@
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+struct test_geos_printdouble_data : public capitest::utility {};
+
+typedef test_group<test_geos_printdouble_data> group;
+typedef group::object object;
+
+group test_geos_printdouble("capi::GEOS_printDouble");
+
+template<>
+template<>
+void object::test<1>()
+{
+    struct TESTCASE {
+        TESTCASE(unsigned int p_p, double p_d, std::string p_expected)
+            : p(p_p), d(p_d), expected(p_expected) {}
+        unsigned int p;
+        double d;
+        std::string expected;
+    };
+    std::vector<TESTCASE> testcase_l{
+        TESTCASE(1, 0.0, "0"),
+        TESTCASE(1, std::nan("0"), "NaN"),
+        TESTCASE(1, std::numeric_limits<double>::infinity(), "Infinity"),
+        TESTCASE(1, -std::numeric_limits<double>::infinity(), "-Infinity"),
+        TESTCASE(16, 1.0, "1"),
+        TESTCASE(16, 1.2e+234, "1.2e+234"),
+        TESTCASE(2, -1.2e+234, "-1.2e+234"),
+        TESTCASE(16, 1.2e-234, "1.2e-234"),
+        TESTCASE(2, -1.2e-234, "-1.2e-234"),
+        TESTCASE(2, 1.1e-5, "1.1e-5"),
+        TESTCASE(0, 1e-4, "0.0001"),
+        TESTCASE(1, 1e-4, "0.0001"),
+        TESTCASE(2, 1e-4, "0.0001"),
+        TESTCASE(3, 1e-4, "0.0001"),
+        TESTCASE(4, 1e-4, "0.0001"),
+        TESTCASE(5, 1e-4, "0.0001"),
+        TESTCASE(0, 5.6e-4, "0.0006"),
+        TESTCASE(1, 5.6e-4, "0.0006"),
+        TESTCASE(2, 5.6e-4, "0.0006"),
+        TESTCASE(3, 5.6e-4, "0.0006"),
+        TESTCASE(4, 5.6e-4, "0.0006"),
+        TESTCASE(5, 5.6e-4, "0.00056"),
+        TESTCASE(0, 1.2345678901234e+15, "1234567890123400"),
+        TESTCASE(1, 1.2345678901234e+15, "1234567890123400"),
+        TESTCASE(0, 1.2345678901234e+16, "12345678901234000"),
+        TESTCASE(1, 1.2345678901234e+16, "12345678901234000"),
+        TESTCASE(0, 1.2345678901234e+17, "1e+17"),
+        TESTCASE(1, 1.2345678901234e+17, "1.2e+17"),
+        TESTCASE(2, 1.2345678901234e+17, "1.23e+17"),
+        TESTCASE(3, 1.2345678901234e+17, "1.235e+17"),
+        TESTCASE(4, 1.2345678901234e+17, "1.2346e+17"),
+        TESTCASE(5, 1.2345678901234e+17, "1.23457e+17"),
+        TESTCASE(6, 1.2345678901234e+17, "1.234568e+17"),
+        TESTCASE(7, 1.2345678901234e+17, "1.2345679e+17"),
+        TESTCASE(8, 1.2345678901234e+17, "1.23456789e+17"),
+        TESTCASE(9, 1.2345678901234e+17, "1.23456789e+17"),
+        TESTCASE(10, 1.2345678901234e+17, "1.2345678901e+17"),
+        TESTCASE(11, 1.2345678901234e+17, "1.23456789012e+17"),
+        TESTCASE(12, 1.2345678901234e+17, "1.234567890123e+17"),
+        TESTCASE(13, 1.2345678901234e+17, "1.2345678901234e+17"),
+        TESTCASE(14, 1.2345678901234e+17, "1.2345678901234e+17"),
+    };
+    for (const auto& testcase : testcase_l) {
+        char buf[28];
+        const auto len = GEOS_printDouble(testcase.d, testcase.p, buf);
+        buf[len] = '\0';
+        const auto res_str = std::string(buf);
+        ensure_equals(res_str, testcase.expected);
+        ensure_equals(len, static_cast<int>(testcase.expected.size()));
+    }
+
+}
+
+} // namespace tut

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -464,4 +464,115 @@ void object::test<15>
 
 }
 
+// Test big, small, and non-finite values
+// https://github.com/libgeos/geos/issues/970
+template<>
+template<>
+void object::test<16>
+()
+{
+    PrecisionModel pmf(PrecisionModel::FLOATING);
+    GeometryFactory::Ptr gff(GeometryFactory::create(&pmf));
+    WKTReader wktreaderf(gff.get());
+
+    // Big values
+    auto big = wktreaderf.read("POINT (-1.234e+15 1.234e+16 1.234e+17 -1.234e+18)");
+
+    // Check precision from 0 to 5
+    wktwriter.setRoundingPrecision(0);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 1e+17 -1e+18)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 123400000000000000 -1234000000000000000)");
+
+    wktwriter.setRoundingPrecision(1);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 1.2e+17 -1.2e+18)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000.0 12340000000000000.0 123400000000000000.0 -1234000000000000000.0)");
+
+    wktwriter.setRoundingPrecision(2);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 1.23e+17 -1.23e+18)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000.00 12340000000000000.00 123400000000000000.00 -1234000000000000000.00)");
+
+    wktwriter.setRoundingPrecision(3);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 1.234e+17 -1.234e+18)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000.000 12340000000000000.000 123400000000000000.000 -1234000000000000000.000)");
+
+    wktwriter.setRoundingPrecision(4);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 1.234e+17 -1.234e+18)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000.0000 12340000000000000.0000 123400000000000000.0000 -1234000000000000000.0000)");
+
+    wktwriter.setRoundingPrecision(5);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000 12340000000000000 1.234e+17 -1.234e+18)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*big), "POINT ZM (-1234000000000000.00000 12340000000000000.00000 123400000000000000.00000 -1234000000000000000.00000)");
+
+    // Small values
+    auto small = wktreaderf.read("POINT (-1.234e-3 2.234e-4 1.234e-5 -1.234e-6)");
+
+    // Check precision from 0 to 5
+    wktwriter.setRoundingPrecision(0);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.001 0.0002 1e-5 -1e-6)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0 0 0 -0)");
+
+    wktwriter.setRoundingPrecision(1);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.001 0.0002 1.2e-5 -1.2e-6)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.0 0.0 0.0 -0.0)");
+
+    wktwriter.setRoundingPrecision(2);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.001 0.0002 1.23e-5 -1.23e-6)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.00 0.00 0.00 -0.00)");
+
+    wktwriter.setRoundingPrecision(3);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.001 0.0002 1.234e-5 -1.234e-6)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.001 0.000 0.000 -0.000)");
+
+    wktwriter.setRoundingPrecision(4);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.0012 0.0002 1.234e-5 -1.234e-6)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.0012 0.0002 0.0000 -0.0000)");
+
+    wktwriter.setRoundingPrecision(5);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.00123 0.00022 1.234e-5 -1.234e-6)");
+    wktwriter.setTrim(false);
+    ensure_equals(wktwriter.write(*small), "POINT ZM (-0.00123 0.00022 0.00001 -0.00000)");
+
+    // Extremely small and big
+    auto extreme = wktreaderf.read("POINT (-1.2e-208 9.1e-191 3.8e+221 4.9e+154)");
+    wktwriter.setRoundingPrecision(5);
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*extreme), "POINT ZM (-1.2e-208 9.1e-191 3.8e+221 4.9e+154)");
+    // Skip non-trim, as this may vary between compilers
+    // wktwriter.setTrim(false);
+    // ensure_equals(wktwriter.write(*extreme), "POINT ZM (-0.00000 0.00000 ...)");
+
+    // Non-finite values
+    auto nonfinite = wktreaderf.read("POINT(-inf inf nan)");
+
+    wktwriter.setTrim(true);
+    ensure_equals(wktwriter.write(*nonfinite), "POINT Z (-Infinity Infinity NaN)");
+    // Skip non-trim, as this may vary between compilers
+    // wktwriter.setTrim(false);
+    // ensure_equals(wktwriter.write(*nonfinite), "POINT Z (-inf inf nan)");
+
+}
+
 } // namespace tut


### PR DESCRIPTION
This PR modifies how big and small values are formatted by WKTWriter by switching from [positional](https://en.wikipedia.org/wiki/Positional_notation) to [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) where necessary, to avoid rounding to zero or overflowing a char buffer crash.

This somewhat expands the "trim" mode definition to mean "print pretty numbers" since it doesn't always honour (e.g.) "3" to show fixed millimetre precision, since it will use scientific notation to show smaller non-zero numbers if necessary. The non-trim mode still uses fixed notation, and will show (e.g.) "-0" in some cases.

Also the char buffer used for these numbers is reduced from 128 to 28.

Some new unit tests are added for `GEOS_printDouble` from the CAPI. Other unit tests check outputs with trim set on/off.

Closes #970

---

Some [unpractical] geometries mapped in SI meters:

1. [Classical electron radius](https://en.wikipedia.org/wiki/Classical_electron_radius): `./bin/geosop -a "point(0 0)" buffer 2.8179403227e-15`
> POLYGON ((2.8179403227e-15 0, 2.763794389558889e-15 -5.497528849777754e-16, 2.6034373879807804e-15 -1.0783790748908248e-15, 2.3430317476070782e-15 -1.5655637617177719e-15, 1.992584711160178e-15 -1.9925847111601778e-15, 1.5655637617177723e-15 -2.3430317476070782e-15, 1.078379074890825e-15 -2.6034373879807804e-15, 5.497528849777756e-16 -2.763794389558889e-15, 1.7254907981914074e-31 -2.8179403227e-15, -5.497528849777752e-16 -2.763794389558889e-15, -1.0783790748908246e-15 -2.6034373879807804e-15, -1.5655637617177713e-15 -2.343031747607079e-15, -1.9925847111601778e-15 -1.992584711160178e-15, -2.3430317476070786e-15 -1.5655637617177719e-15, -2.6034373879807804e-15 -1.078379074890825e-15, -2.763794389558889e-15 -5.497528849777764e-16, -2.8179403227e-15 -3.4509815963828148e-31, -2.763794389558889e-15 5.497528849777757e-16, -2.6034373879807808e-15 1.0783790748908244e-15, -2.343031747607079e-15 1.5655637617177713e-15, -1.9925847111601786e-15 1.9925847111601778e-15, -1.5655637617177719e-15 2.3430317476070782e-15, -1.0783790748908263e-15 2.60343738798078e-15, -5.497528849777765e-16 2.763794389558889e-15, -5.176472394574221e-31 2.8179403227e-15, 5.497528849777755e-16 2.763794389558889e-15, 1.0783790748908253e-15 2.6034373879807804e-15, 1.5655637617177711e-15 2.343031747607079e-15, 1.9925847111601774e-15 1.9925847111601786e-15, 2.3430317476070782e-15 1.5655637617177719e-15, 2.60343738798078e-15 1.0783790748908265e-15, 2.763794389558889e-15 5.497528849777767e-16, 2.8179403227e-15 0))
2. [Observable universe](https://en.wikipedia.org/wiki/Observable_universe): `./bin/geosop -a "point(0 0)" buffer 4.40e26`
> POLYGON ((4.4e+26 0, 4.315455233774214e+26 -8.583974168709644e+25, 4.0650699430496615e+26 -1.683807102406395e+26, 3.658466294131199e+26 -2.4445090252862496e+26, 3.111269837220809e+26 -3.111269837220809e+26, 2.4445090252862503e+26 -3.658466294131199e+26, 1.683807102406395e+26 -4.0650699430496615e+26, 8.583974168709647e+25 -4.315455233774214e+26, 26942229581.24177 -4.4e+26, -8.58397416870964e+25 -4.315455233774214e+26, -1.6838071024063948e+26 -4.0650699430496615e+26, -2.4445090252862486e+26 -3.6584662941312e+26, -3.111269837220809e+26 -3.111269837220809e+26, -3.6584662941312e+26 -2.4445090252862496e+26, -4.0650699430496615e+26 -1.6838071024063955e+26, -4.315455233774214e+26 -8.583974168709659e+25, -4.4e+26 -53884459162.48354, -4.315455233774214e+26 8.583974168709649e+25, -4.065069943049662e+26 1.6838071024063945e+26, -3.6584662941312e+26 2.4445090252862486e+26, -3.11126983722081e+26 3.111269837220809e+26, -2.4445090252862496e+26 3.658466294131199e+26, -1.6838071024063976e+26 4.065069943049661e+26, -8.58397416870966e+25 4.3154552337742135e+26, -80826688743.72531 4.4e+26, 8.583974168709645e+25 4.315455233774214e+26, 1.6838071024063962e+26 4.0650699430496615e+26, 2.4445090252862482e+26 3.6584662941312e+26, 3.1112698372208085e+26 3.11126983722081e+26, 3.658466294131199e+26 2.4445090252862496e+26, 4.065069943049661e+26 1.683807102406398e+26, 4.3154552337742135e+26 8.583974168709664e+25, 4.4e+26 0))
3. The finite extremes of [double-precision](https://en.wikipedia.org/wiki/Double-precision_floating-point_format): `./bin/geosop -a "point(5e-324 1.7e308)"`
> POINT (5e-324 1.7e+308)