### PR TITLE
Fix issue #1191: LineString::getPointN loses 'm' dimension in GEOSGeomGetEndPoint

### DIFF
--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -181,7 +181,12 @@ LineString::getPointN(std::size_t n) const
 {
     assert(getFactory());
     assert(points.get());
-    return std::unique_ptr<Point>(getFactory()->createPoint(points->getAt(n)));
+    if (hasM())
+        return std::unique_ptr<Point>(getFactory()->createPoint(points->getAt<CoordinateXYZM>(n)));
+    else if (hasZ())
+        return std::unique_ptr<Point>(getFactory()->createPoint(points->getAt<Coordinate>(n)));
+    else
+        return std::unique_ptr<Point>(getFactory()->createPoint(points->getAt<CoordinateXY>(n)));
 }
 
 std::unique_ptr<Point>


### PR DESCRIPTION
This PR fixes the bug where the 'm' dimension is lost when calling GEOSGeomGetEndPoint on a LineString. The issue was caused by incorrect usage of the template instantiation for the coordinates of `getAt()` when retrieving the n-index point.

Changes include:
- Fixed the usage of the template instantiation in LineString::getPointN to preserve the 'm' dimension.

Fixes #1191.