### PR TITLE
Update .gitignore to remove *.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Makefile
 *.swp
 *.trs
 *.exe
-*.cmake
 CMakeFiles
 CMakeCache.txt
 CMakeLists.txt.user


### PR DESCRIPTION
I am building a package that includes geos as a dependency, with compilation targeting Python, and builds happening with ``scikit-build-core``. I had a mysterious build failure for missing files in the ``cmake`` folder inside the build folder when built with ``pipx run build``, and tracked down the problem to the fact that the build runs a git clean and doesn't copy over files that are ignored by ``.gitignore``. Fixing that (as in this PR), allowed that part of the build to work properly. I think this change is harmless since there are already ``.cmake`` files in the repo so they should probably not be in the ``.gitignore`` anyhow.