### PR TITLE
CoordinateSequenceFilter.h: Include cstddef for size_t.

### DIFF
--- a/include/geos/geom/CoordinateSequenceFilter.h
+++ b/include/geos/geom/CoordinateSequenceFilter.h
@@ -21,6 +21,7 @@
 #include <geos/export.h>
 
 #include <cassert>
+#include <cstddef>
 
 // Forward declarations
 namespace geos {


### PR DESCRIPTION
Breaks on some funky build setups.