### PR TITLE
CMake: use enable_testing() instead of include(CTest)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,9 +382,12 @@ add_subdirectory(capi)
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
+
+option(BUILD_TESTING "Build the testing tree." ON)
+
 if(PROJECT_IS_TOP_LEVEL)
-  include(CTest)
   if(BUILD_TESTING)
+    enable_testing()
     add_subdirectory(tests)
   endif()
 endif()


### PR DESCRIPTION
According to Craig Scott in https://discourse.cmake.org/t/is-there-any-reason-to-prefer-include-ctest-or-enable-testing-over-the-other/1905/2 , using include(CTest) adds unnecessary clutter that is only needed for dashboard submission. enable_testing() is enough otherwise

"Port" of https://github.com/OSGeo/shapelib/pull/162