### PR TITLE
TopologyPredicate.h: add missing ostream inclusion

### DIFF
--- a/include/geos/operation/relateng/TopologyPredicate.h
+++ b/include/geos/operation/relateng/TopologyPredicate.h
@@ -18,6 +18,7 @@
 #include <geos/geom/Location.h>
 #include <geos/export.h>
 
+#include <ostream> // for operator<<
 
 // Forward declarations
 namespace geos {


### PR DESCRIPTION
Fixes #1172