### PR TITLE
Fix typos, add CI job to help catch them

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./tools/astyle,./src/deps,./web/themes,./util/geosop/cxxopts.hpp
+ignore-words = ./tools/codespell.ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,7 @@ jobs:
         set -e
         sudo -E apt-get update
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install cppcheck
+        python3 -m pip install --disable-pip-version-check --user codespell
 
     - name: 'Check Out'
       uses: actions/checkout@v4
@@ -531,6 +532,8 @@ jobs:
     - name: 'cppcheck'
       run: ./tools/cppcheck.sh
 
+    - name: codespell
+      run: codespell
 
   cmake-subproject:
     name: 'CMake Subproject'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,7 @@ jobs:
 
     - name: codespell
       run: codespell
+      # false-positives can be added to tools/codespell.ignore
 
   cmake-subproject:
     name: 'CMake Subproject'

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@
 
 - Breaking Changes:
   - Zero-length linestrings (eg LINESTRING(1 1, 1 1)) are now treated as equivalent to points (POINT(1 1)) in boolean predicates
-  - CMake 3.15 or later is requried (GH-1143, Mike Taves)
+  - CMake 3.15 or later is required (GH-1143, Mike Taves)
 
 - Fixes/Improvements:
   - WKTReader: Points with all-NaN coordinates are not considered empty anymore (GH-927, Casper van der Wel)
@@ -935,7 +935,7 @@ See 3.7.0 notes
 - Added Polygonizer and LineMerger classes.
 - python wrapper examples
 - General cleanup / warnings removal
-- cleaner win32 / older copilers builds
+- cleaner win32 / older compilers builds
 - Reduced heap allocations
 - debian package builder scripts
 - reduction of standard C lib headers dependency

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -719,7 +719,7 @@ public:
      *   and dissolving the linework.
      * - Unioning a set of [Polygons](@ref Polygon) will always
      *   return a polygonal geometry (unlike Geometry::Union(const Geometry* other) const),
-     *   which may return geometrys of lower dimension if a topology collapse
+     *   which may return geometries of lower dimension if a topology collapse
      *   occurred.
      *
      * @return the union geometry

--- a/include/geos/geom/Surface.h
+++ b/include/geos/geom/Surface.h
@@ -100,7 +100,7 @@ protected:
     int
     compareToSameClass(const Geometry* g) const override;
 
-    // Helper method allowing PolygonImpl to use GeometryFactory without cirular imports
+    // Helper method allowing PolygonImpl to use GeometryFactory without circular imports
     static std::unique_ptr<Geometry> createEmptyRing(const GeometryFactory&);
 
     virtual Curve* getExteriorRing() = 0;

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -107,7 +107,7 @@ public:
     /**
      * Generates the WKT for a N-point <code>LineString</code>.
      *
-     * @param seq the sequence to outpout
+     * @param seq the sequence to output
      *
      * @return the WKT
      */

--- a/include/geos/noding/IteratedNoder.h
+++ b/include/geos/noding/IteratedNoder.h
@@ -104,7 +104,7 @@ public:
 
 
     /** \brief
-     * Fully nodes a list of {@link SegmentString}s, i.e. peforms noding iteratively
+     * Fully nodes a list of {@link SegmentString}s, i.e. performs noding iteratively
      * until no intersections are found between segments.
      *
      * Maintains labelling of edges correctly through the noding.

--- a/include/geos/operation/overlayng/OverlayUtil.h
+++ b/include/geos/operation/overlayng/OverlayUtil.h
@@ -75,7 +75,7 @@ private:
     * are:
     *
     * - INTERSECTION: result envelope is the intersection of the input envelopes
-    * - DIFERENCE: result envelope is the envelope of the A input geometry
+    * - DIFFERENCE: result envelope is the envelope of the A input geometry
     *
     * Otherwise, <code>null</code> is returned to indicate full extent.
     */

--- a/include/geos/planargraph/DirectedEdge.h
+++ b/include/geos/planargraph/DirectedEdge.h
@@ -84,7 +84,7 @@ public:
      * to the given parentEdges vector.
      *
      * @note Parents are pushed to the parentEdges vector, make sure
-     * it is empty if index-based corrispondence is important.
+     * it is empty if index-based correspondence is important.
      */
     static void toEdges(std::vector<DirectedEdge*>& dirEdges,
                         std::vector<Edge*>& parentEdges);

--- a/include/geos/vend/json.hpp
+++ b/include/geos/vend/json.hpp
@@ -5091,7 +5091,7 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
     }
 };
 
-// Wraps another input apdater to convert wide character types into individual bytes.
+// Wraps another input adapter to convert wide character types into individual bytes.
 template<typename BaseInputAdapter, typename WideCharType>
 class wide_string_input_adapter
 {

--- a/src/algorithm/InteriorPointArea.cpp
+++ b/src/algorithm/InteriorPointArea.cpp
@@ -38,7 +38,7 @@ using namespace geos::geom;
 namespace geos {
 namespace algorithm { // geos.algorithm
 
-// file statics
+// file statistics
 namespace {
 
 double

--- a/src/algorithm/MinimumBoundingCircle.cpp
+++ b/src/algorithm/MinimumBoundingCircle.cpp
@@ -45,7 +45,7 @@ namespace algorithm { // geos.algorithm
 std::unique_ptr<Geometry>
 MinimumBoundingCircle::getCircle()
 {
-    //TODO: ensure the output circle contains the extermal points.
+    //TODO: ensure the output circle contains the extremal points.
     //TODO: or maybe even ensure that the returned geometry contains ALL the input points?
 
     compute();

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -318,4 +318,4 @@ Point::getCoordinatesRO() const
 }
 
 } // namespace geos::geom
-} // namesapce geos
+} // namespace geos

--- a/src/geomgraph/Edge.cpp
+++ b/src/geomgraph/Edge.cpp
@@ -55,7 +55,7 @@ using namespace geos::algorithm;
 
 /**
  * Updates an IM from the label for an edge.
- * Handles edges from both L and A geometrys.
+ * Handles edges from both L and A geometries.
  */
 void
 Edge::updateIM(const Label& lbl, IntersectionMatrix& im)

--- a/src/index/bintree/NodeBase.cpp
+++ b/src/index/bintree/NodeBase.cpp
@@ -26,7 +26,7 @@ namespace index { // geos.index
 namespace bintree { // geos.index.bintree
 
 /**
- * Returns the index of the subnode that wholely contains the given interval.
+ * Returns the index of the subnode that wholly contains the given interval.
  * If none does, returns -1.
  */
 int

--- a/src/operation/buffer/BufferCurveSetBuilder.cpp
+++ b/src/operation/buffer/BufferCurveSetBuilder.cpp
@@ -117,7 +117,7 @@ BufferCurveSetBuilder::addCurve(CoordinateSequence* coord,
     // coord ownership transferred to SegmentString
     SegmentString* e = new NodedSegmentString(coord, coord->hasZ(), coord->hasM(), newlabel);
 
-    // SegmentString doesnt own the sequence, so we need to delete in
+    // SegmentString doesn't own the sequence, so we need to delete in
     // the destructor
     newLabels.push_back(newlabel);
     curveList.push_back(e);

--- a/src/operation/relate/RelateComputer.cpp
+++ b/src/operation/relate/RelateComputer.cpp
@@ -181,7 +181,7 @@ RelateComputer::computeIM()
 
     /*
      * Now process improper intersections
-     * (eg where one or other of the geometrys has a vertex at the
+     * (eg where one or other of the geometries has a vertex at the
      * intersection point)
      * We need to compute the edge graph at all nodes to determine
      * the IM.

--- a/src/operation/relateng/RelateNG.cpp
+++ b/src/operation/relateng/RelateNG.cpp
@@ -534,7 +534,7 @@ RelateNG::computeLineEnds(
                 continue;
 
             const LineString* line = static_cast<const LineString*>(elem);
-            //TODO: add optimzation to skip disjoint elements once exterior point found
+            //TODO: add optimization to skip disjoint elements once exterior point found
             const CoordinateXY& e0 = line->getCoordinatesRO()->getAt(0);
             hasExteriorIntersection |= computeLineEnd(geom, isA, &e0, geomTarget, topoComputer);
             if (topoComputer.isResultKnown()) {

--- a/src/operation/relateng/TopologyComputer.cpp
+++ b/src/operation/relateng/TopologyComputer.cpp
@@ -231,7 +231,7 @@ TopologyComputer::addIntersection(NodeSection* a, NodeSection* b)
     // we run this first (unlike JTS) in case the subsequent test throws
     // an exception and the NodeSection pointers are not correctly
     // saved in the memory managed store on the NodeSections, causing
-    // a small memeory leak
+    // a small memory leak
     addNodeSections(a, b);
 
     if (! a->isSameGeometry(b)) {

--- a/tests/unit/capi/GEOSGeom_transformXYZTest.cpp
+++ b/tests/unit/capi/GEOSGeom_transformXYZTest.cpp
@@ -312,7 +312,7 @@ void object::test<14>() {
     ensure_equals(toWKT(result_), "CIRCULARSTRING Z (0 0 0, 2 3 4, 4 3 0)");
 }
 
-// callback should succed on 2D geometry
+// callback should succeed on 2D geometry
 template <>
 template <>
 void object::test<15>() {

--- a/tests/unit/geom/util/GeometryFixerTest.cpp
+++ b/tests/unit/geom/util/GeometryFixerTest.cpp
@@ -70,8 +70,8 @@ struct test_geometryfixer_data {
 
         std::unique_ptr<Geometry> expected = wktreader_.read(wktExpected);
 
-        // std::cout << "Reslt: " << wktwriter_.write(actual.get()) << std::endl;
-        // std::cout << "Expct: " << wktwriter_.write(expected.get()) << std::endl;
+        // std::cout << "Result: " << wktwriter_.write(actual.get()) << std::endl;
+        // std::cout << "Expect: " << wktwriter_.write(expected.get()) << std::endl;
 
         ensure("Result is invalid", actual->isValid());
         ensure_equals_geometry(expected.get(), actual.get());

--- a/tests/xmltester/tests/general/TestPreparedPolygonPredicate.xml
+++ b/tests/xmltester/tests/general/TestPreparedPolygonPredicate.xml
@@ -132,7 +132,7 @@
 <case>
   <desc>mA/L
   	A has 2 shells touching at one vertex and one non-vertex.
-  	B passes between the shells, but is wholely contained
+  	B passes between the shells, but is wholly contained
   </desc>
   <a>
     MULTIPOLYGON (((100 30, 30 110, 150 110, 100 30)), 
@@ -204,7 +204,7 @@
 </case>
 
 <case>
-  <desc>A/L - wholely contained
+  <desc>A/L - wholly contained
   </desc>
   <a> POLYGON ((10 10, 60 100, 110 10, 10 10)) 
     </a>

--- a/tools/codespell.ignore
+++ b/tools/codespell.ignore
@@ -1,0 +1,17 @@
+parms
+Geometrys
+deques
+extracter
+implementors
+translater
+thirdparty
+crate
+eiter
+examplar
+nempty
+ba
+te
+seh
+bLoc
+aLo
+Wel

--- a/web/content/posts/2024-08-13-relateng.md
+++ b/web/content/posts/2024-08-13-relateng.md
@@ -30,5 +30,5 @@ The RelateNG work has been run against the entire regression suite and returns e
 
 * The only exception is the handling of a zero-length LineString, which is now treated as logically equivalent to a point.
 
-The RelateNG code is new and there are no doubt lots of places in the implementation that can still be tightened up. The existing pair-wise predicates can be considered deprecated, as the new [implementation is faster](https://lin-ear-th-inking.blogspot.com/2024/05/relateng-performance.html) and just as correct. The existing prepared geometry implementation is still faster, for the cases it supports, but for all the unsupported cases RelateNG now provides faster default implentations.
+The RelateNG code is new and there are no doubt lots of places in the implementation that can still be tightened up. The existing pair-wise predicates can be considered deprecated, as the new [implementation is faster](https://lin-ear-th-inking.blogspot.com/2024/05/relateng-performance.html) and just as correct. The existing prepared geometry implementation is still faster, for the cases it supports, but for all the unsupported cases RelateNG now provides faster default implementations.
 

--- a/web/content/posts/2024-09-06-geos-3-13-released.md
+++ b/web/content/posts/2024-09-06-geos-3-13-released.md
@@ -51,7 +51,7 @@ The full list of changes is as follows:
 
 - **Breaking Changes:**
   - Zero-length linestrings (eg LINESTRING(1 1, 1 1)) are now treated as equivalent to points (POINT(1 1)) in boolean predicates
-  - CMake 3.15 or later is requried ([GH-1143](https://github.com/libgeos/geos/issues/1143), Mike Taves)
+  - CMake 3.15 or later is required ([GH-1143](https://github.com/libgeos/geos/issues/1143), Mike Taves)
 
 - **Fixes/Improvements:**
   - Add Angle::sinCosSnap to avoid small errors, e.g. with buffer operations ([GH-978](https://github.com/libgeos/geos/issues/978), Mike Taves)

--- a/web/content/usage/tools.md
+++ b/web/content/usage/tools.md
@@ -11,7 +11,7 @@ weight: 100
 `geosop` is a CLI (command-line interface) for GEOS. It can be used to:
 
 * Run GEOS operations on one or many geometries
-* Output geometry resuls in various formats (WKT and WKB)
+* Output geometry results in various formats (WKT and WKB)
 * Convert between WKT and WKB
 * Time the performance of operations
 * Check for memory leaks in operations


### PR DESCRIPTION
Following on #1128, this PR fixes a few more typos (some from me).

It also adds configuration to enable CI to run `codespell` to catch them before they get in. Third-party tools should be ignored, as is done with the configuration.

False-positive words to ignore can be added to `tools/codespell.ignore`.