### PR TITLE
Fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -218,7 +218,7 @@
   - Autoconf build system is dropped in favour of CMake
     See README.md and INSTALL.md for examples of usage
   - Libtool is no longer used for in favour of CMake
-    Therefor libgeos.la is no longer built/installed
+    Therefore libgeos.la is no longer built/installed
   - #1094, #1090: Drop inlines.cpp to address duplicate symbols on many platforms
     (Regina Obe)
   - GH475: Do not return NaN from GEOSProjectNormalized_r (Paul Ramsey)
@@ -243,7 +243,7 @@
   - Update geos-config tool for consistency
     and escape paths (https://git.osgeo.org/gitea/geos/geos/pulls/99)
     changes mostly affect CMake MSVC builds (#1015, Mike Taves)
-  - Testing on Rasberry Pi 32-bit (berrie) (#1017, Bruce Rindahl, Regina Obe)
+  - Testing on Raspberry Pi 32-bit (berrie) (#1017, Bruce Rindahl, Regina Obe)
   - Replace ttmath with JTS DD double-double implementation (Paul Ramsey)
   - Fix bug in DistanceOp for geometries with empty components (#1026, Paul Ramsey)
   - Remove undefined behaviour in CAPI (#1021, Greg Troxel)
@@ -495,7 +495,7 @@ See 3.7.0 notes
     - Fix area boundary return from GEOSPointOnSurface (#623)
     - Speedup GEOSWKBReader_read (#621)
     - Fix RobustLineIntersector handling of invalid intersection points (#622)
-    - Reduce likelyhood of invalid output from snap operation (#629, #501)
+    - Reduce likelihood of invalid output from snap operation (#629, #501)
     - Reduce memory fragmentation of prepared Polygon/Point intersection op
     - Fix mingw64 compile (#630)
     - Fix bug in HotPixel constructor (#635)
@@ -526,7 +526,7 @@ See 3.7.0 notes
 2012-11-15 -- that's Post-GIS day !
 
 - Bug fixes / improvements
-    - Add support for testing with phpunit 3.6 (not loosing support for 3.4)
+    - Add support for testing with phpunit 3.6 (not losing support for 3.4)
     - Segfault from intersection (#586, #598, #599)
 
 ## Changes in 3.3.5
@@ -607,7 +607,7 @@ See 3.7.0 notes
           GEOSGeom_createEmptyPolygon, GEOSGeom_createEmptyCollection
   - CAPI: GEOSGeom_extractUniquePoints
   - CAPI: GEOSGetGeometryN support for single geometries
-  - CAPI: GEOSPolygonize_full to return all informations computed by
+  - CAPI: GEOSPolygonize_full to return all information computed by
           the polygonizer
   - CAPI: GEOSOrientationIndex
   - CAPI: GEOSSharedPaths to find shared paths and their orientation
@@ -700,7 +700,7 @@ See 3.7.0 notes
 	- New operation/predicate package
 	- Added CGAlgorithms::isPointInRing() version working with
 	  Coordinate::ConstVect type (faster!)
-	- Added getAt(int pos, Coordinate &to) funtion to CoordinateSequence
+	- Added getAt(int pos, Coordinate &to) function to CoordinateSequence
 	  class.
 	- Moved GetNumGeometries() and GetGeometryN() interfaces
 	  from GeometryCollection to Geometry class.
@@ -772,12 +772,12 @@ See 3.7.0 notes
 	- Namespaces mapping JTS packages
 	- Renamed classes after JTS names (namespaces use made this possible
 	  w/out name clashes)
-	- Splitted headers, for build speedup and possible API reduction.
+	- Split headers, for build speedup and possible API reduction.
 	- Moved source/bigtest and source/test to tests/bigtest
 	  and test/xmltester
 	- Moved C-API in it's own top-level dir capi/
 	- Reworked automake scripts to produce a static lib for each subdir
-	  and then link all subsystem's libs togheter
+	  and then link all subsystem's libs together
 	- Renamed DefaultCoordinateSequence to CoordinateArraySequence.
 	- Renamed OverlayOp opcodes by prepending the 'op' prefix, and
 	  given the enum a name (OpCode) for type-safety.
@@ -813,7 +813,7 @@ See 3.7.0 notes
 	  	  use unsigned int rather then int
 	- Changed EdgeEndStar to maintain a single container for EdgeEnds
 	- Changed PlanarGraph::addEdges to take a const vector by ref
-	  rathern then a non-const vector by pointer
+	  rather then a non-const vector by pointer
 	- Changed EdgeList::addAll to take a const vector by ref
 	  rather then a non-const vector by pointer
 	- Added apply_rw(CoordinateFilter *) and apply_ro(CoordinateFilter *)

--- a/benchmarks/capi/CMakeLists.txt
+++ b/benchmarks/capi/CMakeLists.txt
@@ -9,7 +9,7 @@
 # See the COPYING file for more information.
 ################################################################################
 add_executable(perf_memleak_mp_prep memleak_mp_prep.c)
-# test_perf_memleak_mp_prep is not dependant against geos target,
+# test_perf_memleak_mp_prep is not dependent against geos target,
 # but geos_c only, so need explicit include directories.
 target_include_directories(perf_memleak_mp_prep
   PUBLIC

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -146,7 +146,7 @@ extern "C" {
 
     /****************************************************************
     ** relate()-related functions
-    ** return 0 = false, 1 = true, 2 = error occured
+    ** return 0 = false, 1 = true, 2 = error occurred
     **
     */
     char

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -2666,7 +2666,7 @@ extern int GEOS_DLL GEOSGetSRID(const GEOSGeometry* g);
 /**
 * Return the anonymous "user data" for this geometry.
 * User data must be managed by the caller, and is not freed when
-* the geometry is destoryed.
+* the geometry is destroyed.
 * \param g Input geometry
 * \return A void* to the user data, caller is responsible for
 *         casting to the appropriate type.
@@ -4060,7 +4060,7 @@ extern GEOSGeometry GEOS_DLL *GEOSConcaveHull(
 * The concave hull is constructed by removing the longest outer edges
 * of the Delaunay Triangulation of the space between the polygons,
 * until the specified maximm edge length is reached.
-* A large value produces the convex hull, 0 produces the hull of maximim concaveness.
+* A large value produces the convex hull, 0 produces the hull of maximum concaveness.
 *
 * \param g The input geometry
 * \param length The maximum edge length (0 or greater)
@@ -4495,7 +4495,7 @@ extern GEOSGeometry GEOS_DLL *GEOSPolygonizer_getCutEdges(
 
 /**
 * Perform the polygonization as GEOSPolygonize() and return the
-* polygonal result as well as all extra ouputs.
+* polygonal result as well as all extra outputs.
 *
 * \param[in] input A single geometry with all the input lines to polygonize.
 * \param[out] cuts Pointer to hold "cut edges", connected on both ends but not part of output. Caller must free.
@@ -4715,7 +4715,7 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXY(
 * \param input An input geometry
 * \param snap_target A geometry to snap the input to
 * \param tolerance Snapping tolerance
-* \return The snapped verion of the input. NULL on exception.
+* \return The snapped version of the input. NULL on exception.
 * Caller is responsible for freeing with GEOSGeom_destroy().
 *
 * \since 3.3
@@ -5268,7 +5268,7 @@ extern GEOSSTRtree GEOS_DLL *GEOSSTRtree_create(size_t nodeCapacity);
 * Construct an STRtree from items that have been inserted. Once constructed,
 * no more items may be inserted into the tree. Functions that require a
 * constructed tree will build it automatically, so there is no need to call
-* `GEOSSTRtree_build` unless it is desired to explicity construct the tree
+* `GEOSSTRtree_build` unless it is desired to explicitly construct the tree
 * in a certain section of code or using a certain thread.
 *
 * \param tree the \ref GEOSSTRtree to apply the build to

--- a/include/geos/algorithm/ConvexHull.h
+++ b/include/geos/algorithm/ConvexHull.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <cassert>
 
-// FIXME: avoid using Cordinate:: typedefs to avoid full include
+// FIXME: avoid using Coordinate:: typedefs to avoid full include
 #include <geos/algorithm/ConvexHull.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateSequence.h>
@@ -153,7 +153,7 @@ private:
 
     /**
      * Write in 'cleaned' a version of 'input' with collinear
-     * vertexes removed.
+     * vertices removed.
      */
     void cleanRing(const geom::Coordinate::ConstVect& input,
                    geom::Coordinate::ConstVect& cleaned);

--- a/include/geos/algorithm/HCoordinate.h
+++ b/include/geos/algorithm/HCoordinate.h
@@ -72,7 +72,7 @@ public:
 
     /** \brief
      * Constructs a homogeneous coordinate which is the intersection
-     * of the lines define by the homogenous coordinates represented
+     * of the lines define by the homogeneous coordinates represented
      * by two [Coordinates](@ref geom::Coordinate).
      *
      * @param p1

--- a/include/geos/geom/CoordinateList.h
+++ b/include/geos/geom/CoordinateList.h
@@ -46,7 +46,7 @@ namespace geom { // geos::geom
 
 /** \brief
  * A list of {@link Coordinate}s, which may
- * be set to prevent repeated coordinates from occuring in the list.
+ * be set to prevent repeated coordinates from occurring in the list.
  *
  * Use this class when fast insertions and removal at arbitrary
  * position is needed.

--- a/include/geos/geom/CoordinateSequences.h
+++ b/include/geos/geom/CoordinateSequences.h
@@ -37,7 +37,7 @@ private:
 public:
     ///
     /// \brief binaryDispatch calls a functor template, explicitly providing the backing types of two CoordinateSequences. The
-    /// CoordinateSequences are not provided to the functor as arguments but can be provided along with any other arugments
+    /// CoordinateSequences are not provided to the functor as arguments but can be provided along with any other arguments
     /// through the `args` argument.
     template<typename F, class... Args>
     static void binaryDispatch(const CoordinateSequence& seq1, const CoordinateSequence& seq2, F& fun, Args... args)

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -126,7 +126,7 @@ public:
     static const GeometryFactory*
     getDefaultInstance();
 
-//Skipped a lot of list to array convertors
+//Skipped a lot of list to array converters
 
     static std::unique_ptr<Point> createPointFromInternalCoord(const Coordinate* coord,
                                         const Geometry* exemplar);
@@ -389,7 +389,7 @@ public:
 
     /// See buildGeometry(std::vector<Geometry *>&) for semantics
     //
-    /// Will clone the geometries accessible trough the iterator.
+    /// Will clone the geometries accessible through the iterator.
     ///
     /// @tparam T an iterator yielding something which casts to const Geometry*
     /// @param from start iterator

--- a/include/geos/geom/IntersectionMatrix.h
+++ b/include/geos/geom/IntersectionMatrix.h
@@ -61,7 +61,7 @@ public:
     IntersectionMatrix();
 
     /** \brief
-     * Overriden constructor.
+     * Overridden constructor.
      *
      * Creates an IntersectionMatrix with the given dimension symbols.
      *

--- a/include/geos/geom/PrecisionModel.h
+++ b/include/geos/geom/PrecisionModel.h
@@ -236,7 +236,7 @@ public:
     /**
     * Computes the grid size for a fixed precision model.
     * This is equal to the reciprocal of the scale factor.
-    * If the grid size has been set explicity (via a negative scale factor)
+    * If the grid size has been set explicitly (via a negative scale factor)
     * it will be returned.
     *
     * @return the grid size at a fixed precision scale.

--- a/include/geos/geom/util/GeometryEditor.h
+++ b/include/geos/geom/util/GeometryEditor.h
@@ -55,7 +55,7 @@ namespace util { // geos.geom.util
  *   this is not checked by the GeometryEditor
  * - the coordinate lists may be changed
  *   (e.g. by adding or deleting coordinates).
- *   The modifed coordinate lists must be consistent with their original
+ *   The modified coordinate lists must be consistent with their original
  *   parent component
  *   (e.g. a LinearRing must always have at least 4 coordinates, and the
  *   first and last coordinate must be equal)

--- a/include/geos/geom/util/GeometryTransformer.h
+++ b/include/geos/geom/util/GeometryTransformer.h
@@ -148,7 +148,7 @@ private:
     bool pruneEmptyGeometry;
 
     /**
-     * `true` if a homogenous collection result
+     * `true` if a homogeneous collection result
      * from a {@link GeometryCollection} should still
      * be a general GeometryCollection
      */

--- a/include/geos/geomgraph/DirectedEdge.h
+++ b/include/geos/geomgraph/DirectedEdge.h
@@ -159,7 +159,7 @@ public:
     };
 
     /** \brief
-     * Tells wheter this edge is a Line
+     * Tells whether this edge is a Line
      *
      * This edge is a line edge if
      * - at least one of the labels is a line label
@@ -169,7 +169,7 @@ public:
     bool isLineEdge();
 
     /** \brief
-     * Tells wheter this edge is an Area
+     * Tells whether this edge is an Area
      *
      * This is an interior Area edge if
      * - its label is an Area label for both Geometries

--- a/include/geos/geomgraph/DirectedEdgeStar.h
+++ b/include/geos/geomgraph/DirectedEdgeStar.h
@@ -117,7 +117,7 @@ public:
     void linkAllDirectedEdges();
 
     /** \brief
-     * Traverse the star of edges, maintaing the current location in the result
+     * Traverse the star of edges, maintaining the current location in the result
      * area at this node (if any).
      *
      * If any L edges are found in the interior of the result, mark them as covered.

--- a/include/geos/index/bintree/Bintree.h
+++ b/include/geos/index/bintree/Bintree.h
@@ -44,7 +44,7 @@ namespace bintree { // geos::index::bintree
  * may be a single point).
  *
  * This implementation does not require specifying the extent of the inserted
- * items beforehand. It will automatically expand to accomodate any extent
+ * items beforehand. It will automatically expand to accommodate any extent
  * of dataset.
  *
  * This index is different to the "Interval Tree of Edelsbrunner"

--- a/include/geos/index/quadtree/Quadtree.h
+++ b/include/geos/index/quadtree/Quadtree.h
@@ -61,7 +61,7 @@ namespace quadtree { // geos::index::quadtree
  * intersection, such as testing other kinds of spatial relationships.
  *
  * This implementation does not require specifying the extent of the inserted
- * items beforehand.  It will automatically expand to accomodate any extent
+ * items beforehand.  It will automatically expand to accommodate any extent
  * of dataset.
  *
  * This data structure is also known as an <i>MX-CIF quadtree</i>

--- a/include/geos/io/GeoJSONReader.h
+++ b/include/geos/io/GeoJSONReader.h
@@ -50,7 +50,7 @@ class GEOS_DLL GeoJSONReader {
 public:
 
     /**
-     * \brief Inizialize parser with given GeometryFactory.
+     * \brief Initialize parser with given GeometryFactory.
      *
      * Note that all Geometry objects created by the
      * parser will contain a pointer to the given factory
@@ -60,7 +60,7 @@ public:
     GeoJSONReader(const geom::GeometryFactory& gf);
 
     /**
-     * \brief Inizialize parser with default GeometryFactory.
+     * \brief Initialize parser with default GeometryFactory.
      *
      */
     GeoJSONReader();

--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -88,7 +88,7 @@ public:
 
     WKBReader(geom::GeometryFactory const& f);
 
-    /// Inizialize parser with default GeometryFactory.
+    /// Initialize parser with default GeometryFactory.
     WKBReader();
 
     void setFixStructure(bool doFixStructure);

--- a/include/geos/linearref/LengthIndexedLine.h
+++ b/include/geos/linearref/LengthIndexedLine.h
@@ -157,7 +157,7 @@ public:
      *
      * (The subline must **conform** to the line; that is,
      * all vertices in the subline (except possibly the first and last)
-     * must be vertices of the line and occcur in the same order).
+     * must be vertices of the line and occur in the same order).
      *
      * @param subLine a subLine of the line
      * @return a pair of indices for the start and end of the subline.

--- a/include/geos/namespaces.h
+++ b/include/geos/namespaces.h
@@ -143,7 +143,7 @@ namespace index { // geos.index
 /// formats.
 ///
 /// The Java Topology Suite (JTS) is a Java API that implements a core set of
-/// spatial data operations usin g an explicit precision model and robust
+/// spatial data operations using an explicit precision model and robust
 /// geometric algorithms. JTS is intended to be used in the devel opment of
 /// applications that support the validation, cleaning, integration and
 /// querying of spatial data sets.

--- a/include/geos/noding/Octant.h
+++ b/include/geos/noding/Octant.h
@@ -46,7 +46,7 @@ namespace noding { // geos.noding
  */
 class GEOS_DLL Octant {
 private:
-    Octant() {} // Can't instanciate it
+    Octant() {} // Can't instantiate it
 public:
 
     /**

--- a/include/geos/operation/overlayng/EdgeNodingBuilder.h
+++ b/include/geos/operation/overlayng/EdgeNodingBuilder.h
@@ -110,7 +110,7 @@ private:
     * This is one of:
     *
     * - Fixed precision: a snap-rounding noder (which should be fully robust)
-    * - Floating precision: a conventional nodel (which may be non-robust).
+    * - Floating precision: a conventional model (which may be non-robust).
     *   In this case, a validation step is applied to the output from the noder.
     */
     Noder* getNoder();

--- a/include/geos/operation/polygonize/BuildArea.h
+++ b/include/geos/operation/polygonize/BuildArea.h
@@ -62,7 +62,7 @@ public:
 
     ~BuildArea() = default;
 
-    /** \brief Return the area built fromthe constituent linework of the input geometry. */
+    /** \brief Return the area built from the constituent linework of the input geometry. */
     std::unique_ptr<geom::Geometry> build(const geom::Geometry* geom);
 };
 

--- a/include/geos/operation/polygonize/PolygonizeGraph.h
+++ b/include/geos/operation/polygonize/PolygonizeGraph.h
@@ -196,7 +196,7 @@ private:
 
     EdgeRing* findEdgeRing(PolygonizeDirectedEdge* startDE);
 
-    /* Tese are for memory management */
+    /* These are for memory management */
     std::vector<planargraph::Edge*> newEdges;
     std::vector<planargraph::DirectedEdge*> newDirEdges;
     std::vector<planargraph::Node*> newNodes;

--- a/include/geos/operation/relate/EdgeEndBundle.h
+++ b/include/geos/operation/relate/EdgeEndBundle.h
@@ -81,7 +81,7 @@ protected:
      * on the boundary and in the interior (e.g. a LineString segment
      * lying on
      * top of a Polygon edge.) In this case the Boundary is
-     * given precendence.
+     * given precedence.
      *
      * These observations result in the following rules for computing
      * the ON location:

--- a/include/geos/operation/sharedpaths/SharedPathsOp.h
+++ b/include/geos/operation/sharedpaths/SharedPathsOp.h
@@ -79,12 +79,12 @@ public:
     /// @param sameDirection
     ///   Shared edges having the same direction are pushed
     ///   onto this vector. They'll be of type LineString.
-    ///   Ownership of the edges is tranferred.
+    ///   Ownership of the edges is transferred.
     ///
     /// @param oppositeDirection
     ///   Shared edges having the opposite direction are pushed
     ///   onto this vector. They'll be of type geom::LineString.
-    ///   Ownership of the edges is tranferred.
+    ///   Ownership of the edges is transferred.
     ///
     static void sharedPathsOp(const geom::Geometry& g1,
                               const geom::Geometry& g2,
@@ -106,12 +106,12 @@ public:
     /// @param sameDirection
     ///   Shared edges having the same direction are pushed
     ///   onto this vector. They'll be of type geom::LineString.
-    ///   Ownership of the edges is tranferred.
+    ///   Ownership of the edges is transferred.
     ///
     /// @param oppositeDirection
     ///   Shared edges having the opposite direction are pushed
     ///   onto this vector. They'll be of type geom::LineString.
-    ///   Ownership of the edges is tranferred.
+    ///   Ownership of the edges is transferred.
     ///
     void getSharedPaths(PathList& sameDirection, PathList& oppositeDirection);
 

--- a/include/geos/operation/union/CascadedPolygonUnion.h
+++ b/include/geos/operation/union/CascadedPolygonUnion.h
@@ -73,7 +73,7 @@ private:
 
     /**
     * An alternative way of unioning polygonal geometries
-    * by using <code>bufer(0)</code>.
+    * by using <code>buffer(0)</code>.
     * Only worth using if regular overlay union fails.
     */
     std::unique_ptr<geom::Geometry> unionPolygonsByBuffer(const geom::Geometry* g0, const geom::Geometry* g1);

--- a/include/geos/operation/valid/IndexedNestedPolygonTester.h
+++ b/include/geos/operation/valid/IndexedNestedPolygonTester.h
@@ -70,7 +70,7 @@ private:
     *
     * @param the shell to test
     * @param the polygon to test against
-    * @param coordNested return parametr for found coordinate
+    * @param coordNested return parameter for found coordinate
     * @return an interior segment point, or null if the shell is nested correctly
     */
     static bool findIncidentSegmentNestedPoint(

--- a/include/geos/planargraph/DirectedEdgeStar.h
+++ b/include/geos/planargraph/DirectedEdgeStar.h
@@ -101,7 +101,7 @@ public:
     }
 
     /**
-     * \brief Returns the coordinate for the node at wich this
+     * \brief Returns the coordinate for the node at which this
      * star is based
      */
     geom::Coordinate& getCoordinate() const;

--- a/include/geos/planargraph/Subgraph.h
+++ b/include/geos/planargraph/Subgraph.h
@@ -83,7 +83,7 @@ public:
      *
      * @return a pair with first element being an iterator
      *         to the Edge in set and second element
-     *	       being a boolean value indicating wheter
+     *	       being a boolean value indicating whether
      *	       the Edge has been inserted now or was
      *	       already in the set.
      */

--- a/include/geos/precision/CommonBitsOp.h
+++ b/include/geos/precision/CommonBitsOp.h
@@ -149,7 +149,7 @@ public:
         double distance);
 
     /** \brief
-     * If required, returning the result to the orginal precision
+     * If required, returning the result to the original precision
      * if required.
      *
      * In this current implementation, no rounding is performed on the

--- a/include/geos/precision/GeometryPrecisionReducer.h
+++ b/include/geos/precision/GeometryPrecisionReducer.h
@@ -45,7 +45,7 @@ namespace precision { // geos.precision
  * It can be forced to be reduced pointwise by using setPointwise(boolean).
  * Note that in this case the result geometry may be invalid.
  * Linear and point geometry is always reduced pointwise (i.e. without further change to
- * its topology or stucture), since this does not change validity.
+ * its topology or structure), since this does not change validity.
  *
  * By default the geometry precision model is not changed.
  * This can be overridden by usingsetChangePrecisionModel(boolean).

--- a/include/geos/simplify/TaggedLineSegment.h
+++ b/include/geos/simplify/TaggedLineSegment.h
@@ -20,7 +20,7 @@
  * makes it useless for a TaggedLineSegment to store copies
  * of coordinates. Using pointers would be good enough here.
  * We don't do it to avoid having to break inheritance from
- * LineSegment, which has copies intead. Wheter LineSegment
+ * LineSegment, which has copies instead. Whether LineSegment
  * itself should be refactored can be discussed.
  *  --strk 2006-04-12
  *

--- a/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
+++ b/include/geos/triangulate/quadedge/QuadEdgeSubdivision.h
@@ -110,7 +110,7 @@ public:
      * that encloses a supplied bounding box.
      * A new super-bounding box that contains the triangle is computed and stored.
      *
-     * @param env the bouding box to surround
+     * @param env the bounding box to surround
      * @param tolerance the tolerance value for determining if two sites are equal
      */
     QuadEdgeSubdivision(const geom::Envelope& env, double tolerance);

--- a/include/geos/vend/json.hpp
+++ b/include/geos/vend/json.hpp
@@ -5255,7 +5255,7 @@ auto input_adapter(T (&array)[N]) -> decltype(input_adapter(array, array + N))
 }
 
 // This class only handles inputs of input_buffer_adapter type.
-// It's required so that expressions like {ptr, len} can be implicitely casted
+// It's required so that expressions like {ptr, len} can be implicitly casted
 // to the correct adapter.
 class span_input_adapter
 {
@@ -10030,7 +10030,7 @@ class binary_reader
 
     @return whether conversion completed
 
-    @note This function needs to respect the system's endianess, because
+    @note This function needs to respect the system's endianness, because
           bytes in CBOR, MessagePack, and UBJSON are stored in network order
           (big endian) and therefore need reordering on little endian systems.
     */
@@ -10202,7 +10202,7 @@ class binary_reader
     /// the number of characters read
     std::size_t chars_read = 0;
 
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = little_endianess();
 
     /// the SAX parser
@@ -14345,7 +14345,7 @@ class binary_writer
     @tparam OutputIsLittleEndian Set to true if output data is
                                  required to be little endian
 
-    @note This function needs to respect the system's endianess, because bytes
+    @note This function needs to respect the system's endianness, because bytes
           in CBOR, MessagePack, and UBJSON are stored in network order (big
           endian) and therefore need reordering on little endian systems.
     */
@@ -14428,7 +14428,7 @@ class binary_writer
     }
 
   private:
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = little_endianess();
 
     /// the output
@@ -17528,7 +17528,7 @@ class basic_json
        - If a subtype is given and the binary array contains exactly 1, 2, 4, 8,
          or 16 elements, the fixext family (fixext1, fixext2, fixext4, fixext8)
          is used. For other sizes, the ext family (ext8, ext16, ext32) is used.
-         The subtype is then added as singed 8-bit integer.
+         The subtype is then added as signed 8-bit integer.
        - If no subtype is given, the bin family (bin8, bin16, bin32) is used.
     - BSON
        - If a subtype is given, it is used and added as unsigned 8-bit integer.
@@ -21482,7 +21482,7 @@ class basic_json
           `key()` returns an empty string.
 
     @warning Using `items()` on temporary objects is dangerous. Make sure the
-             object's lifetime exeeds the iteration. See
+             object's lifetime exceeds the iteration. See
              <https://github.com/nlohmann/json/issues/2040> for more
              information.
 

--- a/src/algorithm/CGAlgorithmsDD.cpp
+++ b/src/algorithm/CGAlgorithmsDD.cpp
@@ -80,7 +80,7 @@ CGAlgorithmsDD::orientationIndex(double p1x, double p1y,
 }
 
 
-// inlining this method worsened performance slighly
+// inlining this method worsened performance slightly
 int
 CGAlgorithmsDD::orientationIndex(const CoordinateXY& p1,
                                  const CoordinateXY& p2,

--- a/src/algorithm/RobustDeterminant.cpp
+++ b/src/algorithm/RobustDeterminant.cpp
@@ -52,7 +52,7 @@ RobustDeterminant::signOfDet2x2(double x1, double y1, double x2, double y2)
 {
     // returns -1 if the determinant is negative,
     // returns  1 if the determinant is positive,
-    // retunrs  0 if the determinant is null.
+    // returns  0 if the determinant is null.
     int sign = 1;
     double swap;
 

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -43,7 +43,7 @@ static Profiler* profiler = Profiler::instance();
 // - XYM sequences will be stored as XYZM
 // This prevents incorrect results when an XYZ Coordinate is read from
 // a sequence storing XY or XYM. When GEOS is changed to check
-// coordinate types throughout the libary, this can be undefined to
+// coordinate types throughout the library, this can be undefined to
 // store coordinates efficiently.
 #define GEOS_COORDSEQ_PADZ
 

--- a/src/operation/buffer/BufferBuilder.cpp
+++ b/src/operation/buffer/BufferBuilder.cpp
@@ -539,7 +539,7 @@ BufferBuilder::buffer(const Geometry* g, double distance)
         std::vector<std::unique_ptr<geom::Polygon>> polys = plgnzr.getPolygons();
 
 #if GEOS_DEBUG
-        std::cerr << "Polygonization of noded linework returend: " << polys.size() << " polygons" << std::endl;
+        std::cerr << "Polygonization of noded linework returned: " << polys.size() << " polygons" << std::endl;
 #endif
 
         if ( polys.size() > 1 )

--- a/src/operation/buffer/BufferCurveSetBuilder.cpp
+++ b/src/operation/buffer/BufferCurveSetBuilder.cpp
@@ -339,7 +339,7 @@ BufferCurveSetBuilder::addRingSide(const CoordinateSequence* coord,
     }
     std::vector<CoordinateSequence*> lineList;
     curveBuilder.getRingCurve(coord, side, offsetDistance, lineList);
-    // ASSERT: lineList contains exactly 1 curve (this is teh JTS semantics)
+    // ASSERT: lineList contains exactly 1 curve (this is the JTS semantics)
     if (lineList.size() > 0) {
         const CoordinateSequence* curve = lineList[0];
         /**

--- a/src/operation/buffer/BufferSubgraph.cpp
+++ b/src/operation/buffer/BufferSubgraph.cpp
@@ -71,7 +71,7 @@ BufferSubgraph::create(Node* node)
     addReachable(node);
 
     // We are assuming that dirEdgeList
-    // contains *at leas* ONE forward DirectedEdge
+    // contains *at least* ONE forward DirectedEdge
     finder.findEdge(&dirEdgeList);
 
     rightMostCoord = &(finder.getCoordinate());

--- a/src/operation/buffer/OffsetCurve.cpp
+++ b/src/operation/buffer/OffsetCurve.cpp
@@ -332,13 +332,13 @@ OffsetCurve::matchSegments(
         }
 
         void select(const geom::LineSegment& seg) override {
-            (void)seg; // quiet ununsed variable warning
+            (void)seg; // quiet unused variable warning
             return;
         }
 
         void select(const MonotoneChain& mc, std::size_t segIndex) override
         {
-            (void)mc; // quiet ununsed variable warning
+            (void)mc; // quiet unused variable warning
             /**
             * A curveRingPt segment may match all or only a portion of a single raw segment.
             * There may be multiple curve ring segs that match along the raw segment.
@@ -467,7 +467,7 @@ OffsetCurve::findSectionEnd(
         /**
          *  End section at gap in raw curve.
          *  Only needed for joined curve, since otherwise
-         *  contigous buffer segments can be in same section
+         *  contiguous buffer segments can be in same section
          */
             double locDelta = std::abs(loc[next] - loc[end]);
             if (locDelta > 1)

--- a/src/operation/buffer/SubgraphDepthLocater.cpp
+++ b/src/operation/buffer/SubgraphDepthLocater.cpp
@@ -70,7 +70,7 @@ public:
     }
 
     /**
-     * Defines a comparision operation on DepthSegments
+     * Defines a comparison operation on DepthSegments
      * which orders them left to right
      *
      * <pre>

--- a/src/operation/linemerge/LineSequencer.cpp
+++ b/src/operation/linemerge/LineSequencer.cpp
@@ -309,7 +309,7 @@ LineSequencer::addReverseSubpath(const planargraph::DirectedEdge* de,
     if(expectedClosed) {
         // the path should end at the toNode of this de,
         // otherwise we have an error
-        util::Assert::isTrue(fromNode == endNode, "path not contiguos");
+        util::Assert::isTrue(fromNode == endNode, "path not contiguous");
         //assert(fromNode == endNode);
     }
 

--- a/src/operation/overlayng/OverlayGraph.cpp
+++ b/src/operation/overlayng/OverlayGraph.cpp
@@ -130,7 +130,7 @@ OverlayGraph::createOverlayEdge(const CoordinateSequence* pts, OverlayLabel* lbl
 OverlayLabel*
 OverlayGraph::createOverlayLabel(const Edge* edge)
 {
-    // Instantate OverlayLabel on the std::deque
+    // Instantiate OverlayLabel on the std::deque
     ovLabelQue.emplace_back();
     // Read back a reference
     OverlayLabel& ovl = ovLabelQue.back();

--- a/src/operation/polygonize/BuildArea.cpp
+++ b/src/operation/polygonize/BuildArea.cpp
@@ -98,7 +98,7 @@ static bool ringsEqualAnyDirection(const LinearRing* r1, const LinearRing* r2)
 
     bool equal = true;
 
-    /* Check equals forward (skip first point, we checked it alread) */
+    /* Check equals forward (skip first point, we checked it already) */
     for (size_t i=1; i<npoints; ++i)
     {
         size_t j = ( i + offset ) % npoints;

--- a/src/operation/sharedpaths/SharedPathsOp.cpp
+++ b/src/operation/sharedpaths/SharedPathsOp.cpp
@@ -108,7 +108,7 @@ SharedPathsOp::findLinearIntersections(PathList& to)
 
     auto full = _g1.intersection(&_g2);
 
-    // NOTE: intersection of equal lines yields splitted lines,
+    // NOTE: intersection of equal lines yields split lines,
     //       should we sew them back ?
 
     for(std::size_t i = 0, n = full->getNumGeometries(); i < n; ++i) {

--- a/src/simplify/LinkedLine.cpp
+++ b/src/simplify/LinkedLine.cpp
@@ -128,7 +128,7 @@ LinkedLine::nextCoordinate(std::size_t index) const
 bool
 LinkedLine::hasCoordinate(std::size_t index) const
 {
-    //-- if not a ring, endpoints are alway present
+    //-- if not a ring, endpoints are always present
     if (! m_isRing && (index == 0 || index == m_coord.size() - 1))
         return true;
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ Note some executables have different names.
 
     bin/test_geos_unit [name] [test number]
     
-The test name is the **tut group name** found in the unit test file on a line begining `group` (e.g. like [this](https://github.com/libgeos/geos/blob/main/tests/unit/operation/buffer/BufferOpTest.cpp#L55).
+The test name is the **tut group name** found in the unit test file on a line beginning `group` (e.g. like [this](https://github.com/libgeos/geos/blob/main/tests/unit/operation/buffer/BufferOpTest.cpp#L55).
 
 ### Run all unit tests
 

--- a/tests/unit/algorithm/distance/DiscreteFrechetDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteFrechetDistanceTest.cpp
@@ -160,7 +160,7 @@ void object::test<4>
     runTest("LINESTRING (0 0, 100 0)", "LINESTRING (0 0, 50 50, 100 0)", 0.5, 50.0);
 }
 
-// 5 - test Line Segments revealing distance intialization bug
+// 5 - test Line Segments revealing distance initialization bug
 template<>
 template<>
 void object::test<5>

--- a/tests/unit/capi/GEOSGeom_createRectangleTest.cpp
+++ b/tests/unit/capi/GEOSGeom_createRectangleTest.cpp
@@ -45,7 +45,7 @@ void object::test<2>() {
     GEOSGeom_destroy(geom);
 }
 
-// verify that a rectange is returned if either but not both width and height are 0
+// verify that a rectangle is returned if either but not both width and height are 0
 template <>
 template <>
 void object::test<3>() {

--- a/tests/unit/geom/CoordinateSequenceTest.cpp
+++ b/tests/unit/geom/CoordinateSequenceTest.cpp
@@ -83,7 +83,7 @@ void object::test<1>
     ensure(!sequence.hasM());
 }
 
-// Test of overriden constructor
+// Test of overridden constructor
 template<>
 template<>
 void object::test<2>
@@ -98,7 +98,7 @@ void object::test<2>
 
     ensure("string rep", sequence.toString() != std::string("()"));
 
-    ensure("Every coodinate in the default sequence should be same.", sequence.hasRepeatedPoints());
+    ensure("Every coordinate in the default sequence should be same.", sequence.hasRepeatedPoints());
 
     ensure_equals("default/empty coordinates now 2D", sequence.getDimension(), 2u);
     ensure("no Z", !sequence.hasZ());
@@ -601,7 +601,7 @@ void object::test<16>
 
     ensure_equals(sequence.size(), std::size_t(3));
 
-    sequence.add(0, Coordinate(4, 4), false); // don't alow repeated
+    sequence.add(0, Coordinate(4, 4), false); // don't allow repeated
     ensure_equals(sequence.size(), std::size_t(4));
     ensure_equals(sequence.getAt(0).x, 4.0);
 

--- a/tests/unit/tut/tut.hpp
+++ b/tests/unit/tut/tut.hpp
@@ -226,7 +226,7 @@ class test_group : public group_base, public test_group_posix
          * Specially treats exceptions in test object destructor;
          * if test itself failed, exceptions in destructor
          * are ignored; if test was successful and destructor failed,
-         * warning exception throwed.
+         * warning exception thrown.
          */
         void release()
         {
@@ -384,7 +384,7 @@ public:
             return false;
         }
 
-        // withing scope; check if given test exists
+        // within scope; check if given test exists
         tests_iterator ti = tests_.find(n);
         if (ti == tests_.end())
         {

--- a/tests/unit/tut/tut_exception.hpp
+++ b/tests/unit/tut/tut_exception.hpp
@@ -83,7 +83,7 @@ struct no_such_test : public tut_error
 };
 
 /**
- * Internal exception to be throwed when
+ * Internal exception to be thrown when
  * test constructor has failed.
  */
 struct bad_ctor : public tut_error
@@ -109,7 +109,7 @@ struct bad_ctor : public tut_error
 };
 
 /**
- * Exception to be throwed when ensure() fails or fail() called.
+ * Exception to be thrown when ensure() fails or fail() called.
  */
 struct failure : public tut_error
 {
@@ -134,7 +134,7 @@ struct failure : public tut_error
 };
 
 /**
- * Exception to be throwed when test desctructor throwed an exception.
+ * Exception to be thrown when test destructor thrown an exception.
  */
 struct warning : public tut_error
 {
@@ -159,7 +159,7 @@ struct warning : public tut_error
 };
 
 /**
- * Exception to be throwed when test issued SEH (Win32)
+ * Exception to be thrown when test issued SEH (Win32)
  */
 struct seh : public tut_error
 {
@@ -184,7 +184,7 @@ struct seh : public tut_error
 };
 
 /**
- * Exception to be throwed when child processes fail.
+ * Exception to be thrown when child processes fail.
  */
 struct rethrown : public failure
 {

--- a/tests/unit/tut/tut_result.hpp
+++ b/tests/unit/tut/tut_result.hpp
@@ -66,7 +66,7 @@ struct test_result_posix
 #endif
 
 /**
- * Return type of runned test/test group.
+ * Return type of ran test/test group.
  *
  * For test: contains result of test and, possible, message
  * for failure or exception.
@@ -95,8 +95,8 @@ struct test_result : public test_result_posix
     {
         ok,       ///< test finished successfully
         fail,     ///< test failed with ensure() or fail() methods
-        ex,       ///< test throwed an exceptions
-        warn,     ///< test finished successfully, but test destructor throwed
+        ex,       ///< test threw an exceptions
+        warn,     ///< test finished successfully, but test destructor thrown
         term,     ///< test forced test application to terminate abnormally
         ex_ctor,  ///<
         rethrown, ///<

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -436,7 +436,7 @@ XMLTester::run(const std::string& source)
     const tinyxml2::XMLNode* node = xml.FirstChildElement("run");
 
     if(! node) {
-        throw(runtime_error("Document has no childs"));
+        throw(runtime_error("Document has no children"));
     }
 
     parseRun(node);
@@ -1531,7 +1531,7 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
             }
         }
 
-        // equalsTopo() is synomym for equals() in JTS
+        // equalsTopo() is synonym for equals() in JTS
         else if(opName == "equalstopo") {
             geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
             geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
@@ -2253,7 +2253,7 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
         }
     }
     catch(...) {
-        std::cerr << "Unknown EXEPTION on case "
+        std::cerr << "Unknown EXCEPTION on case "
                   << caseCount
                   << std::endl;
         actual_result = "Unknown exception thrown";

--- a/tests/xmltester/tests/misc/InvalidRelates.xml
+++ b/tests/xmltester/tests/misc/InvalidRelates.xml
@@ -72,7 +72,7 @@
 
   <case>
     <desc>
-      P/A-3-4: a point on the touching point of boudary [dim(0){A.P.Int = B.A.Bdy.TP}
+      P/A-3-4: a point on the touching point of boundary [dim(0){A.P.Int = B.A.Bdy.TP}
     </desc>
     <a>
       POINT(100 150)

--- a/tests/xmltester/tests/validate/TestRelatePA.xml
+++ b/tests/xmltester/tests/validate/TestRelatePA.xml
@@ -146,7 +146,7 @@
 </case>
 
 <case>
-<desc>P/A-3-2: a point on the boudary of a polygon at a non-vertex [dim(0){A.P.Int = B.A.Bdy.NV}]</desc>
+<desc>P/A-3-2: a point on the boundary of a polygon at a non-vertex [dim(0){A.P.Int = B.A.Bdy.NV}]</desc>
   <a>
     POINT(110 120)
   </a>

--- a/tests/xmltester/tinyxml2/tinyxml2.cpp
+++ b/tests/xmltester/tinyxml2/tinyxml2.cpp
@@ -1038,7 +1038,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
             //
             // Optimized due to a security test case. If the first node is
             // a declaration, and the last node is a declaration, then only
-            // declarations have so far been addded.
+            // declarations have so far been added.
             bool wellLocated = false;
 
             if (ToDocument()) {

--- a/util/geosop/GeometryOp.cpp
+++ b/util/geosop/GeometryOp.cpp
@@ -1145,7 +1145,7 @@ Result::metadata() {
     case typeGeomList:
         return "Geometry[" + std::to_string( valGeomList.size()) + "]";
     }
-    return "Unknonwn type";
+    return "Unknown type";
 }
 
 std::string

--- a/web/content/project/rfcs/rfc01.md
+++ b/web/content/project/rfcs/rfc01.md
@@ -98,7 +98,7 @@ PSC members are expected to be active on both the [geos-devel](http://lists.osge
 
 **Note:** The following is for historical interest only. The current PSC is available [here]({{< ref "/project/psc" >}}).
 
-Prior to annointing itself the PSC must distribute this RFC to the GEOS community via [geos-devel](http://lists.osgeo.org/mailman/listinfo/geos-devel) for comment. Any and all substantive comments must be discussed (and hopefully, but not necessarily, addressed via [geos-devel](http://lists.osgeo.org/mailman/listinfo/geos-devel).
+Prior to announcing itself, the PSC must distribute this RFC to the GEOS community via [geos-devel](http://lists.osgeo.org/mailman/listinfo/geos-devel) for comment. Any and all substantive comments must be discussed (and hopefully, but not necessarily, addressed via [geos-devel](http://lists.osgeo.org/mailman/listinfo/geos-devel).
 
 Initial members are:
 

--- a/web/content/project/rfcs/rfc06.md
+++ b/web/content/project/rfcs/rfc06.md
@@ -56,7 +56,7 @@ This message will continue to be shown in every project that a user tries to com
 
 I propose doing this in GEOS 3.7.0.
 
-The main purpose is to discourage the use of the C++ API because we do not have the manpower to guarantee ABI or API compatiblity from minor version to minor version and thus using it in an environment where the GEOS library is shared across many software is unsupported.  We are also planning significant refactoring in GEOS 3.8 which will very likely break the C++ API.
+The main purpose is to discourage the use of the C++ API because we do not have the manpower to guarantee ABI or API compatibility from minor version to minor version and thus using it in an environment where the GEOS library is shared across many software is unsupported.  We are also planning significant refactoring in GEOS 3.8 which will very likely break the C++ API.
 
 Currently [osm2pgsql](https://github.com/openstreetmap/osm2pgsql/issues/634) and OSSIM are the only ones that used the GEOS C++ API and largely distributed in shared environment.  We want to discourage future projects that plan to be used in a shared environment from using the GEOS C++ API and to stick with the GEOS C API.
 

--- a/web/content/specifications/wkb.md
+++ b/web/content/specifications/wkb.md
@@ -185,7 +185,7 @@ The "Extended WKB" variant is a superset of the standard WKB, which allows appli
 
 The presence of extra dimensions is indicated by adding flag bits to the existing `wkbType` that appears in all WKB geometries.
 
-For example, here is the structure and flagging for a 3D point -- the dimensionaly flag indicates a Z dimension, and the point member therefor has three coordinates.
+For example, here is the structure and flagging for a 3D point -- the dimensionaly flag indicates a Z dimension, and the point member therefore has three coordinates.
 
 ```
 wkbZ = 0x80000000

--- a/web/content/usage/faq/index.md
+++ b/web/content/usage/faq/index.md
@@ -22,7 +22,7 @@ so it is much easier to keep stable.
 GEOS started life as a port of JTS, so its design reflects that heritage.
 JTS is still evolving and improving, so keeping GEOS fairly close to the JTS
 design and organization makes it easier to keep porting JTS changes.
-However, there have been additions to GEOS which were not orginally in JTS
+However, there have been additions to GEOS which were not originally in JTS
 (although in some cases those were superseded by later JTS development).
 Also, GEOS is intended to provide high-performance spatial algorithms,
 which sometimes requires using different code patterns than in Java.

--- a/web/content/usage/install.md
+++ b/web/content/usage/install.md
@@ -34,7 +34,7 @@ sudo apt-get install geos
 
 ### Debian
 
-The [Debian GIS](https://wiki.debian.org/DebianGis) project maintains [GEOS packages](https://tracker.debian.org/pkg/geos) and pushes them into the appropriate Debian respositories.
+The [Debian GIS](https://wiki.debian.org/DebianGis) project maintains [GEOS packages](https://tracker.debian.org/pkg/geos) and pushes them into the appropriate Debian repositories.
 
 ```bash
 sudo apt-get install geos


### PR DESCRIPTION
This fixes numerous typos using [codespell](https://github.com/codespell-project/codespell) interactively. There are a few places that I made a guess to the correct word.

---

Some typos for object names are kept (for now?) including:

- Extracter (normally [extractor](https://en.wiktionary.org/wiki/extractor)), and related:
  -  ComponentCoordinateExtracter
  - GeometryExtracter
  - LinearComponentExtracter
  - PointExtracter
  - PolygonalExtracter
  - PolygonExtracter
- Translater (well at least Wiktionary has an entry for [translater](https://en.wiktionary.org/wiki/translater))
- Geometrys