### PR TITLE
Fix invalid values from CoverageUnionNG

### DIFF
--- a/src/operation/overlayng/CoverageUnion.cpp
+++ b/src/operation/overlayng/CoverageUnion.cpp
@@ -33,7 +33,6 @@ namespace overlayng { // geos.operation.overlayng
 std::unique_ptr<Geometry>
 CoverageUnion::geomunion(const Geometry* coverage)
 {
-    double area_in = coverage->getArea();
     std::unique_ptr<Geometry> result;
 
     // a precision model is not needed since no noding is done
@@ -47,9 +46,10 @@ CoverageUnion::geomunion(const Geometry* coverage)
         result = OverlayNG::geomunion(coverage, nullptr, &bcn);
     }
 
-    double area_out = result->getArea();
+    double area_in = coverage->getArea();
 
-    if (std::abs((area_out - area_in)/area_in) > AREA_PCT_DIFF_TOL) {
+    if ( (area_in != 0.0) &&
+         (std::abs((result->getArea() - area_in)/area_in) > AREA_PCT_DIFF_TOL)) {
         throw geos::util::TopologyException("CoverageUnion cannot process overlapping inputs.");
     }
 

--- a/tests/unit/operation/overlayng/CoverageUnionNGTest.cpp
+++ b/tests/unit/operation/overlayng/CoverageUnionNGTest.cpp
@@ -9,6 +9,7 @@
 #include <geos/util.h>
 
 // std
+#include <cfenv>
 #include <memory>
 
 using namespace geos::geom;
@@ -32,7 +33,9 @@ struct test_coverageunionng_data {
     {
         std::unique_ptr<Geometry> geom = r.read(wkt);
         std::unique_ptr<Geometry> expected = r.read(wktExpected);
+        std::feclearexcept(FE_ALL_EXCEPT);
         std::unique_ptr<Geometry> result = CoverageUnion::geomunion(geom.get());
+        ensure("FE_INVALID raised", !std::fetestexcept(FE_INVALID));
 
         try {
             ensure_equals_geometry_xyzm(result.get(), expected.get());
@@ -220,6 +223,33 @@ void object::test<17>()
 {
     checkUnion("GEOMETRYCOLLECTION( POLYGON M ((0 0 0, 1 0 1, 1 1 2, 0 0 0)), POLYGON M ((0 0 0, 1 1 2, 0 1 3, 0 0 0)) )",
                "POLYGON M ((0 0 0, 1 0 1, 1 1 2, 0 1 3, 0 0 0))");
+}
+
+// Check empty polygon
+template<>
+template<>
+void object::test<18>()
+{
+    checkUnion("POLYGON EMPTY",
+               "POLYGON EMPTY");
+}
+
+// Check empty GeometryCollection, with M dimension
+template<>
+template<>
+void object::test<19>()
+{
+    checkUnion("GEOMETRYCOLLECTION M EMPTY",
+               "GEOMETRYCOLLECTION M EMPTY");
+}
+
+// Check GeometryCollection of empty polygon
+template<>
+template<>
+void object::test<20>()
+{
+    checkUnion("GEOMETRYCOLLECTION( POLYGON EMPTY )",
+               "POLYGON EMPTY");
 }
 
 } // namespace tut


### PR DESCRIPTION
This resolves an invalid value message shown in shapely:
```pycon
>>> import shapely
>>> shapely.geos_version_string
'3.13.0'
>>> shapely.coverage_union_all([])
/home/mtoews/src/shapely/shapely/shapely/set_operations.py:505: RuntimeWarning: invalid value encountered in coverage_union
  return lib.coverage_union(collections, **kwargs)
<GEOMETRYCOLLECTION EMPTY>
```

This is caused by a division by zero in GEOS' `CoverageUnion::geomunion()` with coverage inputs that are empty or don't have an area.

[Tests 9 to 14](https://github.com/libgeos/geos/blob/3.13.0/tests/unit/operation/overlayng/CoverageUnionNGTest.cpp#L141-L205) were silently throwing this warning too, as these input coverages don't have an area.