### PR TITLE
CMakeLists.txt: add compatibility with latest Intel Compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,38 @@ target_compile_definitions(geos_cxx_flags
   INTERFACE
     USE_UNSTABLE_GEOS_CPP_API)
 
+# Deal with Intel Compiler
+if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-fno-fast-math HAVE_FLAG_NO_FAST_MATH)
+  if (HAVE_FLAG_NO_FAST_MATH)
+    # Intel CXX compiler, based on clang, defaults to -ffast-math, which breaks a lot of things
+    target_compile_options(geos_cxx_flags INTERFACE "-fno-fast-math")
+  endif ()
+
+  set(TEST_LINK_STDCPP_SOURCE_CODE
+      "#include <string>
+    int main(){
+      std::string s;
+      s += \"x\";
+      return 0;
+    }")
+  check_cxx_source_compiles("${TEST_LINK_STDCPP_SOURCE_CODE}" _TEST_LINK_STDCPP)
+  if( NOT _TEST_LINK_STDCPP )
+      message(WARNING "Cannot link code using standard C++ library. Automatically adding -lstdc++ to CMAKE_EXE_LINKER_FLAGS, CMAKE_SHARED_LINKER_FLAGS and CMAKE_MODULE_LINKER_FLAGS")
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lstdc++")
+      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -lstdc++")
+
+      include(CheckCXXSourceCompiles)
+      check_cxx_source_compiles("${TEST_LINK_STDCPP_SOURCE_CODE}" _TEST_LINK_STDCPP_AGAIN)
+      if( NOT _TEST_LINK_STDCPP_AGAIN )
+          message(FATAL_ERROR "Cannot link C++ program")
+      endif()
+  endif()
+endif ()
+
+
 target_compile_definitions(geos_developer_cxx_flags
   INTERFACE
     $<$<BOOL:${MSVC}>:_CRT_NONSTDC_NO_DEPRECATE>


### PR DESCRIPTION
With those tunings (mostly forcing -fno-fast-math), build passes without warnings with ICC 2024.0.2.29 in Release mode, and tests pass as well.