### PR TITLE
include/geos/geomgraph: remove useless virtual qualifiers, add final and improve a bit const safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,10 @@ target_compile_options(geos_developer_cxx_flags
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-unknown-warning-option>
     )
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9.2)
+  target_compile_options(geos_developer_cxx_flags INTERFACE -Wsuggest-override)
+endif()
+
 #-----------------------------------------------------------------------------
 # Define a coverage build
 #-----------------------------------------------------------------------------

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -1631,13 +1631,13 @@ extern "C" {
     Geometry*
     GEOSGeom_transformXY_r(GEOSContextHandle_t handle, const GEOSGeometry* g, GEOSTransformXYCallback callback, void* userdata) {
 
-        struct TransformFilter : public geos::geom::CoordinateFilter {
+        struct TransformFilter final: public geos::geom::CoordinateFilter {
             TransformFilter(GEOSTransformXYCallback p_callback,
                             void* p_userdata) :
                             m_callback(p_callback),
                             m_userdata(p_userdata) {}
 
-            void filter_rw(CoordinateXY* c) const final {
+            void filter_rw(CoordinateXY* c) const override {
                 if (!m_callback(&(c->x), &(c->y), m_userdata)) {
                     throw std::runtime_error(std::string("Failed to transform coordinates."));
                 }

--- a/include/geos/algorithm/hull/HullTriangulation.h
+++ b/include/geos/algorithm/hull/HullTriangulation.h
@@ -124,7 +124,7 @@ public:
                 : triList(p_triList)
                 {};
 
-            void visit(std::array<QuadEdge*, 3>& triEdges);
+            void visit(std::array<QuadEdge*, 3>& triEdges) override;
 
     }; // HullTriVisitor
 

--- a/include/geos/geomgraph/DirectedEdge.h
+++ b/include/geos/geomgraph/DirectedEdge.h
@@ -39,7 +39,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /// A directed EdgeEnd
-class GEOS_DLL DirectedEdge: public EdgeEnd {
+class GEOS_DLL DirectedEdge final: public EdgeEnd {
 
 public:
 

--- a/include/geos/geomgraph/Edge.h
+++ b/include/geos/geomgraph/Edge.h
@@ -60,7 +60,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /** The edge component of a geometry graph */
-class GEOS_DLL Edge: public GraphComponent {
+class GEOS_DLL Edge final: public GraphComponent {
     using GraphComponent::updateIM;
 
 private:
@@ -102,27 +102,27 @@ public:
 
     ~Edge() override;
 
-    virtual size_t
+    size_t
     getNumPoints() const
     {
         return pts->getSize();
     }
 
-    virtual const geom::CoordinateSequence*
+    const geom::CoordinateSequence*
     getCoordinates() const
     {
         testInvariant();
         return pts.get();
     }
 
-    virtual const geom::Coordinate&
+    const geom::Coordinate&
     getCoordinate(std::size_t i) const
     {
         testInvariant();
         return pts->getAt(i);
     }
 
-    virtual const geom::Coordinate&
+    const geom::Coordinate&
     getCoordinate() const
     {
         testInvariant();
@@ -130,8 +130,8 @@ public:
     }
 
 
-    virtual Depth&
-    getDepth()
+    const Depth&
+    getDepth() const
     {
         testInvariant();
         return depth;
@@ -142,29 +142,36 @@ public:
      *
      * @return the change in depth as the edge is crossed from R to L
      */
-    virtual int
+    int
     getDepthDelta() const
     {
         testInvariant();
         return depthDelta;
     }
 
-    virtual void
+    void
     setDepthDelta(int newDepthDelta)
     {
         depthDelta = newDepthDelta;
         testInvariant();
     }
 
-    virtual size_t
+    size_t
     getMaximumSegmentIndex() const
     {
         testInvariant();
         return getNumPoints() - 1;
     }
 
-    virtual EdgeIntersectionList&
+    EdgeIntersectionList&
     getEdgeIntersectionList()
+    {
+        testInvariant();
+        return eiList;
+    }
+
+    const EdgeIntersectionList&
+    getEdgeIntersectionList() const
     {
         testInvariant();
         return eiList;
@@ -174,9 +181,9 @@ public:
     /// Return this Edge's index::MonotoneChainEdge,
     /// ownership is retained by this object.
     ///
-    virtual index::MonotoneChainEdge* getMonotoneChainEdge();
+    index::MonotoneChainEdge* getMonotoneChainEdge();
 
-    virtual bool
+    bool
     isClosed() const
     {
         testInvariant();
@@ -187,11 +194,11 @@ public:
      * An Edge is collapsed if it is an Area edge and it consists of
      * two segments which are equal and opposite (eg a zero-width V).
      */
-    virtual bool isCollapsed() const;
+     bool isCollapsed() const;
 
-    virtual Edge* getCollapsedEdge();
+    Edge* getCollapsedEdge();
 
-    virtual void
+    void
     setIsolated(bool newIsIsolated)
     {
         isIsolatedVar = newIsIsolated;
@@ -209,7 +216,7 @@ public:
      * Adds EdgeIntersections for one or both
      * intersections found for a segment of an edge to the edge intersection list.
      */
-    virtual void addIntersections(algorithm::LineIntersector* li, std::size_t segmentIndex,
+    void addIntersections(algorithm::LineIntersector* li, std::size_t segmentIndex,
                                   std::size_t geomIndex);
 
     /// Add an EdgeIntersection for intersection intIndex.
@@ -217,7 +224,7 @@ public:
     /// An intersection that falls exactly on a vertex of the edge is normalized
     /// to use the higher of the two possible segmentIndexes
     ///
-    virtual void addIntersection(algorithm::LineIntersector* li, std::size_t segmentIndex,
+    void addIntersection(algorithm::LineIntersector* li, std::size_t segmentIndex,
                                  std::size_t geomIndex, std::size_t intIndex);
 
     /// Update the IM with the contribution for this component.
@@ -233,11 +240,11 @@ public:
     }
 
     /// return true if the coordinate sequences of the Edges are identical
-    virtual bool isPointwiseEqual(const Edge* e) const;
+    bool isPointwiseEqual(const Edge* e) const;
 
-    virtual std::string print() const;
+    std::string print() const;
 
-    virtual std::string printReverse() const;
+    std::string printReverse() const;
 
     /**
      * equals is defined to be:
@@ -246,16 +253,16 @@ public:
      * <b>iff</b>
      * the coordinates of e1 are the same or the reverse of the coordinates in e2
      */
-    virtual bool equals(const Edge& e) const;
+    bool equals(const Edge& e) const;
 
-    virtual bool
+    bool
     equals(const Edge* e) const
     {
         assert(e);
         return equals(*e);
     }
 
-    virtual const geom::Envelope* getEnvelope();
+    const geom::Envelope* getEnvelope();
 };
 
 

--- a/include/geos/geomgraph/EdgeEnd.h
+++ b/include/geos/geomgraph/EdgeEnd.h
@@ -51,7 +51,7 @@ namespace geomgraph { // geos.geomgraph
  * "a has a greater angle with the x-axis than b".
  * This ordering is used to sort EdgeEnds around a node.
  */
-class GEOS_DLL EdgeEnd {
+class GEOS_DLL EdgeEnd /* non-final */ {
 
 public:
 
@@ -101,7 +101,7 @@ public:
         return label;
     }
 
-    virtual geom::Coordinate& getCoordinate() {
+    geom::Coordinate& getCoordinate() {
         return p0;
     }
 
@@ -111,19 +111,19 @@ public:
         return p0;
     }
 
-    virtual geom::Coordinate& getDirectedCoordinate();
+    geom::Coordinate& getDirectedCoordinate();
 
-    virtual int getQuadrant();
+    int getQuadrant();
 
-    virtual double getDx();
+    double getDx();
 
-    virtual double getDy();
+    double getDy();
 
-    virtual void setNode(Node* newNode);
+    void setNode(Node* newNode);
 
-    virtual Node* getNode();
+    Node* getNode();
 
-    virtual int compareTo(const EdgeEnd* e) const;
+    int compareTo(const EdgeEnd* e) const;
 
     /**
      * Implements the total order relation:
@@ -141,7 +141,7 @@ public:
      *   computeOrientation function can be used to decide
      *   the relative orientation of the vectors.
      */
-    virtual int compareDirection(const EdgeEnd* e) const;
+    int compareDirection(const EdgeEnd* e) const;
 
     virtual void computeLabel(const algorithm::BoundaryNodeRule& bnr);
 
@@ -155,7 +155,7 @@ protected:
 
     EdgeEnd(Edge* newEdge);
 
-    virtual void init(const geom::Coordinate& newP0,
+    void init(const geom::Coordinate& newP0,
                       const geom::Coordinate& newP1);
 
 private:

--- a/include/geos/geomgraph/EdgeEndStar.h
+++ b/include/geos/geomgraph/EdgeEndStar.h
@@ -60,7 +60,7 @@ namespace geomgraph { // geos.geomgraph
  *
  * @version 1.4
  */
-class GEOS_DLL EdgeEndStar {
+class GEOS_DLL EdgeEndStar /* non-final */ {
 public:
 
     typedef std::set<EdgeEnd*, EdgeEndLT> container;
@@ -86,46 +86,46 @@ public:
      * a Coordinate owned by the specific EdgeEnd happening
      * to be the first in the star (ordered CCW)
      */
-    virtual geom::Coordinate& getCoordinate();
+    geom::Coordinate& getCoordinate();
 
     const geom::Coordinate& getCoordinate() const;
 
-    virtual std::size_t getDegree();
+    std::size_t getDegree();
 
-    virtual iterator begin();
+    iterator begin();
 
-    virtual iterator end();
+    iterator end();
 
-    virtual reverse_iterator rbegin();
+    reverse_iterator rbegin();
 
-    virtual reverse_iterator rend();
+    reverse_iterator rend();
 
-    virtual const_iterator
+    const_iterator
     begin() const
     {
         return edgeMap.begin();
     }
 
-    virtual const_iterator
+    const_iterator
     end() const
     {
         return edgeMap.end();
     }
 
-    virtual container& getEdges();
+    container& getEdges();
 
-    virtual EdgeEnd* getNextCW(EdgeEnd* ee);
+    EdgeEnd* getNextCW(EdgeEnd* ee);
 
     virtual void computeLabelling(const std::vector<std::unique_ptr<GeometryGraph>>&geomGraph);
     // throw(TopologyException *);
 
-    virtual bool isAreaLabelsConsistent(const GeometryGraph& geomGraph);
+    bool isAreaLabelsConsistent(const GeometryGraph& geomGraph);
 
-    virtual void propagateSideLabels(uint32_t geomIndex);
+    void propagateSideLabels(uint32_t geomIndex);
     // throw(TopologyException *);
 
     //virtual int findIndex(EdgeEnd *eSearch);
-    virtual iterator find(EdgeEnd* eSearch);
+    iterator find(EdgeEnd* eSearch);
 
     virtual std::string print() const;
 
@@ -140,7 +140,7 @@ protected:
     /** \brief
      * Insert an EdgeEnd into the map.
      */
-    virtual void
+    void
     insertEdgeEnd(EdgeEnd* e)
     {
         edgeMap.insert(e);
@@ -148,7 +148,7 @@ protected:
 
 private:
 
-    virtual geom::Location getLocation(uint32_t geomIndex,
+    geom::Location getLocation(uint32_t geomIndex,
                                        const geom::Coordinate&p,
                                        const std::vector<std::unique_ptr<GeometryGraph>>&geom);
 
@@ -158,9 +158,9 @@ private:
      */
     std::array<geom::Location, 2> ptInAreaLocation;
 
-    virtual void computeEdgeEndLabels(const algorithm::BoundaryNodeRule&);
+    void computeEdgeEndLabels(const algorithm::BoundaryNodeRule&);
 
-    virtual bool checkAreaLabelsConsistent(uint32_t geomIndex);
+    bool checkAreaLabelsConsistent(uint32_t geomIndex);
 
 };
 

--- a/include/geos/geomgraph/EdgeIntersection.h
+++ b/include/geos/geomgraph/EdgeIntersection.h
@@ -39,7 +39,7 @@ namespace geomgraph { // geos.geomgraph
  * The intersection point must be precise.
  *
  */
-class GEOS_DLL EdgeIntersection {
+class GEOS_DLL EdgeIntersection final {
 public:
 
     // the point of intersection

--- a/include/geos/geomgraph/EdgeIntersectionList.h
+++ b/include/geos/geomgraph/EdgeIntersectionList.h
@@ -54,7 +54,7 @@ namespace geomgraph { // geos.geomgraph
  * Implements splitting an edge with intersections
  * into multiple resultant edges.
  */
-class GEOS_DLL EdgeIntersectionList {
+class GEOS_DLL EdgeIntersectionList final {
 public:
     // Instead of storing edge intersections in a set, as JTS does, we store them
     // in a vector and then sort the vector if needed before iterating among the

--- a/include/geos/geomgraph/EdgeList.h
+++ b/include/geos/geomgraph/EdgeList.h
@@ -52,7 +52,7 @@ namespace geomgraph { // geos.geomgraph
  * It supports locating edges
  * that are pointwise equals to a target edge.
  */
-class GEOS_DLL EdgeList {
+class GEOS_DLL EdgeList final {
 
 private:
 
@@ -85,7 +85,7 @@ public:
         ocaMap()
     {}
 
-    virtual ~EdgeList() = default;
+    ~EdgeList() = default;
 
     /**
      * Insert an edge unless it is already in the list

--- a/include/geos/geomgraph/EdgeNodingValidator.h
+++ b/include/geos/geomgraph/EdgeNodingValidator.h
@@ -51,7 +51,7 @@ namespace geomgraph { // geos.geomgraph
  *
  * Throws an appropriate exception if an noding error is found.
  */
-class GEOS_DLL EdgeNodingValidator {
+class GEOS_DLL EdgeNodingValidator final {
 
 private:
     std::vector<noding::SegmentString*>& toSegmentStrings(std::vector<Edge*>& edges);

--- a/include/geos/geomgraph/EdgeRing.h
+++ b/include/geos/geomgraph/EdgeRing.h
@@ -54,7 +54,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /** EdgeRing */
-class GEOS_DLL EdgeRing {
+class GEOS_DLL EdgeRing /* non-final */ {
 
 public:
     friend std::ostream& operator<< (std::ostream& os, const EdgeRing& er);

--- a/include/geos/geomgraph/GeometryGraph.h
+++ b/include/geos/geomgraph/GeometryGraph.h
@@ -68,7 +68,7 @@ namespace geomgraph { // geos.geomgraph
 /** \brief
  * A GeometryGraph is a graph that models a given Geometry.
  */
-class GEOS_DLL GeometryGraph: public PlanarGraph {
+class GEOS_DLL GeometryGraph final: public PlanarGraph {
     using PlanarGraph::add;
     using PlanarGraph::findEdge;
 

--- a/include/geos/geomgraph/GraphComponent.h
+++ b/include/geos/geomgraph/GraphComponent.h
@@ -42,7 +42,7 @@ namespace geomgraph { // geos.geomgraph
  *
  * Each GraphComponent can carry a Label.
  */
-class GEOS_DLL GraphComponent {
+class GEOS_DLL GraphComponent /* non-final */ {
 public:
     GraphComponent();
 
@@ -69,39 +69,39 @@ public:
         label = newLabel;
     }
 
-    virtual void
+    void
     setInResult(bool p_isInResult)
     {
         isInResultVar = p_isInResult;
     }
-    virtual bool
+    bool
     isInResult() const
     {
         return isInResultVar;
     }
-    virtual void setCovered(bool isCovered);
-    virtual bool
+    void setCovered(bool isCovered);
+    bool
     isCovered() const
     {
         return isCoveredVar;
     }
-    virtual bool
+    bool
     isCoveredSet() const
     {
         return isCoveredSetVar;
     }
-    virtual bool
+    bool
     isVisited() const
     {
         return isVisitedVar;
     }
-    virtual void
+    void
     setVisited(bool p_isVisited)
     {
         isVisitedVar = p_isVisited;
     }
     virtual bool isIsolated() const = 0;
-    virtual void updateIM(geom::IntersectionMatrix& im);
+    void updateIM(geom::IntersectionMatrix& im);
 protected:
     Label label;
     virtual void computeIM(geom::IntersectionMatrix& im) = 0;

--- a/include/geos/geomgraph/Label.h
+++ b/include/geos/geomgraph/Label.h
@@ -54,7 +54,7 @@ namespace geomgraph { // geos.geomgraph
  * with specific geometries.
  *
  */
-class GEOS_DLL Label {
+class GEOS_DLL Label final {
 
 public:
 

--- a/include/geos/geomgraph/Node.h
+++ b/include/geos/geomgraph/Node.h
@@ -56,7 +56,7 @@ namespace geos {
 namespace geomgraph { // geos.geomgraph
 
 /** \brief The node component of a geometry graph. */
-class GEOS_DLL Node: public GraphComponent {
+class GEOS_DLL Node /* non-final */: public GraphComponent {
     using GraphComponent::setLabel;
 
 public:
@@ -67,18 +67,18 @@ public:
 
     ~Node() override;
 
-    virtual const geom::Coordinate& getCoordinate() const;
+    const geom::Coordinate& getCoordinate() const;
 
-    virtual EdgeEndStar* getEdges();
+    EdgeEndStar* getEdges();
 
     bool isIsolated() const override;
 
     /** \brief
      * Add the edge to the list of edges at this node
      */
-    virtual void add(EdgeEnd* e);
+    void add(EdgeEnd* e);
 
-    virtual void mergeLabel(const Node& n);
+    void mergeLabel(const Node& n);
 
     /** \brief
      * To merge labels for two nodes,
@@ -87,15 +87,15 @@ public:
      * The location for the corresponding node LabelElement is set
      * to the result, as long as the location is non-null.
      */
-    virtual void mergeLabel(const Label& label2);
+    void mergeLabel(const Label& label2);
 
-    virtual void setLabel(uint8_t argIndex, geom::Location onLocation);
+    void setLabel(uint8_t argIndex, geom::Location onLocation);
 
     /** \brief
      * Updates the label of a node to BOUNDARY,
      * obeying the mod-2 boundaryDetermination rule.
      */
-    virtual void setLabelBoundary(uint8_t argIndex);
+    void setLabelBoundary(uint8_t argIndex);
 
     /**
      * The location for a given eltIndex for a node will be one
@@ -105,13 +105,13 @@ public:
      * in the boundary.
      * The merged location is the maximum of the two input values.
      */
-    virtual geom::Location computeMergedLocation(const Label& label2, uint8_t eltIndex);
+    geom::Location computeMergedLocation(const Label& label2, uint8_t eltIndex);
 
-    virtual std::string print() const;
+    std::string print() const;
 
-    virtual const std::vector<double>& getZ() const;
+    const std::vector<double>& getZ() const;
 
-    virtual void addZ(double);
+    void addZ(double);
 
     /** \brief
      * Tests whether any incident edge is flagged as
@@ -124,7 +124,7 @@ public:
      * @return <code>true</code> if any indicident edge in the in
      *         the result
      */
-    virtual bool isIncidentEdgeInResult() const;
+    bool isIncidentEdgeInResult() const;
 
 protected:
 

--- a/include/geos/geomgraph/NodeFactory.h
+++ b/include/geos/geomgraph/NodeFactory.h
@@ -35,7 +35,7 @@ class Node;
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
-class GEOS_DLL NodeFactory {
+class GEOS_DLL NodeFactory /* non-final */ {
 public:
     virtual Node* createNode(const geom::Coordinate& coord) const;
     static const NodeFactory& instance();

--- a/include/geos/geomgraph/NodeMap.h
+++ b/include/geos/geomgraph/NodeMap.h
@@ -47,7 +47,7 @@ class NodeFactory;
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
-class GEOS_DLL NodeMap {
+class GEOS_DLL NodeMap final {
 public:
 
     typedef std::map<geom::Coordinate*, std::unique_ptr<Node>, geom::CoordinateLessThan> container;
@@ -64,8 +64,6 @@ public:
     /// NodeMap will keep a reference to the NodeFactory,
     /// keep it alive for the whole NodeMap lifetime
     NodeMap(const NodeFactory& newNodeFact);
-
-    virtual ~NodeMap();
 
     Node* addNode(const geom::Coordinate& coord);
 

--- a/include/geos/geomgraph/PlanarGraph.h
+++ b/include/geos/geomgraph/PlanarGraph.h
@@ -69,7 +69,7 @@ namespace geomgraph { // geos.geomgraph
  *    different graphs
  *
  */
-class GEOS_DLL PlanarGraph {
+class GEOS_DLL PlanarGraph /* non-final */ {
 public:
 
     /** \brief
@@ -105,36 +105,36 @@ public:
 
     virtual ~PlanarGraph();
 
-    virtual std::vector<Edge*>::iterator getEdgeIterator();
+    std::vector<Edge*>::iterator getEdgeIterator();
 
-    virtual std::vector<EdgeEnd*>* getEdgeEnds();
+    std::vector<EdgeEnd*>* getEdgeEnds();
 
-    virtual bool isBoundaryNode(uint8_t geomIndex, const geom::Coordinate& coord);
+    bool isBoundaryNode(uint8_t geomIndex, const geom::Coordinate& coord);
 
-    virtual void add(EdgeEnd* e);
+    void add(EdgeEnd* e);
 
-    virtual NodeMap::iterator getNodeIterator();
+    NodeMap::iterator getNodeIterator();
 
-    virtual void getNodes(std::vector<Node*>&);
+    void getNodes(std::vector<Node*>&);
 
-    virtual Node* addNode(Node* node);
+    Node* addNode(Node* node);
 
-    virtual Node* addNode(const geom::Coordinate& coord);
+    Node* addNode(const geom::Coordinate& coord);
 
     /**
      * @return the node if found; null otherwise
      */
-    virtual Node* find(geom::Coordinate& coord);
+    Node* find(geom::Coordinate& coord);
 
     /** \brief
      * Add a set of edges to the graph.  For each edge two DirectedEdges
      * will be created.  DirectedEdges are NOT linked by this method.
      */
-    virtual void addEdges(const std::vector<Edge*>& edgesToAdd);
+    void addEdges(const std::vector<Edge*>& edgesToAdd);
 
-    virtual void linkResultDirectedEdges();
+    void linkResultDirectedEdges();
 
-    virtual void linkAllDirectedEdges();
+    void linkAllDirectedEdges();
 
     /** \brief
      * Returns the EdgeEnd which has edge e as its base edge
@@ -143,7 +143,7 @@ public:
      * @return the edge, if found
      *    <code>null</code> if the edge was not found
      */
-    virtual EdgeEnd* findEdgeEnd(Edge* e);
+    EdgeEnd* findEdgeEnd(Edge* e);
 
     /** \brief
      * Returns the edge whose first two coordinates are p0 and p1
@@ -151,7 +151,7 @@ public:
      * @return the edge, if found
      *    <code>null</code> if the edge was not found
      */
-    virtual Edge* findEdge(const geom::Coordinate& p0,
+    Edge* findEdge(const geom::Coordinate& p0,
                            const geom::Coordinate& p1);
 
     /** \brief
@@ -161,12 +161,12 @@ public:
      * @return the edge, if found
      *    <code>null</code> if the edge was not found
      */
-    virtual Edge* findEdgeInSameDirection(const geom::Coordinate& p0,
+    Edge* findEdgeInSameDirection(const geom::Coordinate& p0,
                                           const geom::Coordinate& p1);
 
-    virtual std::string printEdges();
+    std::string printEdges();
 
-    virtual NodeMap* getNodeMap();
+    NodeMap* getNodeMap();
 
 protected:
 
@@ -176,7 +176,7 @@ protected:
 
     std::vector<EdgeEnd*>* edgeEndList;
 
-    virtual void insertEdge(Edge* e);
+    void insertEdge(Edge* e);
 
 private:
 

--- a/include/geos/operation/relate/RelateNode.h
+++ b/include/geos/operation/relate/RelateNode.h
@@ -42,7 +42,7 @@ namespace relate { // geos::operation::relate
  * Represents a node in the topological graph used to compute spatial
  * relationships.
  */
-class GEOS_DLL RelateNode: public geomgraph::Node {
+class GEOS_DLL RelateNode final: public geomgraph::Node {
 
 public:
 

--- a/include/geos/precision/PointwisePrecisionReducerTransformer.h
+++ b/include/geos/precision/PointwisePrecisionReducerTransformer.h
@@ -63,7 +63,7 @@ protected:
 
     std::unique_ptr<geom::CoordinateSequence> transformCoordinates(
         const geom::CoordinateSequence* coords,
-        const geom::Geometry* parent);
+        const geom::Geometry* parent) override;
 
 
 };

--- a/src/geomgraph/EdgeList.cpp
+++ b/src/geomgraph/EdgeList.cpp
@@ -140,7 +140,7 @@ operator<< (std::ostream& os, const EdgeList& el)
 {
     os << "EdgeList: " << std::endl;
     for(std::size_t j = 0, s = el.edges.size(); j < s; ++j) {
-        Edge* e = el.edges[j];
+        const Edge* e = el.edges[j];
         os << "  " << *e << std::endl;
     }
     return os;

--- a/src/geomgraph/NodeMap.cpp
+++ b/src/geomgraph/NodeMap.cpp
@@ -46,8 +46,6 @@ NodeMap::NodeMap(const NodeFactory& newNodeFact)
 #endif
 }
 
-NodeMap::~NodeMap() = default;
-
 Node*
 NodeMap::addNode(const Coordinate& coord)
 {

--- a/src/operation/overlayng/OverlayPoints.cpp
+++ b/src/operation/overlayng/OverlayPoints.cpp
@@ -27,14 +27,14 @@ namespace geos {      // geos
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-struct PointExtractingFilter: public GeometryComponentFilter {
+struct PointExtractingFilter final: public GeometryComponentFilter {
 
     PointExtractingFilter(std::map<CoordinateXY, std::unique_ptr<Point>>& p_ptMap, const PrecisionModel* p_pm)
         : ptMap(p_ptMap), pm(p_pm)
     {}
 
     void
-    filter_ro(const Geometry* geom)
+    filter_ro(const Geometry* geom) override
     {
         if (geom->getGeometryTypeId() != GEOS_POINT) return;
 

--- a/src/operation/relate/RelateComputer.cpp
+++ b/src/operation/relate/RelateComputer.cpp
@@ -361,10 +361,10 @@ RelateComputer::computeIntersectionNodes(uint8_t argIndex)
 void
 RelateComputer::labelIntersectionNodes(uint8_t argIndex)
 {
-    std::vector<Edge*>* edges = arg[argIndex]->getEdges();
-    for(Edge* e: *edges) {
+    const std::vector<Edge*>* edges = arg[argIndex]->getEdges();
+    for(const Edge* e: *edges) {
         Location eLoc = e->getLabel().getLocation(argIndex);
-        EdgeIntersectionList& eiL = e->getEdgeIntersectionList();
+        const EdgeIntersectionList& eiL = e->getEdgeIntersectionList();
 
         for(const EdgeIntersection& ei : eiL) {
             RelateNode* n = static_cast<RelateNode*>(nodes.find(ei.coord));

--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -189,8 +189,8 @@ public:
       :m_thousands_sep(p_thousands_sep),
        m_grouping(p_grouping){}
 protected:
-   char do_thousands_sep() const {return m_thousands_sep;}
-   std::string do_grouping() const {return m_grouping;}
+   char do_thousands_sep() const override {return m_thousands_sep;}
+   std::string do_grouping() const override {return m_grouping;}
 private:
    char m_thousands_sep;
    std::string m_grouping;


### PR DESCRIPTION
On top of PR #1138 

The removal of the useless virtual qualifiers is safe since the addition of -Wsuggest-override in a previous commit makes sure that all overloaded methods (of methods that ware marked as 'virtual') are marked as 'override', which in turns ensures that all base methods that are overriden are marked as 'virtual'.
(This doesn't change the status quo if a method was overloaded, but the base class lacked a 'virtual' and the overloaded method lacked a 'override'...)

Said otherwise, the dangerous situation would be a
```cpp
class A { virtual void foo(); };
class B: public A { virtual void foo(); };
```
where we would erroneously remove the virtual qualifier.

But given -Wsuggest-override, the above code would have been corrected to
```cpp
class A { virtual void foo(); };
class B: public A { virtual void foo() override; };
```

And thus if we erroneously remove the virtual qualifier from A::foo() the compiler will error out.

This results in a small reduction in the size of libgeos.so (5954240 to 5946336), suggesting that de-virtualizations are done.
