### PR TITLE
GEOSLineSubstring: Avoid crash with NaN length fraction

### DIFF
--- a/src/linearref/LengthIndexedLine.cpp
+++ b/src/linearref/LengthIndexedLine.cpp
@@ -57,6 +57,13 @@ LengthIndexedLine::extractPoint(double index, double offsetDistance) const
 std::unique_ptr<Geometry>
 LengthIndexedLine::extractLine(double startIndex, double endIndex) const
 {
+    if (std::isnan(startIndex)) {
+        throw util::IllegalArgumentException("startIndex is NaN");
+    }
+    if (std::isnan(endIndex)) {
+        throw util::IllegalArgumentException("endIndex is NaN");
+    }
+
     const LocationIndexedLine lil(linearGeom);
     const double startIndex2 = clampIndex(startIndex);
     const double endIndex2 = clampIndex(endIndex);

--- a/tests/unit/capi/GEOSInterpolateTest.cpp
+++ b/tests/unit/capi/GEOSInterpolateTest.cpp
@@ -72,4 +72,14 @@ void object::test<4>
     ensure_geometry_equals(result_, expected_);
 }
 
+// ensure NaN argument does not crash
+template<>
+template<>
+void object::test<5>
+()
+{
+    geom1_ = GEOSGeomFromWKT("LINESTRING (0 0, 1 1)");
+    result_ = GEOSInterpolate(geom1_, std::numeric_limits<double>::quiet_NaN());
+}
+
 } // namespace tut

--- a/tests/unit/capi/GEOSLineSubstringTest.cpp
+++ b/tests/unit/capi/GEOSLineSubstringTest.cpp
@@ -131,5 +131,20 @@ void object::test<7>()
     ensure("curved geometries not supported", result_ == nullptr);
 }
 
+// NaN start fraction
+// https://github.com/libgeos/geos/issues/1077
+template<>
+template<>
+void object::test<8>
+()
+{
+    input_ = fromWKT("LINESTRING EMPTY");
+    double start = std::numeric_limits<double>::quiet_NaN();
+    double end = 0.1;
+    result_ = GEOSLineSubstring(input_, start, end);
+
+    ensure(result_ == nullptr);
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSLineSubstringTest.cpp
+++ b/tests/unit/capi/GEOSLineSubstringTest.cpp
@@ -146,5 +146,16 @@ void object::test<8>
     ensure(result_ == nullptr);
 }
 
+template<>
+template<>
+void object::test<9>
+()
+{
+    input_ = fromWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))");
+    result_ = GEOSLineSubstring(input_, 0.2, 0.3);
+
+    ensure(result_ == nullptr);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Fixes https://github.com/libgeos/geos/issues/1077