### PR TITLE
LineIntersector: Fixed invalid read on mixed-dimensionality inputs

### DIFF
--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -597,7 +597,7 @@ private:
 #endif
                 ptInt = static_cast<const C1&>(nearest);
             } else {
-                if (&ptInt == static_cast<const geom::CoordinateXY*>(&p1) || &ptInt == static_cast<const geom::CoordinateXY*>(&p2)) {
+                if (&nearest == static_cast<const geom::CoordinateXY*>(&p1) || &nearest == static_cast<const geom::CoordinateXY*>(&p2)) {
                     ptInt = static_cast<const C1&>(nearest);
                 } else {
                     ptInt = static_cast<const C2&>(nearest);

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -589,8 +589,20 @@ private:
     {
         geom::CoordinateXYZM ptInt(Intersection::intersection(p1, p2, q1, q2));
         if (ptInt.isNull()) {
-            // FIXME need to cast to correct type in mixed-dimensionality case
-            ptInt = static_cast<const C1&>(nearestEndpoint(p1, p2, q1, q2));
+            const geom::CoordinateXY& nearest = nearestEndpoint(p1, p2, q1, q2);
+#if __cplusplus >= 201703L
+            if constexpr (std::is_same<C1, C2>::value) {
+#else
+            if (std::is_same<C1, C2>::value) {
+#endif
+                ptInt = static_cast<const C1&>(nearest);
+            } else {
+                if (&ptInt == static_cast<const geom::CoordinateXY*>(&p1) || &ptInt == static_cast<const geom::CoordinateXY*>(&p2)) {
+                    ptInt = static_cast<const C1&>(nearest);
+                } else {
+                    ptInt = static_cast<const C2&>(nearest);
+                }
+            }
         }
         return ptInt;
     }

--- a/tests/unit/capi/GEOSIntersectionTest.cpp
+++ b/tests/unit/capi/GEOSIntersectionTest.cpp
@@ -157,5 +157,15 @@ void object::test<8>()
     ensure("curved geometry not supported", result_ == nullptr);
 }
 
+template<>
+template<>
+void object::test<9>()
+{
+    geom1_ = fromWKT("GEOMETRYCOLLECTION(POINT(0 0 59.083333333333336), POINT(1 1 59.083333333333336), LINESTRING(2 4 111 1, 2 223 22 2), POLYGON((42 -2.222222223222222e+155 111 1, 2 3 1 1, 2 4 111 NaN, 42 -2.222222223222222e+155 111 NaN)), POLYGON((2.2222222212222224e+149 4 111 1, 42 -2.222222222222222e+149 22 2, 2 4 111 1, 22 2222222222222223 22 NaN, 2.2222222212222224e+149 4 111 NaN)))");
+    geom2_ = fromWKT("LINESTRING (1.6409301755752343e+149 -5.298190649085575e+148, 1.6666666660752404e+149 -5.55555555396982e+148)");
+
+    result_ = GEOSIntersection(geom1_, geom2_);
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSIntersectionTest.cpp
+++ b/tests/unit/capi/GEOSIntersectionTest.cpp
@@ -157,6 +157,9 @@ void object::test<8>()
     ensure("curved geometry not supported", result_ == nullptr);
 }
 
+// https://github.com/libgeos/geos/issues/1074
+// Make sure no crash occurs when LineIntersector has mixed-dimensionality
+// inputs and substitutes a segment endpoint for intersection point
 template<>
 template<>
 void object::test<9>()
@@ -165,6 +168,9 @@ void object::test<9>()
     geom2_ = fromWKT("LINESTRING (1.6409301755752343e+149 -5.298190649085575e+148, 1.6666666660752404e+149 -5.55555555396982e+148)");
 
     result_ = GEOSIntersection(geom1_, geom2_);
+    ensure(result_ != nullptr);
+    ensure("HasZ", GEOSHasZ(result_));
+    ensure("HasM", GEOSHasM(result_));
 }
 
 } // namespace tut


### PR DESCRIPTION
Fixes https://github.com/libgeos/geos/issues/1074