### PR TITLE
GeometryCollection: Cache flags to avoid O(n) lookups

### DIFF
--- a/benchmarks/operation/CMakeLists.txt
+++ b/benchmarks/operation/CMakeLists.txt
@@ -19,4 +19,12 @@ if (benchmark_FOUND)
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>)
     target_link_libraries(perf_distance PRIVATE
             benchmark::benchmark geos geos_cxx_flags)
+
+    add_executable(perf_coverage_union CoverageUnionPerfTest.cpp)
+    target_include_directories(perf_coverage_union PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>)
+    target_link_libraries(perf_coverage_union PRIVATE
+            benchmark::benchmark geos geos_cxx_flags)
 endif()

--- a/benchmarks/operation/CoverageUnionPerfTest.cpp
+++ b/benchmarks/operation/CoverageUnionPerfTest.cpp
@@ -1,0 +1,65 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2025 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <stdexcept>
+#include <benchmark/benchmark.h>
+
+#include <BenchmarkUtils.h>
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/Geometry.h>
+#include <geos/coverage/CoverageUnion.h>
+#include <geos/operation/union/CoverageUnion.h>
+
+struct SegmentSet {
+    static void Union(const geos::geom::GeometryCollection& coll) {
+        geos::operation::geounion::CoverageUnion::Union(&coll);
+    }
+};
+
+struct BoundaryChain {
+    static void Union(const geos::geom::GeometryCollection& coll) {
+        auto result = geos::coverage::CoverageUnion::Union(&coll);
+    }
+};
+
+template<typename Impl>
+static void BM_CoverageUnion(benchmark::State& state) {
+    const auto& gfact = *geos::geom::GeometryFactory::getDefaultInstance();
+
+    auto nCells = state.range(0);
+
+    auto nx = static_cast<int>(std::ceil(std::sqrt(nCells)));
+    auto ny = static_cast<int>(std::ceil(std::sqrt(nCells)));
+
+    nCells = nx*ny;
+
+    geos::geom::Envelope env(0, nx, 0, ny);
+
+    auto cells = geos::benchmark::createGeometriesOnGrid(env, static_cast<std::size_t>(nCells), [&gfact](const auto& base) {
+        geos::geom::Envelope box(base.x, base.x + 1, base.y, base.y + 1);
+        return gfact.toGeometry(&box);
+    });
+
+    auto coll = gfact.createGeometryCollection(std::move(cells));
+
+    for (auto _ : state) {
+        Impl::Union(*coll);
+    }
+}
+
+BENCHMARK_TEMPLATE(BM_CoverageUnion, SegmentSet)->Range(1000, 1000000);
+BENCHMARK_TEMPLATE(BM_CoverageUnion, BoundaryChain)->Range(1000, 1000000);
+
+BENCHMARK_MAIN();
+

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -198,6 +198,16 @@ public:
 
 protected:
 
+    struct CollectionFlags {
+        bool flagsCalculated;
+        bool hasPoints;
+        bool hasLines;
+        bool hasPolygons;
+        bool hasM;
+        bool hasZ;
+        bool hasCurves;
+    };
+
     GeometryCollection(const GeometryCollection& gc);
     GeometryCollection& operator=(const GeometryCollection& gc);
 
@@ -236,6 +246,7 @@ protected:
     };
 
     std::vector<std::unique_ptr<Geometry>> geometries;
+    mutable CollectionFlags flags;
     mutable Envelope envelope;
 
     Envelope computeEnvelopeInternal() const;
@@ -248,6 +259,7 @@ protected:
 
     bool hasCurvedComponents() const override;
 
+    void setFlags() const;
 
 };
 

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -39,7 +39,7 @@ GeometryCollection::GeometryCollection(const GeometryCollection& gc)
     :
     Geometry(gc),
     geometries(gc.geometries.size()),
-    flags{}, // set all flags to zero
+    flags(gc.flags),
     envelope(gc.envelope)
 {
     for(std::size_t i = 0; i < geometries.size(); ++i) {


### PR DESCRIPTION
As discussed in https://github.com/locationtech/jts/issues/1100. For a collection with 1 million elements, reduces CoverageUnion runtime by 98%.

Increases the size of collections from 88 to 96 bytes. This could be avoided by storing the flags in `Geometry` (which has 4 spare bytes) rather than `GeometryCollection` (which has none).

This PR:
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
BM_CoverageUnion<SegmentSet>/1000          1309915 ns      1309904 ns          544
BM_CoverageUnion<SegmentSet>/4096          5467171 ns      5466976 ns          124
BM_CoverageUnion<SegmentSet>/32768        54011812 ns     54009415 ns           12
BM_CoverageUnion<SegmentSet>/262144      498335728 ns    498323707 ns            2
BM_CoverageUnion<SegmentSet>/1000000    2130948900 ns   2130788554 ns            1
BM_CoverageUnion<BoundaryChain>/1000        866139 ns       866082 ns          745
BM_CoverageUnion<BoundaryChain>/4096       3223064 ns      3222934 ns          216
BM_CoverageUnion<BoundaryChain>/32768     27829346 ns     27825710 ns           25
BM_CoverageUnion<BoundaryChain>/262144   222791662 ns    222777788 ns            3
BM_CoverageUnion<BoundaryChain>/1000000  976485195 ns    976432682 ns            1
```

main:
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
BM_CoverageUnion<SegmentSet>/1000          1204288 ns      1204243 ns          587
BM_CoverageUnion<SegmentSet>/4096          5243907 ns      5243915 ns          130
BM_CoverageUnion<SegmentSet>/32768        51261928 ns     51258943 ns           13
BM_CoverageUnion<SegmentSet>/262144      477953902 ns    477906954 ns            2
BM_CoverageUnion<SegmentSet>/1000000    2052768394 ns   2052653441 ns            1
BM_CoverageUnion<BoundaryChain>/1000        989152 ns       989121 ns          723
BM_CoverageUnion<BoundaryChain>/4096       5400333 ns      5399829 ns          123
BM_CoverageUnion<BoundaryChain>/32768    109018236 ns    109002983 ns            6
BM_CoverageUnion<BoundaryChain>/262144  5086413577 ns   5085701992 ns            1
BM_CoverageUnion<BoundaryChain>/1000000 3.7859e+10 ns   3.7757e+10 ns            1
```