### PR TITLE
Fix MaximumInscribedCircle::computeMaximumIterations for small values

### DIFF
--- a/src/algorithm/construct/MaximumInscribedCircle.cpp
+++ b/src/algorithm/construct/MaximumInscribedCircle.cpp
@@ -85,9 +85,9 @@ MaximumInscribedCircle::computeMaximumIterations(const Geometry* geom, double to
     double diam = geom->getEnvelopeInternal()->getDiameter();
     double ncells = diam / toleranceDist;
     //-- Using log of ncells allows control over number of iterations
-    std::size_t factor = (std::size_t) std::log(ncells);
+    int factor = (int) std::log(ncells);
     if (factor < 1) factor = 1;
-    return 2000 + 2000 * factor;
+    return (std::size_t) (2000 + 2000 * factor);
 }
 
 /* public */


### PR DESCRIPTION
This fixes an issue with `MaximumInscribedCircle::computeMaximumIterations` that sometimes returns bogus values.

For example, with [this example](https://github.com/libgeos/geos/blob/6201229a66ae3eef2b0c62cc39dbab48b2e3df7e/tests/unit/algorithm/construct/LargestEmptyCircleTest.cpp#L333-L343) the number of iterations is needed by [`LargestEmptyCircle::compute()`](https://github.com/libgeos/geos/blob/4907d593aa6aa31c25dbe73933bf66995a04e498/src/algorithm/construct/LargestEmptyCircle.cpp#L235). The geometry calculates ncells=0.0903549, which would normally have a log value -2.40401. But the early cast to `size_t` doesn't correctly handle negative values meaning the maxIter is either 0 or 4294965296 (i.e. it's up to the compiler to decide). This fix will re-establish the maxIter to 4000 for small "ncells" values (less than 1). The bug with MSVC 32-bit is that it was zero, meaning no iteration.

<s>Also clean-up one MSVC warning.</s>

Closes #1129