### PR TITLE
Fix bug of GeoJSONWriter when there are sub-objects or sub-array in an array

### DIFF
--- a/src/io/GeoJSONWriter.cpp
+++ b/src/io/GeoJSONWriter.cpp
@@ -109,15 +109,33 @@ void GeoJSONWriter::encodeGeoJSONValue(const std::string& key, const GeoJSONValu
         }
     }
     else if (value.isArray()) {
-        j[key] = json::array();
-        for (const GeoJSONValue& v : value.getArray()) {
-            encodeGeoJSONValue("", v, j[key]);
+        if (j.is_object()) {
+          j[key] = json::array();
+          for (const GeoJSONValue& v : value.getArray()) {
+              encodeGeoJSONValue("", v, j[key]);
+          }
+        }
+        else {
+          json sub_array = json::array();
+          for (const GeoJSONValue& v : value.getArray()) {
+              encodeGeoJSONValue("", v, sub_array);
+          }
+          j.push_back(sub_array);
         }
     }
     else if (value.isObject()) {
-        j[key] = json::object();
-        for (const auto& entry : value.getObject()) {
-            encodeGeoJSONValue(entry.first, entry.second, j[key]);
+        if (j.is_object()) {
+          j[key] = json::object();
+          for (const auto& entry : value.getObject()) {
+              encodeGeoJSONValue(entry.first, entry.second, j[key]);
+          }
+        }
+        else {
+          json sub_obj = json::object();
+          for (const auto& entry : value.getObject()) {
+              encodeGeoJSONValue(entry.first, entry.second, sub_obj);
+          }
+          j.push_back(sub_obj);
         }
     }
 }

--- a/tests/unit/io/GeoJSONWriterTest.cpp
+++ b/tests/unit/io/GeoJSONWriterTest.cpp
@@ -428,15 +428,12 @@ void object::test<29>
     geos::io::GeoJSONValue row1(std::vector<geos::io::GeoJSONValue>({1.0, 2.0, 3.0}));
     geos::io::GeoJSONValue row2(std::vector<geos::io::GeoJSONValue>({4.0, 5.0, 6.0}));
     std::vector<geos::io::GeoJSONValue> obj_array = {row1, row2};
-    geos::io::GeoJSONFeatureCollection features {{
-        geos::io::GeoJSONFeature { wktreader.read("POINT(0 0)"), std::map<std::string, geos::io::GeoJSONValue> {
-            {"id",     geos::io::GeoJSONValue("id_123")},
-            {"name",   geos::io::GeoJSONValue(std::string{"Kunlin Yu"})},
-            {"matrix", geos::io::GeoJSONValue(obj_array)}
-        }}
-    }};
-    std::string result = geojsonwriter.write(features);
-    ensure_equals(result, "{}");
+    geos::io::GeoJSONFeature feature = {
+        wktreader.read("POINT(0 0)"),
+        std::map<std::string, geos::io::GeoJSONValue> {{"matrix", geos::io::GeoJSONValue(obj_array)}}
+    };
+    std::string result = geojsonwriter.write(feature);
+    ensure_equals(result, "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[0.0,0.0]},\"properties\":{\"matrix\":[[1.0,2.0,3.0],[4.0,5.0,6.0]]}}");
 }
 
 // GeoJSONWriter Write a feature with properties "array": [{"key": "value_1"}, {"key": "value_2"}]
@@ -448,15 +445,12 @@ void object::test<30>
     geos::io::GeoJSONValue obj1(std::map<std::string, geos::io::GeoJSONValue>({{"key", std::string("value_1")}}));
     geos::io::GeoJSONValue obj2(std::map<std::string, geos::io::GeoJSONValue>({{"key", std::string("value_2")}}));
     std::vector<geos::io::GeoJSONValue> obj_array = {obj1, obj2};
-    geos::io::GeoJSONFeatureCollection features {{
-        geos::io::GeoJSONFeature { wktreader.read("POINT(0 0)"), std::map<std::string, geos::io::GeoJSONValue> {
-            {"id",    geos::io::GeoJSONValue("id_123")},
-            {"name",  geos::io::GeoJSONValue(std::string{"Kunlin Yu"})},
-            {"array", geos::io::GeoJSONValue(obj_array)}
-        }}
-    }};
-    std::string result = geojsonwriter.write(features);
-    ensure_equals(result, "{}");
+    geos::io::GeoJSONFeature feature = {
+      wktreader.read("POINT(0 0)"),
+      std::map<std::string, geos::io::GeoJSONValue> {{"array", geos::io::GeoJSONValue(obj_array)}}
+    };
+    std::string result = geojsonwriter.write(feature);
+    ensure_equals(result, "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[0.0,0.0]},\"properties\":{\"array\":[{\"key\":\"value_1\"},{\"key\":\"value_2\"}]}}");
 }
 
 }

--- a/tests/unit/io/GeoJSONWriterTest.cpp
+++ b/tests/unit/io/GeoJSONWriterTest.cpp
@@ -372,7 +372,6 @@ void object::test<25>
     std::string result = geojsonwriter.write(geom.get());
     ensure_equals(result, "{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0,2.0],[103.0,1.0,4.0],[104.0,0.0,8.0],[105.0,1.0,16.0]]}");
 }
-
 // Write a LineString Z with some NaN Z to GeoJSON
 template<>
 template<>
@@ -418,6 +417,26 @@ void object::test<28>
     geojsonwriter.setOutputDimension(2);
     std::string result = geojsonwriter.write(geom.get());
     ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}");
+}
+
+// GeoJSONWriter Write a feature with properties "array": [{"key": "value_1"}, {"key": "value_2"}]
+template<>
+template<>
+void object::test<29>
+()
+{
+    geos::io::GeoJSONValue obj1(std::map<std::string, geos::io::GeoJSONValue>({{"key", std::string("value_1")}}));
+    geos::io::GeoJSONValue obj2(std::map<std::string, geos::io::GeoJSONValue>({{"key", std::string("value_2")}}));
+    std::vector<geos::io::GeoJSONValue> obj_array = {obj1, obj2};
+    geos::io::GeoJSONFeatureCollection features {{
+        geos::io::GeoJSONFeature { wktreader.read("POINT(0 0)"), std::map<std::string, geos::io::GeoJSONValue> {
+            {"id",   geos::io::GeoJSONValue("id_123")},
+            {"name", geos::io::GeoJSONValue(std::string{"Kunlin Yu"})},
+            {"array",  geos::io::GeoJSONValue(obj_array)}
+        }}
+    }};
+    std::string result = geojsonwriter.write(features);
+    ensure_equals(result, "{}");
 }
 
 }

--- a/tests/unit/io/GeoJSONWriterTest.cpp
+++ b/tests/unit/io/GeoJSONWriterTest.cpp
@@ -419,10 +419,30 @@ void object::test<28>
     ensure_equals(result, "{\"type\":\"Point\",\"coordinates\":[-117.0,33.0]}");
 }
 
-// GeoJSONWriter Write a feature with properties "array": [{"key": "value_1"}, {"key": "value_2"}]
+// GeoJSONWriter Write a feature with properties "matrix": [ [1, 2, 3], [4, 5, 6] ]
 template<>
 template<>
 void object::test<29>
+()
+{
+    geos::io::GeoJSONValue row1(std::vector<geos::io::GeoJSONValue>({1.0, 2.0, 3.0}));
+    geos::io::GeoJSONValue row2(std::vector<geos::io::GeoJSONValue>({4.0, 5.0, 6.0}));
+    std::vector<geos::io::GeoJSONValue> obj_array = {row1, row2};
+    geos::io::GeoJSONFeatureCollection features {{
+        geos::io::GeoJSONFeature { wktreader.read("POINT(0 0)"), std::map<std::string, geos::io::GeoJSONValue> {
+            {"id",     geos::io::GeoJSONValue("id_123")},
+            {"name",   geos::io::GeoJSONValue(std::string{"Kunlin Yu"})},
+            {"matrix", geos::io::GeoJSONValue(obj_array)}
+        }}
+    }};
+    std::string result = geojsonwriter.write(features);
+    ensure_equals(result, "{}");
+}
+
+// GeoJSONWriter Write a feature with properties "array": [{"key": "value_1"}, {"key": "value_2"}]
+template<>
+template<>
+void object::test<30>
 ()
 {
     geos::io::GeoJSONValue obj1(std::map<std::string, geos::io::GeoJSONValue>({{"key", std::string("value_1")}}));
@@ -430,9 +450,9 @@ void object::test<29>
     std::vector<geos::io::GeoJSONValue> obj_array = {obj1, obj2};
     geos::io::GeoJSONFeatureCollection features {{
         geos::io::GeoJSONFeature { wktreader.read("POINT(0 0)"), std::map<std::string, geos::io::GeoJSONValue> {
-            {"id",   geos::io::GeoJSONValue("id_123")},
-            {"name", geos::io::GeoJSONValue(std::string{"Kunlin Yu"})},
-            {"array",  geos::io::GeoJSONValue(obj_array)}
+            {"id",    geos::io::GeoJSONValue("id_123")},
+            {"name",  geos::io::GeoJSONValue(std::string{"Kunlin Yu"})},
+            {"array", geos::io::GeoJSONValue(obj_array)}
         }}
     }};
     std::string result = geojsonwriter.write(features);


### PR DESCRIPTION
GeoJSONWriter will throw exception when handle these two cases:
```json
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [ 0, 0 ]
  },
  "properties": {
    "matrix": [
      [ 1, 2, 3 ],
      [ 4, 5, 6 ]
    ]
  }
}
```
```json
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [ 0, 0 ]
  },
  "properties": {
    "array": [
      { "key": "value_1" },
      { "key": "value_2" }
    ]
  }
}

```
the message of the exception is :
```text
cannot use operator[] with a string argument with array
```

The root cause is here:
https://github.com/libgeos/geos/blob/3.13.0/src/io/GeoJSONWriter.cpp#L112
https://github.com/libgeos/geos/blob/3.13.0/src/io/GeoJSONWriter.cpp#L118

All other scalar types will detect the parent node is object or array.
If the parent is object then use key to add child value, else use push_back.
But when it comes to value.is_array() and value.is_object(), we forget to detect the type of parent json node.

So I add two unit tests to trigger the bug and fix it.

