### PR TITLE
Fix overlay op regression with mixed GeometryCollection on 3.9 branch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@ xxxx-xx-xx
   - Remove undefined behaviour in use of null PrecisionModel (GH-931, Jeff Walton)
   - Skip over testing empty distances for mixed collections (GH-979, Paul Ramsey)
   - Add missing cstdint headers (GH-990, GH-743, Regina Obe, Sergei Trofimovich)
+  - HeuristicOverlay: Fix overlay op regression (GH-1050, Mike Taves)
 
 
 ## Changes in 3.9.4

--- a/src/geom/HeuristicOverlay.cpp
+++ b/src/geom/HeuristicOverlay.cpp
@@ -421,7 +421,8 @@ HeuristicOverlay(const Geometry* g0, const Geometry* g1, int opCode)
 
         return ret;
     }
-    catch(const geos::util::TopologyException& ex) {
+    catch(const geos::util::IllegalArgumentException& ex) {
+        // Mixed GeometryCollection; see GH-1050
         ::geos::ignore_unused_variable_warning(ex);
 
 #if GEOS_DEBUG_HEURISTICOVERLAY

--- a/tests/unit/capi/GEOSDifferenceTest.cpp
+++ b/tests/unit/capi/GEOSDifferenceTest.cpp
@@ -40,5 +40,33 @@ void object::test<1>()
     GEOSGeom_destroy(result);
 }
 
+/**
+* Mixed GeometryCollection types permitted at a high-level
+*/
+template<>
+template<>
+void object::test<2>()
+{
+    GEOSGeometry* a = GEOSGeomFromWKT("GEOMETRYCOLLECTION (POINT (51 -1), LINESTRING (52 -1, 49 2))");
+    GEOSGeometry* b = GEOSGeomFromWKT("POINT (2 3)");
+
+    ensure(a);
+    ensure(b);
+
+    GEOSGeometry* ab = GEOSDifference(a, b);
+    GEOSGeometry* ba = GEOSDifference(b, a);
+
+    ensure(ab);
+    ensure(ba);
+
+    ensure_geometry_equals(ab, a);
+    ensure_geometry_equals(ba, b);
+
+    GEOSGeom_destroy(a);
+    GEOSGeom_destroy(b);
+    GEOSGeom_destroy(ab);
+    GEOSGeom_destroy(ba);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
This fixes a regression in the 3.9 branch (only the 3.9.5 release), which permits overlay ops GEOSDifference with mixed-type GeometryCollection inputs. It more-or-less reverts ad62ddf5d97beecc193756c99f6c076963d36536 but limits the caught exception to `geos::util::IllegalArgumentException`.

The added CAPI test passes on newer branches too (with some mods), and I'll possibly add this test into other branches after this PR looks good.

Closes #1023

---

There's just one outstanding thing that I don't fully understand. By design, the low-level C++ level does not support overlay ops with mixed GeometryCollection types. But it doesn't appear to be consistent, e.g. (here "GC" is a mixed GeometryCollection and "PT" is a Point):

- GC.difference(PT) // raises IllegalArgumentException
- PT.difference(GC) // doesn't raise, result is PT

demonstrated with `tests/unit/operation/overlayng/OverlayNGMixedPointsTest.cpp`:
```c++
/**
* Mixed collections not supported at a low-level
*/
template<>
template<>
void object::test<12> ()
{
    std::string a = "GEOMETRYCOLLECTION (POINT (51 -1), LINESTRING (52 -1, 49 2))";
    std::string b = "POINT (2 3)";
    std::unique_ptr<Geometry> geom_a = r.read(a);
    std::unique_ptr<Geometry> geom_b = r.read(b);

    // A.difference(B) does not work
    try {
        std::unique_ptr<Geometry> geom_result = OverlayNG::overlay(geom_a.get(), geom_b.get(), OverlayNG::DIFFERENCE);
        fail();
    } catch(geos::util::IllegalArgumentException const& e) {
        ensure_equals(std::string(e.what()), "IllegalArgumentException: Overlay input is mixed-dimension");
    }
 
    // B.difference(A) works (?!)
    testOverlay(b, a, b, OverlayNG::DIFFERENCE, 1);
} 
```
is this expected, or unusual?