### PR TITLE
Fix IsSimpleOp for MultiPoint with empty element

### DIFF
--- a/src/operation/valid/IsSimpleOp.cpp
+++ b/src/operation/valid/IsSimpleOp.cpp
@@ -145,6 +145,8 @@ IsSimpleOp::isSimpleMultiPoint(const MultiPoint& mp)
 
     for (std::size_t i = 0; i < mp.getNumGeometries(); i++) {
         const Point* pt = mp.getGeometryN(i);
+        if (pt->isEmpty())
+            continue;
         const CoordinateXY* p = pt->getCoordinate();
         if (points.find(*p) != points.end()) {
             nonSimplePts.push_back(*p);

--- a/tests/xmltester/tests/general/TestSimple.xml
+++ b/tests/xmltester/tests/general/TestSimple.xml
@@ -50,6 +50,14 @@
 </case>
 
 <case>
+  <desc>mP - with empty element</desc>
+  <a>
+    MULTIPOINT (EMPTY, (80 220), (160 220))
+  </a>
+<test><op name="isSimple" arg1="A"> true </op></test>
+</case>
+
+<case>
   <desc>L - simple line</desc>
   <a>
     LINESTRING(10 10, 20 20)
@@ -246,7 +254,7 @@
   <desc>mL - intersection between elements at non-vertex</desc>
   <a>
     MULTILINESTRING(
-  (40 140, 160 40),
+  (40 140, 160 40), 
   (160 140, 40 40))
   </a>
 <test>
@@ -260,7 +268,7 @@
   <desc>mL - no intersection between elements</desc>
   <a>
     MULTILINESTRING(
-  (20 160, 20 20),
+  (20 160, 20 20), 
   (100 160, 100 20))
   </a>
 <test>
@@ -273,7 +281,7 @@
 <case>
   <desc>mL - mutual intersection at endpoints only</desc>
   <a>
-    MULTILINESTRING ((60 140, 20 80, 60 40),
+    MULTILINESTRING ((60 140, 20 80, 60 40), 
   (60 40, 100 80, 60 140))
   </a>
 <test>
@@ -286,7 +294,7 @@
 <case>
   <desc>mL - one element is non-simple</desc>
   <a>
-    MULTILINESTRING ((60 40, 140 40, 100 120, 100 0),
+    MULTILINESTRING ((60 40, 140 40, 100 120, 100 0), 
   (100 200, 200 120))
   </a>
 <test>
@@ -299,8 +307,8 @@
 <case>
   <desc>mL - proper intersection between elements at vertex</desc>
   <a>
-    MULTILINESTRING ((40 120, 100 60),
-  (160 120, 100 60),
+    MULTILINESTRING ((40 120, 100 60), 
+  (160 120, 100 60), 
   (40 60, 160 60))
   </a>
 <test>
@@ -313,7 +321,7 @@
 <case>
   <desc>mL - intersection between closed lines</desc>
   <a>
-    MULTILINESTRING ((80 160, 40 220, 40 100, 80 160),
+    MULTILINESTRING ((80 160, 40 220, 40 100, 80 160), 
   (80 160, 120 220, 120 100, 80 160))
   </a>
 <test>
@@ -326,8 +334,8 @@
 <case>
   <desc>mL - intersection between closed and open lines</desc>
   <a>
-    MULTILINESTRING ((80 160, 40 220),
-  (80 160, 120 220, 120 100, 80 160),
+    MULTILINESTRING ((80 160, 40 220), 
+  (80 160, 120 220, 120 100, 80 160), 
   (40 100, 80 160))
   </a>
 <test>
@@ -347,6 +355,14 @@
     false
   </op>
 </test>
+</case>
+
+<case>
+  <desc>mL - with empty element</desc>
+  <a>
+    MULTILINESTRING ((0 0, 100 100), EMPTY)
+  </a>
+<test><op name="isSimple" arg1="A"> true </op></test>
 </case>
 
 <case>
@@ -400,7 +416,7 @@
       <op name="isSimple" arg1="A"> false </op>
    </test>
 </case>
-
+  
 <case>
    <desc>A - polygon with equal segments </desc>
    <a>POLYGON ((50 90, 90 90, 90 50, 50 50, 10 10, 50 50, 50 90))</a>
@@ -408,7 +424,7 @@
       <op name="isSimple" arg1="A"> false </op>
    </test>
 </case>
-
+  
 <case>
   <desc>A - empty</desc>
   <a>
@@ -422,8 +438,8 @@
 <case>
   <desc>mA - valid polygon</desc>
   <a>
-    MULTIPOLYGON (((240 160, 140 220, 80 60, 220 40, 240 160)),
-  ((160 380, 100 240, 20 380, 160 380),
+    MULTIPOLYGON (((240 160, 140 220, 80 60, 220 40, 240 160)), 
+  ((160 380, 100 240, 20 380, 160 380), 
     (120 340, 60 360, 80 320, 120 340)))
   </a>
 <test>
@@ -434,8 +450,8 @@
 <case>
   <desc>mA - with touching elements</desc>
   <a>
-    MULTIPOLYGON (((240 160, 100 240, 80 60, 220 40, 240 160)),
-  ((160 380, 100 240, 20 380, 160 380),
+    MULTIPOLYGON (((240 160, 100 240, 80 60, 220 40, 240 160)), 
+  ((160 380, 100 240, 20 380, 160 380), 
     (120 340, 60 360, 80 320, 120 340)))
   </a>
 <test>
@@ -454,11 +470,19 @@ MULTIPOLYGON (((100 100, 100 200, 200 100, 200 200, 100 100)), ((100 400, 200 40
 </case>
 
 <case>
+  <desc>mA - with empty element</desc>
+  <a>
+MULTIPOLYGON (((0 10, 10 10, 10 0, 0 0, 0 10)), EMPTY)
+</a>
+<test><op name="isSimple" arg1="A"> true </op></test>
+</case>
+
+<case>
   <desc>GC - all components simple</desc>
   <a>
-GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)),
-  LINESTRING (100 300, 200 250),
-  POINT (250 250),
+GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)), 
+  LINESTRING (100 300, 200 250), 
+  POINT (250 250), 
   POINT (250 150))</a>
 <test>
   <op name="isSimple" arg1="A"> true </op>
@@ -468,13 +492,22 @@ GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)),
 <case>
   <desc>GC - one non-simple component</desc>
   <a>
-GEOMETRYCOLLECTION (POLYGON ((100 100, 100 200, 200 100, 200 200, 100 100)),
-  LINESTRING (100 300, 200 250),
-  POINT (250 250),
+GEOMETRYCOLLECTION (POLYGON ((100 100, 100 200, 200 100, 200 200, 100 100)), 
+  LINESTRING (100 300, 200 250), 
+  POINT (250 250), 
   POINT (250 150))</a>
 <test>
   <op name="isSimple" arg1="A"> false </op>
 </test>
+</case>
+
+<case>
+  <desc>GC - with empty element</desc>
+  <a>
+GEOMETRYCOLLECTION (POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10)), 
+  LINESTRING (100 300, 200 250), 
+  POINT EMPTY)</a>
+<test><op name="isSimple" arg1="A"> true </op></test>
 </case>
 
 </run>


### PR DESCRIPTION
Fixes `IsSimpleOp` to handle `MultiPoint`s with empty elements.

Reported in https://trac.osgeo.org/postgis/ticket/5628