### PR TITLE
Fix StringTokenizer::peekNextToken

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
   - Fix DiscreteHausdorffDistance for LinearRing (GH-1000, Martin Davis)
   - Fix IsSimpleOp for MultiPoint with empty element (GH-1005, Martin Davis)
   - Fix PreparedPolygonContains for GC with MultiPoint (GH-1008, Martin Davis)
+  - Fix reading WKT with EMPTY token with white space (GH-1025, Mike Taves)
 
 ## Changes in 3.12.0
 2023-06-27

--- a/src/io/StringTokenizer.cpp
+++ b/src/io/StringTokenizer.cpp
@@ -154,10 +154,8 @@ StringTokenizer::peekNextToken()
         return str[pos];
     }
 
-    // It's either a Number or a Word, let's
-    // see when it ends
-
-    pos = str.find_first_of("\n\r\t() ,", static_cast<string::size_type>(iter - str.begin()));
+    // It's either a Number or a Word, let's see when it ends
+    pos = str.find_first_of("\n\r\t() ,", pos + 1);
 
     if(pos == string::npos) {
         if(iter != str.end()) {

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -462,5 +462,15 @@ void object::test<23>
     ensure(std::isnan(coords->getY(0)));
 }
 
+// EMPTY token with some white space
+template<>
+template<>
+void object::test<24>
+()
+{
+    GeomPtr geom(wktreader.read("MULTIPOINT( EMPTY, (10 10), (20 20))"));
+
+    ensure_equals(geom->getNumGeometries(), 3u);
+}
 
 } // namespace tut


### PR DESCRIPTION
This fixes `StringTokenizer::peekNextToken` so that both `(EMPTY` and `( EMPTY` are `StringTokenizer::TT_WORD`.

The issue was that the second assignment of `pos` (from `str.find_first_of`) was less than the first (from `str.find_first_not_of`), meaning that it started searching from the wrong position. The fix is simply to set the starting position to `pos + 1`.

Closes #1013