### PR TITLE
Fix spatial predicates for MultiPoint with EMPTY

### DIFF
--- a/src/algorithm/PointLocator.cpp
+++ b/src/algorithm/PointLocator.cpp
@@ -74,7 +74,12 @@ PointLocator::locate(const CoordinateXY& p, const Geometry* geom)
 void
 PointLocator::computeLocation(const CoordinateXY& p, const Geometry* geom)
 {
-
+    //-- handle empty elements
+    /*
+    if (geom->isEmpty()) {
+        return;
+    }
+*/
     GeometryTypeId geomTypeId = geom->getGeometryTypeId();
     switch (geomTypeId)
     {

--- a/src/geomgraph/GeometryGraph.cpp
+++ b/src/geomgraph/GeometryGraph.cpp
@@ -209,7 +209,10 @@ GeometryGraph::addCollection(const GeometryCollection* gc)
 {
     for(std::size_t i = 0, n = gc->getNumGeometries(); i < n; ++i) {
         const Geometry* g = gc->getGeometryN(i);
-        add(g);
+        //if (! g->isEmpty()) {
+            add(g);
+        //}
+        
     }
 }
 

--- a/tests/xmltester/tests/general/TestRelatePA.xml
+++ b/tests/xmltester/tests/general/TestRelatePA.xml
@@ -100,4 +100,54 @@
 </test>
 </case>
 
+<case>
+  <desc>mPA - empty Point element</desc>
+  <a>
+    MULTIPOINT(EMPTY,(0 0))
+  </a>
+  <b>
+    POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))
+  </b>
+<test>
+  <op name="relate" arg3="0FFFFF212" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> true  </op></test>
+</case>
+
+<case>
+  <desc>PmA - empty MultiPolygon element</desc>
+  <a>
+    POINT(0 0)
+  </a>
+  <b>
+    MULTIPOLYGON (EMPTY, ((1 0,0 1,-1 0,0 -1, 1 0)))
+  </b>
+<test>
+  <op name="relate" arg3="0FFFFF212" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> true  </op></test>
+</case>
+
 </run>


### PR DESCRIPTION
This is a port of https://github.com/locationtech/jts/pull/1015.  It improves the `RelateOp` algorithm to handle EMPTY elements better in general.

Fixes #988.