### PR TITLE
Added GEOS_DLL for PreparedPolygon

### DIFF
--- a/include/geos/geom/prep/PreparedPolygon.h
+++ b/include/geos/geom/prep/PreparedPolygon.h
@@ -48,7 +48,7 @@ namespace prep { // geos::geom::prep
  * @author mbdavis
  *
  */
-class PreparedPolygon : public BasicPreparedGeometry {
+class GEOS_DLL PreparedPolygon : public BasicPreparedGeometry {
 private:
     bool isRectangle;
     mutable std::unique_ptr<noding::FastSegmentSetIntersectionFinder> segIntFinder;


### PR DESCRIPTION
Without this, the ``PreparedPolygon`` class is incompletely included in the shared library in C++ interfaces. I suspect because LTO is stripping out some of the functions. With this included, all the ``PreparedPolygon`` methods are exported to shared library. Only necessary on windows (I think).

My experience was that I needed this change to call these methods when I dynamically linked GEOS. 