### PR TITLE
Add SegmentSetMutualIntersector for dll-interface class and other MSVC warnings

### DIFF
--- a/include/geos/noding/SegmentSetMutualIntersector.h
+++ b/include/geos/noding/SegmentSetMutualIntersector.h
@@ -33,7 +33,7 @@ namespace noding { // geos::noding
  * @author Martin Davis
  * @version 1.10
  */
-class SegmentSetMutualIntersector {
+class GEOS_DLL SegmentSetMutualIntersector {
 public:
 
     SegmentSetMutualIntersector()

--- a/tests/unit/coverage/CoverageSimplifierTest.cpp
+++ b/tests/unit/coverage/CoverageSimplifierTest.cpp
@@ -475,7 +475,7 @@ void object::test<30> ()
         std::vector<std::unique_ptr<Geometry>> result =
         CoverageSimplifier::simplify(input, 10);
     }
-    catch (geos::util::IllegalArgumentException& iae) {
+    catch (geos::util::IllegalArgumentException&) {
         ensure("caught IllegalArgumentException", true);
         return;
     }


### PR DESCRIPTION
This PR addresses two MSVC warnings (only shown in developer mode; e.g. see [previous build logs](https://github.com/libgeos/geos/actions/runs/10425205367/job/28875593065)):

- 22 instances of [C4275](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275): non dll-interface class 'geos::noding::SegmentSetMutualIntersector' used as base for dll-interface class 'geos::noding::MCIndexSegmentSetMutualIntersector'. The fix is to add `GEOS_DLL` to `SegmentSetMutualIntersector`
- 1 instance of [C4101](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4101): warning C4101: 'iae': unreferenced local variable. The fix is to remove the unused variable.

This does not currently fix:

- 2 instances of [C4244](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244): conversion from '_Ty' to 'uint8_t', possible loss of data. This applies to [src/operation/GeometryGraphOperation.cpp#L58](https://github.com/libgeos/geos/blob/3.13.0beta1/src/operation/GeometryGraphOperation.cpp#L58) and [src/util/string.cpp#L59](https://github.com/libgeos/geos/blob/3.13.0beta1/src/util/string.cpp#L59). Suggestions are welcome, as I'm unable to resolve these warnings.