### PR TITLE
CI: replace deprecated macos-12 with beta macos-15 with C++23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,10 +450,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - xcode: 13.2.1
-          cxxstd: 14
-          build_type: ASAN
-          runs_on: macos-12
         - xcode: 14.3.1
           cxxstd: 17
           build_type: ASAN
@@ -462,6 +458,10 @@ jobs:
           cxxstd: 20
           build_type: Release
           runs_on: macOS-14
+        - xcode: 16.0
+          cxxstd: 23
+          build_type: ASAN
+          runs_on: macos-15
 
     runs-on: ${{ matrix.runs_on }}
     steps:


### PR DESCRIPTION
According to [the runner image docs](https://github.com/actions/runner-images/tree/main) (and in GHA warnings), `macos-12` is deprecated. Replace this with `macos-15` for macOS 15 Arm64 beta with Xcode 16.0. This is also configured to select [C++23](https://developer.apple.com/xcode/cpp/#c++23).