### PR TITLE
Add override specifier in MonotoneChainPerfTest to avoid GCC warning.

### DIFF
--- a/benchmarks/index/chain/MonotoneChainPerfTest.cpp
+++ b/benchmarks/index/chain/MonotoneChainPerfTest.cpp
@@ -53,7 +53,7 @@ static void BM_MonotoneChainOverlaps(benchmark::State& state) {
 
     struct EmptyOverlapAction : public MonotoneChainOverlapAction {
         virtual void
-        overlap(const LineSegment& seg1, const LineSegment& seg2) {
+        overlap(const LineSegment& seg1, const LineSegment& seg2) override {
             (void) seg1;
             (void) seg2;
         }


### PR DESCRIPTION
A single line edit to fix a warning (that is turnde into an error) from GCC when building with -DBUILD_BENCHMARKS=ON.