### PR TITLE
Fix overlay heuristic for GeometryCollections with empty elements

### DIFF
--- a/include/geos/geom/HeuristicOverlay.h
+++ b/include/geos/geom/HeuristicOverlay.h
@@ -63,6 +63,8 @@ public:
         , poly_union(nullptr)
     {};
 
+    static std::unique_ptr<Geometry> overlay(const Geometry* g0, const Geometry* g1, int opCode);
+
     void readCollection(const Geometry* g);
     const Geometry* getPolyUnion()  const { return poly_union.get(); }
     const Geometry* getLineUnion()  const { return line_union.get(); }

--- a/include/geos/geom/HeuristicOverlay.h
+++ b/include/geos/geom/HeuristicOverlay.h
@@ -51,6 +51,7 @@ public:
         , pt_union(nullptr)
         , line_union(nullptr)
         , poly_union(nullptr)
+        , dimension(Dimension::DONTCARE)
     {
         readCollection(g);
         unionByDimension();
@@ -61,9 +62,15 @@ public:
         , pt_union(nullptr)
         , line_union(nullptr)
         , poly_union(nullptr)
+        , dimension(Dimension::DONTCARE)
     {};
 
     static std::unique_ptr<Geometry> overlay(const Geometry* g0, const Geometry* g1, int opCode);
+
+    Dimension::DimensionType getDimension() const
+    {
+        return dimension;
+    };
 
     void readCollection(const Geometry* g);
     const Geometry* getPolyUnion()  const { return poly_union.get(); }
@@ -74,7 +81,6 @@ public:
     std::unique_ptr<Geometry> doIntersection(const StructuredCollection& a) const;
     std::unique_ptr<Geometry> doSymDifference(const StructuredCollection& a) const;
     std::unique_ptr<Geometry> doDifference(const StructuredCollection& a) const;
-    std::unique_ptr<Geometry> doUnaryUnion() const;
 
     static void toVector(const Geometry* g, std::vector<const Geometry*>& v);
     void unionByDimension(void);
@@ -90,6 +96,12 @@ private:
     std::unique_ptr<Geometry> line_union;
     std::unique_ptr<Geometry> poly_union;
 
+    Dimension::DimensionType dimension;
+
+    void addDimension(Dimension::DimensionType dim);
+    std::unique_ptr<Geometry> doUnaryUnion(int resultDim) const;
+    std::unique_ptr<Geometry> computeResult(StructuredCollection& coll, int opCode,
+                Dimension::DimensionType dimA, Dimension::DimensionType dimB) const;
 };
 
 

--- a/include/geos/geom/HeuristicOverlay.h
+++ b/include/geos/geom/HeuristicOverlay.h
@@ -46,6 +46,19 @@ class StructuredCollection {
 
 public:
 
+    static std::unique_ptr<Geometry> overlay(const Geometry* g0, const Geometry* g1, int opCode);
+
+private:
+
+    const GeometryFactory* factory;
+    std::vector<const Geometry*> pts;
+    std::vector<const Geometry*> lines;
+    std::vector<const Geometry*> polys;
+    std::unique_ptr<Geometry> pt_union;
+    std::unique_ptr<Geometry> line_union;
+    std::unique_ptr<Geometry> poly_union;
+    Dimension::DimensionType dimension;
+
     StructuredCollection(const Geometry* g)
         : factory(g->getFactory())
         , pt_union(nullptr)
@@ -65,12 +78,15 @@ public:
         , dimension(Dimension::DONTCARE)
     {};
 
-    static std::unique_ptr<Geometry> overlay(const Geometry* g0, const Geometry* g1, int opCode);
-
     Dimension::DimensionType getDimension() const
     {
         return dimension;
     };
+
+    void addDimension(Dimension::DimensionType dim);
+    std::unique_ptr<Geometry> doUnaryUnion(int resultDim) const;
+    std::unique_ptr<Geometry> computeResult(StructuredCollection& coll, int opCode,
+                Dimension::DimensionType dimA, Dimension::DimensionType dimB) const;
 
     void readCollection(const Geometry* g);
     const Geometry* getPolyUnion()  const { return poly_union.get(); }
@@ -84,24 +100,6 @@ public:
 
     static void toVector(const Geometry* g, std::vector<const Geometry*>& v);
     void unionByDimension(void);
-
-
-private:
-
-    const GeometryFactory* factory;
-    std::vector<const Geometry*> pts;
-    std::vector<const Geometry*> lines;
-    std::vector<const Geometry*> polys;
-    std::unique_ptr<Geometry> pt_union;
-    std::unique_ptr<Geometry> line_union;
-    std::unique_ptr<Geometry> poly_union;
-
-    Dimension::DimensionType dimension;
-
-    void addDimension(Dimension::DimensionType dim);
-    std::unique_ptr<Geometry> doUnaryUnion(int resultDim) const;
-    std::unique_ptr<Geometry> computeResult(StructuredCollection& coll, int opCode,
-                Dimension::DimensionType dimA, Dimension::DimensionType dimB) const;
 };
 
 

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -619,43 +619,6 @@ Geometry::intersection(const Geometry* other) const
 std::unique_ptr<Geometry>
 Geometry::Union(const Geometry* other) const
 {
-#ifdef SHORTCIRCUIT_PREDICATES
-    // if envelopes are disjoint return a MULTI geom or
-    // a geometrycollection
-    if(! getEnvelopeInternal()->intersects(other->getEnvelopeInternal())) {
-//cerr<<"SHORTCIRCUITED-UNION engaged"<<endl;
-        const GeometryCollection* coll;
-
-        std::size_t ngeomsThis = getNumGeometries();
-        std::size_t ngeomsOther = other->getNumGeometries();
-
-        // Allocated for ownership transfer
-        std::vector<std::unique_ptr<Geometry>> v;
-        v.reserve(ngeomsThis + ngeomsOther);
-
-
-        if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(this))) {
-            for(std::size_t i = 0; i < ngeomsThis; ++i) {
-                v.push_back(coll->getGeometryN(i)->clone());
-            }
-        }
-        else {
-            v.push_back(this->clone());
-        }
-
-        if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(other))) {
-            for(std::size_t i = 0; i < ngeomsOther; ++i) {
-                v.push_back(coll->getGeometryN(i)->clone());
-            }
-        }
-        else {
-            v.push_back(other->clone());
-        }
-
-        return _factory->buildGeometry(std::move(v));
-    }
-#endif
-
     return HeuristicOverlay(this, other, OverlayNG::UNION);
 }
 
@@ -676,40 +639,6 @@ Geometry::difference(const Geometry* other) const
 std::unique_ptr<Geometry>
 Geometry::symDifference(const Geometry* other) const
 {
-    // if envelopes are disjoint return a MULTI geom or
-    // a geometrycollection
-    if(! getEnvelopeInternal()->intersects(other->getEnvelopeInternal()) && !(isEmpty() && other->isEmpty())) {
-        const GeometryCollection* coll;
-
-        std::size_t ngeomsThis = getNumGeometries();
-        std::size_t ngeomsOther = other->getNumGeometries();
-
-        // Allocated for ownership transfer
-        std::vector<std::unique_ptr<Geometry>> v;
-        v.reserve(ngeomsThis + ngeomsOther);
-
-
-        if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(this))) {
-            for(std::size_t i = 0; i < ngeomsThis; ++i) {
-                v.push_back(coll->getGeometryN(i)->clone());
-            }
-        }
-        else {
-            v.push_back(this->clone());
-        }
-
-        if(nullptr != (coll = dynamic_cast<const GeometryCollection*>(other))) {
-            for(std::size_t i = 0; i < ngeomsOther; ++i) {
-                v.push_back(coll->getGeometryN(i)->clone());
-            }
-        }
-        else {
-            v.push_back(other->clone());
-        }
-
-        return _factory->buildGeometry(std::move(v));
-    }
-
     return HeuristicOverlay(this, other, OverlayNG::SYMDIFFERENCE);
 }
 

--- a/src/geom/HeuristicOverlay.cpp
+++ b/src/geom/HeuristicOverlay.cpp
@@ -20,6 +20,13 @@
  * This file provides a single function, taking two
  * const Geometry pointers, applying a binary operator to them
  * and returning a result Geometry in an unique_ptr<>.
+ * 
+ * It implements a "combine-disjoint" heuristic for optimizing some overlay cases.
+ * It also implements overlay for GeometryCollections, which is not (yet)
+ * provided by OverlayNG.
+ * Internal overlay usage should call OverlayNG directly 
+ * if this behaviour is not needed (i.e. when the inputs are known to be simple
+ * or when full overlay is desired to be computed.)
  *
  **********************************************************************/
 

--- a/src/operation/union/CascadedPolygonUnion.cpp
+++ b/src/operation/union/CascadedPolygonUnion.cpp
@@ -20,11 +20,11 @@
 
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryFactory.h>
-#include <geos/geom/HeuristicOverlay.h>
 #include <geos/geom/MultiPolygon.h>
 #include <geos/geom/Polygon.h>
 #include <geos/index/strtree/TemplateSTRtree.h>
 #include <geos/operation/overlayng/OverlayNG.h>
+#include <geos/operation/overlayng/OverlayNGRobust.h>
 #include <geos/operation/union/CascadedPolygonUnion.h>
 #include <geos/operation/valid/IsValidOp.h>
 #include <geos/operation/valid/IsSimpleOp.h>
@@ -201,10 +201,8 @@ CascadedPolygonUnion::restrictToPolygons(std::unique_ptr<geom::Geometry> g)
 std::unique_ptr<geom::Geometry>
 ClassicUnionStrategy::Union(const geom::Geometry* g0, const geom::Geometry* g1)
 {
-    // TODO make an rvalue overload for this that can consume its inputs.
-    // At a minimum, a copy in the buffer fallback can be eliminated.
     try {
-        return geom::HeuristicOverlay(g0, g1, operation::overlayng::OverlayNG::UNION);
+        return operation::overlayng::OverlayNGRobust::Overlay(g0, g1, operation::overlayng::OverlayNG::UNION);
     }
     catch (const util::TopologyException &ex) {
         ::geos::ignore_unused_variable_warning(ex);

--- a/src/operation/valid/MakeValid.cpp
+++ b/src/operation/valid/MakeValid.cpp
@@ -23,9 +23,9 @@
 #include <geos/operation/valid/IsValidOp.h>
 
 #include <geos/operation/overlayng/OverlayNG.h>
+#include <geos/operation/overlayng/OverlayNGRobust.h>
 #include <geos/operation/polygonize/BuildArea.h>
 #include <geos/operation/union/UnaryUnionOp.h>
-#include <geos/geom/HeuristicOverlay.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryCollection.h>
 #include <geos/geom/GeometryFactory.h>
@@ -51,6 +51,7 @@
 
 using namespace geos::geom;
 using geos::operation::overlayng::OverlayNG;
+using geos::operation::overlayng::OverlayNGRobust;
 
 namespace geos {
 namespace operation { // geos.operation
@@ -60,19 +61,19 @@ namespace valid { // geos.operation.valid
 static std::unique_ptr<geom::Geometry>
 makeValidSymDifference(const geom::Geometry* g0, const geom::Geometry* g1)
 {
-    return HeuristicOverlay(g0, g1, OverlayNG::SYMDIFFERENCE);
+    return OverlayNGRobust::Overlay(g0, g1, OverlayNG::SYMDIFFERENCE);
 }
 
 static std::unique_ptr<geom::Geometry>
 makeValidDifference(const geom::Geometry* g0, const geom::Geometry* g1)
 {
-    return HeuristicOverlay(g0, g1, OverlayNG::DIFFERENCE);
+    return OverlayNGRobust::Overlay(g0, g1, OverlayNG::DIFFERENCE);
 }
 
 static std::unique_ptr<geom::Geometry>
 makeValidUnion(const geom::Geometry* g0, const geom::Geometry* g1)
 {
-    return HeuristicOverlay(g0, g1, OverlayNG::UNION);
+    return OverlayNGRobust::Overlay(g0, g1, OverlayNG::UNION);
 }
 
 /*

--- a/tests/unit/geom/HeuristicOverlayTest.cpp
+++ b/tests/unit/geom/HeuristicOverlayTest.cpp
@@ -163,7 +163,7 @@ void object::test<8> ()
         "GEOMETRYCOLLECTION(POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)))",
         "GEOMETRYCOLLECTION(POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)), POINT(20 20))",
         OverlayNG::DIFFERENCE,
-        "GEOMETRYCOLLECTION EMPTY"
+        "POLYGON EMPTY"
         );
 }
 
@@ -201,6 +201,18 @@ void object::test<11> ()
         "GEOMETRYCOLLECTION(POLYGON((2 2, 12 2, 12 12, 2 12, 2 2)), LINESTRING EMPTY, MULTIPOINT(4 4, 11 11), LINESTRING(5 6, 6 5))",
         OverlayNG::UNION,
         "POLYGON ((2 12, 12 12, 12 2, 10 2, 10 0, 0 0, 0 10, 2 10, 2 12))"
+        );
+}
+
+template<>
+template<>
+void object::test<12> ()
+{
+    checkOverlay(
+        "GEOMETRYCOLLECTION (POLYGON ((1 5, 5 5, 5 1, 1 1, 1 5)), POLYGON ((9 5, 9 1, 5 1, 5 5, 9 5)))",
+        "POLYGON ((1 5, 9 5, 9 1, 1 1, 1 5))",
+        OverlayNG::DIFFERENCE,
+        "POLYGON EMPTY"
         );
 }
 

--- a/tests/xmltester/BufferResultMatcher.cpp
+++ b/tests/xmltester/BufferResultMatcher.cpp
@@ -19,7 +19,6 @@
 #include "BufferResultMatcher.h"
 
 #include <geos/geom/Geometry.h>
-#include <geos/geom/HeuristicOverlay.h>
 #include <geos/operation/overlayng/OverlayNG.h>
 #include <geos/algorithm/distance/DiscreteHausdorffDistance.h>
 
@@ -65,15 +64,8 @@ BufferResultMatcher::isSymDiffAreaInTolerance(
     const geom::Geometry& actualBuffer,
     const geom::Geometry& expectedBuffer)
 {
-    typedef std::unique_ptr<geom::Geometry> GeomPtr;
-
-    using geos::geom::HeuristicOverlay;
-
     double area = expectedBuffer.getArea();
-    GeomPtr diff = HeuristicOverlay(&actualBuffer, &expectedBuffer,
-                            operation::overlayng::OverlayNG::SYMDIFFERENCE);
-
-    double areaDiff = diff->getArea();
+    double areaDiff = actualBuffer.symDifference(&expectedBuffer)->getArea();
 
     // can't get closer than difference area = 0 !
     // This also handles case when symDiff is empty

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -48,6 +48,7 @@
 #include <geos/simplify/TopologyPreservingSimplifier.h>
 #include <geos/simplify/DouglasPeuckerSimplifier.h>
 #include <geos/util.h>
+#include <geos/util/string.h>
 #include <geos/util/Interrupt.h>
 #include <geos/io/WKBReader.h>
 #include <geos/io/WKBWriter.h>
@@ -175,17 +176,6 @@ tolower(std::string& str)
         str.end(),
         str.begin(),
         [](char c){ return (char)std::tolower(c); }
-        );
-}
-
-void
-toupper(std::string& str)
-{
-    std::transform(
-        str.begin(),
-        str.end(),
-        str.begin(),
-        [](char c){ return (char)std::toupper(c); }
         );
 }
 
@@ -886,13 +876,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
-        toupper(opArg1);
+        geos::util::toUpper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
-        toupper(opArg2);
+        geos::util::toUpper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -877,13 +877,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
-        geos::util::toUpper(opArg1);
+        util::toUpper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
-        geos::util::toUpper(opArg2);
+        util::toUpper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -300,9 +300,6 @@ checkSingleSidedBufferSuccess(geom::Geometry& gRes,
     return success;
 }
 
-const std::string ARG_A = "A";
-const std::string ARG_B = "B";
-
 XMLTester::XMLTester()
     :
     gA(nullptr),

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -178,7 +178,7 @@ tolower(std::string& str)
         );
 }
 
-void toUpper(std::string& s)
+void toupper(std::string& s)
 {
     std::transform(s.begin(), s.end(), s.begin(), ::toupper);
 }
@@ -880,13 +880,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
-        toUpper(opArg1);
+        toupper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
-        toUpper(opArg2);
+        toupper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -92,6 +92,7 @@ using namespace geos::operation::polygonize;
 using namespace geos::operation::linemerge;
 using namespace geos::geom::prep;
 using std::runtime_error;
+using geos::util::toUpper;
 using geos::operation::overlayng::OverlayNG;
 using geos::operation::overlayng::UnaryUnionNG;
 using geos::operation::overlayng::OverlayNGRobust;
@@ -876,13 +877,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
-        geos::util::toUpper(opArg1);
+        toUpper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
-        geos::util::toUpper(opArg2);
+        toUpper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -178,6 +178,17 @@ tolower(std::string& str)
         );
 }
 
+void
+toupper(std::string& str)
+{
+    std::transform(
+        str.begin(),
+        str.end(),
+        str.begin(),
+        [](char c){ return (char)std::toupper(c); }
+        );
+}
+
 std::string
 normalize_filename(const std::string& str)
 {
@@ -288,6 +299,9 @@ checkSingleSidedBufferSuccess(geom::Geometry& gRes,
 
     return success;
 }
+
+const std::string ARG_A = "A";
+const std::string ARG_B = "B";
 
 XMLTester::XMLTester()
     :
@@ -875,11 +889,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
+        toupper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
+        toupper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");
@@ -988,13 +1004,15 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
         }
 
         else if(opName == "intersection") {
+            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
+            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
 
             GeomPtr gRes(parseGeometry(opRes, "expected"));
             gRes->normalize();
 
             profile.start();
 
-            GeomPtr gRealRes(gA->intersection(gB));
+            GeomPtr gRealRes(g1->intersection(g2));
 
             profile.stop();
 
@@ -1312,6 +1330,9 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
 
 
         else if(opName == "union") {
+            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
+            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
+
             GeomPtr gRes(parseGeometry(opRes, "expected"));
             gRes->normalize();
 
@@ -1319,10 +1340,10 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
 
             GeomPtr gRealRes;
             if(gB) {
-                gRealRes = gA->Union(gB);
+                gRealRes = g1->Union(g2);
             }
             else {
-                gRealRes = gA->Union();
+                gRealRes = g1->Union();
             }
 
             profile.stop();
@@ -1339,11 +1360,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
         }
 
         else if(opName == "difference") {
+            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
+            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
 
             GeomPtr gRes(parseGeometry(opRes, "expected"));
             gRes->normalize();
 
-            GeomPtr gRealRes(gA->difference(gB));
+            GeomPtr gRealRes(g1->difference(g2));
 
             gRealRes->normalize();
 
@@ -1360,10 +1383,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
         }
 
         else if(opName == "symdifference") {
+            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
+            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
+
             GeomPtr gRes(parseGeometry(opRes, "expected"));
             gRes->normalize();
 
-            GeomPtr gRealRes(gA->symDifference(gB));
+            GeomPtr gRealRes(g1->symDifference(g2));
 
             gRealRes->normalize();
 

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -48,7 +48,6 @@
 #include <geos/simplify/TopologyPreservingSimplifier.h>
 #include <geos/simplify/DouglasPeuckerSimplifier.h>
 #include <geos/util.h>
-#include <geos/util/string.h>
 #include <geos/util/Interrupt.h>
 #include <geos/io/WKBReader.h>
 #include <geos/io/WKBWriter.h>
@@ -92,7 +91,6 @@ using namespace geos::operation::polygonize;
 using namespace geos::operation::linemerge;
 using namespace geos::geom::prep;
 using std::runtime_error;
-using geos::util::toUpper;
 using geos::operation::overlayng::OverlayNG;
 using geos::operation::overlayng::UnaryUnionNG;
 using geos::operation::overlayng::OverlayNGRobust;
@@ -178,6 +176,11 @@ tolower(std::string& str)
         str.begin(),
         [](char c){ return (char)std::tolower(c); }
         );
+}
+
+void toUpper(std::string& s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
 }
 
 std::string
@@ -877,13 +880,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
-        util::toUpper(opArg1);
+        toUpper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
-        util::toUpper(opArg2);
+        toUpper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -877,13 +877,13 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     tmp = opel->Attribute("arg1");
     if(tmp) {
         opArg1 = tmp;
-        toUpper(opArg1);
+        geos::util::toUpper(opArg1);
     }
 
     tmp = opel->Attribute("arg2");
     if(tmp) {
         opArg2 = tmp;
-        toUpper(opArg2);
+        geos::util::toUpper(opArg2);
     }
 
     tmp = opel->Attribute("arg3");

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -180,7 +180,9 @@ tolower(std::string& str)
 
 void toupper(std::string& s)
 {
-    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+    std::transform(s.begin(), s.end(), s.begin(), 
+        [](char c){ return (char)std::toupper(c); }
+    );
 }
 
 std::string

--- a/tests/xmltester/tests/general/TestOverlayEmpty.xml
+++ b/tests/xmltester/tests/general/TestOverlayEmpty.xml
@@ -1025,7 +1025,7 @@ POINT (1 1)
 GEOMETRYCOLLECTION (POLYGON EMPTY, POINT EMPTY, LINESTRING (2 2, 3 3))
   </b>
 <test>  <op name="intersection" arg1="A" arg2="B">
-GEOMETRYCOLLECTION EMPTY
+POINT EMPTY
   </op></test>
 <test>  <op name="union" arg1="A" arg2="B">
 GEOMETRYCOLLECTION (LINESTRING (2 2, 3 3), POINT (1 1))
@@ -1050,7 +1050,7 @@ POINT (1 1)
 GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POLYGON EMPTY, POINT EMPTY), GEOMETRYCOLLECTION(POLYGON EMPTY, LINESTRING (2 2, 3 3)))
   </b>
 <test>  <op name="intersection" arg1="A" arg2="B">
-GEOMETRYCOLLECTION EMPTY
+POINT EMPTY
   </op></test>
 <test>  <op name="union" arg1="A" arg2="B">
 GEOMETRYCOLLECTION (LINESTRING (2 2, 3 3), POINT (1 1))

--- a/tests/xmltester/tests/general/TestOverlayEmpty.xml
+++ b/tests/xmltester/tests/general/TestOverlayEmpty.xml
@@ -1016,6 +1016,55 @@
 <test> <op name='symDifference' arg1='A' arg2='B'>  POLYGON EMPTY   </op> </test>
 </case>
 
+<case>
+  <desc>PC - point and disjoint GC with empty elements</desc>
+  <a>
+POINT (1 1)
+  </a>
+  <b>
+GEOMETRYCOLLECTION (POLYGON EMPTY, POINT EMPTY, LINESTRING (2 2, 3 3))
+  </b>
+<test>  <op name="intersection" arg1="A" arg2="B">
+GEOMETRYCOLLECTION EMPTY
+  </op></test>
+<test>  <op name="union" arg1="A" arg2="B">
+GEOMETRYCOLLECTION (LINESTRING (2 2, 3 3), POINT (1 1))
+  </op></test>
+<test>  <op name="difference" arg1="A" arg2="B">
+POINT (1 1)
+  </op></test>
+<test>  <op name="difference" arg1="B" arg2="A">
+LINESTRING (2 2, 3 3)
+  </op></test>
+<test>  <op name="symdifference" arg1="A" arg2="B">
+GEOMETRYCOLLECTION (LINESTRING (2 2, 3 3), POINT (1 1))
+  </op></test>
+</case>
+
+<case>
+  <desc>PC - point and disjoint GC with nested empty elements</desc>
+  <a>
+POINT (1 1)
+  </a>
+  <b>
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POLYGON EMPTY, POINT EMPTY), GEOMETRYCOLLECTION(POLYGON EMPTY, LINESTRING (2 2, 3 3)))
+  </b>
+<test>  <op name="intersection" arg1="A" arg2="B">
+GEOMETRYCOLLECTION EMPTY
+  </op></test>
+<test>  <op name="union" arg1="A" arg2="B">
+GEOMETRYCOLLECTION (LINESTRING (2 2, 3 3), POINT (1 1))
+  </op></test>
+<test>  <op name="difference" arg1="A" arg2="B">
+POINT (1 1)
+  </op></test>
+<test>  <op name="difference" arg1="B" arg2="A">
+LINESTRING (2 2, 3 3)
+  </op></test>
+<test>  <op name="symdifference" arg1="A" arg2="B">
+GEOMETRYCOLLECTION (LINESTRING (2 2, 3 3), POINT (1 1))
+  </op></test>
+</case>
 
 </run>
 


### PR DESCRIPTION
This fixes the behaviour of the "combine disjoint" overlay heuristic for GeometryCollections containing empty elements (which are now removed).   

Fixes #1224 

(Note: part of #1224 requires #1136 to be fixed as well).

The PR also:
* centralizes overlay heuristic logic in `HeuristicOverlay` (moving code from `Geometry`)
* modularizes the `HeuristicOverlay` code
* improves `HeuristicOverlay` semantics to return empty results as an empty typed atomic geometry instead of an empty GeometryCollection (this matches `OverlayNG`)
* removes unnecessary dependencies on `HeuristicOverlay` (by calling `OverlayNGRobust` directly where it is known the heuristics do not apply)
* fixes `XMLTester` to correctly handle operation A & B argument switching