### PR TITLE
Bump minimum C++ standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ include(CMakeDependentOption)
 
 ## CMake global variables
 option(BUILD_SHARED_LIBS "Build GEOS with shared libraries" ON)
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard version to use (default is 14)")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard version to use (minimum requirement is c++17)")
 
 ## GEOS custom variables
 option(BUILD_BENCHMARKS "Build GEOS benchmarks" OFF)
@@ -214,7 +214,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Target geos_cxx_flags: common compilation flags
 #-----------------------------------------------------------------------------
 add_library(geos_cxx_flags INTERFACE)
-target_compile_features(geos_cxx_flags INTERFACE cxx_std_11)
+target_compile_features(geos_cxx_flags INTERFACE cxx_std_17)
 
 #-----------------------------------------------------------------------------
 # Add flags to prevent 'fused multiply-add' operations on targets (ARM64)


### PR DESCRIPTION
As titled, this bumps our floor to C++17. It is proposed to implement this for GEOS 3.14+, not GEOS 3.13, which is expected soon.

The [C++11 RFC](https://libgeos.org/project/rfcs/rfc05/) has this comment:

> Is there a plan to upgrade to C++14 or C++17 to allow use of the C++ latest features? No, there is no plan. It is, however, recognized, such motion may be put to the vote around 2020.

I think that given we are near the end of 2024, it's time to finally increment. I don't think it requires an RFC due to us lagging the increment of many other projects and compilers on the systems that GEOS is used on. It was the C++11 increment that was disruptive and C++17 is not expected to be this late in the cycle.
