### PR TITLE
Add clustering functions to C API

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -24,6 +24,7 @@
 #include <geos/io/GeoJSONReader.h>
 #include <geos/io/GeoJSONWriter.h>
 #include <geos/operation/buffer/BufferParameters.h>
+#include <geos/operation/cluster/Clusters.h>
 #include <geos/util/Interrupt.h>
 
 #include <stdexcept>
@@ -40,6 +41,7 @@
 // violations.
 #define GEOSGeometry geos::geom::Geometry
 #define GEOSPreparedGeometry geos::geom::prep::PreparedGeometry
+#define GEOSClusterInfo geos::operation::cluster::Clusters
 #define GEOSCoordSequence geos::geom::CoordinateSequence
 #define GEOSBufferParams geos::operation::buffer::BufferParameters
 #define GEOSSTRtree geos::index::strtree::TemplateSTRtree<void*>
@@ -343,34 +345,59 @@ extern "C" {
         return GEOSNearestPoints_r(handle, g1, g2);
     }
 
-    unsigned*
-    GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints, unsigned* numClusters)
+    GEOSClusterInfo*
+    GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints)
     {
-        return GEOSClusterDBSCAN_r(handle, g, eps, minPoints, numClusters);
+        return GEOSClusterDBSCAN_r(handle, g, eps, minPoints);
     }
 
-    unsigned*
-    GEOSClusterGeometryDistance(const GEOSGeometry* g, double d, unsigned* numClusters)
+    GEOSClusterInfo*
+    GEOSClusterGeometryDistance(const GEOSGeometry* g, double d)
     {
-        return GEOSClusterGeometryDistance_r(handle, g, d, numClusters);
+        return GEOSClusterGeometryDistance_r(handle, g, d);
     }
 
-    unsigned*
-    GEOSClusterGeometryIntersects(const GEOSGeometry* g, unsigned* numClusters)
+    GEOSClusterInfo*
+    GEOSClusterGeometryIntersects(const GEOSGeometry* g)
     {
-        return GEOSClusterGeometryIntersects_r(handle, g, numClusters);
+        return GEOSClusterGeometryIntersects_r(handle, g);
     }
 
-    unsigned*
-    GEOSClusterEnvelopeDistance(const GEOSGeometry* g, double d, unsigned* numClusters)
+    GEOSClusterInfo*
+    GEOSClusterEnvelopeDistance(const GEOSGeometry* g, double d)
     {
-        return GEOSClusterEnvelopeDistance_r(handle, g, d, numClusters);
+        return GEOSClusterEnvelopeDistance_r(handle, g, d);
     }
 
-    unsigned*
-    GEOSClusterEnvelopeIntersects(const GEOSGeometry* g, unsigned* numClusters)
+    GEOSClusterInfo*
+    GEOSClusterEnvelopeIntersects(const GEOSGeometry* g)
     {
-        return GEOSClusterEnvelopeIntersects_r(handle, g, numClusters);
+        return GEOSClusterEnvelopeIntersects_r(handle, g);
+    }
+
+    std::size_t GEOSClusterInfo_getNumClusters(const GEOSClusterInfo* clusters)
+    {
+        return GEOSClusterInfo_getNumClusters_r(handle, clusters);
+    }
+
+    std::size_t GEOSClusterInfo_getClusterSize(const GEOSClusterInfo* clusters, size_t i)
+    {
+        return GEOSClusterInfo_getClusterSize_r(handle, clusters, i);
+    }
+
+    const std::size_t* GEOSClusterInfo_getInputsForClusterN(const GEOSClusterInfo* clusters, size_t i)
+    {
+        return GEOSClusterInfo_getInputsForClusterN_r(handle, clusters, i);
+    }
+
+    std::size_t* GEOSClusterInfo_getClustersForInputs(const GEOSClusterInfo* clusters)
+    {
+        return GEOSClusterInfo_getClustersForInputs_r(handle, clusters);
+    }
+
+    void GEOSClusterInfo_destroy(GEOSClusterInfo* info)
+    {
+        GEOSClusterInfo_destroy_r(handle, info);
     }
 
     Geometry*

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -343,6 +343,31 @@ extern "C" {
         return GEOSNearestPoints_r(handle, g1, g2);
     }
 
+    GEOSGeometry*
+    GEOSClusterDBSCAN(Geometry* g, double eps, unsigned minPoints) {
+        return GEOSClusterDBSCAN_r(handle, g, eps, minPoints);
+    }
+
+    GEOSGeometry*
+    GEOSClusterGeometryDistance(GEOSGeometry* g, double d) {
+        return GEOSClusterGeometryDistance_r(handle, g, d);
+    }
+
+    GEOSGeometry*
+    GEOSClusterGeometryIntersects(GEOSGeometry* g) {
+        return GEOSClusterGeometryIntersects_r(handle, g);
+    }
+
+    GEOSGeometry*
+    GEOSClusterEnvelopeDistance(GEOSGeometry* g, double d) {
+        return GEOSClusterEnvelopeDistance_r(handle, g, d);
+    }
+
+    GEOSGeometry*
+    GEOSClusterEnvelopeIntersects(GEOSGeometry* g) {
+        return GEOSClusterEnvelopeIntersects_r(handle, g);
+    }
+
     Geometry*
     GEOSGeomFromWKT(const char* wkt)
     {

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -343,29 +343,34 @@ extern "C" {
         return GEOSNearestPoints_r(handle, g1, g2);
     }
 
-    GEOSGeometry*
-    GEOSClusterDBSCAN(Geometry* g, double eps, unsigned minPoints) {
-        return GEOSClusterDBSCAN_r(handle, g, eps, minPoints);
+    unsigned*
+    GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints, unsigned* numClusters)
+    {
+        return GEOSClusterDBSCAN_r(handle, g, eps, minPoints, numClusters);
     }
 
-    GEOSGeometry*
-    GEOSClusterGeometryDistance(GEOSGeometry* g, double d) {
-        return GEOSClusterGeometryDistance_r(handle, g, d);
+    unsigned*
+    GEOSClusterGeometryDistance(const GEOSGeometry* g, double d, unsigned* numClusters)
+    {
+        return GEOSClusterGeometryDistance_r(handle, g, d, numClusters);
     }
 
-    GEOSGeometry*
-    GEOSClusterGeometryIntersects(GEOSGeometry* g) {
-        return GEOSClusterGeometryIntersects_r(handle, g);
+    unsigned*
+    GEOSClusterGeometryIntersects(const GEOSGeometry* g, unsigned* numClusters)
+    {
+        return GEOSClusterGeometryIntersects_r(handle, g, numClusters);
     }
 
-    GEOSGeometry*
-    GEOSClusterEnvelopeDistance(GEOSGeometry* g, double d) {
-        return GEOSClusterEnvelopeDistance_r(handle, g, d);
+    unsigned*
+    GEOSClusterEnvelopeDistance(const GEOSGeometry* g, double d, unsigned* numClusters)
+    {
+        return GEOSClusterEnvelopeDistance_r(handle, g, d, numClusters);
     }
 
-    GEOSGeometry*
-    GEOSClusterEnvelopeIntersects(GEOSGeometry* g) {
-        return GEOSClusterEnvelopeIntersects_r(handle, g);
+    unsigned*
+    GEOSClusterEnvelopeIntersects(const GEOSGeometry* g, unsigned* numClusters)
+    {
+        return GEOSClusterEnvelopeIntersects_r(handle, g, numClusters);
     }
 
     Geometry*

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -175,6 +175,12 @@ typedef struct GEOSBufParams_t GEOSBufferParams;
 */
 typedef struct GEOSMakeValidParams_t GEOSMakeValidParams;
 
+/**
+* Object containing information about cluster of geometries.
+* \see GEOSClusterInfo_destroy()
+*/
+typedef struct GEOSClusterInfo_t GEOSClusterInfo;
+
 #endif
 
 /** \cond */
@@ -1849,38 +1855,48 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXYZ_r(
     void* userdata);
 
 /** \see GEOSClusterDBSCAN */
-extern unsigned GEOS_DLL* GEOSClusterDBSCAN_r(
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterDBSCAN_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g,
     double eps,
-    unsigned minPoints,
-    unsigned* numClusters);
+    unsigned minPoints);
 
 /** \see GEOSClusterGeometryDistance */
-extern unsigned GEOS_DLL* GEOSClusterGeometryDistance_r(
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterGeometryDistance_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g,
-    double d,
-    unsigned* numClusters);
+    double d);
 
 /** \see GEOSClusterGeometryIntersects */
-extern unsigned GEOS_DLL* GEOSClusterGeometryIntersects_r(
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterGeometryIntersects_r(
     GEOSContextHandle_t handle,
-    const GEOSGeometry* g,
-    unsigned* numClusters);
+    const GEOSGeometry* g);
 
 /** \see GEOSClusterEnvelopeDistance */
-extern unsigned GEOS_DLL* GEOSClusterEnvelopeDistance_r(
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterEnvelopeDistance_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g,
-    double d,
-    unsigned* numClusters);
+    double d);
 
 /** \see GEOSClusterEnvelopeIntersects */
-extern unsigned GEOS_DLL* GEOSClusterEnvelopeIntersects_r(
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterEnvelopeIntersects_r(
     GEOSContextHandle_t handle,
-    const GEOSGeometry* g,
-    unsigned* numClusters);
+    const GEOSGeometry* g);
+
+/** \see GEOSClusterInfo_getNumClusters */
+extern size_t GEOS_DLL GEOSClusterInfo_getNumClusters_r(GEOSContextHandle_t, const GEOSClusterInfo* clusters);
+
+/** \see GEOSClusterInfo_getClusterSize */
+extern size_t GEOS_DLL GEOSClusterInfo_getClusterSize_r(GEOSContextHandle_t, const GEOSClusterInfo* clusters, size_t i);
+
+/** \see GEOSClusterInfo_getClustersForInputs */
+extern size_t GEOS_DLL* GEOSClusterInfo_getClustersForInputs_r(GEOSContextHandle_t, const GEOSClusterInfo* clusters);
+
+/** \see GEOSClusterInfo_getInputsForClusterN */
+extern const size_t GEOS_DLL* GEOSClusterInfo_getInputsForClusterN_r(GEOSContextHandle_t, const GEOSClusterInfo* clusters, size_t i);
+
+/** \see GEOSClusterInfo_destroy */
+extern void GEOS_DLL GEOSClusterInfo_destroy_r(GEOSContextHandle_t, GEOSClusterInfo* info);
 
 /* ========= Algorithms ========= */
 
@@ -3800,7 +3816,10 @@ extern GEOSGeometry GEOS_DLL *GEOSSharedPaths(
 * Functions for clustering geometries
 */
 
-static const unsigned GEOS_CLUSTER_NONE = 4294967295;
+
+
+
+static const size_t GEOS_CLUSTER_NONE = (size_t) -1;
 
 ///@{
 /**
@@ -3811,11 +3830,9 @@ static const unsigned GEOS_CLUSTER_NONE = 4294967295;
  * @param g a collection of geometries to be clustered
  * @param eps distance parameter for clustering
  * @param minPoints density parameter for clustering
- * @param numClusters the number of clusters formed
- * @return an array of cluster identifiers
+ * @return cluster information object
  */
-extern unsigned GEOS_DLL* GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints,
-        unsigned* numClusters);
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints);
 
 /**
  * @brief GEOSClusterGeometryDistance
@@ -3824,10 +3841,9 @@ extern unsigned GEOS_DLL* GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, u
  *
  * @param g a collection of geometries to be clustered
  * @param d minimum distance between geometries in the same cluster
- * @param numClusters the number of clusters formed
- * @return an array of cluster identifiers
+ * @return cluster information object
  */
-extern unsigned GEOS_DLL* GEOSClusterGeometryDistance(const GEOSGeometry* g, double d, unsigned* numClusters);
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterGeometryDistance(const GEOSGeometry* g, double d);
 
 /**
  * @brief GEOSClusterGeometryIntersects
@@ -3835,10 +3851,9 @@ extern unsigned GEOS_DLL* GEOSClusterGeometryDistance(const GEOSGeometry* g, dou
  * Cluster geometries that intersect
  *
  * @param g a collection of geometries to be clustered
- * @param numClusters the number of clusters formed
- * @return an array of cluster identifiers
+ * @return cluster information object
  */
-extern unsigned GEOS_DLL* GEOSClusterGeometryIntersects(const GEOSGeometry* g, unsigned* numClusters);
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterGeometryIntersects(const GEOSGeometry* g);
 
 /**
  * @brief GEOSClusterEnvelopeDistance
@@ -3847,10 +3862,9 @@ extern unsigned GEOS_DLL* GEOSClusterGeometryIntersects(const GEOSGeometry* g, u
  *
  * @param g a collection of geometries to be clustered
  * @param d minimum envelope distance between geometries in the same cluster
- * @param numClusters the number of clusters formed
- * @return an array of cluster identifiers
+ * @return cluster information object
  */
-extern unsigned GEOS_DLL* GEOSClusterEnvelopeDistance(const GEOSGeometry* g, double d, unsigned* numClusters);
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterEnvelopeDistance(const GEOSGeometry* g, double d);
 
 /**
  * @brief GEOSClusterEnvelopeIntersects
@@ -3858,10 +3872,61 @@ extern unsigned GEOS_DLL* GEOSClusterEnvelopeDistance(const GEOSGeometry* g, dou
  * Cluster geometries whose envelopes intersect
  *
  * @param g
- * @param numClusters the number of clusters formed
- * @return an array of cluster identifiers
+ * @return cluster information object
  */
-extern unsigned GEOS_DLL* GEOSClusterEnvelopeIntersects(const GEOSGeometry* g, unsigned* numClusters);
+extern GEOSClusterInfo GEOS_DLL* GEOSClusterEnvelopeIntersects(const GEOSGeometry* g);
+
+/**
+ * @brief GEOSClusterInfo_getNumClusters
+ *
+ * Get the number of clusters identifed by a clustering operation
+ *
+ * @param clusters cluster information object
+ * @return number of clusters identifed
+ */
+extern size_t GEOS_DLL GEOSClusterInfo_getNumClusters(const GEOSClusterInfo* clusters);
+
+/**
+ * @brief GEOSClusterInfo_getSize
+ *
+ * Get the number of elements in the ith cluster (0-indexed)
+ *
+ * @param clusters cluster information object
+ * @param i cluster for which a size will be returned
+ * @return number of elements in the cluster
+ */
+extern size_t GEOS_DLL GEOSClusterInfo_getClusterSize(const GEOSClusterInfo* clusters, size_t i );
+
+/**
+ * @brief GEOSClusterInfo_getClustersForInputs
+ *
+ * Get the cluster index associated with each input to the clustering operation.
+ * Inputs that do are not associated with any cluster will have an index of GEOS_CLUSTER_NONE.
+ *
+ * @param clusters cluster information object
+ * @return an array of cluster indices, to be freed by the caller.
+ */
+extern size_t GEOS_DLL* GEOSClusterInfo_getClustersForInputs(const GEOSClusterInfo* clusters);
+
+/**
+ * @brief GEOSClusterInfo_getInputsForClusterN
+ * @param clusters cluster information object
+ * @param i index of the cluster for which indices should be retrieved
+ * @return a pointer to an array of cluster indices. Size of the array is indicated by
+ *         GEOSClusterInfo_getNumElements. The array is owner by the cluster information
+ *         object and should not be modified or freed by the caller.
+ */
+extern const size_t GEOS_DLL* GEOSClusterInfo_getInputsForClusterN(const GEOSClusterInfo* clusters, size_t i);
+
+/**
+ * @brief GEOSClusterInfo_destroy
+ *
+ * Destroy a cluster information object.
+ *
+ * @param clusters cluster information object
+ */
+extern void GEOS_DLL GEOSClusterInfo_destroy(GEOSClusterInfo* clusters);
+
 ///@}
 
 /* ========== Buffer related functions ========== */

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1849,34 +1849,38 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXYZ_r(
     void* userdata);
 
 /** \see GEOSClusterDBSCAN */
-extern GEOSGeometry GEOS_DLL *GEOSClusterDBSCAN_r(
-        GEOSContextHandle_t handle,
-        GEOSGeometry* g,
-        double eps,
-        unsigned minPoints);
-
+extern unsigned GEOS_DLL* GEOSClusterDBSCAN_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g,
+    double eps,
+    unsigned minPoints,
+    unsigned* numClusters);
 
 /** \see GEOSClusterGeometryDistance */
-extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryDistance_r(
-        GEOSContextHandle_t handle,
-        GEOSGeometry* g,
-        double d);
+extern unsigned GEOS_DLL* GEOSClusterGeometryDistance_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g,
+    double d,
+    unsigned* numClusters);
 
 /** \see GEOSClusterGeometryIntersects */
-extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryIntersects_r(
-        GEOSContextHandle_t handle,
-        GEOSGeometry* g);
+extern unsigned GEOS_DLL* GEOSClusterGeometryIntersects_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g,
+    unsigned* numClusters);
 
 /** \see GEOSClusterEnvelopeDistance */
-extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeDistance_r(
-        GEOSContextHandle_t handle,
-        GEOSGeometry* g,
-        double d);
+extern unsigned GEOS_DLL* GEOSClusterEnvelopeDistance_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g,
+    double d,
+    unsigned* numClusters);
 
 /** \see GEOSClusterEnvelopeIntersects */
-extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeIntersects_r(
-        GEOSContextHandle_t handle,
-        GEOSGeometry* g);
+extern unsigned GEOS_DLL* GEOSClusterEnvelopeIntersects_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* g,
+    unsigned* numClusters);
 
 /* ========= Algorithms ========= */
 
@@ -3791,10 +3795,13 @@ extern GEOSGeometry GEOS_DLL *GEOSSharedPaths(
     const GEOSGeometry* g2);
 ///@}
 
-/* ========== Buffer related functions ========== */
+/* ========== Clustering functions ========== */
 /** @name Clustering
 * Functions for clustering geometries
 */
+
+static const unsigned GEOS_CLUSTER_NONE = 4294967295;
+
 ///@{
 /**
  * @brief GEOSClusterDBSCAN
@@ -3804,9 +3811,11 @@ extern GEOSGeometry GEOS_DLL *GEOSSharedPaths(
  * @param g a collection of geometries to be clustered
  * @param eps distance parameter for clustering
  * @param minPoints density parameter for clustering
- * @return GeometryCollection whose components represent individual clusters
+ * @param numClusters the number of clusters formed
+ * @return an array of cluster identifiers
  */
-extern GEOSGeometry GEOS_DLL *GEOSClusterDBSCAN(GEOSGeometry* g, double eps, unsigned minPoints);
+extern unsigned GEOS_DLL* GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints,
+        unsigned* numClusters);
 
 /**
  * @brief GEOSClusterGeometryDistance
@@ -3814,10 +3823,11 @@ extern GEOSGeometry GEOS_DLL *GEOSClusterDBSCAN(GEOSGeometry* g, double eps, uns
  * Cluster geometries according to a distance threshold
  *
  * @param g a collection of geometries to be clustered
- * @param d minimim distance between geometries in the same cluster
- * @return GeometryCollection whose components represent individual clusters
+ * @param d minimum distance between geometries in the same cluster
+ * @param numClusters the number of clusters formed
+ * @return an array of cluster identifiers
  */
-extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryDistance(GEOSGeometry* g, double d);
+extern unsigned GEOS_DLL* GEOSClusterGeometryDistance(const GEOSGeometry* g, double d, unsigned* numClusters);
 
 /**
  * @brief GEOSClusterGeometryIntersects
@@ -3825,9 +3835,10 @@ extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryDistance(GEOSGeometry* g, doubl
  * Cluster geometries that intersect
  *
  * @param g a collection of geometries to be clustered
- * @return GeometryCollection whose components represent individual clusters
+ * @param numClusters the number of clusters formed
+ * @return an array of cluster identifiers
  */
-extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryIntersects(GEOSGeometry* g);
+extern unsigned GEOS_DLL* GEOSClusterGeometryIntersects(const GEOSGeometry* g, unsigned* numClusters);
 
 /**
  * @brief GEOSClusterEnvelopeDistance
@@ -3835,10 +3846,11 @@ extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryIntersects(GEOSGeometry* g);
  * Cluster geometries according to an envelope distance threshold
  *
  * @param g a collection of geometries to be clustered
- * @param d minimim envelope distance between geometries in the same cluster
- * @return GeometryCollection whose components represent individual clusters
+ * @param d minimum envelope distance between geometries in the same cluster
+ * @param numClusters the number of clusters formed
+ * @return an array of cluster identifiers
  */
-extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeDistance(GEOSGeometry* g, double d);
+extern unsigned GEOS_DLL* GEOSClusterEnvelopeDistance(const GEOSGeometry* g, double d, unsigned* numClusters);
 
 /**
  * @brief GEOSClusterEnvelopeIntersects
@@ -3846,9 +3858,10 @@ extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeDistance(GEOSGeometry* g, doubl
  * Cluster geometries whose envelopes intersect
  *
  * @param g
- * @return GeometryCollection whose components represent individual clusters
+ * @param numClusters the number of clusters formed
+ * @return an array of cluster identifiers
  */
-extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeIntersects(GEOSGeometry* g);
+extern unsigned GEOS_DLL* GEOSClusterEnvelopeIntersects(const GEOSGeometry* g, unsigned* numClusters);
 ///@}
 
 /* ========== Buffer related functions ========== */
@@ -5064,9 +5077,9 @@ extern char GEOS_DLL GEOSEqualsIdentical(
 
 /**
 * Calculate the [DE9IM](https://en.wikipedia.org/wiki/DE-9IM) string for a geometry pair
-* and compare against a DE9IM pattern. 
+* and compare against a DE9IM pattern.
 * Returns true if the computed matrix matches the pattern.
-* The pattern is a 9-character string 
+* The pattern is a 9-character string
 * containing symbols in the set "012TF*".
 * "012F" match the corresponding dimension symbol;
 * "T" matches any non-empty dimension; "*" matches any dimension.

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1848,6 +1848,36 @@ extern GEOSGeometry GEOS_DLL *GEOSGeom_transformXYZ_r(
     GEOSTransformXYZCallback callback,
     void* userdata);
 
+/** \see GEOSClusterDBSCAN */
+extern GEOSGeometry GEOS_DLL *GEOSClusterDBSCAN_r(
+        GEOSContextHandle_t handle,
+        GEOSGeometry* g,
+        double eps,
+        unsigned minPoints);
+
+
+/** \see GEOSClusterGeometryDistance */
+extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryDistance_r(
+        GEOSContextHandle_t handle,
+        GEOSGeometry* g,
+        double d);
+
+/** \see GEOSClusterGeometryIntersects */
+extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryIntersects_r(
+        GEOSContextHandle_t handle,
+        GEOSGeometry* g);
+
+/** \see GEOSClusterEnvelopeDistance */
+extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeDistance_r(
+        GEOSContextHandle_t handle,
+        GEOSGeometry* g,
+        double d);
+
+/** \see GEOSClusterEnvelopeIntersects */
+extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeIntersects_r(
+        GEOSContextHandle_t handle,
+        GEOSGeometry* g);
+
 /* ========= Algorithms ========= */
 
 /** \see GEOSOrientationIndex */
@@ -3759,7 +3789,66 @@ extern GEOSGeometry GEOS_DLL *GEOSClipByRect(
 extern GEOSGeometry GEOS_DLL *GEOSSharedPaths(
     const GEOSGeometry* g1,
     const GEOSGeometry* g2);
+///@}
 
+/* ========== Buffer related functions ========== */
+/** @name Clustering
+* Functions for clustering geometries
+*/
+///@{
+/**
+ * @brief GEOSClusterDBSCAN
+ *
+ * Cluster geometries using the DBSCAN algorithm
+ *
+ * @param g a collection of geometries to be clustered
+ * @param eps distance parameter for clustering
+ * @param minPoints density parameter for clustering
+ * @return GeometryCollection whose components represent individual clusters
+ */
+extern GEOSGeometry GEOS_DLL *GEOSClusterDBSCAN(GEOSGeometry* g, double eps, unsigned minPoints);
+
+/**
+ * @brief GEOSClusterGeometryDistance
+ *
+ * Cluster geometries according to a distance threshold
+ *
+ * @param g a collection of geometries to be clustered
+ * @param d minimim distance between geometries in the same cluster
+ * @return GeometryCollection whose components represent individual clusters
+ */
+extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryDistance(GEOSGeometry* g, double d);
+
+/**
+ * @brief GEOSClusterGeometryIntersects
+ *
+ * Cluster geometries that intersect
+ *
+ * @param g a collection of geometries to be clustered
+ * @return GeometryCollection whose components represent individual clusters
+ */
+extern GEOSGeometry GEOS_DLL *GEOSClusterGeometryIntersects(GEOSGeometry* g);
+
+/**
+ * @brief GEOSClusterEnvelopeDistance
+ *
+ * Cluster geometries according to an envelope distance threshold
+ *
+ * @param g a collection of geometries to be clustered
+ * @param d minimim envelope distance between geometries in the same cluster
+ * @return GeometryCollection whose components represent individual clusters
+ */
+extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeDistance(GEOSGeometry* g, double d);
+
+/**
+ * @brief GEOSClusterEnvelopeIntersects
+ *
+ * Cluster geometries whose envelopes intersect
+ *
+ * @param g
+ * @return GeometryCollection whose components represent individual clusters
+ */
+extern GEOSGeometry GEOS_DLL *GEOSClusterEnvelopeIntersects(GEOSGeometry* g);
 ///@}
 
 /* ========== Buffer related functions ========== */

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -73,6 +73,11 @@
 #include <geos/operation/buffer/BufferOp.h>
 #include <geos/operation/buffer/BufferParameters.h>
 #include <geos/operation/buffer/OffsetCurve.h>
+#include <geos/operation/cluster/DBSCANClusterFinder.h>
+#include <geos/operation/cluster/EnvelopeDistanceClusterFinder.h>
+#include <geos/operation/cluster/EnvelopeIntersectsClusterFinder.h>
+#include <geos/operation/cluster/GeometryDistanceClusterFinder.h>
+#include <geos/operation/cluster/GeometryIntersectsClusterFinder.h>
 #include <geos/operation/distance/DistanceOp.h>
 #include <geos/operation/distance/IndexedFacetDistance.h>
 #include <geos/operation/linemerge/LineMerger.h>
@@ -948,6 +953,55 @@ extern "C" {
         });
     }
 
+    Geometry*
+    GEOSClusterDBSCAN_r(GEOSContextHandle_t extHandle, Geometry* g, double eps, unsigned minPoints)
+    {
+        return execute(extHandle, [&]() {
+            std::unique_ptr<Geometry> in(g);
+            geos::operation::cluster::DBSCANClusterFinder finder(eps, minPoints);
+            return finder.clusterToCollection(std::move(in)).release();
+        });
+    }
+
+    Geometry*
+    GEOSClusterGeometryIntersects_r(GEOSContextHandle_t extHandle, Geometry* g)
+    {
+        return execute(extHandle, [&]() {
+            std::unique_ptr<Geometry> in(g);
+            geos::operation::cluster::GeometryIntersectsClusterFinder finder;
+            return finder.clusterToCollection(std::move(in)).release();
+        });
+    }
+
+    Geometry*
+    GEOSClusterEnvelopeIntersects_r(GEOSContextHandle_t extHandle, Geometry* g)
+    {
+        return execute(extHandle, [&]() {
+            std::unique_ptr<Geometry> in(g);
+            geos::operation::cluster::EnvelopeIntersectsClusterFinder finder;
+            return finder.clusterToCollection(std::move(in)).release();
+        });
+    }
+
+    Geometry*
+    GEOSClusterEnvelopeDistance_r(GEOSContextHandle_t extHandle, Geometry* g, double d)
+    {
+        return execute(extHandle, [&]() {
+            std::unique_ptr<Geometry> in(g);
+            geos::operation::cluster::EnvelopeDistanceClusterFinder finder(d);
+            return finder.clusterToCollection(std::move(in)).release();
+        });
+    }
+
+    Geometry*
+    GEOSClusterGeometryDistance_r(GEOSContextHandle_t extHandle, Geometry* g, double d)
+    {
+        return execute(extHandle, [&]() {
+            std::unique_ptr<Geometry> in(g);
+            geos::operation::cluster::GeometryDistanceClusterFinder finder(d);
+            return finder.clusterToCollection(std::move(in)).release();
+        });
+    }
 
     Geometry*
     GEOSGeomFromWKT_r(GEOSContextHandle_t extHandle, const char* wkt)

--- a/tests/unit/capi/GEOSClusterTest.cpp
+++ b/tests/unit/capi/GEOSClusterTest.cpp
@@ -1,0 +1,101 @@
+//
+// Test Suite for C-API GEOSCluster*
+
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used in test cases.
+struct test_capicluster_data : public capitest::utility {
+
+    test_capicluster_data() {
+        m_reader = GEOSWKTReader_create();
+    }
+
+    ~test_capicluster_data() {
+        GEOSWKTReader_destroy(m_reader);
+    }
+
+    GEOSWKTReader* m_reader;
+};
+
+
+typedef test_group<test_capicluster_data> group;
+typedef group::object object;
+
+group test_capicluster_group("capi::GEOSCluster");
+
+//
+// Test Cases
+//
+template<>
+template<> void object::test<1>
+()
+{
+    GEOSGeometry* input = GEOSWKTReader_read(m_reader,
+                                             "GEOMETRYCOLLECTION ("
+                                             "POINT (0 1),"
+                                             "LINESTRING (0 0, 0 0.1),"
+                                             "LINESTRING (0 0, 1.0 1.0),"
+                                             "POINT (0.9 1.0),"
+                                             "POINT (0 7))");
+
+    GEOSGeometry* result;
+    result = GEOSClusterEnvelopeIntersects(GEOSGeom_clone(input));
+    ensure_equals("two clusters by envelope intersection", GEOSGetNumGeometries(result), 2);
+    GEOSGeom_destroy(result);
+
+    result = GEOSClusterEnvelopeDistance(GEOSGeom_clone(input), 6);
+    ensure_equals("one cluster by envelope distance", GEOSGetNumGeometries(result), 1);
+    GEOSGeom_destroy(result);
+
+    result = GEOSClusterGeometryIntersects(GEOSGeom_clone(input));
+    ensure_equals("four clusters by geometry intersection", GEOSGetNumGeometries(result), 4);
+    GEOSGeom_destroy(result);
+
+    result = GEOSClusterGeometryDistance(GEOSGeom_clone(input), 0.2);
+    ensure_equals("three clusters by distance", GEOSGetNumGeometries(result), 3);
+    GEOSGeom_destroy(result);
+
+    GEOSGeom_destroy(input);
+}
+
+template<>
+template<>
+void object::test<2>()
+{
+    GEOSGeometry* input = GEOSWKTReader_read(m_reader,
+                                             "GEOMETRYCOLLECTION ("
+                                             "POINT (0 0),"
+                                             "POINT (-1 0),"
+                                             "POINT (-1 -0.1),"
+                                             "POINT (-1 0.1),"
+                                             "POINT (1 0),"
+                                             "POINT (2 0),"
+                                             "POINT (3  0),"
+                                             "POINT ( 3 -0.1),"
+                                             "POINT ( 3 0.1)"
+                                             ")");
+
+    GEOSGeometry* result;
+    result = GEOSClusterDBSCAN(GEOSGeom_clone(input), 1.01, 5);
+    ensure_equals("two clusters with minPoints = 5", GEOSGetNumGeometries(result), 2);
+    GEOSGeom_destroy(result);
+
+    result = GEOSClusterDBSCAN(GEOSGeom_clone(input), 1.01, 2);
+    ensure_equals("one cluster with minPoints = 2", GEOSGetNumGeometries(result), 1);
+    GEOSGeom_destroy(result);
+
+    GEOSGeom_destroy(input);
+}
+
+
+} // namespace tut
+

--- a/tests/unit/capi/GEOSClusterTest.cpp
+++ b/tests/unit/capi/GEOSClusterTest.cpp
@@ -15,37 +15,24 @@ namespace tut {
 // Common data used in test cases.
 struct test_capicluster_data : public capitest::utility {
     static GEOSGeometry* construct_clusters(const GEOSGeometry* input,
-                                            unsigned numClusters,
-                                            unsigned* clusterIds)
+                                            const GEOSClusterInfo* clusters)
     {
-        GEOSGeometry* input_cloned = GEOSGeom_clone(input);
-        unsigned ngeoms;
-        GEOSGeometry** components = GEOSGeom_releaseCollection(input_cloned, &ngeoms);
-        GEOSGeom_destroy(input_cloned);
+        auto ngeoms = static_cast<std::size_t>(GEOSGetNumGeometries(input));
+        auto numClusters = GEOSClusterInfo_getNumClusters(clusters);
 
-        // collect the indices associated with each cluster
-        std::vector<std::vector<unsigned>> cluster_component_ids(numClusters);
-        for (unsigned i = 0; i < ngeoms; i++) {
-            cluster_component_ids[clusterIds[i]].push_back(i);
-        }
-
+        std::vector<GEOSGeometry*> cluster_components(ngeoms);
         std::vector<GEOSGeometry*> cluster_geoms(numClusters);
 
-        // assemble a GeometryCollection for each cluster
-        for (unsigned cluster_id = 0; cluster_id < numClusters; cluster_id++) {
-            const std::vector<unsigned> component_ids = cluster_component_ids[cluster_id];
-
-            std::vector<GEOSGeometry*> cluster_component_geoms(component_ids.size());
-            for (std::size_t i = 0; i < component_ids.size(); i++) {
-                cluster_component_geoms[i] = components[component_ids[i]];
+        for (std::size_t cluster_id = 0; cluster_id < numClusters; cluster_id++) {
+            auto sz = GEOSClusterInfo_getClusterSize(clusters, cluster_id);
+            const std::size_t* indices = GEOSClusterInfo_getInputsForClusterN(clusters, cluster_id);
+            for (std::size_t i = 0; i < sz; i++) {
+                cluster_components[i] = GEOSGeom_clone(GEOSGetGeometryN(input, static_cast<int>(indices[i])));
             }
-
             cluster_geoms[cluster_id] = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION,
-                                                                  cluster_component_geoms.data(),
-                                                                  static_cast<unsigned>(cluster_component_geoms.size()));
+                                                                  cluster_components.data(),
+                                                                  static_cast<unsigned>(sz));
         }
-
-        GEOSFree(components);
 
         // combine the clusters into a single nested GeometryCollection
         return GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION,
@@ -75,11 +62,10 @@ template<> void object::test<1>
                  "POINT (0 7))");
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterEnvelopeIntersects(input_, &numClusters);
-        ensure_equals("two clusters by envelope intersection", numClusters, 2u);
+        GEOSClusterInfo* clusters = GEOSClusterEnvelopeIntersects(input_);
+        ensure_equals("two clusters by envelope intersection", GEOSClusterInfo_getNumClusters(clusters), 2u);
 
-        GEOSGeometry* geom_result = construct_clusters(input_, numClusters, cluster_ids);
+        GEOSGeometry* geom_result = construct_clusters(input_, clusters);
         GEOSGeometry* geom_expected = fromWKT("GEOMETRYCOLLECTION ("
                                               "  GEOMETRYCOLLECTION ("
                                               "    POINT (0 1),"
@@ -93,31 +79,25 @@ template<> void object::test<1>
         GEOSGeom_destroy(geom_result);
         GEOSGeom_destroy(geom_expected);
 
-        GEOSFree(cluster_ids);
+        GEOSClusterInfo_destroy(clusters);
     }
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterEnvelopeDistance(input_, 6, &numClusters);
-        ensure_equals("one cluster by envelope distance", numClusters, 1u);
-
-        GEOSFree(cluster_ids);
+        GEOSClusterInfo* clusters = GEOSClusterEnvelopeDistance(input_, 6);
+        ensure_equals("one cluster by envelope distance", GEOSClusterInfo_getNumClusters(clusters), 1u);
+        GEOSClusterInfo_destroy(clusters);
     }
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterGeometryIntersects(input_, &numClusters);
-        ensure_equals("four clusters by geometry intersection", numClusters, 4u);
-
-        GEOSFree(cluster_ids);
+        GEOSClusterInfo* clusters = GEOSClusterGeometryIntersects(input_);
+        ensure_equals("four clusters by geometry intersection", GEOSClusterInfo_getNumClusters(clusters), 4u);
+        GEOSClusterInfo_destroy(clusters);
     }
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterGeometryDistance(input_, 0.2, &numClusters);
-        ensure_equals("three clusters by distance", numClusters, 3u);
-
-        GEOSFree(cluster_ids);
+        GEOSClusterInfo* clusters = GEOSClusterGeometryDistance(input_, 0.2);
+        ensure_equals("three clusters by distance", GEOSClusterInfo_getNumClusters(clusters), 3u);
+        GEOSClusterInfo_destroy(clusters);
     }
 }
 
@@ -139,29 +119,26 @@ void object::test<2>()
                  ")");
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterDBSCAN(input_, 1.01, 5, &numClusters);
-        ensure_equals("two clusters with minPoints = 5", numClusters, 2u);
-
-        GEOSFree(cluster_ids);
+        GEOSClusterInfo* clusters = GEOSClusterDBSCAN(input_, 1.01, 5);
+        ensure_equals("two clusters with minPoints = 5", GEOSClusterInfo_getNumClusters(clusters), 2u);
+        GEOSClusterInfo_destroy(clusters);
     }
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterDBSCAN(input_, 1.01, 2, &numClusters);
-        ensure_equals("one cluster with minPoints = 2", numClusters, 1u);
-
-        GEOSFree(cluster_ids);
+        GEOSClusterInfo* clusters = GEOSClusterDBSCAN(input_, 1.01, 2);
+        ensure_equals("one cluster with minPoints = 2", GEOSClusterInfo_getNumClusters(clusters), 1u);
+        GEOSClusterInfo_destroy(clusters);
     }
 
     {
-        unsigned numClusters = 123;
-        unsigned* cluster_ids = GEOSClusterDBSCAN(input_, 1.01, 20, &numClusters);
-        ensure_equals("no clusters with minPoints = 20", numClusters, 0u);
+        GEOSClusterInfo* clusters = GEOSClusterDBSCAN(input_, 1.01, 20);
+        ensure_equals("no clusters with minPoints = 20", GEOSClusterInfo_getNumClusters(clusters), 0u);
 
+        auto* cluster_ids = GEOSClusterInfo_getClustersForInputs(clusters);
         for (int i = 0; i < GEOSGetNumGeometries(input_); i++) {
             ensure_equals(cluster_ids[i], GEOS_CLUSTER_NONE);
         }
+        GEOSClusterInfo_destroy(clusters);
         GEOSFree(cluster_ids);
     }
 }

--- a/tests/unit/capi/GEOSClusterTest.cpp
+++ b/tests/unit/capi/GEOSClusterTest.cpp
@@ -14,18 +14,45 @@ namespace tut {
 
 // Common data used in test cases.
 struct test_capicluster_data : public capitest::utility {
+    static GEOSGeometry* construct_clusters(const GEOSGeometry* input,
+                                            unsigned numClusters,
+                                            unsigned* clusterIds)
+    {
+        GEOSGeometry* input_cloned = GEOSGeom_clone(input);
+        unsigned ngeoms;
+        GEOSGeometry** components = GEOSGeom_releaseCollection(input_cloned, &ngeoms);
+        GEOSGeom_destroy(input_cloned);
 
-    test_capicluster_data() {
-        m_reader = GEOSWKTReader_create();
+        // collect the indices associated with each cluster
+        std::vector<std::vector<unsigned>> cluster_component_ids(numClusters);
+        for (unsigned i = 0; i < ngeoms; i++) {
+            cluster_component_ids[clusterIds[i]].push_back(i);
+        }
+
+        std::vector<GEOSGeometry*> cluster_geoms(numClusters);
+
+        // assemble a GeometryCollection for each cluster
+        for (unsigned cluster_id = 0; cluster_id < numClusters; cluster_id++) {
+            const std::vector<unsigned> component_ids = cluster_component_ids[cluster_id];
+
+            std::vector<GEOSGeometry*> cluster_component_geoms(component_ids.size());
+            for (std::size_t i = 0; i < component_ids.size(); i++) {
+                cluster_component_geoms[i] = components[component_ids[i]];
+            }
+
+            cluster_geoms[cluster_id] = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION,
+                                                                  cluster_component_geoms.data(),
+                                                                  static_cast<unsigned>(cluster_component_geoms.size()));
+        }
+
+        GEOSFree(components);
+
+        // combine the clusters into a single nested GeometryCollection
+        return GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION,
+                                         cluster_geoms.data(),
+                                         static_cast<unsigned>(cluster_geoms.size()));
     }
-
-    ~test_capicluster_data() {
-        GEOSWKTReader_destroy(m_reader);
-    }
-
-    GEOSWKTReader* m_reader;
 };
-
 
 typedef test_group<test_capicluster_data> group;
 typedef group::object object;
@@ -39,61 +66,104 @@ template<>
 template<> void object::test<1>
 ()
 {
-    GEOSGeometry* input = GEOSWKTReader_read(m_reader,
-                                             "GEOMETRYCOLLECTION ("
-                                             "POINT (0 1),"
-                                             "LINESTRING (0 0, 0 0.1),"
-                                             "LINESTRING (0 0, 1.0 1.0),"
-                                             "POINT (0.9 1.0),"
-                                             "POINT (0 7))");
+    input_ = fromWKT(
+                 "GEOMETRYCOLLECTION ("
+                 "POINT (0 1),"
+                 "LINESTRING (0 0, 0 0.1),"
+                 "LINESTRING (0 0, 1.0 1.0),"
+                 "POINT (0.9 1.0),"
+                 "POINT (0 7))");
 
-    GEOSGeometry* result;
-    result = GEOSClusterEnvelopeIntersects(GEOSGeom_clone(input));
-    ensure_equals("two clusters by envelope intersection", GEOSGetNumGeometries(result), 2);
-    GEOSGeom_destroy(result);
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterEnvelopeIntersects(input_, &numClusters);
+        ensure_equals("two clusters by envelope intersection", numClusters, 2u);
 
-    result = GEOSClusterEnvelopeDistance(GEOSGeom_clone(input), 6);
-    ensure_equals("one cluster by envelope distance", GEOSGetNumGeometries(result), 1);
-    GEOSGeom_destroy(result);
+        GEOSGeometry* geom_result = construct_clusters(input_, numClusters, cluster_ids);
+        GEOSGeometry* geom_expected = fromWKT("GEOMETRYCOLLECTION ("
+                                              "  GEOMETRYCOLLECTION ("
+                                              "    POINT (0 1),"
+                                              "    LINESTRING (0 0, 0 0.1),"
+                                              "    LINESTRING (0 0, 1.0 1.0),"
+                                              "    POINT (0.9 1.0)),"
+                                              "  GEOMETRYCOLLECTION ("
+                                              "    POINT (0 7)))");
 
-    result = GEOSClusterGeometryIntersects(GEOSGeom_clone(input));
-    ensure_equals("four clusters by geometry intersection", GEOSGetNumGeometries(result), 4);
-    GEOSGeom_destroy(result);
+        ensure_geometry_equals_identical(geom_expected, geom_result);
+        GEOSGeom_destroy(geom_result);
+        GEOSGeom_destroy(geom_expected);
 
-    result = GEOSClusterGeometryDistance(GEOSGeom_clone(input), 0.2);
-    ensure_equals("three clusters by distance", GEOSGetNumGeometries(result), 3);
-    GEOSGeom_destroy(result);
+        GEOSFree(cluster_ids);
+    }
 
-    GEOSGeom_destroy(input);
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterEnvelopeDistance(input_, 6, &numClusters);
+        ensure_equals("one cluster by envelope distance", numClusters, 1u);
+
+        GEOSFree(cluster_ids);
+    }
+
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterGeometryIntersects(input_, &numClusters);
+        ensure_equals("four clusters by geometry intersection", numClusters, 4u);
+
+        GEOSFree(cluster_ids);
+    }
+
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterGeometryDistance(input_, 0.2, &numClusters);
+        ensure_equals("three clusters by distance", numClusters, 3u);
+
+        GEOSFree(cluster_ids);
+    }
 }
 
 template<>
 template<>
 void object::test<2>()
 {
-    GEOSGeometry* input = GEOSWKTReader_read(m_reader,
-                                             "GEOMETRYCOLLECTION ("
-                                             "POINT (0 0),"
-                                             "POINT (-1 0),"
-                                             "POINT (-1 -0.1),"
-                                             "POINT (-1 0.1),"
-                                             "POINT (1 0),"
-                                             "POINT (2 0),"
-                                             "POINT (3  0),"
-                                             "POINT ( 3 -0.1),"
-                                             "POINT ( 3 0.1)"
-                                             ")");
+    input_ = fromWKT(
+                 "GEOMETRYCOLLECTION ("
+                 "POINT (0 0),"
+                 "POINT (-1 0),"
+                 "POINT (-1 -0.1),"
+                 "POINT (-1 0.1),"
+                 "POINT (1 0),"
+                 "POINT (2 0),"
+                 "POINT (3  0),"
+                 "POINT ( 3 -0.1),"
+                 "POINT ( 3 0.1)"
+                 ")");
 
-    GEOSGeometry* result;
-    result = GEOSClusterDBSCAN(GEOSGeom_clone(input), 1.01, 5);
-    ensure_equals("two clusters with minPoints = 5", GEOSGetNumGeometries(result), 2);
-    GEOSGeom_destroy(result);
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterDBSCAN(input_, 1.01, 5, &numClusters);
+        ensure_equals("two clusters with minPoints = 5", numClusters, 2u);
 
-    result = GEOSClusterDBSCAN(GEOSGeom_clone(input), 1.01, 2);
-    ensure_equals("one cluster with minPoints = 2", GEOSGetNumGeometries(result), 1);
-    GEOSGeom_destroy(result);
+        GEOSFree(cluster_ids);
+    }
 
-    GEOSGeom_destroy(input);
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterDBSCAN(input_, 1.01, 2, &numClusters);
+        ensure_equals("one cluster with minPoints = 2", numClusters, 1u);
+
+        GEOSFree(cluster_ids);
+    }
+
+    {
+        unsigned numClusters = 123;
+        unsigned* cluster_ids = GEOSClusterDBSCAN(input_, 1.01, 20, &numClusters);
+        ensure_equals("no clusters with minPoints = 20", numClusters, 0u);
+
+        for (int i = 0; i < GEOSGetNumGeometries(input_); i++) {
+            ensure_equals(cluster_ids[i], GEOS_CLUSTER_NONE);
+        }
+        GEOSFree(cluster_ids);
+    }
 }
 
 


### PR DESCRIPTION
This PR resurrects the C API that was removed from  #688 and changes it to return an array of cluster IDs instead of a GeometryCollection, as suggested in #823.

This is clearly a more flexible API than the one implemented in e464b798a6f6bb04f5de2bd0909ac3a7c4530754, but it becomes somewhat awkward to construct geometries representing the clusters (see function `construct_clusters` in the test suite).

I am a bit averse to adding new types to the C API, but I am wondering if something like the following would be an improvement.

```
struct GEOSClusterInfo;

// return cluster info or NULL on error
GEOSClusterInfo* GEOSClusterDBSCAN(const GEOSGeometry* g, double eps, unsigned minPoints);

unsigned GEOSClusterInfo_getNumClusters(const GEOSClusterInfo* clusters);
unsigned GEOSClusterInfo_getClusterSize(const GEOSClusterInfo* clusters, unsigned i);

// Return an array with the input indices associated with the cluster i
unsigned* GEOSClusterInfo_getIndicesForCluster(const GEOSClusterInfo* clusters, unsigned i);

// Return an array with the cluster id associated with each input index
// Input indices not associated with a cluster will have a cluster id of GEOS_CLUSTER_NONE
unsigned* GEOSClusterInfo_getClusterForIndices(const GEOSClusterInfo*);

void GEOSClusterInfo_destroy(GEOSClusterInfo*);


```