### PR TITLE
geos_c.cpp: fix declarations to avoid C++ One Definition Rule violations

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -23,6 +23,7 @@
 #include <geos/io/WKBWriter.h>
 #include <geos/io/GeoJSONReader.h>
 #include <geos/io/GeoJSONWriter.h>
+#include <geos/operation/buffer/BufferParameters.h>
 #include <geos/util/Interrupt.h>
 
 #include <stdexcept>
@@ -32,10 +33,15 @@
 #pragma warning(disable : 4099)
 #endif
 
-// Some extra magic to make type declarations in geos_c.h work - for cross-checking of types in header.
+// Some extra magic to make type declarations in geos_c.h work -
+// for cross-checking of types in header.
+// NOTE: the below defines or struct definition must be kept in exact
+// sync between geos_c.cpp and geos_ts_c.cpp to avoid C++ One Definition Rule
+// violations.
 #define GEOSGeometry geos::geom::Geometry
 #define GEOSPreparedGeometry geos::geom::prep::PreparedGeometry
 #define GEOSCoordSequence geos::geom::CoordinateSequence
+#define GEOSBufferParams geos::operation::buffer::BufferParameters
 #define GEOSSTRtree geos::index::strtree::TemplateSTRtree<void*>
 #define GEOSWKTReader geos::io::WKTReader
 #define GEOSWKTWriter geos::io::WKTWriter
@@ -43,8 +49,12 @@
 #define GEOSWKBWriter geos::io::WKBWriter
 #define GEOSGeoJSONReader geos::io::GeoJSONReader
 #define GEOSGeoJSONWriter geos::io::GeoJSONWriter
-typedef struct GEOSBufParams_t GEOSBufferParams;
-typedef struct GEOSMakeValidParams_t GEOSMakeValidParams;
+
+// Implementation struct for the GEOSMakeValidParams object
+typedef struct {
+    int method;
+    int keepCollapsed;
+} GEOSMakeValidParams;
 
 #include "geos_c.h"
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -119,6 +119,9 @@
 
 // Some extra magic to make type declarations in geos_c.h work -
 // for cross-checking of types in header.
+// NOTE: the below defines or struct definition must be kept in exact
+// sync between geos_c.cpp and geos_ts_c.cpp to avoid C++ One Definition Rule
+// violations.
 #define GEOSGeometry geos::geom::Geometry
 #define GEOSPreparedGeometry geos::geom::prep::PreparedGeometry
 #define GEOSCoordSequence geos::geom::CoordinateSequence


### PR DESCRIPTION
Currently building with GCC link-time-optimization with -flto -Wodr leads to the following type of warnings:
```
/home/even/geos/geos/build_cmake/capi/geos_c.h:665:31: warning: ‘GEOSBufferWithParams_r’ violates the C++ One Definition Rule [-Wodr]
  665 | extern GEOSGeometry GEOS_DLL *GEOSBufferWithParams_r(
      |                               ^
/home/even/geos/geos/capi/geos_ts_c.cpp:4034:5: note: type mismatch in parameter 3
 4034 |     GEOSBufferWithParams_r(GEOSContextHandle_t extHandle, const Geometry* g1, const BufferParameters* bp, double width)
      |     ^
/home/even/geos/geos/capi/geos_ts_c.cpp:4034:5: note: type name ‘geos::operation::buffer::BufferParameters’ should match type name ‘GEOSBufParams_t’
/home/even/geos/geos/capi/geos_ts_c.cpp:4034:5: note: ‘GEOSBufferWithParams_r’ was previously declared here
```

This is due to geos_c.cpp using slightly different definitions of the aliases between C API and C++ classes than the ones set in geos_ts_c.cpp.
Use exactly the ones from geos_tc_c.cpp to fix that issue