### PR TITLE
Improve RelateNG performance for A/L cases in prepared predicates

### DIFF
--- a/include/geos/operation/relateng/RelateGeometry.h
+++ b/include/geos/operation/relateng/RelateGeometry.h
@@ -179,6 +179,10 @@ public:
             case Dimension::A: return hasAreas;
         }
         return false;
+    }    
+    
+    bool hasAreaAndLine() const {
+        return hasAreas && hasLines;
     }
 
     /**

--- a/src/operation/relateng/TopologyComputer.cpp
+++ b/src/operation/relateng/TopologyComputer.cpp
@@ -132,11 +132,16 @@ TopologyComputer::getDimension(bool isA) const
 bool
 TopologyComputer::isSelfNodingRequired() const
 {
-    if (predicate.requireSelfNoding()) {
-        if (geomA.isSelfNodingRequired() ||
-            geomB.isSelfNodingRequired())
-        return true;
-    }
+    if (! predicate.requireSelfNoding())
+      return false;
+    
+    if (geomA.isSelfNodingRequired()) 
+      return true;
+    
+    //-- if B is a mixed GC with A and L require full noding
+    if (geomB.hasAreaAndLine())
+      return true;
+
     return false;
 }
 

--- a/tests/unit/operation/relateng/RelateNGGCTest.cpp
+++ b/tests/unit/operation/relateng/RelateNGGCTest.cpp
@@ -320,6 +320,10 @@ void object::test<23> ()
     std::string a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
     std::string b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), MULTIPOINT ((0 2), (0 5)))";
     checkEquals(a, b, true);
+    checkContainsWithin(a, b, true);
+    checkCoversCoveredBy(a, b, true);
+    checkContainsWithin(b, a, true);
+    checkCoversCoveredBy(b, a, true);
 }
 
 
@@ -331,6 +335,10 @@ void object::test<24> ()
     std::string a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
     std::string b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (0 2, 0 5))";
     checkEquals(a, b, true);
+    checkContainsWithin(a, b, true);
+    checkCoversCoveredBy(a, b, true);
+    checkContainsWithin(b, a, true);
+    checkCoversCoveredBy(b, a, true);
 }
 
 
@@ -341,7 +349,10 @@ void object::test<25> ()
     std::string a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
     std::string b = "GEOMETRYCOLLECTION (POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)),LINESTRING(0 2, 0 5, 5 5))";
     checkEquals(a, b, true);
-}
+    checkContainsWithin(a, b, true);
+    checkCoversCoveredBy(a, b, true);
+    checkContainsWithin(b, a, true);
+    checkCoversCoveredBy(b, a, true);}
 
 
 

--- a/tests/xmltester/tests/general/TestRelateGC.xml
+++ b/tests/xmltester/tests/general/TestRelateGC.xml
@@ -574,6 +574,17 @@ GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), P
   <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
   <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
   <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+
+  <test><op name="contains"   arg1="B" arg2="A"> true </op></test>
+  <test><op name="coveredBy"  arg1="B" arg2="A"> true </op></test>
+  <test><op name="covers"     arg1="B" arg2="A"> true </op></test>
+  <test><op name="crosses"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="disjoint"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="equalsTopo" arg1="B" arg2="A"> true </op></test>
+  <test><op name="intersects" arg1="B" arg2="A"> true </op></test>
+  <test><op name="overlaps"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="touches"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="within"     arg1="B" arg2="A"> true </op></test>
 </case>
 
 <case>
@@ -596,6 +607,17 @@ GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), P
   <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
   <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
   <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+
+  <test><op name="contains"   arg1="B" arg2="A"> true </op></test>
+  <test><op name="coveredBy"  arg1="B" arg2="A"> true </op></test>
+  <test><op name="covers"     arg1="B" arg2="A"> true </op></test>
+  <test><op name="crosses"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="disjoint"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="equalsTopo" arg1="B" arg2="A"> true </op></test>
+  <test><op name="intersects" arg1="B" arg2="A"> true </op></test>
+  <test><op name="overlaps"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="touches"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="within"     arg1="B" arg2="A"> true </op></test>
 </case>
 
 </run>


### PR DESCRIPTION
Improve the `RelateNG` self-noding check to allow A-L cases to take advantage of prepared predicates.

Previously, A/L cases were not using the prepared noder cache for predicates which require self-noding (such as `contains`, `covers`, `relate` etc). This caused significantly poor performance for a common situation. The self-noding check has been refined to allow A/L cases to be use the cached noder.

This makes `RelateNG` in prepared mode as fast as `PreparedGeometry` for all cases (and it handles more cases).

Port of https://github.com/locationtech/jts/pull/1099

For example, a test in `perf_topo_predicate` has dramatically reduced execution time (133x faster):
```
16001, 961, 759, LineString, 101, RelateOp - contains, 221629, 1.0
16001, 961, 759, LineString, 101, Geometry - contains, 62459, 3.5
16001, 961, 604, LineString, 101, PreparedGeom - contains, 1984, 111.7
BEFORE:
16001, 961, 604, LineString, 101, RelateNGPrepared - contains, 102700, 2.2
AFTER:
16001, 961, 604, LineString, 101, RelateNGPrepared - contains, 2236, 99.1
```
