### PR TITLE
DistanceOp: Optimize some implementation details

### DIFF
--- a/benchmarks/operation/DistancePerfTest.cpp
+++ b/benchmarks/operation/DistancePerfTest.cpp
@@ -34,7 +34,47 @@ static void BM_PointPointDistance(benchmark::State& state) {
     }
 }
 
+static void BM_PointLineDistance(benchmark::State& state) {
+    geos::geom::Envelope e(-100, 100, -100, 100);
+
+    auto points = geos::benchmark::createPoints(e, 1000);
+
+    std::size_t points_per_line = 30;
+    std::size_t nlines = 100;
+    double line_size = e.getWidth() / static_cast<double>(nlines * nlines);
+
+    auto lines = geos::benchmark::createLines(e, nlines, line_size, points_per_line);
+
+    for (auto _ : state) {
+        for (const auto& line : lines) {
+            for (const auto& point : points) {
+                line->distance(point.get());
+            }
+        }
+    }
+}
+
+static void BM_LineLineDistance(benchmark::State& state) {
+    geos::geom::Envelope e(-100, 100, -100, 100);
+
+    std::size_t points_per_line = 30;
+    std::size_t nlines = 100;
+    double line_size = e.getWidth() / static_cast<double>(nlines * nlines);
+
+    auto lines = geos::benchmark::createLines(e, nlines, line_size, points_per_line);
+
+    for (auto _ : state) {
+        for (const auto& line1 : lines) {
+            for (const auto& line2 : lines) {
+                line1->distance(line2.get());
+            }
+        }
+    }
+}
+
 BENCHMARK(BM_PointPointDistance);
+BENCHMARK(BM_PointLineDistance);
+BENCHMARK(BM_LineLineDistance);
 
 BENCHMARK_MAIN();
 

--- a/include/geos/operation/distance/ConnectedElementLocationFilter.h
+++ b/include/geos/operation/distance/ConnectedElementLocationFilter.h
@@ -50,7 +50,7 @@ namespace distance { // geos::operation::distance
 class GEOS_DLL ConnectedElementLocationFilter: public geom::GeometryFilter {
 private:
 
-    std::vector<std::unique_ptr<GeometryLocation>> locations;
+    std::vector<GeometryLocation> locations;
     ConnectedElementLocationFilter() = default;
     ConnectedElementLocationFilter(const ConnectedElementLocationFilter&) = delete;
     ConnectedElementLocationFilter& operator=(const ConnectedElementLocationFilter&) = delete;
@@ -63,7 +63,7 @@ public:
      * an empty list will be returned. The elements of the list
      * are [GeometryLocations](@ref operation::distance::GeometryLocation).
      */
-    static std::vector<std::unique_ptr<GeometryLocation>> getLocations(const geom::Geometry* geom);
+    static std::vector<GeometryLocation> getLocations(const geom::Geometry* geom);
 
     void filter_ro(const geom::Geometry* geom) override;
     void filter_rw(geom::Geometry* geom) override;

--- a/include/geos/operation/distance/DistanceOp.h
+++ b/include/geos/operation/distance/DistanceOp.h
@@ -172,19 +172,19 @@ private:
 
     // working
     algorithm::PointLocator ptLocator;
-    std::array<std::unique_ptr<GeometryLocation>, 2> minDistanceLocation;
+    std::array<GeometryLocation, 2> minDistanceLocation;
     double minDistance;
     bool computed = false;
 
-    void updateMinDistance(std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom, bool flip);
+    void updateMinDistance(std::array<GeometryLocation, 2> & locGeom, bool flip);
 
     void computeMinDistance();
 
     void computeContainmentDistance();
 
-    void computeInside(std::vector<std::unique_ptr<GeometryLocation>> & locs,
+    void computeInside(std::vector<GeometryLocation> & locs,
                        const std::vector<const geom::Polygon*>& polys,
-                       std::array<std::unique_ptr<GeometryLocation>, 2> & locPtPoly);
+                       std::array<GeometryLocation, 2> & locPtPoly);
 
 
     /**
@@ -196,25 +196,25 @@ private:
     void computeMinDistanceLines(
         const std::vector<const geom::LineString*>& lines0,
         const std::vector<const geom::LineString*>& lines1,
-        std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom);
+        std::array<GeometryLocation, 2> & locGeom);
 
     void computeMinDistancePoints(
         const std::vector<const geom::Point*>& points0,
         const std::vector<const geom::Point*>& points1,
-        std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom);
+        std::array<GeometryLocation, 2> & locGeom);
 
     void computeMinDistanceLinesPoints(
         const std::vector<const geom::LineString*>& lines0,
         const std::vector<const geom::Point*>& points1,
-        std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom);
+        std::array<GeometryLocation, 2> & locGeom);
 
     void computeMinDistance(const geom::LineString* line0,
                             const geom::LineString* line1,
-                            std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom);
+                            std::array<GeometryLocation, 2> & locGeom);
 
     void computeMinDistance(const geom::LineString* line,
                             const geom::Point* pt,
-                            std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom);
+                            std::array<GeometryLocation, 2> & locGeom);
 };
 
 

--- a/include/geos/operation/distance/GeometryLocation.h
+++ b/include/geos/operation/distance/GeometryLocation.h
@@ -62,6 +62,13 @@ public:
      */
     static const int INSIDE_AREA = -1;
 
+    GeometryLocation() :
+        component(nullptr),
+        segIndex(0),
+        inside_area(false),
+        pt()
+    {}
+
     /** \brief
      * Constructs a GeometryLocation specifying a point on a geometry,
      * as well as the segment that the point is on (or INSIDE_AREA if

--- a/src/geom/util/LinearComponentExtracter.cpp
+++ b/src/geom/util/LinearComponentExtracter.cpp
@@ -32,6 +32,10 @@ LinearComponentExtracter::LinearComponentExtracter(std::vector<const LineString*
 void
 LinearComponentExtracter::getLines(const Geometry& geom, std::vector<const LineString*>& ret)
 {
+    if (geom.getDimension() == Dimension::P) {
+        return;
+    }
+
     LinearComponentExtracter lce(ret);
     geom.apply_ro(&lce);
 }

--- a/src/geom/util/PointExtracter.cpp
+++ b/src/geom/util/PointExtracter.cpp
@@ -28,6 +28,10 @@ namespace util { // geos.geom.util
 void
 PointExtracter::getPoints(const Geometry& geom, Point::ConstVect& ret)
 {
+    if (!geom.hasDimension(Dimension::P)) {
+        return;
+    }
+
     PointExtracter pe(ret);
     geom.apply_ro(&pe);
 }
@@ -44,16 +48,16 @@ PointExtracter::PointExtracter(Point::ConstVect& newComps)
 void
 PointExtracter::filter_rw(Geometry* geom)
 {
-    if(const Point* p = dynamic_cast<const Point*>(geom)) {
-        comps.push_back(p);
+    if (geom->getGeometryTypeId() == GEOS_POINT) {
+        comps.push_back(static_cast<const Point*>(geom));
     }
 }
 
 void
 PointExtracter::filter_ro(const Geometry* geom)
 {
-    if(const Point* p = dynamic_cast<const Point*>(geom)) {
-        comps.push_back(p);
+    if (geom->getGeometryTypeId() == GEOS_POINT) {
+        comps.push_back(static_cast<const Point*>(geom));
     }
 }
 }

--- a/src/geom/util/PolygonExtracter.cpp
+++ b/src/geom/util/PolygonExtracter.cpp
@@ -27,6 +27,10 @@ namespace util { // geos.geom.util
 void
 PolygonExtracter::getPolygons(const Geometry& geom, std::vector<const Polygon*>& ret)
 {
+    if (!geom.hasDimension(Dimension::A)) {
+        return;
+    }
+
     PolygonExtracter pe(ret);
     geom.apply_ro(&pe);
 }

--- a/src/operation/distance/ConnectedElementLocationFilter.cpp
+++ b/src/operation/distance/ConnectedElementLocationFilter.cpp
@@ -35,7 +35,7 @@ namespace operation { // geos.operation
 namespace distance { // geos.operation.distance
 
 /*public*/
-std::vector<std::unique_ptr<GeometryLocation>>
+std::vector<GeometryLocation>
 ConnectedElementLocationFilter::getLocations(const Geometry* geom)
 {
     ConnectedElementLocationFilter c;
@@ -51,7 +51,7 @@ ConnectedElementLocationFilter::filter_ro(const Geometry* geom)
             (typeid(*geom) == typeid(LineString)) ||
             (typeid(*geom) == typeid(LinearRing)) ||
             (typeid(*geom) == typeid(Polygon))) {
-        locations.emplace_back(new GeometryLocation(geom, 0, *(geom->getCoordinate())));
+        locations.emplace_back(geom, 0, *(geom->getCoordinate()));
     }
 }
 
@@ -64,7 +64,7 @@ ConnectedElementLocationFilter::filter_rw(Geometry* geom)
             (typeid(*geom) == typeid(LineString)) ||
             (typeid(*geom) == typeid(LinearRing)) ||
             (typeid(*geom) == typeid(Polygon))) {
-        locations.emplace_back(new GeometryLocation(geom, 0, *(geom->getCoordinate())));
+        locations.emplace_back(geom, 0, *(geom->getCoordinate()));
     }
 }
 

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -128,26 +128,26 @@ DistanceOp::nearestPoints()
     auto& locs = minDistanceLocation;
 
     // Empty input geometries result in this behaviour
-    if(locs[0] == nullptr || locs[1] == nullptr) {
+    if(locs[0].getGeometryComponent() == nullptr || locs[1].getGeometryComponent() == nullptr) {
         // either both or none are set..
-        assert(locs[0] == nullptr && locs[1] == nullptr);
+        assert(locs[0].getGeometryComponent() == nullptr && locs[1].getGeometryComponent() == nullptr);
 
         return nullptr;
     }
 
     auto nearestPts = detail::make_unique<CoordinateSequence>(2u);
-    nearestPts->setAt(locs[0]->getCoordinate(), 0);
-    nearestPts->setAt(locs[1]->getCoordinate(), 1);
+    nearestPts->setAt(locs[0].getCoordinate(), 0);
+    nearestPts->setAt(locs[1].getCoordinate(), 1);
 
     return nearestPts;
 }
 
 void
-DistanceOp::updateMinDistance(std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom, bool flip)
+DistanceOp::updateMinDistance(std::array<GeometryLocation, 2> & locGeom, bool flip)
 {
     // if not set then don't update
-    if(locGeom[0] == nullptr) {
-        assert(locGeom[1] == nullptr);
+    if(locGeom[0].getGeometryComponent() == nullptr) {
+        assert(locGeom[1].getGeometryComponent() == nullptr);
 #if GEOS_DEBUG
         std::cerr << "updateMinDistance called with loc[0] == null and loc[1] == null" << std::endl;
 #endif
@@ -210,15 +210,15 @@ DistanceOp::computeContainmentDistance()
     // Expected to fill minDistanceLocation items
     // if minDistance <= terminateDistance
 
-    std::array<std::unique_ptr<GeometryLocation>, 2> locPtPoly;
+    std::array<GeometryLocation, 2> locPtPoly;
     // test if either geometry has a vertex inside the other
     if(! polys1.empty()) {
         auto insideLocs0 = ConnectedElementLocationFilter::getLocations(geom[0]);
         computeInside(insideLocs0, polys1, locPtPoly);
 
         if(minDistance <= terminateDistance) {
-            assert(locPtPoly[0]);
-            assert(locPtPoly[1]);
+            assert(locPtPoly[0].getGeometryComponent());
+            assert(locPtPoly[1].getGeometryComponent());
 
             minDistanceLocation[0] = std::move(locPtPoly[0]);
             minDistanceLocation[1] = std::move(locPtPoly[1]);
@@ -240,8 +240,8 @@ DistanceOp::computeContainmentDistance()
         computeInside(insideLocs1, polys0, locPtPoly);
         if(minDistance <= terminateDistance) {
             // flip locations, since we are testing geom 1 VS geom 0
-            assert(locPtPoly[0]);
-            assert(locPtPoly[1]);
+            assert(locPtPoly[0].getGeometryComponent());
+            assert(locPtPoly[1].getGeometryComponent());
 
             minDistanceLocation[0] = std::move(locPtPoly[1]);
             minDistanceLocation[1] = std::move(locPtPoly[0]);
@@ -254,18 +254,18 @@ DistanceOp::computeContainmentDistance()
 
 /*private*/
 void
-DistanceOp::computeInside(std::vector<std::unique_ptr<GeometryLocation>> & locs,
+DistanceOp::computeInside(std::vector<GeometryLocation> & locs,
                           const Polygon::ConstVect& polys,
-                          std::array<std::unique_ptr<GeometryLocation>, 2> & locPtPoly)
+                          std::array<GeometryLocation, 2> & locPtPoly)
 {
     for(auto& loc : locs) {
         for(const auto& poly : polys) {
-            const auto& pt = loc->getCoordinate();
+            const auto& pt = loc.getCoordinate();
 
 			if (Location::EXTERIOR != ptLocator.locate(pt, static_cast<const Geometry*>(poly))) {
 				minDistance = 0.0;
 				locPtPoly[0] = std::move(loc);
-				locPtPoly[1].reset(new GeometryLocation(poly, pt));
+                locPtPoly[1] = GeometryLocation(poly, pt);
 				return;
 			}
         }
@@ -279,7 +279,7 @@ DistanceOp::computeFacetDistance()
     using geom::util::LinearComponentExtracter;
     using geom::util::PointExtracter;
 
-    std::array<std::unique_ptr<GeometryLocation>, 2> locGeom;
+    std::array<GeometryLocation, 2> locGeom;
 
     /*
      * Geometries are not wholly inside, so compute distance from lines
@@ -314,8 +314,8 @@ DistanceOp::computeFacetDistance()
     std::cerr << "PointExtracter found " << pts1.size() << " points in geometry 2" << std::endl;
 #endif
 
-    locGeom[0] = nullptr;
-    locGeom[1] = nullptr;
+    locGeom[0] = GeometryLocation();
+    locGeom[1] = GeometryLocation();
     computeMinDistanceLinesPoints(lines0, pts1, locGeom);
     updateMinDistance(locGeom, false);
     if(minDistance <= terminateDistance) {
@@ -332,8 +332,8 @@ DistanceOp::computeFacetDistance()
     std::cerr << "PointExtracter found " << pts0.size() << " points in geometry 1" << std::endl;
 #endif
 
-    locGeom[0] = nullptr;
-    locGeom[1] = nullptr;
+    locGeom[0] = GeometryLocation();
+    locGeom[1] = GeometryLocation();
     computeMinDistanceLinesPoints(lines1, pts0, locGeom);
     updateMinDistance(locGeom, true);
     if(minDistance <= terminateDistance) {
@@ -343,8 +343,8 @@ DistanceOp::computeFacetDistance()
         return;
     }
 
-    locGeom[0] = nullptr;
-    locGeom[1] = nullptr;
+    locGeom[0] = GeometryLocation();
+    locGeom[1] = GeometryLocation();
     computeMinDistancePoints(pts0, pts1, locGeom);
     updateMinDistance(locGeom, false);
 
@@ -358,7 +358,7 @@ void
 DistanceOp::computeMinDistanceLines(
     const LineString::ConstVect& lines0,
     const LineString::ConstVect& lines1,
-    std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom)
+    std::array<GeometryLocation, 2> & locGeom)
 {
     for(const LineString* line0 : lines0) {
         for(const LineString* line1 : lines1) {
@@ -379,7 +379,7 @@ void
 DistanceOp::computeMinDistancePoints(
     const Point::ConstVect& points0,
     const Point::ConstVect& points1,
-    std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom)
+    std::array<GeometryLocation, 2> & locGeom)
 {
     for(const Point* pt0 : points0) {
         for(const Point* pt1 : points1) {
@@ -400,8 +400,8 @@ DistanceOp::computeMinDistancePoints(
             if(dist < minDistance) {
                 minDistance = dist;
                 // this is wrong - need to determine closest points on both segments!!!
-                locGeom[0].reset(new GeometryLocation(pt0, 0, *(pt0->getCoordinate())));
-                locGeom[1].reset(new GeometryLocation(pt1, 0, *(pt1->getCoordinate())));
+                locGeom[0] = GeometryLocation(pt0, 0, *(pt0->getCoordinate()));
+                locGeom[1] = GeometryLocation(pt1, 0, *(pt1->getCoordinate()));
             }
 
             if(minDistance <= terminateDistance) {
@@ -416,7 +416,7 @@ void
 DistanceOp::computeMinDistanceLinesPoints(
     const LineString::ConstVect& lines,
     const Point::ConstVect& points,
-    std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom)
+    std::array<GeometryLocation, 2> & locGeom)
 {
     for(const LineString* line : lines) {
         for(const Point* pt : points) {
@@ -437,7 +437,7 @@ void
 DistanceOp::computeMinDistance(
     const LineString* line0,
     const LineString* line1,
-    std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom)
+    std::array<GeometryLocation, 2> & locGeom)
 {
     using geos::algorithm::Distance;
 
@@ -484,8 +484,8 @@ DistanceOp::computeMinDistance(
                 LineSegment seg1{Coordinate(p10), Coordinate(p11)};
                 auto closestPt = seg0.closestPoints(seg1);
 
-                locGeom[0].reset(new GeometryLocation(line0, i, closestPt[0]));
-                locGeom[1].reset(new GeometryLocation(line1, j, closestPt[1]));
+                locGeom[0] = GeometryLocation(line0, i, closestPt[0]);
+                locGeom[1] = GeometryLocation(line1, j, closestPt[1]);
             }
             if(minDistance <= terminateDistance) {
                 return;
@@ -498,7 +498,7 @@ DistanceOp::computeMinDistance(
 void
 DistanceOp::computeMinDistance(const LineString* line,
                                const Point* pt,
-                               std::array<std::unique_ptr<GeometryLocation>, 2> & locGeom)
+                               std::array<GeometryLocation, 2> & locGeom)
 {
     using geos::algorithm::Distance;
 
@@ -524,8 +524,8 @@ DistanceOp::computeMinDistance(const LineString* line,
             Coordinate segClosestPoint;
             seg.closestPoint(*coord, segClosestPoint);
 
-            locGeom[0].reset(new GeometryLocation(line, i, segClosestPoint));
-            locGeom[1].reset(new GeometryLocation(pt, 0, *coord));
+            locGeom[0] = GeometryLocation(line, i, segClosestPoint);
+            locGeom[1] = GeometryLocation(pt, 0, *coord);
         }
         if(minDistance <= terminateDistance) {
             return;


### PR DESCRIPTION
- Add short-circuits to Extracter classes
- Avoid heap allocation of GeometryLocation

main:
```
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_PointPointDistance       2.15 ms         2.15 ms          315
BM_PointLineDistance        60.4 ms         60.4 ms           11
BM_LineLineDistance         41.5 ms         41.5 ms           17
```

this PR:
```
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_PointPointDistance       2.10 ms         2.10 ms          329
BM_PointLineDistance        39.5 ms         39.5 ms           18
BM_LineLineDistance         35.0 ms         35.0 ms           20
```