### PR TITLE
IntersectionMatrix: Ignore patterns longer than 9 characters

### DIFF
--- a/src/geom/IntersectionMatrix.cpp
+++ b/src/geom/IntersectionMatrix.cpp
@@ -144,7 +144,7 @@ IntersectionMatrix::set(Location row, Location col, int dimensionValue)
 void
 IntersectionMatrix::set(const std::string& dimensionSymbols)
 {
-    auto limit = dimensionSymbols.length();
+    auto limit = std::min(dimensionSymbols.length(), static_cast<std::size_t>(9));
 
     for(std::size_t i = 0; i < limit; i++) {
         auto row = i / firstDim;

--- a/tests/unit/capi/GEOSRelatePatternMatchTest.cpp
+++ b/tests/unit/capi/GEOSRelatePatternMatchTest.cpp
@@ -78,5 +78,18 @@ void object::test<5>
     ensure_equals(ret, char(0));
 }
 
+// invalid DE-9IM argument
+// https://github.com/libgeos/geos/issues/1084
+template<>
+template<>
+void object::test<6>
+()
+{
+    const char* mat = "0000000000";
+    ensure_equals(strlen(mat), 10u); // not a valid DE-9IM!
+
+    GEOSRelatePatternMatch(mat,  "111111111");
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSRelatePatternTest.cpp
+++ b/tests/unit/capi/GEOSRelatePatternTest.cpp
@@ -33,7 +33,7 @@ void object::test<1>()
 
 template<>
 template<>
-void object::test<11>()
+void object::test<2>()
 {
     geom1_ = fromWKT("CIRCULARSTRING (0 0, 1 1, 2 0)");
     geom2_ = fromWKT("LINESTRING (1 0, 2 1)");
@@ -43,6 +43,27 @@ void object::test<11>()
 
     ensure_equals("curved geometry not supported", GEOSRelatePattern(geom1_, geom2_, "0********"), 2);
     ensure_equals("curved geometry not supported", GEOSRelatePattern(geom2_, geom1_, "0********"), 2);
+}
+
+// invalid DE-9IM
+template<>
+template<>
+void object::test<3>()
+{
+    geom1_ = fromWKT("POINT(1 2)");
+    geom2_ = fromWKT("POINT(1 2)");
+
+    ensure(geom1_);
+    ensure(geom2_);
+
+    // pattern too long
+    ensure_equals(2, GEOSRelatePattern(geom1_, geom2_, "0FFFFF2120000000000000000000"));
+
+    // pattern too short
+    ensure_equals(2, GEOSRelatePattern(geom1_, geom2_, "0F"));
+
+    // pattern has invalid characters
+    ensure_equals(0, GEOSRelatePattern(geom1_, geom2_, "123456789"));
 }
 
 } // namespace tut


### PR DESCRIPTION
Fixes https://github.com/libgeos/geos/issues/1084