### PR TITLE
Fix DiscreteHausdorffDistance for LinearRing

### DIFF
--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -36,18 +36,10 @@
 #endif
 
 namespace geos {
-namespace algorithm {
-//class RayCrossingCounter;
-}
 namespace geom {
 class Geometry;
 class Coordinate;
 //class CoordinateSequence;
-}
-namespace index {
-namespace intervalrtree {
-//class SortedPackedIntervalRTree;
-}
 }
 }
 

--- a/src/algorithm/distance/DistanceToPoint.cpp
+++ b/src/algorithm/distance/DistanceToPoint.cpp
@@ -45,7 +45,7 @@ DistanceToPoint::computeDistance(const geom::Geometry& geom,
         return;
     }
 
-    if(geom.getGeometryTypeId() == GEOS_LINESTRING) {
+    if(geom.getGeometryTypeId() == GEOS_LINESTRING || geom.getGeometryTypeId() == GEOS_LINEARRING) {
         const LineString* ls = static_cast<const LineString*>(&geom);
         computeDistance(*ls, pt, ptDist);
     }

--- a/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
@@ -216,5 +216,16 @@ void object::test<7>
                   DiscreteHausdorffDistance::distance(*g2, *g3));
 }
 
+// see https://github.com/libgeos/geos/issues/987
+template<>
+template<>
+void object::test<8>
+()
+{
+    runTest("LINEARRING (0 0, 0 10, 10 10, 10 0, 0 0)",
+            "LINEARRING (1 1, 1 9, 8 8, 9 1, 1 1)", 
+            2.8284271247461903);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fix regression in `DiscreteHausdorffDistance` to handle `LinearRing`s.

Fixes #987