### PR TITLE
fix typo for clarity on GEOSCoordSeq_copyFromBuffer docs

### DIFF
--- a/web/content/usage/c_api.md
+++ b/web/content/usage/c_api.md
@@ -178,7 +178,7 @@ GEOSCoordSequence* seq = GEOSCoordSeq_copyFromArrays(
 GEOSCoordSeq_destroy(seq);
 ```
 
-Finally, you can create a `GEOSCoordSequence` and initialize it from a coordinate buffer (an array of double in coordinate order, eg: `XYXYXYX`).
+Finally, you can create a `GEOSCoordSequence` and initialize it from a coordinate buffer (an array of double in coordinate order, eg: `XYXYXY`).
 
 ```c
 /* Coordinates in a buffer (X,Y, X,Y, X,Y) */


### PR DESCRIPTION
in the example we have more x coordinates than y coordinates which could be slightly confusing to the most pedantic of readers. i've removed the extra x to match the code example below it.

thanks for the wonderfully useful/pervasive library!