### PR TITLE
Move using-declarations into class body to avoid polluting the global namespace

### DIFF
--- a/include/geos/algorithm/CGAlgorithmsDD.h
+++ b/include/geos/algorithm/CGAlgorithmsDD.h
@@ -29,13 +29,12 @@ class CoordinateSequence;
 }
 }
 
-using namespace geos::math;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 
 /// Implements basic computational geometry algorithms using extended precision float-point arithmetic.
 class GEOS_DLL CGAlgorithmsDD {
+    using DD = geos::math::DD;
 
 public:
 

--- a/include/geos/algorithm/MinimumAreaRectangle.h
+++ b/include/geos/algorithm/MinimumAreaRectangle.h
@@ -32,15 +32,6 @@ namespace geos {
 	}
 }
 
-using geos::geom::CoordinateSequence;
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::LineSegment;
-using geos::geom::LineString;
-using geos::geom::Polygon;
-
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 
@@ -65,6 +56,13 @@ namespace algorithm { // geos::algorithm
  *
  */
 class GEOS_DLL MinimumAreaRectangle {
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LineSegment = geos::geom::LineSegment;
+    using LineString = geos::geom::LineString;
+    using Polygon = geos::geom::Polygon;
 
 private:
 

--- a/include/geos/algorithm/PolygonNodeTopology.h
+++ b/include/geos/algorithm/PolygonNodeTopology.h
@@ -25,9 +25,6 @@ class CoordinateXY;
 }
 }
 
-using geos::geom::CoordinateXY;
-
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 
@@ -39,6 +36,7 @@ namespace algorithm { // geos::algorithm
  *
  */
 class GEOS_DLL PolygonNodeTopology {
+    using CoordinateXY = geos::geom::CoordinateXY;
 
 public:
 

--- a/include/geos/algorithm/Rectangle.h
+++ b/include/geos/algorithm/Rectangle.h
@@ -26,15 +26,14 @@ class Polygon;
 }
 }
 
-using geos::geom::CoordinateXY;
-using geos::geom::GeometryFactory;
-using geos::geom::LineSegment;
-using geos::geom::Polygon;
-
 namespace geos {
 namespace algorithm {
 
 class GEOS_DLL Rectangle {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LineSegment = geos::geom::LineSegment;
+    using Polygon = geos::geom::Polygon;
 
 public:
 

--- a/include/geos/algorithm/construct/IndexedDistanceToPoint.h
+++ b/include/geos/algorithm/construct/IndexedDistanceToPoint.h
@@ -25,10 +25,6 @@
 #include <geos/algorithm/construct/IndexedPointInPolygonsLocator.h>
 #include <geos/operation/distance/IndexedFacetDistance.h>
 
-using geos::geom::Geometry;
-using geos::geom::Point;
-using geos::operation::distance::IndexedFacetDistance;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace construct { // geos::algorithm::construct
@@ -43,6 +39,9 @@ namespace construct { // geos::algorithm::construct
  * \author Martin Davis
  */
 class GEOS_DLL IndexedDistanceToPoint {
+    using Geometry = geos::geom::Geometry;
+    using Point = geos::geom::Point;
+    using IndexedFacetDistance = geos::operation::distance::IndexedFacetDistance;
 
 public:
     /** 

--- a/include/geos/algorithm/construct/IndexedPointInPolygonsLocator.h
+++ b/include/geos/algorithm/construct/IndexedPointInPolygonsLocator.h
@@ -25,12 +25,6 @@
 #include <geos/index/strtree/TemplateSTRtree.h>
 #include <geos/algorithm/locate/IndexedPointInAreaLocator.h>
 
-using geos::geom::Geometry;
-using geos::geom::CoordinateXY;
-using geos::geom::Location;
-using geos::index::strtree::TemplateSTRtree;
-using geos::algorithm::locate::IndexedPointInAreaLocator;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace construct { // geos::algorithm::construct
@@ -43,6 +37,12 @@ namespace construct { // geos::algorithm::construct
  * \author Martin Davis
  */
 class GEOS_DLL IndexedPointInPolygonsLocator {
+    using Geometry = geos::geom::Geometry;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Location = geos::geom::Location;
+    template<typename ItemType>
+    using TemplateSTRtree = geos::index::strtree::TemplateSTRtree<ItemType>;
+    using IndexedPointInAreaLocator = geos::algorithm::locate::IndexedPointInAreaLocator;
 
 public:
     /** 

--- a/include/geos/algorithm/construct/LargestEmptyCircle.h
+++ b/include/geos/algorithm/construct/LargestEmptyCircle.h
@@ -40,8 +40,6 @@ class Point;
 }
 }
 
-using geos::operation::distance::IndexedFacetDistance;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace construct { // geos::algorithm::construct
@@ -75,6 +73,7 @@ namespace construct { // geos::algorithm::construct
 * \author Martin Davis
 */
 class GEOS_DLL LargestEmptyCircle {
+    using IndexedFacetDistance = geos::operation::distance::IndexedFacetDistance;
 
 public:
 

--- a/include/geos/algorithm/construct/MaximumInscribedCircle.h
+++ b/include/geos/algorithm/construct/MaximumInscribedCircle.h
@@ -41,9 +41,6 @@ class Point;
 }
 }
 
-using geos::algorithm::locate::IndexedPointInAreaLocator;
-using geos::operation::distance::IndexedFacetDistance;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace construct { // geos::algorithm::construct
@@ -54,6 +51,8 @@ namespace construct { // geos::algorithm::construct
  * Also computes two points which are separated by the distance.
  */
 class GEOS_DLL MaximumInscribedCircle {
+    using IndexedPointInAreaLocator = geos::algorithm::locate::IndexedPointInAreaLocator;
+    using IndexedFacetDistance = geos::operation::distance::IndexedFacetDistance;
 
 public:
 

--- a/include/geos/algorithm/hull/ConcaveHull.h
+++ b/include/geos/algorithm/hull/ConcaveHull.h
@@ -37,16 +37,6 @@ class QuadEdgeSubdivision;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::Triangle;
-using geos::triangulate::quadedge::QuadEdge;
-using geos::triangulate::quadedge::QuadEdgeSubdivision;
-using geos::triangulate::quadedge::TriangleVisitor;
-using geos::triangulate::tri::Tri;
-using geos::triangulate::tri::TriList;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace hull {      // geos::algorithm::hull
@@ -93,6 +83,15 @@ typedef std::priority_queue<HullTri*, std::vector<HullTri*>, HullTri::HullTriCom
 * @author mdavis
 */
 class GEOS_DLL ConcaveHull {
+    using Coordinate = geos::geom::Coordinate;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using Triangle = geos::geom::Triangle;
+    using QuadEdge = geos::triangulate::quadedge::QuadEdge;
+    using QuadEdgeSubdivision = geos::triangulate::quadedge::QuadEdgeSubdivision;
+    using Tri = geos::triangulate::tri::Tri;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
 
 public:
 

--- a/include/geos/algorithm/hull/ConcaveHullOfPolygons.h
+++ b/include/geos/algorithm/hull/ConcaveHullOfPolygons.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <geos/triangulate/tri/TriList.h>
+#include <geos/triangulate/tri/Tri.h>
 
 #include <set>
 #include <deque>
@@ -37,21 +38,6 @@ class Tri;
 }
 }
 }
-
-#include <geos/triangulate/tri/Tri.h>
-
-
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Envelope;
-using geos::geom::Geometry;
-using geos::geom::GeometryCollection;
-using geos::geom::GeometryFactory;
-using geos::geom::LinearRing;
-using geos::geom::Polygon;
-using geos::triangulate::tri::Tri;
-using geos::triangulate::tri::TriList;
-
 
 namespace geos {
 namespace algorithm { // geos::algorithm
@@ -95,6 +81,17 @@ namespace hull {      // geos::algorithm::hull
  *
  */
 class GEOS_DLL ConcaveHullOfPolygons {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
+    using Geometry = geos::geom::Geometry;
+    using GeometryCollection = geos::geom::GeometryCollection;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LinearRing = geos::geom::LinearRing;
+    using Polygon = geos::geom::Polygon;
+    using Tri = geos::triangulate::tri::Tri;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
 
 private:
 

--- a/include/geos/algorithm/hull/HullTri.h
+++ b/include/geos/algorithm/hull/HullTri.h
@@ -33,20 +33,20 @@ namespace quadedge {
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Triangle;
-using geos::triangulate::tri::Tri;
-using geos::triangulate::tri::TriList;
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace hull {      // geos::algorithm::hull
 
 
 
-class HullTri : public Tri
-{
-    private:
+class HullTri : public geos::triangulate::tri::Tri {
+    using Coordinate = geos::geom::Coordinate;
+    using Triangle = geos::geom::Triangle;
+    using Tri = geos::triangulate::tri::Tri;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
+
+private:
 
         double m_size;
         bool m_isMarked = false;

--- a/include/geos/algorithm/hull/HullTriangulation.h
+++ b/include/geos/algorithm/hull/HullTriangulation.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <geos/algorithm/hull/HullTri.h>
-#include <geos/triangulate/tri/Tri.h>
 #include <geos/triangulate/tri/TriList.h>
 #include <geos/triangulate/quadedge/TriangleVisitor.h>
 
@@ -34,16 +33,6 @@ class QuadEdgeSubdivision;
 }
 }
 
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::Coordinate;
-using geos::triangulate::tri::Tri;
-using geos::triangulate::tri::TriList;
-using geos::triangulate::quadedge::QuadEdge;
-using geos::triangulate::quadedge::QuadEdgeSubdivision;
-using geos::triangulate::quadedge::TriangleVisitor;
-
-
 namespace geos {
 namespace algorithm { // geos::algorithm
 namespace hull {      // geos::algorithm::hull
@@ -51,6 +40,14 @@ namespace hull {      // geos::algorithm::hull
 
 class HullTriangulation
 {
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using Coordinate = geos::geom::Coordinate;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
+    using QuadEdge = geos::triangulate::quadedge::QuadEdge;
+    using QuadEdgeSubdivision = geos::triangulate::quadedge::QuadEdgeSubdivision;
+    using TriangleVisitor = geos::triangulate::quadedge::TriangleVisitor;
 
 private:
 

--- a/include/geos/algorithm/hull/OuterShellsExtracter.h
+++ b/include/geos/algorithm/hull/OuterShellsExtracter.h
@@ -18,19 +18,10 @@
 
 namespace geos {
 namespace geom {
-class Coordinate;
-class CoordinateSequence;
-class Envelope;
 class Geometry;
-class GeometryCollection;
-class GeometryFactory;
 class LinearRing;
-class Polygon;
 }
 }
-
-using geos::geom::Geometry;
-using geos::geom::LinearRing;
 
 namespace geos {
 namespace algorithm { // geos::algorithm
@@ -44,6 +35,9 @@ namespace hull {      // geos::algorithm::hull
  * \author Martin Davis
  */
 class OuterShellsExtracter {
+    using Geometry = geos::geom::Geometry;
+    using LinearRing = geos::geom::LinearRing;
+
 private:
 
     OuterShellsExtracter(const Geometry& g);

--- a/include/geos/coverage/Corner.h
+++ b/include/geos/coverage/Corner.h
@@ -32,19 +32,16 @@ class LineString;
 }
 }
 
-
-using geos::geom::Coordinate;
-using geos::geom::Envelope;
-using geos::geom::LineString;
-using geos::simplify::LinkedLine;
-
-
 namespace geos {
 namespace coverage { // geos::coverage
 
 
 class Corner
 {
+    using Coordinate = geos::geom::Coordinate;
+    using Envelope = geos::geom::Envelope;
+    using LineString = geos::geom::LineString;
+    using LinkedLine = geos::simplify::LinkedLine;
 
 public:
 

--- a/include/geos/coverage/CoverageBoundarySegmentFinder.h
+++ b/include/geos/coverage/CoverageBoundarySegmentFinder.h
@@ -28,18 +28,16 @@ class Geometry;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::CoordinateSequenceFilter;
-using geos::geom::Geometry;
-using geos::geom::LineSegment;
-
 namespace geos {
 namespace coverage { // geos::coverage
 
-class CoverageBoundarySegmentFinder : public CoordinateSequenceFilter
+class CoverageBoundarySegmentFinder : public geos::geom::CoordinateSequenceFilter
 {
-
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using CoordinateSequenceFilter = geos::geom::CoordinateSequenceFilter;
+    using Geometry = geos::geom::Geometry;
+    using LineSegment = geos::geom::LineSegment;
 
 public:
 

--- a/include/geos/coverage/CoverageEdge.h
+++ b/include/geos/coverage/CoverageEdge.h
@@ -32,14 +32,6 @@ class GeometryFactory;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::GeometryFactory;
-using geos::geom::LinearRing;
-using geos::geom::LineString;
-using geos::geom::LineSegment;
-using geos::geom::MultiLineString;
-
 namespace geos {      // geos.
 namespace coverage { // geos.coverage
 
@@ -52,6 +44,14 @@ namespace coverage { // geos.coverage
  *
  */
 class GEOS_DLL CoverageEdge {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LinearRing = geos::geom::LinearRing;
+    using LineString = geos::geom::LineString;
+    using LineSegment = geos::geom::LineSegment;
+    using MultiLineString = geos::geom::MultiLineString;
+
 
 private:
 

--- a/include/geos/coverage/CoverageGapFinder.h
+++ b/include/geos/coverage/CoverageGapFinder.h
@@ -27,8 +27,6 @@ class LinearRing;
 }
 }
 
-using geos::geom::Geometry;
-using geos::geom::LinearRing;
 
 
 namespace geos {      // geos
@@ -50,6 +48,8 @@ namespace coverage { // geos::coverage
  *
  */
 class GEOS_DLL CoverageGapFinder {
+    using Geometry = geos::geom::Geometry;
+    using LinearRing = geos::geom::LinearRing;
 
 private:
 

--- a/include/geos/coverage/CoveragePolygon.h
+++ b/include/geos/coverage/CoveragePolygon.h
@@ -25,15 +25,14 @@ class Polygon;
 }
 }
 
-using geos::geom::CoordinateXY;
-using geos::geom::Envelope;
-using geos::geom::Polygon;
-using geos::algorithm::locate::IndexedPointInAreaLocator;
-
 namespace geos {        // geos
 namespace coverage {    // geos::coverage
 
 class GEOS_DLL CoveragePolygon {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Envelope = geos::geom::Envelope;
+    using Polygon = geos::geom::Polygon;
+    using IndexedPointInAreaLocator = geos::algorithm::locate::IndexedPointInAreaLocator;
 
     // Members
     const Polygon* m_polygon;

--- a/include/geos/coverage/CoveragePolygonValidator.h
+++ b/include/geos/coverage/CoveragePolygonValidator.h
@@ -33,12 +33,6 @@ class GeometryFactory;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Envelope;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::LineSegment;
-using geos::algorithm::locate::IndexedPointInAreaLocator;
 
 namespace geos {      // geos
 namespace coverage { // geos::coverage
@@ -96,6 +90,15 @@ namespace coverage { // geos::coverage
  *
  */
 class GEOS_DLL CoveragePolygonValidator {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
+    using Polygon = geos::geom::Polygon;
+    using LinearRing = geos::geom::LinearRing;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LineSegment = geos::geom::LineSegment;
+    using IndexedPointInAreaLocator = geos::algorithm::locate::IndexedPointInAreaLocator;
 
 private:
 

--- a/include/geos/coverage/CoverageRing.h
+++ b/include/geos/coverage/CoverageRing.h
@@ -31,18 +31,17 @@ class Polygon;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::Polygon;
-using geos::geom::LineString;
-using geos::geom::LinearRing;
-
 namespace geos {      // geos.
 namespace coverage { // geos.coverage
 
 class GEOS_DLL CoverageRing : public noding::BasicSegmentString {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using Polygon = geos::geom::Polygon;
+    using LineString = geos::geom::LineString;
+    using LinearRing = geos::geom::LinearRing;
 
 private:
 

--- a/include/geos/coverage/CoverageRingEdges.h
+++ b/include/geos/coverage/CoverageRingEdges.h
@@ -36,14 +36,6 @@ class CoverageEdge;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Geometry;
-using geos::geom::LinearRing;
-using geos::geom::LineSegment;
-using geos::geom::MultiPolygon;
-using geos::geom::Polygon;
-
 namespace geos {     // geos
 namespace coverage { // geos.coverage
 
@@ -58,6 +50,13 @@ namespace coverage { // geos.coverage
  * @author Martin Davis
  */
 class GEOS_DLL CoverageRingEdges {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
+    using LinearRing = geos::geom::LinearRing;
+    using LineSegment = geos::geom::LineSegment;
+    using MultiPolygon = geos::geom::MultiPolygon;
+    using Polygon = geos::geom::Polygon;
 
 private:
 

--- a/include/geos/coverage/CoverageSimplifier.h
+++ b/include/geos/coverage/CoverageSimplifier.h
@@ -32,13 +32,6 @@ class CoverageEdge;
 }
 }
 
-
-using geos::coverage::CoverageEdge;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::MultiLineString;
-
-
 namespace geos {
 namespace coverage { // geos::coverage
 
@@ -74,7 +67,10 @@ namespace coverage { // geos::coverage
  * @author Martin Davis
  */
 class GEOS_DLL CoverageSimplifier {
-
+    using CoverageEdge = geos::coverage::CoverageEdge;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using MultiLineString = geos::geom::MultiLineString;
 
 public:
 

--- a/include/geos/coverage/CoverageUnion.h
+++ b/include/geos/coverage/CoverageUnion.h
@@ -25,8 +25,6 @@ class Geometry;
 }
 }
 
-using geos::geom::Geometry;
-
 namespace geos {      // geos
 namespace coverage { // geos::coverage
 
@@ -39,6 +37,7 @@ namespace coverage { // geos::coverage
  *
  */
 class GEOS_DLL CoverageUnion {
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/coverage/CoverageValidator.h
+++ b/include/geos/coverage/CoverageValidator.h
@@ -24,9 +24,6 @@ class Geometry;
 }
 }
 
-using geos::geom::Geometry;
-using geos::index::strtree::TemplateSTRtree;
-
 namespace geos {      // geos
 namespace coverage { // geos::coverage
 
@@ -63,6 +60,9 @@ namespace coverage { // geos::coverage
  *
  */
 class GEOS_DLL CoverageValidator {
+    using Geometry = geos::geom::Geometry;
+    template <typename ItemType>
+    using TemplateSTRtree = geos::index::strtree::TemplateSTRtree<ItemType>;
 
 private:
 

--- a/include/geos/coverage/InvalidSegmentDetector.h
+++ b/include/geos/coverage/InvalidSegmentDetector.h
@@ -30,12 +30,6 @@ class CoverageRing;
 }
 }
 
-
-using geos::noding::SegmentIntersector;
-using geos::noding::SegmentString;
-using geos::geom::Coordinate;
-
-
 namespace geos {      // geos.
 namespace coverage { // geos.coverage
 
@@ -52,7 +46,9 @@ namespace coverage { // geos.coverage
  * @author Martin Davis
  *
  */
-class GEOS_DLL InvalidSegmentDetector : public SegmentIntersector {
+class GEOS_DLL InvalidSegmentDetector : public geos::noding::SegmentIntersector {
+    using SegmentString = geos::noding::SegmentString;
+    using Coordinate = geos::geom::Coordinate;
 
 private:
 

--- a/include/geos/coverage/TPVWSimplifier.h
+++ b/include/geos/coverage/TPVWSimplifier.h
@@ -35,20 +35,6 @@ class MultiLineString;
 }
 }
 
-
-using geos::coverage::Corner;
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Envelope;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::LineString;
-using geos::geom::MultiLineString;
-using geos::index::VertexSequencePackedRtree;
-using geos::index::strtree::TemplateSTRtree;
-using geos::simplify::LinkedLine;
-
-
 namespace geos {
 namespace coverage { // geos::coverage
 
@@ -73,6 +59,18 @@ namespace coverage { // geos::coverage
  */
 class GEOS_DLL TPVWSimplifier
 {
+    using Corner = geos::coverage::Corner;
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LineString = geos::geom::LineString;
+    using MultiLineString = geos::geom::MultiLineString;
+    using VertexSequencePackedRtree = geos::index::VertexSequencePackedRtree;
+    template<typename ItemType>
+    using TemplateSTRtree = geos::index::strtree::TemplateSTRtree<ItemType>;
+    using LinkedLine = geos::simplify::LinkedLine;
 
 public:
 

--- a/include/geos/coverage/VertexRingCounter.h
+++ b/include/geos/coverage/VertexRingCounter.h
@@ -27,17 +27,14 @@ class Geometry;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::CoordinateSequenceFilter;
-using geos::geom::Geometry;
-
-
 namespace geos {
 namespace coverage { // geos::coverage
 
-class VertexRingCounter : public CoordinateSequenceFilter
+class VertexRingCounter : public geos::geom::CoordinateSequenceFilter
 {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
 
 public:
 

--- a/include/geos/geom/prep/BasicPreparedGeometry.h
+++ b/include/geos/geom/prep/BasicPreparedGeometry.h
@@ -38,8 +38,6 @@ namespace geos {
 namespace geom { // geos::geom
 namespace prep { // geos::geom::prep
 
-using geos::operation::relateng::RelateNG;
-
 // * \class BasicPreparedGeometry
 
 /**
@@ -56,6 +54,8 @@ using geos::operation::relateng::RelateNG;
  *
  */
 class BasicPreparedGeometry: public PreparedGeometry {
+    using RelateNG = geos::operation::relateng::RelateNG;
+
 private:
     const geom::Geometry* baseGeom;
     std::vector<const CoordinateXY*> representativePts;

--- a/include/geos/geomgraph/Label.h
+++ b/include/geos/geomgraph/Label.h
@@ -55,6 +55,7 @@ namespace geomgraph { // geos.geomgraph
  *
  */
 class GEOS_DLL Label final {
+    using Position = geos::geom::Position;
 
 public:
 

--- a/include/geos/geomgraph/TopologyLocation.h
+++ b/include/geos/geomgraph/TopologyLocation.h
@@ -34,9 +34,6 @@
 #pragma warning(disable: 4251) // warning C4251: needs to have dll-interface to be used by clients of class
 #endif
 
-using geos::geom::Position;
-using geos::geom::Location;
-
 namespace geos {
 namespace geomgraph { // geos.geomgraph
 
@@ -61,6 +58,8 @@ namespace geomgraph { // geos.geomgraph
  * where j has the values ON, LEFT, RIGHT
  */
 class GEOS_DLL TopologyLocation {
+    using Position = geos::geom::Position;
+    using Location = geos::geom::Location;
 
 public:
 

--- a/include/geos/index/VertexSequencePackedRtree.h
+++ b/include/geos/index/VertexSequencePackedRtree.h
@@ -26,11 +26,6 @@ class Envelope;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Envelope;
-
-
 namespace geos {
 namespace index {
 
@@ -52,6 +47,9 @@ namespace index {
  *
  */
 class GEOS_DLL VertexSequencePackedRtree {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
 
 private:
 

--- a/include/geos/noding/BoundaryChainNoder.h
+++ b/include/geos/noding/BoundaryChainNoder.h
@@ -31,8 +31,6 @@ class NodedSegmentString;
 }
 }
 
-using geos::geom::Coordinate;
-
 namespace geos {   // geos
 namespace noding { // geos::noding
 
@@ -55,6 +53,7 @@ namespace noding { // geos::noding
  *
  */
 class GEOS_DLL BoundaryChainNoder : public Noder {
+    using Coordinate = geos::geom::Coordinate;
 
 private:
 

--- a/include/geos/operation/buffer/BufferCurveSetBuilder.h
+++ b/include/geos/operation/buffer/BufferCurveSetBuilder.h
@@ -70,6 +70,7 @@ namespace buffer { // geos.operation.buffer
  *
  */
 class GEOS_DLL BufferCurveSetBuilder {
+    using CoordinateSequence = geos::geom::CoordinateSequence;
 
 private:
 

--- a/include/geos/operation/buffer/OffsetCurve.h
+++ b/include/geos/operation/buffer/OffsetCurve.h
@@ -37,13 +37,6 @@ class SegmentMCIndex;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::LineString;
-using geos::geom::Polygon;
-
 namespace geos {
 namespace operation {
 namespace buffer {
@@ -88,7 +81,12 @@ namespace buffer {
  *
  */
 class GEOS_DLL OffsetCurve {
-
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LineString = geos::geom::LineString;
+    using Polygon = geos::geom::Polygon;
 
 private:
 

--- a/include/geos/operation/buffer/OffsetCurveBuilder.h
+++ b/include/geos/operation/buffer/OffsetCurveBuilder.h
@@ -40,9 +40,6 @@ class PrecisionModel;
 }
 }
 
-using geos::geom::CoordinateSequence;
-using geos::geom::PrecisionModel;
-
 namespace geos {
 namespace operation { // geos.operation
 namespace buffer { // geos.operation.buffer
@@ -66,6 +63,9 @@ namespace buffer { // geos.operation.buffer
  * See removeRepeatedAndInvalidPoints.
  */
 class GEOS_DLL OffsetCurveBuilder {
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using PrecisionModel = geos::geom::PrecisionModel;
+
 public:
 
     /*

--- a/include/geos/operation/buffer/OffsetCurveSection.h
+++ b/include/geos/operation/buffer/OffsetCurveSection.h
@@ -31,12 +31,6 @@ class LineString;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::LineString;
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace buffer {    // geos.operation.buffer
@@ -53,6 +47,11 @@ namespace buffer {    // geos.operation.buffer
  * @author mdavis
  */
 class GEOS_DLL OffsetCurveSection {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LineString = geos::geom::LineString;
 
 private:
 

--- a/include/geos/operation/buffer/SegmentMCIndex.h
+++ b/include/geos/operation/buffer/SegmentMCIndex.h
@@ -26,20 +26,22 @@ class Envelope;
 }
 }
 
-using geos::geom::CoordinateSequence;
-using geos::geom::Envelope;
-using namespace geos::index;
-
 namespace geos {
 namespace operation {
 namespace buffer {
 
 class GEOS_DLL SegmentMCIndex {
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
+    using MonotoneChain = geos::index::chain::MonotoneChain;
+    using MonotoneChainSelectAction = geos::index::chain::MonotoneChainSelectAction;
+    template<typename ItemType>
+    using TemplateSTRtree = geos::index::strtree::TemplateSTRtree<ItemType>;
 
 private:
 
-    strtree::TemplateSTRtree<const index::chain::MonotoneChain*> index;
-    std::vector<chain::MonotoneChain> segChains;
+    TemplateSTRtree<const MonotoneChain*> index;
+    std::vector<MonotoneChain> segChains;
 
     void buildIndex(const CoordinateSequence* segs);
 
@@ -47,7 +49,7 @@ public:
 
     SegmentMCIndex(const CoordinateSequence* segs);
 
-    void query(const Envelope* env, chain::MonotoneChainSelectAction& action);
+    void query(const Envelope* env, MonotoneChainSelectAction& action);
 };
 
 

--- a/include/geos/operation/overlayng/CoverageUnion.h
+++ b/include/geos/operation/overlayng/CoverageUnion.h
@@ -24,8 +24,6 @@ class Geometry;
 }
 }
 
-using geos::geom::Geometry;
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
@@ -67,6 +65,7 @@ namespace overlayng { // geos.operation.overlayng
  *
  */
 class GEOS_DLL CoverageUnion {
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/overlayng/Edge.h
+++ b/include/geos/operation/overlayng/Edge.h
@@ -53,6 +53,7 @@ namespace overlayng { // geos.operation.overlayng
  * @author mdavis
  */
 class GEOS_DLL Edge {
+    using Location = geos::geom::Location;
 
 private:
 

--- a/include/geos/operation/overlayng/EdgeKey.h
+++ b/include/geos/operation/overlayng/EdgeKey.h
@@ -26,9 +26,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-
-using geos::geom::Coordinate;
-
 /**
  * A key for sorting and comparing edges in a noded arrangement.
  * Relies on the fact that in a correctly noded arrangement
@@ -39,6 +36,7 @@ using geos::geom::Coordinate;
  *
  */
 class GEOS_DLL EdgeKey {
+    using Coordinate = geos::geom::Coordinate;
 
 private:
 

--- a/include/geos/operation/overlayng/EdgeNodingBuilder.h
+++ b/include/geos/operation/overlayng/EdgeNodingBuilder.h
@@ -62,6 +62,14 @@ namespace overlayng { // geos.operation.overlayng
  * @author mdavis
  */
 class GEOS_DLL EdgeNodingBuilder {
+    using PrecisionModel = geos::geom::PrecisionModel;
+    using Envelope = geos::geom::Envelope;
+    using GeometryCollection = geos::geom::GeometryCollection;
+    using Polygon = geos::geom::Polygon;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using LinearRing = geos::geom::LinearRing;
+    using LineString = geos::geom::LineString;
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/overlayng/InputGeometry.h
+++ b/include/geos/operation/overlayng/InputGeometry.h
@@ -38,10 +38,12 @@ namespace overlayng { // geos.operation.overlayng
  *
  */
 
-using namespace geos::algorithm::locate;
-using namespace geos::geom;
-
 class GEOS_DLL InputGeometry {
+    using Geometry = geos::geom::Geometry;
+    using Envelope = geos::geom::Envelope;
+    using Coordinate = geos::geom::Coordinate;
+    using Location = geos::geom::Location;
+    using PointOnGeometryLocator = geos::algorithm::locate::PointOnGeometryLocator;
 
 private:
 

--- a/include/geos/operation/overlayng/LineLimiter.h
+++ b/include/geos/operation/overlayng/LineLimiter.h
@@ -30,8 +30,6 @@ class CoordinateSequence;
 }
 }
 
-using namespace geos::geom;
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
@@ -54,6 +52,9 @@ namespace overlayng { // geos.operation.overlayng
  * @author Martin Davis
  */
 class GEOS_DLL LineLimiter {
+    using Envelope = geos::geom::Envelope;
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
 
 private:
 

--- a/include/geos/operation/overlayng/MaximalEdgeRing.h
+++ b/include/geos/operation/overlayng/MaximalEdgeRing.h
@@ -24,7 +24,6 @@
 namespace geos {
 namespace geom {
 class Coordinate;
-class CoordinateArray;
 class GeometryFactory;
 }
 namespace operation {
@@ -39,9 +38,9 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-
 class GEOS_DLL MaximalEdgeRing {
+    using Coordinate = geos::geom::Coordinate;
+    using GeometryFactory = geos::geom::GeometryFactory;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayEdge.h
+++ b/include/geos/operation/overlayng/OverlayEdge.h
@@ -37,11 +37,6 @@ class MaximalEdgeRing;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateXYZM;
-using geos::geom::CoordinateSequence;
-using geos::geom::Location;
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
@@ -50,6 +45,10 @@ namespace overlayng { // geos.operation.overlayng
 * Creates a single OverlayEdge.
 */
 class GEOS_DLL OverlayEdge : public edgegraph::HalfEdge {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateXYZM = geos::geom::CoordinateXYZM;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Location = geos::geom::Location;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayEdgeRing.h
+++ b/include/geos/operation/overlayng/OverlayEdgeRing.h
@@ -44,11 +44,14 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-using algorithm::locate::PointOnGeometryLocator;
-using algorithm::locate::IndexedPointInAreaLocator;
-
 class GEOS_DLL OverlayEdgeRing {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LinearRing = geos::geom::LinearRing;
+    using Polygon = geos::geom::Polygon;
+    using PointOnGeometryLocator = algorithm::locate::PointOnGeometryLocator;
+    using IndexedPointInAreaLocator = algorithm::locate::IndexedPointInAreaLocator;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayGraph.h
+++ b/include/geos/operation/overlayng/OverlayGraph.h
@@ -39,8 +39,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-
 /**
  * A planar graph of {@link OverlayEdge}, representing
  * the topology resulting from an overlay operation.
@@ -52,6 +50,8 @@ using namespace geos::geom;
  *
  */
 class GEOS_DLL OverlayGraph {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayLabel.h
+++ b/include/geos/operation/overlayng/OverlayLabel.h
@@ -20,9 +20,6 @@
 #include <geos/geom/Position.h>
 #include <geos/export.h>
 
-using geos::geom::Location;
-using geos::geom::Position;
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
@@ -87,6 +84,8 @@ namespace overlayng { // geos.operation.overlayng
 * @author Martin Davis
 */
 class GEOS_DLL OverlayLabel {
+    using Location = geos::geom::Location;
+    using Position = geos::geom::Position;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayMixedPoints.h
+++ b/include/geos/operation/overlayng/OverlayMixedPoints.h
@@ -46,9 +46,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-using algorithm::locate::PointOnGeometryLocator;
-
 /**
  * Computes an overlay where one input is Point(s) and one is not.
  * This class supports overlay being used as an efficient way
@@ -77,6 +74,16 @@ using algorithm::locate::PointOnGeometryLocator;
  * @author Martin Davis
  */
 class GEOS_DLL OverlayMixedPoints {
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using PrecisionModel = geos::geom::PrecisionModel;
+    using Geometry = geos::geom::Geometry;
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Point = geos::geom::Point;
+    using Polygon = geos::geom::Polygon;
+    using LineString = geos::geom::LineString;
+    using PointOnGeometryLocator = algorithm::locate::PointOnGeometryLocator;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayNG.h
+++ b/include/geos/operation/overlayng/OverlayNG.h
@@ -118,6 +118,9 @@ namespace overlayng { // geos.operation.overlayng
  *
  */
 class GEOS_DLL OverlayNG {
+    using Geometry = geos::geom::Geometry;
+    using PrecisionModel = geos::geom::PrecisionModel;
+    using Location = geos::geom::Location;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayNGRobust.h
+++ b/include/geos/operation/overlayng/OverlayNGRobust.h
@@ -62,6 +62,7 @@ namespace overlayng { // geos.operation.overlayng
  * @author Martin Davis
  */
 class GEOS_DLL OverlayNGRobust {
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayPoints.h
+++ b/include/geos/operation/overlayng/OverlayPoints.h
@@ -37,8 +37,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-
 /**
  * Performs an overlay operation on inputs which are both point geometries.
  *
@@ -53,6 +51,13 @@ using namespace geos::geom;
  * @author Martin Davis
  */
 class GEOS_DLL OverlayPoints {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using Geometry = geos::geom::Geometry;
+    using Point = geos::geom::Point;
+    using PrecisionModel = geos::geom::PrecisionModel;
 
 private:
 

--- a/include/geos/operation/overlayng/OverlayUtil.h
+++ b/include/geos/operation/overlayng/OverlayUtil.h
@@ -41,12 +41,9 @@ class OverlayGraph;
 }
 }
 
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
-
-using namespace geos::geom;
 
 /**
  * Utility methods for overlay processing.
@@ -55,6 +52,15 @@ using namespace geos::geom;
  *
  */
 class GEOS_DLL OverlayUtil {
+    using Geometry = geos::geom::Geometry;
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
+    using Point = geos::geom::Point;
+    using LineString = geos::geom::LineString;
+    using Polygon = geos::geom::Polygon;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using PrecisionModel = geos::geom::PrecisionModel;
 
 private:
 

--- a/include/geos/operation/overlayng/PrecisionReducer.h
+++ b/include/geos/operation/overlayng/PrecisionReducer.h
@@ -35,8 +35,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-
 /**
 * Reduces the precision of a geometry by rounding it to the
 * supplied {@link geom::PrecisionModel}.
@@ -50,6 +48,8 @@ using namespace geos::geom;
 * This provides an effective way to node / snap-round a collection of {@link geom::LineString}s.
 */
 class GEOS_DLL PrecisionReducer {
+    using PrecisionModel = geos::geom::PrecisionModel;
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/overlayng/PrecisionUtil.h
+++ b/include/geos/operation/overlayng/PrecisionUtil.h
@@ -38,8 +38,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-
 /**
  * Unions a collection of geometries in an
  * efficient way, using {@link OverlayNG}
@@ -47,6 +45,10 @@ using namespace geos::geom;
  * @author Martin Davis
  */
 class GEOS_DLL PrecisionUtil {
+    using Geometry = geos::geom::Geometry;
+    using Envelope = geos::geom::Envelope;
+    using PrecisionModel = geos::geom::PrecisionModel;
+    using CoordinateFilter = geos::geom::CoordinateFilter;
 
 private:
 

--- a/include/geos/operation/overlayng/RingClipper.h
+++ b/include/geos/operation/overlayng/RingClipper.h
@@ -27,8 +27,6 @@ class CoordinateSequence;
 }
 }
 
-using namespace geos::geom;
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
@@ -62,6 +60,9 @@ namespace overlayng { // geos.operation.overlayng
  *
  */
 class GEOS_DLL RingClipper {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
 
 private:
 

--- a/include/geos/operation/overlayng/RobustClipEnvelopeComputer.h
+++ b/include/geos/operation/overlayng/RobustClipEnvelopeComputer.h
@@ -38,8 +38,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
-using namespace geos::geom;
-
 /**
  * Computes a robust clipping envelope for a pair of polygonal geometries.
  * The envelope is computed to be large enough to include the full
@@ -50,6 +48,12 @@ using namespace geos::geom;
  * @author mdavis
  */
 class GEOS_DLL RobustClipEnvelopeComputer {
+    using Coordinate = geos::geom::Coordinate;
+    using Geometry = geos::geom::Geometry;
+    using GeometryCollection = geos::geom::GeometryCollection;
+    using Polygon = geos::geom::Polygon;
+    using LinearRing = geos::geom::LinearRing;
+    using Envelope = geos::geom::Envelope;
 
 private:
 

--- a/include/geos/operation/overlayng/UnaryUnionNG.h
+++ b/include/geos/operation/overlayng/UnaryUnionNG.h
@@ -42,6 +42,8 @@ namespace overlayng { // geos.operation.overlayng
  *
  */
 class GEOS_DLL UnaryUnionNG {
+    using Geometry = geos::geom::Geometry;
+    using PrecisionModel = geos::geom::PrecisionModel;
 
 private:
 

--- a/include/geos/operation/relateng/AdjacentEdgeLocator.h
+++ b/include/geos/operation/relateng/AdjacentEdgeLocator.h
@@ -36,16 +36,6 @@ namespace geom {
 }
 }
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::CoordinateSequence;
-using geos::geom::Geometry;
-using geos::geom::LinearRing;
-using geos::geom::Polygon;
-using geos::geom::Location;
-
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng {  // geos.operation.relateng
@@ -65,6 +55,12 @@ namespace relateng {  // geos.operation.relateng
  *
  */
 class GEOS_DLL AdjacentEdgeLocator {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
+    using LinearRing = geos::geom::LinearRing;
+    using Polygon = geos::geom::Polygon;
+    using Location = geos::geom::Location;
 
 public:
 

--- a/include/geos/operation/relateng/BasicPredicate.h
+++ b/include/geos/operation/relateng/BasicPredicate.h
@@ -29,17 +29,15 @@ namespace geom {
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Location;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation.
 namespace relateng {  // geos.operation.relateng
 
 
 class GEOS_DLL BasicPredicate : public TopologyPredicate {
+protected:
+    using Envelope = geos::geom::Envelope;
+    using Location = geos::geom::Location;
 
 private:
 

--- a/include/geos/operation/relateng/DimensionLocation.h
+++ b/include/geos/operation/relateng/DimensionLocation.h
@@ -18,16 +18,13 @@
 #include <geos/geom/Location.h>
 #include <geos/export.h>
 
-
-using geos::geom::Location;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 
 class GEOS_DLL DimensionLocation {
+    using Location = geos::geom::Location;
 
 public:
 

--- a/include/geos/operation/relateng/EdgeSegmentIntersector.h
+++ b/include/geos/operation/relateng/EdgeSegmentIntersector.h
@@ -34,17 +34,13 @@ namespace relateng {
 }
 }
 
-
-using geos::noding::SegmentIntersector;
-using geos::noding::SegmentString;
-using geos::algorithm::LineIntersector;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
-class GEOS_DLL EdgeSegmentIntersector : public SegmentIntersector {
+class GEOS_DLL EdgeSegmentIntersector : public geos::noding::SegmentIntersector {
+    using SegmentString = geos::noding::SegmentString;
+    using LineIntersector = geos::algorithm::LineIntersector;
 
 private:
 

--- a/include/geos/operation/relateng/EdgeSegmentOverlapAction.h
+++ b/include/geos/operation/relateng/EdgeSegmentOverlapAction.h
@@ -35,12 +35,6 @@ namespace noding {
 }
 }
 
-
-using geos::index::chain::MonotoneChain;
-using geos::index::chain::MonotoneChainOverlapAction;
-using geos::noding::SegmentIntersector;
-
-
 namespace geos {
 namespace operation { // geos::operation
 namespace relateng {  // geos::operation::relateng
@@ -49,7 +43,9 @@ namespace relateng {  // geos::operation::relateng
  * The action for the internal iterator for performing
  * overlap queries on a MonotoneChain.
  */
-class GEOS_DLL EdgeSegmentOverlapAction : public MonotoneChainOverlapAction {
+class GEOS_DLL EdgeSegmentOverlapAction : public geos::index::chain::MonotoneChainOverlapAction {
+    using MonotoneChain = geos::index::chain::MonotoneChain;
+    using SegmentIntersector = geos::noding::SegmentIntersector;
 
 private:
 

--- a/include/geos/operation/relateng/EdgeSetIntersector.h
+++ b/include/geos/operation/relateng/EdgeSetIntersector.h
@@ -38,20 +38,18 @@ namespace relateng {
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Geometry;
-using geos::index::strtree::TemplateSTRtree;
-using geos::index::chain::MonotoneChain;
-using geos::noding::SegmentString;
-using geos::operation::relateng::EdgeSegmentIntersector;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 class GEOS_DLL EdgeSetIntersector {
+    using Envelope = geos::geom::Envelope;
+    using Geometry = geos::geom::Geometry;
+    template <typename ItemType>
+    using TemplateSTRtree = geos::index::strtree::TemplateSTRtree<ItemType>;
+    using MonotoneChain = geos::index::chain::MonotoneChain;
+    using SegmentString = geos::noding::SegmentString;
+    using EdgeSegmentIntersector = geos::operation::relateng::EdgeSegmentIntersector;
 
 private:
 

--- a/include/geos/operation/relateng/IMPatternMatcher.h
+++ b/include/geos/operation/relateng/IMPatternMatcher.h
@@ -31,20 +31,16 @@ namespace geom {
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Location;
-using geos::geom::Dimension;
-using geos::geom::IntersectionMatrix;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation.
 namespace relateng {  // geos.operation.relateng
 
 
 class GEOS_DLL IMPatternMatcher : public IMPredicate {
-
+    using Envelope = geos::geom::Envelope;
+    using Location = geos::geom::Location;
+    using Dimension = geos::geom::Dimension;
+    using IntersectionMatrix = geos::geom::IntersectionMatrix;
 
 private:
 

--- a/include/geos/operation/relateng/IMPredicate.h
+++ b/include/geos/operation/relateng/IMPredicate.h
@@ -31,19 +31,17 @@ namespace geom {
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Location;
-using geos::geom::Dimension;
-using geos::geom::IntersectionMatrix;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation.
 namespace relateng {  // geos.operation.relateng
 
 
 class GEOS_DLL IMPredicate : public BasicPredicate {
+protected:
+    using Envelope = geos::geom::Envelope;
+    using Location = geos::geom::Location;
+    using Dimension = geos::geom::Dimension;
+    using IntersectionMatrix = geos::geom::IntersectionMatrix;
 
 private:
 

--- a/include/geos/operation/relateng/LineStringExtracter.h
+++ b/include/geos/operation/relateng/LineStringExtracter.h
@@ -29,18 +29,14 @@ namespace geom {
 }
 }
 
-
-using geos::geom::LineString;
-using geos::geom::Geometry;
-using geos::geom::GeometryFilter;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng {  // geos.operation.relateng
 
 
-class GEOS_DLL LineStringExtracter : public GeometryFilter {
+class GEOS_DLL LineStringExtracter : public geos::geom::GeometryFilter {
+    using LineString = geos::geom::LineString;
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/relateng/LinearBoundary.h
+++ b/include/geos/operation/relateng/LinearBoundary.h
@@ -32,18 +32,15 @@ namespace geom {
 }
 }
 
-
-using geos::algorithm::BoundaryNodeRule;
-using geos::geom::Coordinate;
-using geos::geom::CoordinateXY;
-using geos::geom::LineString;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 class GEOS_DLL LinearBoundary {
+    using BoundaryNodeRule = geos::algorithm::BoundaryNodeRule;
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using LineString = geos::geom::LineString;
 
 private:
 

--- a/include/geos/operation/relateng/NodeSection.h
+++ b/include/geos/operation/relateng/NodeSection.h
@@ -28,11 +28,6 @@ namespace geom {
 }
 }
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
@@ -53,6 +48,8 @@ namespace relateng { // geos.operation.relateng
  *
  */
 class GEOS_DLL NodeSection {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/relateng/NodeSections.h
+++ b/include/geos/operation/relateng/NodeSections.h
@@ -35,17 +35,14 @@ namespace geom {
 }
 }
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 
 class GEOS_DLL NodeSections {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/relateng/PolygonNodeConverter.h
+++ b/include/geos/operation/relateng/PolygonNodeConverter.h
@@ -64,6 +64,7 @@ namespace relateng {  // geos.operation.relateng
  * @see RelateNode
  */
 class GEOS_DLL PolygonNodeConverter {
+    using CoordinateXY = geos::geom::CoordinateXY;
 
 public:
 

--- a/include/geos/operation/relateng/RelateEdge.h
+++ b/include/geos/operation/relateng/RelateEdge.h
@@ -34,18 +34,15 @@ namespace geom {
 }
 }
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-using geos::geom::Location;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 
 class GEOS_DLL RelateEdge {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
+    using Location = geos::geom::Location;
 
 private:
 

--- a/include/geos/operation/relateng/RelateGeometry.h
+++ b/include/geos/operation/relateng/RelateGeometry.h
@@ -48,12 +48,20 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
-using namespace geos::geom;
-using geos::algorithm::BoundaryNodeRule;
-using geos::noding::SegmentString;
-
-
 class GEOS_DLL RelateGeometry {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Dimension = geos::geom::Dimension;
+    using Envelope = geos::geom::Envelope;
+    using Geometry = geos::geom::Geometry;
+    using Location = geos::geom::Location;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using LinearRing = geos::geom::LinearRing;
+    using LineString = geos::geom::LineString;
+    using MultiPolygon = geos::geom::MultiPolygon;
+    using Point = geos::geom::Point;
+    using BoundaryNodeRule = geos::algorithm::BoundaryNodeRule;
+    using SegmentString = geos::noding::SegmentString;
 
 private:
 

--- a/include/geos/operation/relateng/RelateMatrixPredicate.h
+++ b/include/geos/operation/relateng/RelateMatrixPredicate.h
@@ -31,19 +31,16 @@ namespace geom {
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Location;
-using geos::geom::Dimension;
-using geos::geom::IntersectionMatrix;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation.
 namespace relateng {  // geos.operation.relateng
 
 
 class GEOS_DLL RelateMatrixPredicate : public IMPredicate {
+    using Envelope = geos::geom::Envelope;
+    using Location = geos::geom::Location;
+    using Dimension = geos::geom::Dimension;
+    using IntersectionMatrix = geos::geom::IntersectionMatrix;
 
 public:
 

--- a/include/geos/operation/relateng/RelateNG.h
+++ b/include/geos/operation/relateng/RelateNG.h
@@ -48,13 +48,6 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-using geos::algorithm::BoundaryNodeRule;
-using geos::noding::MCIndexSegmentSetMutualIntersector;
-
-
 /**
  * Computes the value of topological predicates between two geometries based on the
  * Dimensionally-Extended 9-Intersection Model <https://en.wikipedia.org/wiki/DE-9IM> (DE-9IM).
@@ -91,6 +84,14 @@ using geos::noding::MCIndexSegmentSetMutualIntersector;
  * @see PreparedGeometry
  */
 class GEOS_DLL RelateNG {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
+    using BoundaryNodeRule = geos::algorithm::BoundaryNodeRule;
+    using MCIndexSegmentSetMutualIntersector = geos::noding::MCIndexSegmentSetMutualIntersector;
+    using LinearRing = geos::geom::LinearRing;
+    using Envelope = geos::geom::Envelope;
+    using SegmentString = geos::noding::SegmentString;
+    using IntersectionMatrix = geos::geom::IntersectionMatrix;
 
 private:
 

--- a/include/geos/operation/relateng/RelateNode.h
+++ b/include/geos/operation/relateng/RelateNode.h
@@ -37,17 +37,14 @@ namespace geom {
 }
 }
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 
 class GEOS_DLL RelateNode {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
 
 private:
 

--- a/include/geos/operation/relateng/RelatePointLocator.h
+++ b/include/geos/operation/relateng/RelatePointLocator.h
@@ -47,17 +47,6 @@ namespace geom {
 }
 }
 
-
-using geos::algorithm::BoundaryNodeRule;
-using geos::algorithm::locate::PointOnGeometryLocator;
-using geos::geom::Coordinate;
-using geos::geom::CoordinateXY;
-using geos::geom::Geometry;
-using geos::geom::LineString;
-using geos::geom::Point;
-using geos::geom::Location;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
@@ -84,6 +73,14 @@ namespace relateng { // geos.operation.relateng
  * @author Martin Davis
  */
 class GEOS_DLL RelatePointLocator {
+    using BoundaryNodeRule = geos::algorithm::BoundaryNodeRule;
+    using PointOnGeometryLocator = geos::algorithm::locate::PointOnGeometryLocator;
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Geometry = geos::geom::Geometry;
+    using LineString = geos::geom::LineString;
+    using Point = geos::geom::Point;
+    using Location = geos::geom::Location;
 
 private:
 

--- a/include/geos/operation/relateng/RelatePredicate.h
+++ b/include/geos/operation/relateng/RelatePredicate.h
@@ -23,17 +23,14 @@
 #include <geos/geom/Envelope.h>
 #include <geos/export.h>
 
-
-using geos::geom::Envelope;
-using geos::geom::Location;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation.
 namespace relateng {  // geos.operation.relateng
 
 
 class GEOS_DLL RelatePredicate {
+    using Envelope = geos::geom::Envelope;
+    using Location = geos::geom::Location;
 
 public:
 

--- a/include/geos/operation/relateng/RelateSegmentString.h
+++ b/include/geos/operation/relateng/RelateSegmentString.h
@@ -38,20 +38,17 @@ namespace relateng {
 }
 }
 
-
-using geos::noding::BasicSegmentString;
-using geos::geom::Geometry;
-using geos::geom::CoordinateXY;
-using geos::geom::CoordinateSequence;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 
 
-class GEOS_DLL RelateSegmentString : public BasicSegmentString {
+class GEOS_DLL RelateSegmentString : public geos::noding::BasicSegmentString {
+    using BasicSegmentString = geos::noding::BasicSegmentString;
+    using Geometry = geos::geom::Geometry;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
 
 private:
 

--- a/include/geos/operation/relateng/TopologyComputer.h
+++ b/include/geos/operation/relateng/TopologyComputer.h
@@ -32,22 +32,19 @@ namespace relateng {
 }
 }
 
-
-using geos::geom::CoordinateXY;
-using geos::geom::Location;
-using geos::operation::relateng::NodeSection;
-using geos::operation::relateng::NodeSections;
-using geos::operation::relateng::RelateGeometry;
-using geos::operation::relateng::RelateNode;
-using geos::operation::relateng::TopologyPredicate;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng { // geos.operation.relateng
 
 
 class GEOS_DLL TopologyComputer {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using Location = geos::geom::Location;
+    using NodeSection = geos::operation::relateng::NodeSection;
+    using NodeSections = geos::operation::relateng::NodeSections;
+    using RelateGeometry = geos::operation::relateng::RelateGeometry;
+    using RelateNode = geos::operation::relateng::RelateNode;
+    using TopologyPredicate = geos::operation::relateng::TopologyPredicate;
 
 private:
 

--- a/include/geos/operation/relateng/TopologyPredicate.h
+++ b/include/geos/operation/relateng/TopologyPredicate.h
@@ -28,17 +28,14 @@ namespace geom {
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Location;
-
-
 namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace relateng {  // geos.operation.relateng
 
 
 class GEOS_DLL TopologyPredicate {
+    using Envelope = geos::geom::Envelope;
+    using Location = geos::geom::Location;
 
 public:
 

--- a/include/geos/operation/union/CoverageUnion.h
+++ b/include/geos/operation/union/CoverageUnion.h
@@ -28,19 +28,19 @@ namespace geos {
     }
 }
 
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::Polygon;
-using geos::geom::LineString;
-using geos::geom::LinearRing;
-using geos::geom::LineSegment;
-
-
 namespace geos {
 namespace operation {
 namespace geounion {
 
     class GEOS_DLL CoverageUnion {
+        using Geometry = geos::geom::Geometry;
+        using GeometryFactory = geos::geom::GeometryFactory;
+        using Polygon = geos::geom::Polygon;
+        using LineString = geos::geom::LineString;
+        using LinearRing = geos::geom::LinearRing;
+        using LineSegment = geos::geom::LineSegment;
+
+
     public:
         static std::unique_ptr<Geometry> Union(const Geometry* geom);
 

--- a/include/geos/operation/valid/IndexedNestedHoleTester.h
+++ b/include/geos/operation/valid/IndexedNestedHoleTester.h
@@ -34,12 +34,10 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Polygon;
-using geos::geom::LinearRing;
-using geos::geom::CoordinateXY;
-
-
 class GEOS_DLL IndexedNestedHoleTester {
+    using Polygon = geos::geom::Polygon;
+    using LinearRing = geos::geom::LinearRing;
+    using CoordinateXY = geos::geom::CoordinateXY;
 
 private:
 

--- a/include/geos/operation/valid/IndexedNestedPolygonTester.h
+++ b/include/geos/operation/valid/IndexedNestedPolygonTester.h
@@ -37,14 +37,14 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::Polygon;
-using geos::geom::MultiPolygon;
-using geos::geom::LinearRing;
-using geos::geom::CoordinateXY;
-using algorithm::locate::IndexedPointInAreaLocator;
-using index::strtree::TemplateSTRtree;
-
 class GEOS_DLL IndexedNestedPolygonTester {
+    using Polygon = geos::geom::Polygon;
+    using MultiPolygon = geos::geom::MultiPolygon;
+    using LinearRing = geos::geom::LinearRing;
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using IndexedPointInAreaLocator = algorithm::locate::IndexedPointInAreaLocator;
+    template<typename ItemType>
+    using TemplateSTRtree = index::strtree::TemplateSTRtree<ItemType>;
 
 private:
 

--- a/include/geos/operation/valid/IsValidOp.h
+++ b/include/geos/operation/valid/IsValidOp.h
@@ -55,6 +55,7 @@ namespace valid {     // geos.operation.valid
  * @version 1.7
  */
 class GEOS_DLL IsValidOp {
+    using CoordinateXY = geos::geom::CoordinateXY;
 
 private:
 

--- a/include/geos/operation/valid/PolygonIntersectionAnalyzer.h
+++ b/include/geos/operation/valid/PolygonIntersectionAnalyzer.h
@@ -36,10 +36,9 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::CoordinateXY;
-using geos::noding::SegmentString;
-
 class GEOS_DLL PolygonIntersectionAnalyzer : public noding::SegmentIntersector {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using SegmentString = geos::noding::SegmentString;
 
 private:
 

--- a/include/geos/operation/valid/PolygonRing.h
+++ b/include/geos/operation/valid/PolygonRing.h
@@ -35,11 +35,9 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::CoordinateXY;
-using geos::geom::LinearRing;
-
-
 class GEOS_DLL PolygonRing {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using LinearRing = geos::geom::LinearRing;
 
 private:
 

--- a/include/geos/operation/valid/PolygonRingSelfNode.h
+++ b/include/geos/operation/valid/PolygonRingSelfNode.h
@@ -26,9 +26,8 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::CoordinateXY;
-
 class GEOS_DLL PolygonRingSelfNode {
+    using CoordinateXY = geos::geom::CoordinateXY;
 
 private:
 

--- a/include/geos/operation/valid/PolygonRingTouch.h
+++ b/include/geos/operation/valid/PolygonRingTouch.h
@@ -34,9 +34,8 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::CoordinateXY;
-
 class GEOS_DLL PolygonRingTouch {
+    using CoordinateXY = geos::geom::CoordinateXY;
 
 private:
 

--- a/include/geos/operation/valid/PolygonTopologyAnalyzer.h
+++ b/include/geos/operation/valid/PolygonTopologyAnalyzer.h
@@ -35,12 +35,12 @@ namespace geos {      // geos.
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
-using geos::geom::CoordinateXY;
-using geos::geom::CoordinateSequence;
-using geos::geom::Geometry;
-using geos::geom::LinearRing;
-
 class GEOS_DLL PolygonTopologyAnalyzer {
+    using CoordinateXY = geos::geom::CoordinateXY;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Geometry = geos::geom::Geometry;
+    using LinearRing = geos::geom::LinearRing;
+    using SegmentString = geos::noding::SegmentString;
 
 private:
 

--- a/include/geos/simplify/ComponentJumpChecker.h
+++ b/include/geos/simplify/ComponentJumpChecker.h
@@ -34,15 +34,14 @@ class TaggedLineString;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Envelope;
-using geos::geom::LineSegment;
-
 namespace geos {
 namespace simplify { // geos::simplify
 
 
 class GEOS_DLL ComponentJumpChecker {
+    using Coordinate = geos::geom::Coordinate;
+    using Envelope = geos::geom::Envelope;
+    using LineSegment = geos::geom::LineSegment;
 
 private:
 

--- a/include/geos/simplify/LinkedLine.h
+++ b/include/geos/simplify/LinkedLine.h
@@ -29,15 +29,13 @@ class CoordinateSequence;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-
-
 namespace geos {
 namespace simplify { // geos::simplify
 
 class LinkedLine
 {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
 
 public:
 

--- a/include/geos/simplify/LinkedRing.h
+++ b/include/geos/simplify/LinkedRing.h
@@ -20,9 +20,6 @@
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/constants.h>
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-
 namespace geos {
 namespace simplify { // geos::simplify
 
@@ -30,6 +27,9 @@ namespace simplify { // geos::simplify
 
 class LinkedRing
 {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+
     private:
 
         const CoordinateSequence& m_coord;

--- a/include/geos/simplify/PolygonHullSimplifier.h
+++ b/include/geos/simplify/PolygonHullSimplifier.h
@@ -33,15 +33,6 @@ class RingHullIndex;
 }
 }
 
-
-using geos::geom::Envelope;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::LinearRing;
-using geos::geom::MultiPolygon;
-using geos::geom::Polygon;
-
-
 namespace geos {
 namespace simplify { // geos::simplify
 
@@ -84,6 +75,12 @@ namespace simplify { // geos::simplify
  */
 class GEOS_DLL PolygonHullSimplifier
 {
+    using Envelope = geos::geom::Envelope;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using LinearRing = geos::geom::LinearRing;
+    using MultiPolygon = geos::geom::MultiPolygon;
+    using Polygon = geos::geom::Polygon;
 
 public:
 

--- a/include/geos/simplify/RingHull.h
+++ b/include/geos/simplify/RingHull.h
@@ -32,21 +32,20 @@ class RingHullIndex;
 }
 }
 
-
-using geos::geom::Coordinate;
-using geos::geom::Envelope;
-using geos::geom::LinearRing;
-using geos::geom::LineString;
-using geos::geom::Polygon;
-using geos::index::VertexSequencePackedRtree;
-
-
 namespace geos {
 namespace simplify { // geos::simplify
 
 
 class RingHull
 {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Envelope = geos::geom::Envelope;
+    using LinearRing = geos::geom::LinearRing;
+    using LineString = geos::geom::LineString;
+    using Polygon = geos::geom::Polygon;
+    using VertexSequencePackedRtree = geos::index::VertexSequencePackedRtree;
+
 
 public:
 

--- a/include/geos/simplify/TaggedLineString.h
+++ b/include/geos/simplify/TaggedLineString.h
@@ -47,9 +47,6 @@ class TaggedLineSegment;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-
 namespace geos {
 namespace simplify { // geos::simplify
 
@@ -58,6 +55,8 @@ namespace simplify { // geos::simplify
  * Contains and owns a list of TaggedLineSegments.
  */
 class GEOS_DLL TaggedLineString {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
 
 public:
 

--- a/include/geos/simplify/TaggedLineStringSimplifier.h
+++ b/include/geos/simplify/TaggedLineStringSimplifier.h
@@ -51,11 +51,6 @@ class ComponentJumpChecker;
 }
 }
 
-using geos::geom::CoordinateSequence;
-using geos::geom::Coordinate;
-using geos::geom::LineSegment;
-
-
 namespace geos {
 namespace simplify { // geos::simplify
 
@@ -67,6 +62,9 @@ namespace simplify { // geos::simplify
  *
  */
 class GEOS_DLL TaggedLineStringSimplifier {
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Coordinate = geos::geom::Coordinate;
+    using LineSegment = geos::geom::LineSegment;
 
 public:
 

--- a/include/geos/triangulate/polygon/ConstrainedDelaunayTriangulator.h
+++ b/include/geos/triangulate/polygon/ConstrainedDelaunayTriangulator.h
@@ -26,13 +26,6 @@ class Polygon;
 }
 }
 
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::Polygon;
-using geos::triangulate::tri::TriList;
-using geos::triangulate::tri::Tri;
-
-
 namespace geos {
 namespace triangulate {
 namespace polygon {
@@ -48,6 +41,12 @@ namespace polygon {
  * Holes are supported.
  */
 class GEOS_DLL ConstrainedDelaunayTriangulator {
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using Polygon = geos::geom::Polygon;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
+    using Tri = geos::triangulate::tri::Tri;
 
 private:
 

--- a/include/geos/triangulate/polygon/PolygonEarClipper.h
+++ b/include/geos/triangulate/polygon/PolygonEarClipper.h
@@ -32,13 +32,6 @@ class Envelope;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Polygon;
-using geos::geom::Envelope;
-using geos::triangulate::tri::Tri;
-using geos::triangulate::tri::TriList;
-using geos::index::VertexSequencePackedRtree;
-
 namespace geos {
 namespace triangulate {
 namespace polygon {
@@ -65,6 +58,14 @@ namespace polygon {
  *
  */
 class GEOS_DLL PolygonEarClipper {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Polygon = geos::geom::Polygon;
+    using Envelope = geos::geom::Envelope;
+    using Tri = geos::triangulate::tri::Tri;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
+    using VertexSequencePackedRtree = geos::index::VertexSequencePackedRtree;
 
 private:
 

--- a/include/geos/triangulate/polygon/PolygonHoleJoiner.h
+++ b/include/geos/triangulate/polygon/PolygonHoleJoiner.h
@@ -37,14 +37,6 @@ namespace noding {
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::geom::Polygon;
-using geos::geom::LinearRing;
-using geos::noding::BasicSegmentString;
-using geos::noding::SegmentSetMutualIntersector;
-
-
 namespace geos {
 namespace triangulate {
 namespace polygon {
@@ -68,6 +60,12 @@ namespace polygon {
  * The output ring is always CW.
  */
 class GEOS_DLL PolygonHoleJoiner {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using Polygon = geos::geom::Polygon;
+    using LinearRing = geos::geom::LinearRing;
+    using BasicSegmentString = geos::noding::BasicSegmentString;
+    using SegmentSetMutualIntersector = geos::noding::SegmentSetMutualIntersector;
 
 private:
 

--- a/include/geos/triangulate/polygon/PolygonNoder.h
+++ b/include/geos/triangulate/polygon/PolygonNoder.h
@@ -19,6 +19,7 @@
 //#include <geos/geom/CoordinateSequence.h>
 
 #include <geos/export.h>
+#include <geos/triangulate/tri/Tri.h>
 
 #include <map>
 #include <memory>
@@ -38,12 +39,6 @@ class LineIntersector;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::CoordinateSequence;
-using geos::noding::NodedSegmentString;
-using geos::algorithm::LineIntersector;
-
-
 namespace geos {
 namespace triangulate {
 namespace polygon {
@@ -60,6 +55,13 @@ namespace polygon {
  * and does not trigger an error.
  */
 class GEOS_DLL PolygonNoder {
+    using Coordinate = geos::geom::Coordinate;
+    using CoordinateSequence = geos::geom::CoordinateSequence;
+    using NodedSegmentString = geos::noding::NodedSegmentString;
+    using LineIntersector = geos::algorithm::LineIntersector;
+    using Tri = geos::triangulate::tri::Tri;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
 
 public:
 

--- a/include/geos/triangulate/polygon/PolygonTriangulator.h
+++ b/include/geos/triangulate/polygon/PolygonTriangulator.h
@@ -26,13 +26,6 @@ class Polygon;
 }
 }
 
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-using geos::geom::Polygon;
-using geos::triangulate::tri::TriList;
-using geos::triangulate::tri::Tri;
-
-
 namespace geos {
 namespace triangulate {
 namespace polygon {
@@ -57,6 +50,12 @@ namespace polygon {
  *
  */
 class GEOS_DLL PolygonTriangulator {
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using Polygon = geos::geom::Polygon;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
+    using Tri = geos::triangulate::tri::Tri;
 
 private:
 

--- a/include/geos/triangulate/polygon/TriDelaunayImprover.h
+++ b/include/geos/triangulate/polygon/TriDelaunayImprover.h
@@ -26,11 +26,6 @@ class Coordinate;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::triangulate::tri::TriList;
-using geos::triangulate::tri::Tri;
-
-
 namespace geos {
 namespace triangulate {
 namespace polygon {
@@ -46,6 +41,10 @@ namespace polygon {
  *
  */
 class GEOS_DLL TriDelaunayImprover {
+    using Coordinate = geos::geom::Coordinate;
+    using Tri = geos::triangulate::tri::Tri;
+    template<typename TriType>
+    using TriList = geos::triangulate::tri::TriList<TriType>;
 
 private:
 

--- a/include/geos/triangulate/tri/Tri.h
+++ b/include/geos/triangulate/tri/Tri.h
@@ -28,10 +28,6 @@ class Polygon;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Polygon;
-using geos::geom::GeometryFactory;
-
 namespace geos {        // geos.
 namespace triangulate { // geos.triangulate
 namespace tri {         // geos.triangulate.tri
@@ -47,6 +43,10 @@ namespace tri {         // geos.triangulate.tri
  *
  */
 class GEOS_DLL Tri {
+    using Coordinate = geos::geom::Coordinate;
+    using Polygon = geos::geom::Polygon;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
 
 protected:
 

--- a/include/geos/triangulate/tri/TriEdge.h
+++ b/include/geos/triangulate/tri/TriEdge.h
@@ -18,8 +18,6 @@
 #include <geos/geom/Coordinate.h>
 #include <iostream>
 
-using geos::geom::Coordinate;
-
 namespace geos {        // geos.
 namespace triangulate { // geos.triangulate
 namespace tri {         // geos.triangulate.tri
@@ -35,6 +33,7 @@ namespace tri {         // geos.triangulate.tri
  * @author mdavis
  */
 class GEOS_DLL TriEdge {
+    using Coordinate = geos::geom::Coordinate;
 
 private:
 

--- a/include/geos/triangulate/tri/TriList.h
+++ b/include/geos/triangulate/tri/TriList.h
@@ -31,10 +31,6 @@ class Geometry;
 }
 }
 
-using geos::geom::Coordinate;
-using geos::geom::Geometry;
-using geos::geom::GeometryFactory;
-
 typedef int TriIndex;
 
 namespace geos {        // geos.
@@ -52,6 +48,9 @@ namespace tri {         // geos.triangulate.tri
  */
 template<typename TriType>
 class TriList {
+    using Coordinate = geos::geom::Coordinate;
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
 
 private:
 

--- a/include/geos/triangulate/tri/TriangulationBuilder.h
+++ b/include/geos/triangulate/tri/TriangulationBuilder.h
@@ -32,8 +32,6 @@ class Tri;
 }
 }
 
-using geos::geom::Coordinate;
-
 namespace geos {        // geos.
 namespace triangulate { // geos.triangulate
 namespace tri {         // geos.triangulate.tri
@@ -47,6 +45,7 @@ namespace tri {         // geos.triangulate.tri
  *
  */
 class GEOS_DLL TriangulationBuilder {
+    using Coordinate = geos::geom::Coordinate;
 
 private:
 

--- a/src/algorithm/CGAlgorithmsDD.cpp
+++ b/src/algorithm/CGAlgorithmsDD.cpp
@@ -20,11 +20,11 @@
 #include <geos/algorithm/CGAlgorithmsDD.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/util/IllegalArgumentException.h>
-#include <sstream>
 #include <cmath>
 
 using namespace geos::geom;
 using namespace geos::algorithm;
+using geos::math::DD;
 
 namespace {
 

--- a/src/algorithm/construct/IndexedPointInPolygonsLocator.cpp
+++ b/src/algorithm/construct/IndexedPointInPolygonsLocator.cpp
@@ -24,6 +24,7 @@
 
 using geos::algorithm::locate::IndexedPointInAreaLocator;
 using geos::geom::Envelope;
+using geos::geom::Location;
 using geos::geom::util::PolygonalExtracter;
 
 namespace geos {

--- a/src/algorithm/hull/HullTriangulation.cpp
+++ b/src/algorithm/hull/HullTriangulation.cpp
@@ -39,6 +39,7 @@ using geos::geom::Polygon;
 using geos::geom::Triangle;
 using geos::triangulate::DelaunayTriangulationBuilder;
 using geos::triangulate::tri::TriangulationBuilder;
+using geos::triangulate::tri::Tri;
 using geos::operation::overlayng::CoverageUnion;
 
 namespace geos {

--- a/src/coverage/Corner.cpp
+++ b/src/coverage/Corner.cpp
@@ -25,9 +25,11 @@
 
 using geos::coverage::Corner;
 using geos::geom::Coordinate;
+using geos::geom::CoordinateSequence;
 using geos::geom::Envelope;
 using geos::geom::GeometryFactory;
 using geos::geom::Triangle;
+using geos::geom::LineString;
 using geos::io::WKTWriter;
 
 namespace geos {

--- a/src/coverage/CoverageBoundarySegmentFinder.cpp
+++ b/src/coverage/CoverageBoundarySegmentFinder.cpp
@@ -19,6 +19,7 @@
 
 using geos::geom::CoordinateSequence;
 using geos::geom::Geometry;
+using geos::geom::LineSegment;
 
 
 namespace geos {     // geos

--- a/src/coverage/CoverageEdge.cpp
+++ b/src/coverage/CoverageEdge.cpp
@@ -26,6 +26,9 @@ using geos::geom::Coordinate;
 using geos::geom::GeometryFactory;
 using geos::geom::LinearRing;
 using geos::geom::LineSegment;
+using geos::geom::MultiLineString;
+using geos::geom::LineString;
+using geos::geom::CoordinateSequence;
 
 
 namespace geos {     // geos

--- a/src/coverage/CoveragePolygonValidator.cpp
+++ b/src/coverage/CoveragePolygonValidator.cpp
@@ -43,6 +43,7 @@ using geos::geom::Location;
 using geos::geom::Polygon;
 using geos::geom::util::PolygonExtracter;
 using geos::noding::MCIndexSegmentSetMutualIntersector;
+using geos::noding::SegmentString;
 using geos::operation::valid::RepeatedPointRemover;
 
 namespace geos {     // geos

--- a/src/coverage/TPVWSimplifier.cpp
+++ b/src/coverage/TPVWSimplifier.cpp
@@ -26,6 +26,7 @@
 #include <geos/simplify/LinkedLine.h>
 
 using geos::geom::Coordinate;
+using geos::geom::CoordinateSequence;
 using geos::geom::Envelope;
 using geos::geom::Geometry;
 using geos::geom::GeometryFactory;

--- a/src/index/VertexSequencePackedRtree.cpp
+++ b/src/index/VertexSequencePackedRtree.cpp
@@ -21,6 +21,8 @@
 
 #include <algorithm>
 
+using geos::geom::Envelope;
+
 namespace geos {
 namespace index {
 

--- a/src/operation/overlayng/EdgeNodingBuilder.cpp
+++ b/src/operation/overlayng/EdgeNodingBuilder.cpp
@@ -32,6 +32,7 @@ namespace geos {      // geos
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
+using namespace geos::geom;
 using geos::operation::valid::RepeatedPointRemover;
 using geos::noding::snapround::SnapRoundingNoder;
 using geos::noding::Noder;

--- a/src/operation/overlayng/InputGeometry.cpp
+++ b/src/operation/overlayng/InputGeometry.cpp
@@ -18,6 +18,11 @@ namespace geos {      // geos
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
+using geos::geom::Location;
+using geos::geom::Geometry;
+using geos::geom::Envelope;
+using geos::algorithm::locate::IndexedPointInAreaLocator;
+using geos::algorithm::locate::PointOnGeometryLocator;
 
 /*public*/
 InputGeometry::InputGeometry(const Geometry* geomA, const Geometry* geomB)

--- a/src/operation/overlayng/IntersectionPointBuilder.cpp
+++ b/src/operation/overlayng/IntersectionPointBuilder.cpp
@@ -19,7 +19,7 @@
 #include <geos/operation/overlayng/OverlayLabel.h>
 #include <geos/geom/GeometryFactory.h>
 
-
+using namespace geos::geom;
 
 namespace geos {      // geos
 namespace operation { // geos.operation

--- a/src/operation/overlayng/LineLimiter.cpp
+++ b/src/operation/overlayng/LineLimiter.cpp
@@ -20,6 +20,8 @@
 
 #include <algorithm>
 
+using geos::geom::CoordinateSequence;
+
 namespace geos {      // geos
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng

--- a/src/operation/overlayng/OverlayEdgeRing.cpp
+++ b/src/operation/overlayng/OverlayEdgeRing.cpp
@@ -31,6 +31,7 @@ namespace overlayng { // geos.operation.overlayng
 
 using namespace geos::geom;
 using geos::operation::polygonize::EdgeRing;
+using geos::algorithm::locate::PointOnGeometryLocator;
 
 
 

--- a/src/operation/overlayng/OverlayLabel.cpp
+++ b/src/operation/overlayng/OverlayLabel.cpp
@@ -14,6 +14,7 @@
 
 #include <geos/operation/overlayng/OverlayLabel.h>
 
+using geos::geom::Location;
 
 namespace geos {      // geos
 namespace operation { // geos.operation

--- a/src/operation/overlayng/OverlayMixedPoints.cpp
+++ b/src/operation/overlayng/OverlayMixedPoints.cpp
@@ -36,6 +36,8 @@ namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
 using namespace geos::geom;
+using geos::algorithm::locate::PointOnGeometryLocator;
+using geos::algorithm::locate::IndexedPointInAreaLocator;
 
 /**
  * @brief Extracts and rounds coordinates from a geometry

--- a/src/operation/overlayng/OverlayPoints.cpp
+++ b/src/operation/overlayng/OverlayPoints.cpp
@@ -21,7 +21,7 @@
 #include <geos/operation/overlayng/OverlayNG.h>
 #include <geos/operation/overlayng/OverlayUtil.h>
 
-
+using namespace geos::geom;
 
 namespace geos {      // geos
 namespace operation { // geos.operation

--- a/src/operation/overlayng/PolygonBuilder.cpp
+++ b/src/operation/overlayng/PolygonBuilder.cpp
@@ -20,6 +20,7 @@
 #include <geos/util/TopologyException.h>
 
 
+using geos::geom::Polygon;
 
 namespace geos {      // geos
 namespace operation { // geos.operation

--- a/src/operation/overlayng/PrecisionReducer.cpp
+++ b/src/operation/overlayng/PrecisionReducer.cpp
@@ -22,6 +22,9 @@ namespace geos {      // geos
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
+using geos::geom::Geometry;
+using geos::geom::GeometryFactory;
+
 /*public static*/
 std::unique_ptr<Geometry>
 PrecisionReducer::reducePrecision(const Geometry* geom, const PrecisionModel* pm, bool replacePrecisionModel)

--- a/src/operation/overlayng/RingClipper.cpp
+++ b/src/operation/overlayng/RingClipper.cpp
@@ -14,6 +14,7 @@
 
 #include <geos/operation/overlayng/RingClipper.h>
 
+using geos::geom::CoordinateSequence;
 
 namespace geos {      // geos
 namespace operation { // geos.operation

--- a/src/operation/overlayng/RobustClipEnvelopeComputer.cpp
+++ b/src/operation/overlayng/RobustClipEnvelopeComputer.cpp
@@ -25,6 +25,7 @@ namespace geos {      // geos
 namespace operation { // geos.operation
 namespace overlayng { // geos.operation.overlayng
 
+using namespace geos::geom;
 
 RobustClipEnvelopeComputer::RobustClipEnvelopeComputer(const Envelope* p_targetEnv)
     : targetEnv(p_targetEnv)

--- a/src/operation/relateng/RelateEdge.cpp
+++ b/src/operation/relateng/RelateEdge.cpp
@@ -28,6 +28,7 @@ using geos::algorithm::PolygonNodeTopology;
 using geos::geom::CoordinateXY;
 using geos::geom::Dimension;
 using geos::geom::Position;
+using geos::geom::Location;
 using geos::io::WKTWriter;
 
 

--- a/src/operation/relateng/RelateGeometry.cpp
+++ b/src/operation/relateng/RelateGeometry.cpp
@@ -43,6 +43,7 @@ using geos::geom::util::ComponentCoordinateExtracter;
 using geos::geom::util::GeometryLister;
 using geos::geom::util::PointExtracter;
 using geos::operation::valid::RepeatedPointRemover;
+using geos::noding::SegmentString;
 
 
 namespace geos {      // geos

--- a/src/operation/relateng/RelateNode.cpp
+++ b/src/operation/relateng/RelateNode.cpp
@@ -29,6 +29,7 @@ using geos::geom::Geometry;
 using geos::geom::Dimension;
 using geos::geom::Position;
 using geos::io::WKTWriter;
+using geos::geom::Location;
 
 
 namespace geos {      // geos

--- a/src/operation/valid/IndexedNestedPolygonTester.cpp
+++ b/src/operation/valid/IndexedNestedPolygonTester.cpp
@@ -32,6 +32,7 @@ namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
 
 using namespace geos::geom;
+using geos::algorithm::locate::IndexedPointInAreaLocator;
 
 
 /* public */

--- a/src/operation/valid/PolygonIntersectionAnalyzer.cpp
+++ b/src/operation/valid/PolygonIntersectionAnalyzer.cpp
@@ -21,13 +21,14 @@
 #include <geos/operation/valid/TopologyValidationError.h>
 #include <geos/util/IllegalStateException.h>
 
-using geos::geom::Coordinate;
-using geos::noding::SegmentString;
-
 
 namespace geos {      // geos
 namespace operation { // geos.operation
 namespace valid {     // geos.operation.valid
+
+using geos::geom::Coordinate;
+using geos::geom::CoordinateXY;
+using geos::noding::SegmentString;
 
 /* public */
 void

--- a/src/simplify/LinkedRing.cpp
+++ b/src/simplify/LinkedRing.cpp
@@ -19,6 +19,7 @@
 
 
 using geos::geom::Coordinate;
+using geos::geom::CoordinateSequence;
 
 
 namespace geos {

--- a/src/triangulate/polygon/ConstrainedDelaunayTriangulator.cpp
+++ b/src/triangulate/polygon/ConstrainedDelaunayTriangulator.cpp
@@ -22,6 +22,7 @@
 #include <geos/triangulate/polygon/PolygonEarClipper.h>
 #include <geos/triangulate/polygon/TriDelaunayImprover.h>
 
+using namespace geos::geom;
 
 namespace geos {
 namespace triangulate {

--- a/src/triangulate/polygon/PolygonEarClipper.cpp
+++ b/src/triangulate/polygon/PolygonEarClipper.cpp
@@ -24,6 +24,8 @@
 #include <geos/triangulate/polygon/PolygonEarClipper.h>
 #include <geos/util/IllegalStateException.h>
 
+using geos::geom::Envelope;
+using geos::geom::Polygon;
 using geos::algorithm::Orientation;
 using geos::algorithm::Angle;
 using geos::triangulate::tri::TriList;

--- a/src/triangulate/polygon/PolygonHoleJoiner.cpp
+++ b/src/triangulate/polygon/PolygonHoleJoiner.cpp
@@ -38,6 +38,8 @@ using geos::algorithm::Orientation;
 using geos::algorithm::PolygonNodeTopology;
 using geos::geom::Coordinate;
 using geos::geom::CoordinateSequence;
+using geos::geom::LinearRing;
+using geos::geom::Polygon;
 using geos::noding::BasicSegmentString;
 using geos::noding::SegmentString;
 using geos::noding::NodedSegmentString;

--- a/src/triangulate/polygon/PolygonNoder.cpp
+++ b/src/triangulate/polygon/PolygonNoder.cpp
@@ -24,6 +24,7 @@
 
 using geos::algorithm::LineIntersector;
 using geos::geom::Coordinate;
+using geos::geom::CoordinateSequence;
 using geos::noding::SegmentString;
 using geos::noding::NodedSegmentString;
 using geos::noding::SegmentIntersector;

--- a/src/triangulate/polygon/PolygonTriangulator.cpp
+++ b/src/triangulate/polygon/PolygonTriangulator.cpp
@@ -20,7 +20,7 @@
 #include <geos/triangulate/polygon/PolygonHoleJoiner.h>
 #include <geos/triangulate/polygon/PolygonEarClipper.h>
 
-
+using geos::geom::Geometry;
 
 namespace geos {
 namespace triangulate {

--- a/src/triangulate/tri/Tri.cpp
+++ b/src/triangulate/tri/Tri.cpp
@@ -25,7 +25,7 @@
 #include <geos/util/IllegalStateException.h>
 #include <geos/util.h>
 
-
+using namespace geos::geom;
 using geos::util::IllegalArgumentException;
 using geos::algorithm::Orientation;
 using geos::geom::Triangle;

--- a/tests/unit/coverage/TPVWSimplifierTest.cpp
+++ b/tests/unit/coverage/TPVWSimplifierTest.cpp
@@ -7,6 +7,7 @@
 // geos
 #include <geos/coverage/TPVWSimplifier.h>
 
+using namespace geos::geom;
 using geos::coverage::TPVWSimplifier;
 
 namespace tut {

--- a/tests/unit/index/VertexSequencePackedRtreeTest.cpp
+++ b/tests/unit/index/VertexSequencePackedRtreeTest.cpp
@@ -15,8 +15,8 @@
 // std
 #include <stdio.h>
 
+using namespace geos::geom;
 using geos::index::VertexSequencePackedRtree;
-using geos::geom::Point;
 
 namespace tut {
 //

--- a/tests/unit/operation/relateng/RelateNGBoundaryNodeRuleTest.cpp
+++ b/tests/unit/operation/relateng/RelateNGBoundaryNodeRuleTest.cpp
@@ -18,6 +18,7 @@
 
 using namespace geos::geom;
 using namespace geos::operation::relateng;
+using geos::algorithm::BoundaryNodeRule;
 using geos::io::WKTReader;
 using geos::io::WKTWriter;
 


### PR DESCRIPTION
Polygon, LineString, etc.,  are declared in the global namespace with the using-declaration keyword, which is very likely to confilict with other types of the same name.

Move them to geos::operation::buffer fixes this.

https://github.com/libgeos/geos/blob/46972ad89a143d01ed3ec9a6c2d91d904a87ab0a/include/geos/operation/buffer/OffsetCurve.h#L39-L50