### PR TITLE
Use Ozaki et al.'s error bound and single-branch evaluation in orientation index filter.

### DIFF
--- a/include/geos/algorithm/CGAlgorithmsDD.h
+++ b/include/geos/algorithm/CGAlgorithmsDD.h
@@ -20,6 +20,7 @@
 
 #include <geos/export.h>
 #include <geos/math/DD.h>
+#include <cmath>
 
 // Forward declarations
 namespace geos {
@@ -92,41 +93,14 @@ public:
         double pbx, double pby,
         double pcx, double pcy)
     {
-        /**
-         * A value which is safely greater than the relative round-off
-         * error in double-precision numbers
-         */
-        double constexpr DP_SAFE_EPSILON =  1e-15;
-
-        double detsum;
         double const detleft = (pax - pcx) * (pby - pcy);
         double const detright = (pay - pcy) * (pbx - pcx);
         double const det = detleft - detright;
-
-        if(detleft > 0.0) {
-            if(detright <= 0.0) {
-                return orientation(det);
-            }
-            else {
-                detsum = detleft + detright;
-            }
-        }
-        else if(detleft < 0.0) {
-            if(detright >= 0.0) {
-                return orientation(det);
-            }
-            else {
-                detsum = -detleft - detright;
-            }
-        }
-        else {
-            return orientation(det);
-        }
-
-        double const errbound = DP_SAFE_EPSILON * detsum;
-        if((det >= errbound) || (-det >= errbound)) {
-            return orientation(det);
-        }
+        // Coefficient due to https://doi.org/10.1007/s10543-015-0574-9
+        double const error = std::abs(detleft + detright)
+                             * 3.3306690621773724e-16;
+        if (std::abs(det) >= error)
+            return (det > 0) - (det < 0);
         return CGAlgorithmsDD::FAILURE;
     };
 
@@ -188,6 +162,3 @@ protected:
 
 } // namespace geos::algorithm
 } // namespace geos
-
-
-


### PR DESCRIPTION
This PR is separated out of #1162 . It contains two changes to the orientation predicate. 

The first change changes the relative error bound from currently 1e-15 to ~3.33e-16, which is proven to be sufficient in https://doi.org/10.1007/s10543-015-0574-9 by Ozaki et al. A tighter error bound can reduce the calls to the expensive exact computation in some degenerate cases (Edit: Here is a gist demonstrating this for a sequence of 100k generated near-collinear inputs https://gist.github.com/tinko92/ce44f93d8d4e4d5909310c00cf19b391 ) and has no disadvantages.

The second changes is also motivated by https://doi.org/10.1007/s10543-015-0574-9 and reduces the number of branches and instructions in the evaluation. This is more concise and may result in faster evaluation (benchmarks are in the referenced paper) but I am not currently aware of any geos-benchmarks, beside the Orientation Index micro benchmark, for which the orientation predicate is the bottle neck. The original logic that is replaced is from the function body of `REAL orient2d(pa, pb, pc)` https://www.cs.cmu.edu/afs/cs/project/quake/public/code/predicates.c , where the early returns make use of the branching in the fabs-computation, discussed in the comment preceding `#define Absolute(a)  ((a) >= 0.0 ? (a) : -(a))`. This reasoning is obsolete because modern compilers with enabled optimizations will compile fabs to a branchless masking of the sign bit.

Edit: I did not remove the `orientation(double x)` function, which seems unused now, because I don't know if that would be considered an API change (it's not in a namespace called detail or internal or sth. like that and I don't know the geos conventions). But I can edit the commit if it is no longer needed.

Edit2: Sorry for only now reading more about the jts-geos-relationship/-process. I will propose the same change to JTS, when I find time. Having said that, since patched and unpatched always return the correct orientation by deferring filter misses to the exact computation for inputs that do not go near overflow/underflow, this would not change observable behavior between JTS/Geos for the same inputs, except in computation time, so I think it classifies as an implementation detail/optimization.