### PR TITLE
Fix InteriorPointPoint to handle empty elements

### DIFF
--- a/src/algorithm/InteriorPointPoint.cpp
+++ b/src/algorithm/InteriorPointPoint.cpp
@@ -47,6 +47,9 @@ InteriorPointPoint::InteriorPointPoint(const Geometry* g)
 void
 InteriorPointPoint::add(const Geometry* geom)
 {
+    if (geom->isEmpty())
+        return;
+
     const Point* po = dynamic_cast<const Point*>(geom);
     if (po) {
         add(po->getCoordinate());

--- a/tests/xmltester/tests/general/TestInteriorPoint.xml
+++ b/tests/xmltester/tests/general/TestInteriorPoint.xml
@@ -14,10 +14,17 @@
 </case>
 
 <case>
-  <desc>P - single point</desc>
+  <desc>P - multipoint</desc>
   <a>    MULTIPOINT ((60 300), (200 200), (240 240), (200 300), (40 140), (80 240), (140 240), (100 160), (140 200), (60 200))
 	</a>
 <test><op name="getInteriorPoint" arg1="A" >    POINT (140 240)   </op></test>
+</case>
+
+<case>
+  <desc>P - multipoint with EMPTY</desc>
+  <a>    MULTIPOINT((0 0), EMPTY)
+	</a>
+<test><op name="getInteriorPoint" arg1="A" >    POINT (0 0)   </op></test>
 </case>
 
 <case>


### PR DESCRIPTION
Fix `InteriorPointPoint` to handle empty elements (e.g. `MULTIPOINT((0 0), EMPTY)`).

Fixes #976.

Original report in https://trac.osgeo.org/postgis/ticket/5595