### PR TITLE
Add 3D coordinates supports to GeoJSON reader and writer

### DIFF
--- a/include/geos/io/GeoJSONWriter.h
+++ b/include/geos/io/GeoJSONWriter.h
@@ -74,11 +74,33 @@ public:
 
     std::string write(const GeoJSONFeatureCollection& features);
 
+    /*
+     * \brief
+     * Returns the output dimension used by the
+     * <code>GeoJSONWriter</code>.
+     */
+    int
+    getOutputDimension() const
+    {
+        return defaultOutputDimension;
+    }
+
+    /*
+     * Sets the output dimension used by the <code>GeoJSONWriter</code>.
+     *
+     * @param newOutputDimension Supported values are 2 or 3.
+     *        Default since GEOS 3.12 is 3.
+     *        Note that 3 indicates up to 3 dimensions will be
+     *        written but 2D GeoJSON is still produced for 2D geometries.
+     */
+    void setOutputDimension(uint8_t newOutputDimension);
+
 private:
+    uint8_t defaultOutputDimension = 3;
 
-    std::pair<double, double> convertCoordinate(const geom::CoordinateXY* c);
+    std::vector<double> convertCoordinate(const geom::Coordinate* c);
 
-    std::vector<std::pair<double, double>> convertCoordinateSequence(const geom::CoordinateSequence* c);
+    std::vector<std::vector<double>> convertCoordinateSequence(const geom::CoordinateSequence* c);
 
     void encode(const geom::Geometry* g, GeoJSONType type, geos_nlohmann::ordered_json& j);
 

--- a/tests/unit/io/GeoJSONWriterTest.cpp
+++ b/tests/unit/io/GeoJSONWriterTest.cpp
@@ -318,5 +318,106 @@ void object::test<20>
     ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[null,null]}");
 }
 
+// Write a Point Z to GeoJSON 
+template<>
+template<>
+void object::test<21>
+()
+{
+    GeomPtr geom(wktreader.read("POINT Z (-117 33 10)"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0,10.0]}");
+}
+
+// Write a Point Z with NaN to GeoJSON 
+template<>
+template<>
+void object::test<22>
+()
+{
+    GeomPtr geom(wktreader.read("POINT Z (-117 33 NaN)"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}");
+}
+
+// Write a Point M to GeoJSON ignores M
+template<>
+template<>
+void object::test<23>
+()
+{
+    GeomPtr geom(wktreader.read("POINT M (-117 33 10)"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}");
+}
+
+// Write a Point ZM to GeoJSON ignores M
+template<>
+template<>
+void object::test<24>
+()
+{
+    GeomPtr geom(wktreader.read("POINT ZM (-117 33 10 2)"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0,10.0]}");
+}
+
+// Write a LineString Z to GeoJSON
+template<>
+template<>
+void object::test<25>
+()
+{
+    GeomPtr geom(wktreader.read("LINESTRING Z (102 0 2, 103 1 4, 104 0 8, 105 1 16)"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0,2.0],[103.0,1.0,4.0],[104.0,0.0,8.0],[105.0,1.0,16.0]]}");
+}
+
+// Write a LineString Z with some NaN Z to GeoJSON
+template<>
+template<>
+void object::test<26>
+()
+{
+    GeomPtr geom(wktreader.read("LINESTRING Z (102 0 2, 103 1 NaN, 104 0 8, 105 1 NaN)"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0,2.0],[103.0,1.0],[104.0,0.0,8.0],[105.0,1.0]]}");
+}
+
+
+// Setting outputs dimensions to an invalid value should raise
+template<>
+template<>
+void object::test<27>
+()
+{
+    std::string errorMessage;    
+    bool error;
+    for (auto dims: { uint8_t{1}, uint8_t{4} }) {
+        errorMessage = "";
+        error = false;
+        try {
+            geojsonwriter.setOutputDimension(dims);
+        } catch (geos::util::IllegalArgumentException& e) {
+            error = true;
+            errorMessage = e.what();
+        }
+        ensure(error == true);
+        ensure_equals(errorMessage, "IllegalArgumentException: GeoJSON output dimension must be 2 or 3");
+    }
+}
+
+
+// GeoJSONWriter without output dimensions set to 2 ignores Z and M values
+template<>
+template<>
+void object::test<28>
+()
+{
+    GeomPtr geom(wktreader.read("POINT ZM (-117 33 10 2)"));
+    geojsonwriter.setOutputDimension(2);
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}");
+}
 
 }


### PR DESCRIPTION
This PR adds 3D (Z) coordinates support to GeoJSON reader and writer.

It includes a new method `setOutputDimensions` for the writer, similar to the WKT one, but which (for now ?) only accepts values 2 or 3. Support for M coordinates was left out of this PR as it is discouraged by the specification, and would require more thinking about special cases. Any M values in the coordinates being serialized are therefore ignored (like the Z values were before this PR).

Considering the handling of mixed 2D/3D coordinates and NaN values isn't clearly specified, I made some decisions in that regard which are of course all open for debate:

- Mixed coordinates are allowed. If a coordinate sequence contains any Z value, the missing coordinates in the parsed geometry will be `NaN`.  This behavior is different than PostGIS and OGR, which both interpret missing Z coordinates as `0`:

```sql
SELECT '{"type":"LineString","coordinates":[[-117, 33], [-116, 34, 4]]}'::geometry;
-- LINESTRING(-117 33 0,-116 34 4)
```
```py
>>> ogr.CreateGeometryFromJson("{\"type\":\"LineString\",\"coordinates\":[[-117, 33], [-116, 34, 4]]}")
LINESTRING Z (-117 33 0,-116 34 4)
```
As a side note, PostGIS also converts *any* null value in a GeoJSON string as 0:
```sql
SELECT '{"type":"Point","coordinates":[1,null,null]}'::geometry;
-- POINT(1 0 0)
```
But OGR will instead consider it an invalid input:
```py
>>> ogr.CreateGeometryFromJson("{\"type\":\"Point\",\"coordinates\":[0, null, null]}")
None
```

- `NaN` Z values are never included in the coordinate array, regardless of the writer output dimension. This choice was made to facilitate interoperability and round-trips within GEOS, as parsing a GeoJSON string with `null`s will result in a ParsingError... But maybe this is something we want to change, even though it would deviate from the standard which states that the `coordinates` GeoJSON member should only contain numbers.