### PR TITLE
fix building in C++23 language mode

### DIFF
--- a/include/geos/constants.h
+++ b/include/geos/constants.h
@@ -29,6 +29,7 @@ typedef __int64 int64;
 #include <cmath>
 #include <limits>
 #include <cinttypes>
+#include <cstddef> // for std::size_t
 
 namespace geos {
 

--- a/include/geos/coverage/CoverageRingEdges.h
+++ b/include/geos/coverage/CoverageRingEdges.h
@@ -17,6 +17,7 @@
 
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/LineSegment.h>
+#include <geos/coverage/CoverageEdge.h> // to materialize CoverageEdge
 
 #include <set>
 #include <map>

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -34,6 +34,7 @@
 #include <geos/geom/Envelope.h>
 #include <geos/geom/Dimension.h> // for Dimension::DimensionType
 #include <geos/geom/GeometryComponentFilter.h> // for inheritance
+#include <geos/geom/CoordinateSequence.h> // to materialize CoordinateSequence
 
 #include <algorithm>
 #include <string>

--- a/include/geos/operation/buffer/BufferOp.h
+++ b/include/geos/operation/buffer/BufferOp.h
@@ -25,6 +25,7 @@
 
 #include <geos/export.h>
 #include <geos/operation/buffer/BufferParameters.h> // for enum values
+#include <geos/geom/Geometry.h> // to materialize Geometry
 
 #include <geos/util/TopologyException.h> // for composition
 

--- a/include/geos/operation/buffer/OffsetCurveSection.h
+++ b/include/geos/operation/buffer/OffsetCurveSection.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <geos/export.h>
+#include <geos/geom/CoordinateSequence.h> // to materialize CoordinateSequence
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
This commit resolves issues with building GEOS in C++23 language mode (both -std=c++23 and -std=gnu++23 are supported). 

In particular, this resolves the following issues:
1. https://github.com/libgeos/geos/issues/1120
2. https://github.com/libgeos/geos/issues/1121
 