### PR TITLE
DistanceOp: Add short-circuit for point-point distance

### DIFF
--- a/benchmarks/operation/CMakeLists.txt
+++ b/benchmarks/operation/CMakeLists.txt
@@ -10,3 +10,13 @@
 ################################################################################
 add_subdirectory(buffer)
 add_subdirectory(predicate)
+
+if (benchmark_FOUND)
+    add_executable(perf_distance DistancePerfTest.cpp)
+    target_include_directories(perf_distance PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>)
+    target_link_libraries(perf_distance PRIVATE
+            benchmark::benchmark geos geos_cxx_flags)
+endif()

--- a/benchmarks/operation/DistancePerfTest.cpp
+++ b/benchmarks/operation/DistancePerfTest.cpp
@@ -1,0 +1,40 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2024 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <benchmark/benchmark.h>
+
+#include <BenchmarkUtils.h>
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/Geometry.h>
+#include <geos/operation/distance/DistanceOp.h>
+
+using geos::operation::distance::DistanceOp;
+
+static void BM_PointPointDistance(benchmark::State& state) {
+    geos::geom::Envelope e(-100, 100, -100, 100);
+    auto points = geos::benchmark::createPoints(e, 100000);
+
+    for (auto _ : state) {
+        for (std::size_t i = 0; i < points.size(); i++) {
+            for (std::size_t j = 0; i < points.size(); i++) {
+                points[i]->distance(points[j].get());
+           }
+        }
+    }
+}
+
+BENCHMARK(BM_PointPointDistance);
+
+BENCHMARK_MAIN();
+

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -110,6 +110,10 @@ DistanceOp::distance()
     if(geom[0]->isEmpty() || geom[1]->isEmpty()) {
         return 0.0;
     }
+    if(geom[0]->getGeometryTypeId() == GEOS_POINT && geom[1]->getGeometryTypeId() == GEOS_POINT) {
+        return static_cast<const Point*>(geom[0])->getCoordinate()->distance(*static_cast<const Point*>(geom[1])->getCoordinate());
+    }
+
     computeMinDistance();
     return minDistance;
 }


### PR DESCRIPTION
Relates to https://github.com/libgeos/geos/issues/1066

Add a short circuit to reduce point-point computation time by ~90%.