### PR TITLE
Fix inscribed circle initialization

### DIFF
--- a/src/algorithm/construct/MaximumInscribedCircle.cpp
+++ b/src/algorithm/construct/MaximumInscribedCircle.cpp
@@ -164,8 +164,8 @@ MaximumInscribedCircle::distanceToBoundary(double x, double y)
 MaximumInscribedCircle::Cell
 MaximumInscribedCircle::createInteriorPointCell(const Geometry* geom)
 {
-    Coordinate c;
     std::unique_ptr<Point> p = geom->getInteriorPoint();
+    Coordinate c(p->getX(), p->getY());
     Cell cell(p->getX(), p->getY(), 0, distanceToBoundary(c));
     return cell;
 }

--- a/tests/unit/algorithm/construct/MaximumInscribedCircleTest.cpp
+++ b/tests/unit/algorithm/construct/MaximumInscribedCircleTest.cpp
@@ -173,7 +173,7 @@ void object::test<5>
 ()
 {
     checkCircle("POLYGON ((100 100, 200 200, 100 100, 100 100))",
-       0.01, 150, 150, 0 );
+       0.01, 100, 100, 0 );
 }
 
 
@@ -198,7 +198,7 @@ void object::test<7>
 ()
 {
      checkCircle("POLYGON((1 2, 1 2, 1 2, 1 2, 3 2, 1 2))",
-       0.01, 2, 2, 0 );
+       0.01, 1, 2, 0 );
 }
 
 // Exception thrown to avoid infinite loop with infinite envelope


### PR DESCRIPTION
Fix a bug in `MaximumInscribedCircle` that gives a bad result

```
import shapely, shapely.constructive
import numpy as np
poly = shapely.from_geojson('{"type":"Polygon","coordinates":[[[0.0,-10.0],[-7.07107,-7.07107],[-10.0,0.0],[-7.07107,7.07107],[0.0,10.0],[7.07107,7.07107],[10.0,0.0],[7.07107,-7.07107],[0.0,-10.0]]]}')

u = shapely.constructive.maximum_inscribed_circle(poly, tolerance=0.1)
a, b = np.array(u.coords)
print(a,b,np.linalg.norm(a-b))

```


Actual: 
`[0.       3.535535] [-2.28553181  9.05330273] 5.972387826209451`

Expected:
`[0. 0.] [ 8.53553655 -3.53553126] 9.238796754579768`
