### PR TITLE
Refactor XMLTester

### DIFF
--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -205,8 +205,8 @@ XMLTester::XMLTester()
     wktwriter(nullptr),
     wkbreader(nullptr),
     wkbwriter(nullptr),
-    failed(0),
-    succeeded(0),
+    failedCount(0),
+    succeededCount(0),
     caseCount(0),
     testCount(0),
     testLineNum(0),
@@ -356,14 +356,14 @@ XMLTester::resultSummary(std::ostream& os) const
 {
     os << "Files: " << testFileCount << std::endl;
     os << "Tests: " << totalTestCount << std::endl;
-    os << "Failed: " << failed << std::endl;
-    os << "Succeeded: " << succeeded << std::endl;
+    os << "Failed: " << failedCount << std::endl;
+    os << "Succeeded: " << succeededCount << std::endl;
 }
 
 void
 XMLTester::resetCounters()
 {
-    testFileCount = totalTestCount = failed = succeeded = 0;
+    testFileCount = totalTestCount = failedCount = succeededCount = 0;
 }
 
 void
@@ -637,10 +637,10 @@ XMLTester::runTest(const tinyxml2::XMLNode* node)
     bool success = test.run(node, gA, gB);
 
     if(success) {
-        ++succeeded;
+        ++succeededCount;
     }
     else {
-        ++failed;
+        ++failedCount;
     }
 }
 
@@ -1455,7 +1455,7 @@ main(int argC, char* argV[])
                 continue;
             }
             if(! std::strcmp(argV[i], "--test-valid-output")) {
-                tester.testOutputValidity(true);
+                tester.setTestOutputValidity(true);
                 continue;
             }
             if(! std::strcmp(argV[i], "--sql-output")) {
@@ -1469,7 +1469,7 @@ main(int argC, char* argV[])
                 continue;
             }
             if(! std::strcmp(argV[i], "--test-valid-input")) {
-                tester.testInputValidity(true);
+                tester.setTestInputValidity(true);
                 continue;
             }
 

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -1120,76 +1120,40 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         checkResult( den.getResultGeometry() );
     }
     else if(opName == "intersects") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->intersects(gB));
-        }
-        else {
-            checkResult( gA->intersects(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->intersects(gB) : gA->intersects(gB);
+        checkResult( res );
     }
     else if(opName == "contains") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->contains(gB));
-        }
-        else {
-            checkResult( gA->contains(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->contains(gB) : gA->contains(gB);
+        checkResult( res );
     }
     else if(opName == "overlaps") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->overlaps(gB));
-        }
-        else {
-            checkResult( gA->overlaps(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->overlaps(gB) : gA->overlaps(gB);
+        checkResult( res );
     }
     else if(opName == "within") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->within(gB));
-        }
-        else {
-            checkResult( gA->within(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->within(gB) : gA->within(gB);
+        checkResult( res );
     }
     else if(opName == "touches") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->touches(gB));
-        }
-        else {
-            checkResult( gA->touches(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->touches(gB) : gA->touches(gB);
+        checkResult( res );
     }
     else if(opName == "crosses") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->crosses(gB));
-        }
-        else {
-            checkResult( gA->crosses(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->crosses(gB) : gA->crosses(gB);
+        checkResult( res );
     }
     else if(opName == "disjoint") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->disjoint(gB));
-        }
-        else {
-            checkResult( gA->disjoint(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->disjoint(gB) : gA->disjoint(gB);
+        checkResult( res );
     }
     else if(opName == "covers") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->covers(gB));
-        }
-        else {
-            checkResult( gA->covers(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->covers(gB) : gA->covers(gB);
+        checkResult( res );
     }
     else if(opName == "coveredby") {
-        if (tester.isPrepared()) {
-            checkResult( prepare(gA)->coveredBy(gB));
-        }
-        else {
-            checkResult( gA->coveredBy(gB) );
-        }
+        bool res = tester.isPrepared() ? prepare(gA)->coveredBy(gB) : gA->coveredBy(gB);
+        checkResult( res );
     }
     else if(opName == "equalstopo") {
         // equalsTopo() is synonym for equals() in JTS

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -309,39 +309,45 @@ XMLTester::testcaseRef()
 
 /*private*/
 void
+XMLTester::printTestSQL(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result)
+{
+    std::cout << "INSERT INTO \"" << normalize_filename(*curr_file) << "\" VALUES ("
+                << caseCount << ", "
+                << testCount << ", "
+                //<< "'" << opSignature << "', "
+                << "'" << curr_case_desc << "', ";
+
+    std::string geomOut;
+
+    if(gA) {
+        std::cout << "'" << printGeom(gA) << "', ";
+    }
+    else {
+        std::cout << "NULL, ";
+    }
+    if(gB) {
+        std::cout << "'" << printGeom(gB) << "', ";
+    }
+    else {
+        std::cout << "NULL, ";
+    }
+    std::cout << "'" << expected_result << "', "
+                << "'" << actual_result << "', ";
+
+    if(success) {
+        std::cout << "'t'";
+    }
+    else {
+        std::cout << "'f'";
+    }
+    std::cout << ");" << std::endl;
+}
+
+void
 XMLTester::printTest(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result)
 {
     if(sqlOutput) {
-        std::cout << "INSERT INTO \"" << normalize_filename(*curr_file) << "\" VALUES ("
-                  << caseCount << ", "
-                  << testCount << ", "
-                  //<< "'" << opSignature << "', "
-                  << "'" << curr_case_desc << "', ";
-
-        std::string geomOut;
-
-        if(gA) {
-            std::cout << "'" << printGeom(gA) << "', ";
-        }
-        else {
-            std::cout << "NULL, ";
-        }
-        if(gB) {
-            std::cout << "'" << printGeom(gB) << "', ";
-        }
-        else {
-            std::cout << "NULL, ";
-        }
-        std::cout << "'" << expected_result << "', "
-                  << "'" << actual_result << "', ";
-
-        if(success) {
-            std::cout << "'t'";
-        }
-        else {
-            std::cout << "'f'";
-        }
-        std::cout << ");" << std::endl;
+        printTestSQL(success, op, expected_result, actual_result);
         return;
     }
     //-- no output for quiet success
@@ -352,18 +358,15 @@ XMLTester::printTest(bool success, const std::string& op, const std::string& exp
     std::cout << op << " " << (success ? "ok." : "failed.");
 
     // print geometry on failure for -v
-    // print geometry no matter what for -v -v and above
+    // print geometry always for -v -v and above
     if (verbose > 1 || (verbose == 1 && !success)) {
         std::cout << "\tDescription: " << curr_case_desc << std::endl;
-
         if(gA) {
             std::cout << "\tGeometry A: " << printGeom(gA) << std::endl;
         }
-
         if(gB) {
             std::cout << "\tGeometry B: " << printGeom(gB) << std::endl;
         }
-
         std::cout << "\tExpected: " << expected_result << std::endl;
         std::cout << "\tActual:   " << actual_result << std::endl;
     }
@@ -412,7 +415,6 @@ XMLTester::run(const std::string& source)
     }
 
     parseRun(node);
-
 }
 
 void

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -1226,7 +1226,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
     else if(opName == "buffer") {
         using namespace operation::buffer;
 
-        std::unique_ptr<Geometry> gRes(parseGeometry(opRes, "expected"));
+        std::unique_ptr<Geometry> gRes(tester.parseGeometry(opRes, "expected"));
         gRes->normalize();
 
         std::unique_ptr<Geometry> gRealRes;
@@ -1236,8 +1236,6 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         if(opArg3 != "") {
             params.setQuadrantSegments(std::atoi(opArg3.c_str()));
         }
-
-
         BufferOp op(gA, params);
         gRealRes = op.getResultGeometry(dist);
 
@@ -1246,18 +1244,17 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         // Validate the buffer operation
         success = checkBufferSuccess(*gRes, *gRealRes, dist);
 
-        actual_result = printGeom(gRealRes.get());
-        expected_result = printGeom(gRes.get());
+        actual_result = tester.printGeom(gRealRes.get());
+        expected_result = tester.printGeom(gRes.get());
 
         if(testValidOutput) {
-            success &= int(testValid(gRealRes.get(), "result"));
+            success &= int(tester.testValid(gRealRes.get(), "result"));
         }
     }
-
     else if(opName == "buffersinglesided") {
         using namespace operation::buffer;
 
-        std::unique_ptr<Geometry> gRes(parseGeometry(opRes, "expected"));
+        std::unique_ptr<Geometry> gRes(tester.parseGeometry(opRes, "expected"));
         gRes->normalize();
 
         std::unique_ptr<Geometry> gRealRes;
@@ -1283,18 +1280,17 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         success = checkSingleSidedBufferSuccess(*gRes,
                                                 *gRealRes, dist);
 
-        actual_result = printGeom(gRealRes.get());
-        expected_result = printGeom(gRes.get());
+        actual_result = tester.printGeom(gRealRes.get());
+        expected_result = tester.printGeom(gRes.get());
 
         if(testValidOutput) {
-            success &= int(testValid(gRealRes.get(), "result"));
+            success &= int(tester.testValid(gRealRes.get(), "result"));
         }
     }
-
     else if(opName == "buffermitredjoin") {
         using namespace operation::buffer;
 
-        std::unique_ptr<Geometry> gRes(parseGeometry(opRes, "expected"));
+        std::unique_ptr<Geometry> gRes(tester.parseGeometry(opRes, "expected"));
         gRes->normalize();
 
         std::unique_ptr<Geometry> gRealRes;
@@ -1315,11 +1311,11 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         // Validate the buffer operation
         success = checkBufferSuccess(*gRes, *gRealRes, dist);
 
-        actual_result = printGeom(gRealRes.get());
-        expected_result = printGeom(gRes.get());
+        actual_result = tester.printGeom(gRealRes.get());
+        expected_result = tester.printGeom(gRes.get());
 
         if(testValidOutput) {
-            success &= int(testValid(gRealRes.get(), "result"));
+            success &= int(tester.testValid(gRealRes.get(), "result"));
         }
     }
     else if(opName == "getinteriorpoint") {
@@ -1380,7 +1376,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         std::unique_ptr<Geometry> gI(gA->intersection(gB));
 
         if(testValidOutput) {
-            validOut &= int(testValid(gI.get(), "areatest intersection"));
+            validOut &= int(tester.testValid(gI.get(), "areatest intersection"));
         }
 
         if(verbose > 1) {
@@ -1390,7 +1386,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         std::unique_ptr<Geometry> gDab(gA->difference(gB));
 
         if(testValidOutput) {
-            validOut &= int(testValid(gI.get(), "areatest difference(a,b)"));
+            validOut &= int(tester.testValid(gI.get(), "areatest difference(a,b)"));
         }
 
         if(verbose > 1) {
@@ -1400,7 +1396,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         std::unique_ptr<Geometry> gDba(gB->difference(gA));
 
         if(testValidOutput) {
-            validOut &= int(testValid(gI.get(), "areatest difference(b,a)"));
+            validOut &= int(tester.testValid(gI.get(), "areatest difference(b,a)"));
         }
 
         if(verbose > 1) {
@@ -1410,7 +1406,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         std::unique_ptr<Geometry> gSD(gA->symDifference(gB));
 
         if(testValidOutput) {
-            validOut &= int(testValid(gI.get(), "areatest symdifference"));
+            validOut &= int(tester.testValid(gI.get(), "areatest symdifference"));
         }
 
         if(verbose > 1) {
@@ -1508,6 +1504,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         checkResult( geos::simplify::TopologyPreservingSimplifier::simplify(gA, tolerance).get() );
     }
     else {
+        //TODO: error out here?
         std::cerr << tester.testcaseRef() << " - " << opName;
         std::cerr << ": skipped (unrecognized)." << std::endl;
     }

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -619,9 +619,6 @@ XMLTester::parseCase(const tinyxml2::XMLNode* node)
     gA = nullptr;
     gB = nullptr;
 
-
-    //dump_to_stdout(node);
-
     curr_case_desc.clear();
     const tinyxml2::XMLNode* txt = node->FirstChildElement("desc");
     if(txt) {
@@ -630,10 +627,6 @@ XMLTester::parseCase(const tinyxml2::XMLNode* node)
             curr_case_desc = trimBlanks(txt->Value());
         }
     }
-
-    //std::cerr << "Desc: " << curr_case_desc << std::endl;
-
-
     try {
         const tinyxml2::XMLNode* el = node->FirstChildElement("a");
         geomAin = el->FirstChild()->Value();
@@ -1125,7 +1118,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         checkResult( den.getResultGeometry().get() );
     }
     else if(opName == "intersects") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->intersects(gB));
         }
         else {
@@ -1133,7 +1126,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "contains") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->contains(gB));
         }
         else {
@@ -1141,7 +1134,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "overlaps") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->overlaps(gB));
         }
         else {
@@ -1149,7 +1142,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "within") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->within(gB));
         }
         else {
@@ -1157,7 +1150,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "touches") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->touches(gB));
         }
         else {
@@ -1165,7 +1158,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "crosses") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->crosses(gB));
         }
         else {
@@ -1173,7 +1166,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "disjoint") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->disjoint(gB));
         }
         else {
@@ -1181,7 +1174,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
     }
     else if(opName == "covers") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->covers(gB));
         }
         else {
@@ -1204,7 +1197,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         checkResult( gA->equalsExact(gB));
     }
     else if(opName == "coveredby") {
-        if (tester.isUsePrepared()) {
+        if (tester.isPrepared()) {
             checkResult( prepare(gA)->coveredBy(gB));
         }
         else {
@@ -1367,47 +1360,24 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
             throw std::runtime_error("malformed testcase: missing tolerated area difference in 'areatest' op");
         }
 
-        if(verbose > 1) {
-            std::cerr << "Running intersection for areatest" << std::endl;
-        }
         std::unique_ptr<Geometry> gI(gA->intersection(gB));
-
         if(testValidOutput) {
             validOut &= tester.testValid(gI.get(), "areatest intersection");
         }
 
-        if(verbose > 1) {
-            std::cerr << "Running difference(A,B) for areatest" << std::endl;
-        }
-
         std::unique_ptr<Geometry> gDab(gA->difference(gB));
-
         if(testValidOutput) {
             validOut &= tester.testValid(gI.get(), "areatest difference(a,b)");
         }
 
-        if(verbose > 1) {
-            std::cerr << "Running difference(B,A) for areatest" << std::endl;
-        }
-
         std::unique_ptr<Geometry> gDba(gB->difference(gA));
-
         if(testValidOutput) {
             validOut &= tester.testValid(gI.get(), "areatest difference(b,a)");
         }
 
-        if(verbose > 1) {
-            std::cerr << "Running symdifference for areatest" << std::endl;
-        }
-
         std::unique_ptr<Geometry> gSD(gA->symDifference(gB));
-
         if(testValidOutput) {
             validOut &= tester.testValid(gI.get(), "areatest symdifference");
-        }
-
-        if(verbose > 1) {
-            std::cerr << "Running union for areatest" << std::endl;
         }
 
         std::unique_ptr<Geometry> gU(gA->Union(gB));

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -1041,7 +1041,6 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
 {        
     using namespace operation::buffer;
 
-    int success = 0;
     if(opName == "relate") {
         std::unique_ptr<geom::IntersectionMatrix> im(gA->relate(gB));
         checkResult( im->matches(opArg3) );
@@ -1235,6 +1234,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
             });
     }
     else if(opName == "getinteriorpoint") {
+        //-- may return null
         std::unique_ptr<Geometry> res(gA->getInteriorPoint());
         if (! res.get()) {
             res = tester.getFactory()->createPoint();
@@ -1353,7 +1353,7 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         }
 
         if(maxdiff <= toleratedDiff) {
-            success = 1 && validOut;
+            isSuccess = validOut;
         }
 
         std::stringstream p_tmp;
@@ -1400,8 +1400,6 @@ void Test::executeOp(Geometry* gA, Geometry* gB)
         std::cerr << tester.testcaseRef() << " - " << opName;
         std::cerr << ": skipped (unrecognized)." << std::endl;
     }
-    //-- for ops which set success local var
-    if (success > 0) isSuccess = true;
 }
 
 //==================================================================================

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -98,44 +98,15 @@ using operation::valid::TopologyValidationError;
 
 namespace {
 
+using geos::geom::Geometry;
+
+//--------------------------------------------------
+
 std::unique_ptr<const PreparedGeometry>
 prepare(const geom::Geometry* g)
 {
     return PreparedGeometryFactory::prepare(g);
 }
-
-// Asymmetric Rounding Algorithm  - equivalent to Java Math.round()
-// Copy from geos/util/math.cpp
-double
-java_math_round(double val)
-{
-    double n;
-    double f = std::fabs(std::modf(val, &n));
-
-    if(val >= 0) {
-        if(f < 0.5) {
-            return std::floor(val);
-        }
-        else if(f > 0.5) {
-            return std::ceil(val);
-        }
-        else {
-            return (n + 1.0);
-        }
-    }
-    else {
-        if(f < 0.5) {
-            return std::ceil(val);
-        }
-        else if(f > 0.5) {
-            return std::floor(val);
-        }
-        else {
-            return n;
-        }
-    }
-} // java_math_round
-
 
 #ifdef not_used
 // a utility function defining a very simple method to indent a line of text
@@ -186,6 +157,21 @@ void toupper(std::string& s)
 }
 
 std::string
+trimBlanks(const std::string& in)
+{
+    std::string out;
+    std::string::size_type pos = in.find_first_not_of(" \t\n\r");
+    if(pos != std::string::npos) {
+        out = in.substr(pos);
+    }
+    pos = out.find_last_not_of(" \t\n\r");
+    if(pos != std::string::npos) {
+        out = out.substr(0, pos + 1);
+    }
+    return out;
+}
+
+std::string
 normalize_filename(const std::string& str)
 {
     std::string newstring;
@@ -223,77 +209,56 @@ checkOverlaySuccess(geom::Geometry const& gRes, geom::Geometry const& gRealRes)
     return 0;
 }
 
-/* Could be an XMLTester class private but oh well.. */
-static int
-checkBufferSuccess(geom::Geometry const& gRes, geom::Geometry const& gRealRes, double dist)
+/* static */
+int
+Test::checkBufferSuccess(Geometry const& gRes, Geometry const& gRealRes, double dist)
 {
-
     using geos::xmltester::BufferResultMatcher;
 
-    int success = 1;
-    do {
-
-        if(gRes.getGeometryTypeId() != gRealRes.getGeometryTypeId()) {
-            std::cerr << "Expected result is of type "
-                      << gRes.getGeometryType()
-                      << "; obtained result is of type "
-                      << gRealRes.getGeometryType()
-                      << std::endl;
-            success = 0;
-            break;
-        }
-
-        // Is a buffer always an area ?
-        if(gRes.getDimension() != 2) {
-            std::cerr << "Don't know how to validate "
-                      << "result of buffer operation "
-                      << "when expected result is not an "
-                      << "areal type."
-                      << std::endl;
-        }
-
-        if(!BufferResultMatcher::isBufferResultMatch(gRealRes, gRes, dist)) {
-            std::cerr << "BufferResultMatcher FAILED" << std::endl;
-            success = 0;
-            break;
-        }
-
+    if(gRes.getGeometryTypeId() != gRealRes.getGeometryTypeId()) {
+        std::cerr << "Expected result is of type "
+                    << gRes.getGeometryType()
+                    << "; obtained result is of type "
+                    << gRealRes.getGeometryType()
+                    << std::endl;
+        return 0;
     }
-    while(0);
-
-    return success;
+    // Is a buffer always an area ?
+    if(gRes.getDimension() != 2) {
+        std::cerr << "Don't know how to validate "
+                    << "result of buffer operation "
+                    << "when expected result is not an "
+                    << "areal type."
+                    << std::endl;
+    }
+    if(!BufferResultMatcher::isBufferResultMatch(gRealRes, gRes, dist)) {
+        std::cerr << "BufferResultMatcher FAILED" << std::endl;
+        return 0;
+    }
+    return 1;
 }
 
-static int
-checkSingleSidedBufferSuccess(geom::Geometry& gRes,
+/* static */
+int
+Test::checkSingleSidedBufferSuccess(geom::Geometry& gRes,
                               geom::Geometry& gRealRes, double dist)
 {
-    int success = 1;
-    do {
-
-        if(gRes.getGeometryTypeId() != gRealRes.getGeometryTypeId()) {
-            std::cerr << "Expected result is of type "
-                      << gRes.getGeometryType()
-                      << "; obtained result is of type "
-                      << gRealRes.getGeometryType()
-                      << std::endl;
-            success = 0;
-            break;
-        }
-
-        geos::xmltester::SingleSidedBufferResultMatcher matcher;
-        if(! matcher.isBufferResultMatch(gRealRes,
-                                         gRes,
-                                         dist)) {
-            std::cerr << "SingleSidedBufferResultMatcher FAILED" << std::endl;
-            success = 0;
-            break;
-        }
-
+    if(gRes.getGeometryTypeId() != gRealRes.getGeometryTypeId()) {
+        std::cerr << "Expected result is of type "
+                    << gRes.getGeometryType()
+                    << "; obtained result is of type "
+                    << gRealRes.getGeometryType()
+                    << std::endl;
+        return 0;
     }
-    while(0);
-
-    return success;
+    geos::xmltester::SingleSidedBufferResultMatcher matcher;
+    if(! matcher.isBufferResultMatch(gRealRes,
+                                        gRes,
+                                        dist)) {
+        std::cerr << "SingleSidedBufferResultMatcher FAILED" << std::endl;
+        return 0;
+    }
+    return 1;
 }
 
 XMLTester::XMLTester()
@@ -306,11 +271,11 @@ XMLTester::XMLTester()
     wktwriter(nullptr),
     wkbreader(nullptr),
     wkbwriter(nullptr),
-    test_predicates(0),
     failed(0),
     succeeded(0),
     caseCount(0),
     testCount(0),
+    testLineNum(0),
     testFileCount(0),
     totalTestCount(0),
     curr_file(nullptr),
@@ -332,16 +297,25 @@ XMLTester::setVerbosityLevel(int value)
     return old_value;
 }
 
+std::string 
+XMLTester::testcaseRef()
+{
+    std::stringstream ref;
+    ref << "case " << caseCount;
+    ref << ", test " << testCount;
+    ref << " (" << testLineNum << ")";
+    return ref.str();
+}
+
 /*private*/
 void
-XMLTester::printTest(bool success, const std::string& expected_result, const std::string& actual_result,
-                     const util::Profile& prof)
+XMLTester::printTest(bool success, const std::string& expected_result, const std::string& actual_result)
 {
     if(sqlOutput) {
         std::cout << "INSERT INTO \"" << normalize_filename(*curr_file) << "\" VALUES ("
                   << caseCount << ", "
                   << testCount << ", "
-                  << "'" << opSignature << "', "
+                  //<< "'" << opSignature << "', "
                   << "'" << curr_case_desc << "', ";
 
         std::string geomOut;
@@ -374,34 +348,27 @@ XMLTester::printTest(bool success, const std::string& expected_result, const std
     }
 
     else {
-        std::cout << *curr_file << ":";
-        std::cout << " case" << caseCount << ":";
-        std::cout << " test" << testCount << ": "
-                  << opSignature;
+        std::cout << *curr_file << ": ";
+        std::cout << testcaseRef() << opSignature;
         std::cout << ": " << (success ? "ok." : "failed.");
-        std::cout << " (" << std::setprecision(15) << java_math_round(prof.getTot() / 1000) << " ms)" << std::endl;
-
+    
         // print geometry on failure for -v
         // print geometry no matter what for -v -v and above
         if (verbose > 1 || (verbose == 1 && !success)) {
             std::cout << "\tDescription: " << curr_case_desc << std::endl;
 
             if(gA) {
-                std::cout << "\tGeometry A: ";
-                printGeom(std::cout, gA);
-                std::cout << std::endl;
+                std::cout << "\tGeometry A: " << printGeom(gA) << std::endl;
             }
 
             if(gB) {
-                std::cout << "\tGeometry B: ";
-                printGeom(std::cout, gB);
-                std::cout << std::endl;
+                std::cout << "\tGeometry B: " << printGeom(gB) << std::endl;
             }
 
-            std::cout << "\tExpected result: " << expected_result << std::endl;
-            std::cout << "\tObtained result: " << actual_result << std::endl;
-            std::cout << std::endl;
+            std::cout << "\tExpected: " << expected_result << std::endl;
+            std::cout << "\tActual:   " << actual_result << std::endl;
         }
+        std::cout << std::endl;
     }
 }
 
@@ -584,7 +551,6 @@ XMLTester::testValid(const geom::Geometry* g, const std::string& label)
         std::cerr << *curr_file << ":"
                   << " case" << caseCount << ":"
                   << " test" << testCount << ": "
-                  << opSignature << ": "
                   << " invalid geometry (" << label
                   << "): " << err->toString() << std::endl;
     }
@@ -643,21 +609,6 @@ XMLTester::parseGeometry(const std::string& in, const char* label)
     return ret.release();
 }
 
-std::string
-XMLTester::trimBlanks(const std::string& in)
-{
-    std::string out;
-    std::string::size_type pos = in.find_first_not_of(" \t\n\r");
-    if(pos != std::string::npos) {
-        out = in.substr(pos);
-    }
-    pos = out.find_last_not_of(" \t\n\r");
-    if(pos != std::string::npos) {
-        out = out.substr(0, pos + 1);
-    }
-    return out;
-}
-
 void
 XMLTester::parseCase(const tinyxml2::XMLNode* node)
 {
@@ -710,7 +661,7 @@ XMLTester::parseCase(const tinyxml2::XMLNode* node)
 
     if(thrownException != "") {
         std::cout << *curr_file << ":";
-        std::cout << " case" << caseCount << ":";
+        std::cout << " case" << caseCount << " (" << node->GetLineNum() << "): ";
         std::cout << " skipped (" << thrownException << ")." << std::endl;
         if (gA) delete gA;
         if (gB) delete gB;
@@ -724,20 +675,13 @@ XMLTester::parseCase(const tinyxml2::XMLNode* node)
     for(testnode = node->FirstChildElement("test");
             testnode;
             testnode = testnode->NextSiblingElement("test")) {
-        parseTest(testnode);
+       runTest(testnode);
     }
 
     totalTestCount += testCount;
 
     delete gA;
     delete gB;
-}
-
-/*private*/
-void
-XMLTester::printGeom(std::ostream& os, const geom::Geometry* g)
-{
-    os << printGeom(g);
 }
 
 std::string
@@ -756,6 +700,64 @@ XMLTester::printGeom(const geom::Geometry* g)
     }
 }
 
+void
+XMLTester::runTest(const tinyxml2::XMLNode* node)
+{
+    Test test(*this); 
+    ++testCount;
+    testLineNum = node->GetLineNum();
+
+    bool success = test.run(node, gA, gB);
+
+    if(success) {
+        ++succeeded;
+    }
+    else {
+        ++failed;
+    }
+}
+
+void
+XMLTester::runPredicates(const geom::Geometry* p_gA, const geom::Geometry* p_gB)
+{
+    std::cout << "\t    Equals:\tAB=" << (p_gA->equals(p_gB) ? "T" : "F") << ", BA=" << (p_gB->equals(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t  Disjoint:\tAB=" << (p_gA->disjoint(p_gB) ? "T" : "F") << ", BA=" << (p_gB->disjoint(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\tIntersects:\tAB=" << (p_gA->intersects(p_gB) ? "T" : "F") << ", BA=" << (p_gB->intersects(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t   Touches:\tAB=" << (p_gA->touches(p_gB) ? "T" : "F") << ", BA=" << (p_gB->touches(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t   Crosses:\tAB=" << (p_gA->crosses(p_gB) ? "T" : "F") << ", BA=" << (p_gB->crosses(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t    Within:\tAB=" << (p_gA->within(p_gB) ? "T" : "F") << ", BA=" << (p_gB->within(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t  Contains:\tAB=" << (p_gA->contains(p_gB) ? "T" : "F") << ", BA=" << (p_gB->contains(
+                  p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t  Overlaps:\tAB=" << (p_gA->overlaps(p_gB) ? "T" : "F") << ", BA=" << (p_gB->overlaps(
+                  p_gA) ? "T" : "F") << std::endl;
+
+    std::cout << "\t  Prepared Disjoint:\tAB=" << (prepare(p_gA)->disjoint(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->disjoint(p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\tPrepared Intersects:\tAB=" << (prepare(p_gA)->intersects(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->intersects(p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t   Prepared Touches:\tAB=" << (prepare(p_gA)->touches(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->touches(p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t   Prepared Crosses:\tAB=" << (prepare(p_gA)->crosses(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->crosses(p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t    Prepared Within:\tAB=" << (prepare(p_gA)->within(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->within(p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t  Prepared Contains:\tAB=" << (prepare(p_gA)->contains(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->contains(p_gA) ? "T" : "F") << std::endl;
+    std::cout << "\t Prepared Overlaps:\tAB=" << (prepare(p_gA)->overlaps(p_gB) ? "T" : "F") << ", BA=" << (prepare(
+                  p_gB)->overlaps(p_gA) ? "T" : "F") << std::endl;
+}
+
+XMLTester::~XMLTester()
+{
+}
+//============================================================================
+
 /**
 * Computes the maximum area delta value
 * resulting from identity equations over the overlay operations.
@@ -763,8 +765,9 @@ XMLTester::printGeom(const geom::Geometry* g)
 * If the overlay operations are computed correctly
 * the area delta is expected to be very small (e.g. < 1e-6).
 */
+/* static */
 double
-XMLTester::areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& rsltMaxDiffOp, double maxDiff, std::stringstream& ss)
+Test::areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& rsltMaxDiffOp, double maxDiff, std::stringstream& ss)
 {
     double areaA = a == nullptr ? 0 : a->getArea();
     double areaB = b == nullptr ? 0 : b->getArea();
@@ -847,27 +850,96 @@ XMLTester::areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::stri
     return diffScore;
 }
 
+void
+Test::checkResult( Geometry* res ) 
+{
+    std::string expectedRes = opRes;
+    std::unique_ptr<Geometry> gExpectedRes(tester.parseGeometry(expectedRes, "expected"));
+    gExpectedRes->normalize();
+
+    std::unique_ptr<Geometry> gActualRes(res->clone());
+    gActualRes->normalize();
+
+    isSuccess = false;
+    if (gExpectedRes->compareTo(gActualRes.get()) == 0) {
+        isSuccess = true;
+    }
+
+    if (testValidOutput) {
+        isSuccess &= tester.testValid(gActualRes.get(), "result");
+    }
+
+    if ((!isSuccess && verbose) || verbose > 0) {
+        actual_result = tester.printGeom(gActualRes.get());
+        tester.printTest(isSuccess, expectedRes, actual_result);
+    }
+}
+
+//TODO: fix this hack.  Only used for union now, and has a bug where empties test equal
+void
+Test::checkUnionResult( Geometry* res ) 
+{
+    std::string expectedRes = opRes;
+    std::unique_ptr<Geometry> gExpectedRes(tester.parseGeometry(expectedRes, "expected"));
+    gExpectedRes->normalize();
+
+    std::unique_ptr<Geometry> gActualRes(res->clone());
+    gActualRes->normalize();
+
+    isSuccess = checkOverlaySuccess(*gExpectedRes.get(), *gActualRes.get());
+
+    if(testValidOutput) {
+        isSuccess &= tester.testValid(gActualRes.get(), "result");
+    }
+    if((!isSuccess && verbose) || verbose > 0) {
+        actual_result = tester.printGeom(gActualRes.get());
+        tester.printTest(isSuccess, expectedRes, actual_result);
+    }
+}
 
 void
-XMLTester::parseTest(const tinyxml2::XMLNode* node)
+Test::checkResult( bool res ) 
 {
-    using namespace operation::overlay;
+    actual_result = res ? "true" : "false";
+    if (actual_result == opRes) {
+        isSuccess = true;
+    }
+    if((!isSuccess && verbose) || verbose > 0) {
+        tester.printTest(isSuccess, opRes, actual_result);
+    }
+}
 
-    typedef std::unique_ptr< geom::Geometry > GeomPtr;
+void
+Test::checkResult( double res) 
+{
+    char* rest;
+    double expectedRes = std::strtod(opRes.c_str(), &rest);
+    if(rest == opRes.c_str()) {
+        throw std::runtime_error("malformed testcase: missing expected double value");
+    }
+    if (expectedRes == 0.0) {
+        if (res == 0.0) {
+            isSuccess = true;
+        }
+    }
+    else {
+        if (std::abs(expectedRes - res) / expectedRes < 1e-3) {
+            isSuccess = true;
+        }
+    }
+    std::stringstream ss;
+    ss << expectedRes;
+    actual_result = ss.str();
 
-    int success = 0; // no success by default
-    std::string opName;
-    std::string opArg1;
-    std::string opArg2;
-    std::string opArg3;
-    std::string opArg4;
-    std::string opRes;
+    if((!isSuccess && verbose) || verbose > 0) {
+        tester.printTest(isSuccess, opRes, actual_result);
+    }
+}
 
-    ++testCount;
-
+void Test::parse(const tinyxml2::XMLNode* node) {
     const tinyxml2::XMLNode* opnode = node->FirstChildElement("op");
     if(! opnode) {
-        throw(runtime_error("case has no op"));
+        throw(runtime_error("test has no op"));
     }
 
     //dump_to_stdout(opnode);
@@ -904,9 +976,7 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     const tinyxml2::XMLNode* resnode = opnode->FirstChild();
     if(! resnode) {
         std::stringstream p_tmp;
-        p_tmp << "op of test " << testCount
-              << " of case " << caseCount
-              << " has no expected result child";
+        p_tmp << tester.testcaseRef() << ": op has no expected result child";
         throw(runtime_error(p_tmp.str()));
     }
     opRes = resnode->Value();
@@ -941,1398 +1011,518 @@ XMLTester::parseTest(const tinyxml2::XMLNode* node)
     }
 
     opSignature = opName + "(" + opSig + ")";
+}
 
-    std::string actual_result = "NONE";
+bool Test::run(const tinyxml2::XMLNode* node, Geometry* geomA, Geometry* geomB)
+{
+    parse(node);
+    Geometry* argA = geomA;
+    Geometry* argB = geomB;
+    //-- switch geom args if specified
+    if (opArg1 == "B") {
+        argA = geomB;
+        argB = geomA;
+    }
+    execute(argA, argB);
+    return isSuccess;
+}
 
-    // expected_result will be modified by specific tests
-    // if needed (geometry normalization, for example)
-    std::string expected_result = opRes;
-
-    util::Profile profile("op");
-
+void Test::execute(Geometry* geomA, Geometry* geomB)
+{
     try {
-        if(opName == "relate") {
-            std::unique_ptr<geom::IntersectionMatrix> im(gA->relate(gB));
-            assert(im.get());
-
-            if(im->matches(opArg3)) {
-                actual_result = "true";
-            }
-            else {
-                actual_result = "false";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-        else if(opName == "relatestring") {
-            std::unique_ptr<geom::IntersectionMatrix> im(gA->relate(gB));
-            assert(im.get());
-
-            actual_result = im->toString();
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "isvalid") {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            if(p_gT->isValid()) {
-                actual_result = "true";
-            }
-            else {
-                actual_result = "false";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-
-        }
-
-        else if(opName == "intersection") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes(g1->intersection(g2));
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "intersectionng") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes = OverlayNG::overlay(gA, gB, OverlayNG::INTERSECTION);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "unionng") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes = OverlayNG::overlay(gA, gB, OverlayNG::UNION);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "differenceng") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            const geom::Geometry* dgA = gA;
-            const geom::Geometry* dgB = gB;
-
-            // Swap arguments if necessary
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                dgA = gB;
-                dgB = gA;
-            }
-
-            GeomPtr gRealRes = OverlayNG::overlay(dgA, dgB, OverlayNG::DIFFERENCE);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "symdifferenceng") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes = OverlayNG::overlay(gA, gB, OverlayNG::SYMDIFFERENCE);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-
-        else if(opName == "intersectionsr") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-            double precision = 1.0;
-
-            if(opArg3 != "") {
-                precision = std::atof(opArg3.c_str());
-            }
-
-            profile.start();
-            geom::PrecisionModel precMod(precision);
-            GeomPtr gRealRes = OverlayNG::overlay(gA, gB, OverlayNG::INTERSECTION, &precMod);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "intersectionsin") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-            double precision = 1.0;
-
-            if(opArg3 != "") {
-                precision = std::atof(opArg3.c_str());
-            }
-
-            profile.start();
-            geom::PrecisionModel precMod(precision);
-            GeomPtr gRealRes = OverlayNGRobust::Intersection(gA, gB);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-
-        else if(opName == "unionsr") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-            double precision = 1.0;
-            GeomPtr gRealRes;
-
-            if (gB) {
-                geom::PrecisionModel precMod(precision);
-                gRealRes = OverlayNG::overlay(gA, gB, OverlayNG::UNION, &precMod);
-                if(opArg3 != "") {
-                    precision = std::atof(opArg3.c_str());
-                }
-            }
-            else {
-                geom::PrecisionModel precMod(precision);
-
-                // gRealRes = OverlayNG::geomunion(gA, &precMod);
-                gRealRes = UnaryUnionNG::Union(gA, precMod);
-                if(opArg2 != "") {
-                    precision = std::atof(opArg2.c_str());
-                }
-            }
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "differencesr") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-            double precision = 1.0;
-
-            if(opArg3 != "") {
-                precision = std::atof(opArg3.c_str());
-            }
-
-            const geom::Geometry* dgA = gA;
-            const geom::Geometry* dgB = gB;
-
-            // Swap arguments if necessary
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                dgA = gB;
-                dgB = gA;
-            }
-
-            profile.start();
-            geom::PrecisionModel precMod(precision);
-            GeomPtr gRealRes = OverlayNG::overlay(dgA, dgB, OverlayNG::DIFFERENCE, &precMod);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-
-        else if(opName == "symdifferencesr") {
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-            double precision = 1.0;
-
-            if(opArg3 != "") {
-                precision = std::atof(opArg3.c_str());
-            }
-
-            profile.start();
-            geom::PrecisionModel precMod(precision);
-            GeomPtr gRealRes = OverlayNG::overlay(gA, gB, OverlayNG::SYMDIFFERENCE, &precMod);
-
-            profile.stop();
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "densify") {
-            geom::Geometry* p_gT = gA;
-
-            geom::util::Densifier den(p_gT);
-            double distanceTolerance = std::atof(opArg2.c_str());
-            den.setDistanceTolerance(distanceTolerance);
-            GeomPtr gRealRes = den.getResultGeometry();
-            gRealRes->normalize();
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-        }
-
-
-        else if(opName == "union") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes;
-            if(gB) {
-                gRealRes = g1->Union(g2);
-            }
-            else {
-                gRealRes = g1->Union();
-            }
-
-            profile.stop();
-            gRealRes->normalize();
-
-            success = checkOverlaySuccess(*gRes, *gRealRes);
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "difference") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            GeomPtr gRealRes(g1->difference(g2));
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "symdifference") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            GeomPtr gRealRes(g1->symDifference(g2));
-
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "intersects") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->intersects(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->intersects(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "contains") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->contains(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->contains(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "overlaps") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->overlaps(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->overlaps(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "within") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->within(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->within(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "touches") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->touches(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->touches(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "crosses") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->crosses(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->crosses(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "disjoint") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->disjoint(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->disjoint(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "covers") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->covers(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->covers(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        // equalsTopo() is synonym for equals() in JTS
-        else if(opName == "equalstopo") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(g1->equals(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "equalsexact") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(g1->equalsExact(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        // rather than implementing equalsnorm in the library,
-        // we just do it in this one test case for now
-        else if(opName == "equalsnorm") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            g1->normalize();
-            g2->normalize();
-
-            actual_result = "false";
-            if(g1->equalsExact(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-
-        else if(opName == "coveredby") {
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-
-            actual_result = "false";
-            if(usePrepared) {
-                if(prepare(g1)->coveredBy(g2)) {
-                    actual_result = "true";
-                }
-            }
-            else if(g1->coveredBy(g2)) {
-                actual_result = "true";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-        }
-
-        else if(opName == "getboundary") {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            GeomPtr gRealRes(p_gT->getBoundary());
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "getcentroid") {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            GeomPtr gRealRes(p_gT->getCentroid());
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "issimple") {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            if(p_gT->isSimple()) {
-                actual_result = "true";
-            }
-            else {
-                actual_result = "false";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-
-        }
-
-        else if(opName == "convexhull") {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            GeomPtr gRealRes(p_gT->convexHull());
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "buffer") {
-            using namespace operation::buffer;
-
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes;
-            double dist = std::atof(opArg2.c_str());
-
-            BufferParameters params;
-            if(opArg3 != "") {
-                params.setQuadrantSegments(std::atoi(opArg3.c_str()));
-            }
-
-
-            BufferOp op(p_gT, params);
-            gRealRes = op.getResultGeometry(dist);
-
-            profile.stop();
-            gRealRes->normalize();
-
-            // Validate the buffer operation
-            success = checkBufferSuccess(*gRes, *gRealRes, dist);
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "buffersinglesided") {
-            using namespace operation::buffer;
-
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes;
-            double dist = std::atof(opArg2.c_str());
-
-            BufferParameters params ;
-            params.setJoinStyle(BufferParameters::JOIN_ROUND) ;
-            if(opArg3 != "") {
-                params.setQuadrantSegments(std::atoi(opArg3.c_str()));
-            }
-
-            bool leftSide = true ;
-            if(opArg4 == "right") {
-                leftSide = false ;
-            }
-
-            BufferBuilder bufBuilder(params) ;
-            gRealRes = bufBuilder.bufferLineSingleSided(p_gT, dist, leftSide);
-
-            profile.stop();
-            gRealRes->normalize();
-
-            // Validate the single sided buffer operation
-            success = checkSingleSidedBufferSuccess(*gRes,
-                                                    *gRealRes, dist);
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "buffermitredjoin") {
-            using namespace operation::buffer;
-
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes;
-            double dist = std::atof(opArg2.c_str());
-
-            BufferParameters params;
-            params.setJoinStyle(BufferParameters::JOIN_MITRE);
-
-            if(opArg3 != "") {
-                params.setQuadrantSegments(std::atoi(opArg3.c_str()));
-            }
-
-            BufferOp op(p_gT, params);
-            gRealRes = op.getResultGeometry(dist);
-
-            profile.stop();
-            gRealRes->normalize();
-
-            // Validate the buffer operation
-            success = checkBufferSuccess(*gRes, *gRealRes, dist);
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-
-        else if(opName == "getinteriorpoint") {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            GeomPtr gRealRes(p_gT->getInteriorPoint());
-            if(gRealRes.get()) {
-                gRealRes->normalize();
-            }
-            else {
-                gRealRes = factory->createPoint();
-            }
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "iswithindistance") {
-            double dist = std::atof(opArg3.c_str());
-            if(gA->isWithinDistance(gB, dist)) {
-                actual_result = "true";
-            }
-            else {
-                actual_result = "false";
-            }
-
-            if(actual_result == opRes) {
-                success = 1;
-            }
-
-        }
-
-        else if(opName == "polygonize") {
-
-            GeomPtr gRes(wktreader->read(opRes));
-            gRes->normalize();
-
-            Polygonizer plgnzr;
-            plgnzr.add(gA);
-
-
-            auto polys = plgnzr.getPolygons();
-            GeomPtr gRealRes(factory->createGeometryCollection(std::move(polys)));
-            gRealRes->normalize();
-
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "linemerge") {
-            GeomPtr gRes(wktreader->read(opRes));
-            gRes->normalize();
-
-            geom::Geometry* p_gT = gA;
-
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            LineMerger merger;
-            merger.add(p_gT);
-            auto lines = merger.getMergedLineStrings();
-
-            GeomPtr gRealRes(factory->createGeometryCollection(std::move(lines)));
-            gRealRes->normalize();
-
-            if(gRes->compareTo(gRealRes.get()) == 0) {
-                success = 1;
-            }
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else if(opName == "overlayareatest") {
-
-            std::string maxDiffOp;
-            std::stringstream p_tmp;
-            double maxDiff = 1e-6;
-            double areaDiff = areaDelta(gA, gB, maxDiffOp, maxDiff, p_tmp);
-
-            // Debug output of actual geometries returned
-            if (areaDiff < maxDiff && false) {
-                std::cout << p_tmp.str();
-            }
-
-            p_tmp.str("");
-            p_tmp << maxDiffOp << ": " << areaDiff;
-            actual_result = p_tmp.str();
-            p_tmp.str("");
-            p_tmp << maxDiff;
-            expected_result = p_tmp.str();
-
-            if (areaDiff < maxDiff)
-                success = 1;
-        }
-
-        else if(opName == "unionlength") {
-
-            char* rest;
-            GeomPtr result = OverlayNGRobust::Union(gA);
-            double resultLength = result->getLength();
-            double expectedLength = std::strtod(opRes.c_str(), &rest);
-            if(rest == opRes.c_str()) {
-                throw std::runtime_error("malformed testcase: missing expected length 'unionlength' op");
-            }
-
-            std::stringstream ss;
-            ss << resultLength;
-            actual_result = ss.str();
-
-            if (std::abs(expectedLength-resultLength) / expectedLength < 1e-3) {
-                success = 1;
-            }
-
-        }
-
-        else if(opName == "unionarea") {
-
-            char* rest;
-            GeomPtr result = OverlayNGRobust::Union(gA);
-            double resultArea  = result->getArea();
-            double expectedArea = std::strtod(opRes.c_str(), &rest);
-            if(rest == opRes.c_str()) {
-                throw std::runtime_error("malformed testcase: missing expected area 'unionarea' op");
-            }
-
-            std::stringstream ss;
-            ss << resultArea;
-            actual_result = ss.str();
-
-            if (std::abs(expectedArea-resultArea) / expectedArea < 1e-3) {
-                success = 1;
-            }
-
-        }
-
-        else if(opName == "areatest") {
-            char* rest;
-            double toleratedDiff = std::strtod(opRes.c_str(), &rest);
-            int validOut = 1;
-
-            if(rest == opRes.c_str()) {
-                throw std::runtime_error("malformed testcase: missing tolerated area difference in 'areatest' op");
-            }
-
-            if(verbose > 1) {
-                std::cerr << "Running intersection for areatest" << std::endl;
-            }
-            GeomPtr gI(gA->intersection(gB));
-
-            if(testValidOutput) {
-                validOut &= int(testValid(gI.get(), "areatest intersection"));
-            }
-
-            if(verbose > 1) {
-                std::cerr << "Running difference(A,B) for areatest" << std::endl;
-            }
-
-            GeomPtr gDab(gA->difference(gB));
-
-            if(testValidOutput) {
-                validOut &= int(testValid(gI.get(), "areatest difference(a,b)"));
-            }
-
-            if(verbose > 1) {
-                std::cerr << "Running difference(B,A) for areatest" << std::endl;
-            }
-
-            GeomPtr gDba(gB->difference(gA));
-
-            if(testValidOutput) {
-                validOut &= int(testValid(gI.get(), "areatest difference(b,a)"));
-            }
-
-            if(verbose > 1) {
-                std::cerr << "Running symdifference for areatest" << std::endl;
-            }
-
-            GeomPtr gSD(gA->symDifference(gB));
-
-            if(testValidOutput) {
-                validOut &= int(testValid(gI.get(), "areatest symdifference"));
-            }
-
-            if(verbose > 1) {
-                std::cerr << "Running union for areatest" << std::endl;
-            }
-
-            GeomPtr gU(gA->Union(gB));
-
-            double areaA = gA->getArea();
-            double areaB = gB->getArea();
-            double areaI = gI->getArea();
-            double areaDab = gDab->getArea();
-            double areaDba = gDba->getArea();
-            double areaSD = gSD->getArea();
-            double areaU = gU->getArea();
-
-            double maxdiff = 0;
-            std::string maxdiffop;
-
-            // @ : symdifference
-            // - : difference
-            // + : union
-            // ^ : intersection
-
-            // A == ( A ^ B ) + ( A - B )
-            double diff = std::fabs(areaA - areaI - areaDab);
-            if(diff > maxdiff) {
-                maxdiffop = "A == ( A ^ B ) + ( A - B )";
-                maxdiff = diff;
-            }
-
-            // B == ( A ^ B ) + ( B - A )
-            diff = std::fabs(areaB - areaI - areaDba);
-            if(diff > maxdiff) {
-                maxdiffop = "B == ( A ^ B ) + ( B - A )";
-                maxdiff = diff;
-            }
-
-            //  ( A @ B ) == ( A - B ) + ( B - A )
-            diff = std::fabs(areaDab + areaDba - areaSD);
-            if(diff > maxdiff) {
-                maxdiffop = "( A @ B ) == ( A - B ) + ( B - A )";
-                maxdiff = diff;
-            }
-
-            //  ( A u B ) == ( A ^ B ) + ( A @ B )
-            diff = std::fabs(areaI + areaSD - areaU);
-            if(diff > maxdiff) {
-                maxdiffop = "( A u B ) == ( A ^ B ) + ( A @ B )";
-                maxdiff = diff;
-            }
-
-            if(maxdiff <= toleratedDiff) {
-                success = 1 && validOut;
-            }
-
-            std::stringstream p_tmp;
-            p_tmp << maxdiffop << ": " << maxdiff;
-            actual_result = p_tmp.str();
-            expected_result = opRes;
-
-        }
-        else if(opName == "distance") {
-            char* rest;
-            double distE = std::strtod(opRes.c_str(), &rest);
-            if(rest == opRes.c_str()) {
-                throw std::runtime_error("malformed testcase: missing expected result in 'distance' op");
-            }
-
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            geom::Geometry* g2 = opArg2 == "B" ? gB : gA;
-            double distO = g1->distance(g2);
-            std::stringstream ss;
-            ss << distO;
-            actual_result = ss.str();
-
-            // TODO: Use a tolerance ?
-            success = (distO == distE) ? 1 : 0;
-        }
-        else if(opName == "minclearance") {
-            char* rest;
-            double minclearanceE = std::strtod(opRes.c_str(), &rest);
-            if(rest == opRes.c_str()) {
-                throw std::runtime_error("malformed testcase: missing expected result in 'minclearance' op");
-            }
-
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            precision::MinimumClearance mc(g1);
-
-            double minclearanceO = mc.getDistance();
-            std::stringstream ss;
-            ss << minclearanceO;
-            actual_result = ss.str();
-
-            // Hack for Inf/1.7976931348623157E308 comparison
-            if(minclearanceO > 1.7976931348623157E308) {
-                minclearanceO = 1.7976931348623157E308;
-            }
-
-            // TODO: Use a tolerance ?
-            success = (minclearanceO == minclearanceE) ? 1 : 0;
-        }
-        else if(opName == "minclearanceline") {
-
-            double tol = 0.0000001;
-            GeomPtr lineE(parseGeometry(opRes, "expected"));
-            if(!lineE) {
-                throw std::runtime_error("malformed testcase: missing expected result in 'minclearanceline' op");
-            }
-
-            geom::Geometry* g1 = opArg1 == "B" ? gB : gA;
-            precision::MinimumClearance mc(g1);
-            std::unique_ptr<geom::Geometry> lineO = mc.getLine();
-            lineO.get()->normalize();
-            lineE.get()->normalize();
-
-            actual_result = printGeom(lineO.get());
-            success = lineE.get()->equalsExact(lineO.get(), tol) ? 1 : 0;
-        }
-
-        else if (opName == "buildarea")
-        {
-            GeomPtr gExpected(parseGeometry(opRes, "expected"));
-            gExpected->normalize();
-
-            auto gGot = BuildArea().build(gA);
-            if( gGot )
-            {
-                GeomPtr gRealRes(gGot.release());
-                gRealRes->normalize();
-
-                if (gExpected->equals(gRealRes.get())) success=1;
-
-                actual_result=printGeom(gRealRes.get());
-                expected_result=printGeom(gExpected.get());
-                if( actual_result == expected_result ) success=1;
-
-                if ( testValidOutput )
-                    success &= int(testValid(gRealRes.get(), "result"));
-            }
-            else
-            {
-                success = false;
-            }
-        }
-
-        else if (opName == "makevalid")
-        {
-            GeomPtr gExpected(parseGeometry(opRes, "expected"));
-            gExpected->normalize();
-
-            auto gGot = geos::operation::valid::MakeValid().build(gA);
-            if( gGot )
-            {
-                GeomPtr gRealRes(gGot.release());
-                gRealRes->normalize();
-
-                if (gExpected->equals(gRealRes.get())) success=1;
-
-                actual_result=printGeom(gRealRes.get());
-                expected_result=printGeom(gExpected.get());
-                if( actual_result == expected_result ) success=1;
-
-                if ( testValidOutput )
-                    success &= int(testValid(gRealRes.get(), "result"));
-            }
-            else
-            {
-                success = false;
-            }
-        }
-
-        else if(opName == "simplifydp" || opName == "simplifytp")
-        {
-            geom::Geometry* p_gT = gA;
-            if((opArg1 == "B" || opArg1 == "b") && gB) {
-                p_gT = gB;
-            }
-
-            GeomPtr gRes(parseGeometry(opRes, "expected"));
-            gRes->normalize();
-
-            profile.start();
-
-            GeomPtr gRealRes;
-            double tolerance = std::atof(opArg2.c_str());
-
-            if (opName == "simplifydp") {
-                gRealRes = geos::simplify::DouglasPeuckerSimplifier::simplify(p_gT, tolerance);
-            }
-            else {
-                gRealRes = geos::simplify::TopologyPreservingSimplifier::simplify(p_gT, tolerance);
-            }
-
-            profile.stop();
-            gRealRes->normalize();
-
-            actual_result = printGeom(gRealRes.get());
-            expected_result = printGeom(gRes.get());
-
-            success = gRealRes.get()->equalsExact(gRes.get(), 0.000001) ? 1 : 0;
-
-            if(testValidOutput) {
-                success &= int(testValid(gRealRes.get(), "result"));
-            }
-        }
-
-        else {
-            std::cerr << *curr_file << ":";
-            std::cerr << " case" << caseCount << ":";
-            std::cerr << " test" << testCount << ": "
-                      << opName << "(" << opSig << ")";
-            std::cerr << ": skipped (unrecognized)." << std::endl;
-            return;
-        }
-
+        executeOp(geomA, geomB);
     }
     catch(const std::exception& e) {
-        if (expected_result == "exception") {
-            success = true;
+        if (opRes == "exception") {
+            isSuccess = true;
             actual_result = "exception";
         }
         else {
-            std::cerr << "EXCEPTION on case " << caseCount
-                      << " test " << testCount << ": " << e.what()
+            std::cerr << "EXCEPTION in " << tester.testcaseRef() << ": " << e.what()
                       << std::endl;
             actual_result = e.what();
         }
     }
     catch(...) {
-        std::cerr << "Unknown EXCEPTION on case "
-                  << caseCount
+        std::cerr << "Unknown EXCEPTION in "
+                  << tester.testcaseRef()
                   << std::endl;
         actual_result = "Unknown exception thrown";
     }
+}
 
-    if(success) {
-        ++succeeded;
+void Test::executeOp(Geometry* gA, Geometry* gB)
+{
+    int success = 0;
+    if(opName == "relate") {
+        std::unique_ptr<geom::IntersectionMatrix> im(gA->relate(gB));
+        checkResult( im->matches(opArg3) );
+    }
+    else if(opName == "isvalid") {
+        checkResult( gA->isValid() );
+    }
+    else if(opName == "intersection" || opName == "intersectionng"
+            //TODO: remove this opname by fixing test
+            || opName == "intersectionsin") {
+        checkResult( gA->intersection(gB).get() );
+    }
+    //-- in current GEOS all overlay is OverlayNG
+    else if(opName == "union"|| opName == "unionng") {
+        if (gB) {
+            checkUnionResult( gA->Union(gB).get() );
+        }
+        else {
+            checkUnionResult( gA->Union().get() );
+        }
+    }
+    else if(opName == "difference" || opName == "differenceng") {
+        checkResult( gA->difference(gB).get() );
+    }
+    else if(opName == "symdifference" || opName == "symdifferenceng") {
+        checkResult( gA->symDifference(gB).get() );
+    }
+    else if(opName == "intersectionsr") {
+        double precision = 1.0;
+        if(opArg3 != "") {
+            precision = std::atof(opArg3.c_str());
+        }
+        geom::PrecisionModel precMod(precision);
+        std::unique_ptr<Geometry> res = OverlayNG::overlay(gA, gB, OverlayNG::INTERSECTION, &precMod);
+        checkResult( res.get() );
+    }
+    else if(opName == "unionsr") {
+        double precision = 1.0;
+        std::unique_ptr<Geometry> res;
+        if (gB) {
+            geom::PrecisionModel precMod(precision);
+            if(opArg3 != "") {
+                precision = std::atof(opArg3.c_str());
+            }
+            res = OverlayNG::overlay(gA, gB, OverlayNG::UNION, &precMod);
+        }
+        else {
+            if(opArg2 != "") {
+                precision = std::atof(opArg2.c_str());
+            }
+            geom::PrecisionModel precMod(precision);
+            // gRealRes = OverlayNG::geomunion(gA, &precMod);
+            res = UnaryUnionNG::Union(gA, precMod);
+        }
+        checkResult( res.get() );
+    }
+    else if(opName == "differencesr") {
+        double precision = 1.0;
+        if(opArg3 != "") {
+            precision = std::atof(opArg3.c_str());
+        }
+        geom::PrecisionModel precMod(precision);
+        std::unique_ptr<Geometry> res = OverlayNG::overlay(gA, gB, OverlayNG::DIFFERENCE, &precMod);
+        checkResult( res.get() );
+    }
+    else if(opName == "symdifferencesr") {
+        double precision = 1.0;
+        if(opArg3 != "") {
+            precision = std::atof(opArg3.c_str());
+        }
+        geom::PrecisionModel precMod(precision);
+        std::unique_ptr<Geometry> res = OverlayNG::overlay(gA, gB, OverlayNG::SYMDIFFERENCE, &precMod);
+        checkResult( res.get() );
+    }
+    else if(opName == "densify") {
+        double distanceTolerance = std::atof(opArg2.c_str());
+        geom::util::Densifier den(gA);
+        den.setDistanceTolerance(distanceTolerance);
+        checkResult( den.getResultGeometry().get() );
+    }
+    else if(opName == "intersects") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->intersects(gB));
+        }
+        else {
+            checkResult( gA->intersects(gB) );
+        }
+    }
+    else if(opName == "contains") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->contains(gB));
+        }
+        else {
+            checkResult( gA->contains(gB) );
+        }
+    }
+    else if(opName == "overlaps") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->overlaps(gB));
+        }
+        else {
+            checkResult( gA->overlaps(gB) );
+        }
+    }
+    else if(opName == "within") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->within(gB));
+        }
+        else {
+            checkResult( gA->within(gB) );
+        }
+    }
+    else if(opName == "touches") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->touches(gB));
+        }
+        else {
+            checkResult( gA->touches(gB) );
+        }
+    }
+    else if(opName == "crosses") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->crosses(gB));
+        }
+        else {
+            checkResult( gA->crosses(gB) );
+        }
+    }
+    else if(opName == "disjoint") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->disjoint(gB));
+        }
+        else {
+            checkResult( gA->disjoint(gB) );
+        }
+    }
+    else if(opName == "covers") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->covers(gB));
+        }
+        else {
+            checkResult( gA->covers(gB) );
+        }
+    }
+    else if(opName == "equalstopo") {
+        // equalsTopo() is synonym for equals() in JTS
+        checkResult( gA->equals(gB));
+    }
+    else if(opName == "equalsexact") {
+        checkResult( gA->equalsExact(gB));
+    }
+    else if(opName == "equalsnorm") {
+        // rather than implementing equalsnorm in the library,
+        // we just do it in this one test case for now
+        // NOTE: mutates A and B !!!!
+        gA->normalize();
+        gB->normalize();
+        checkResult( gA->equalsExact(gB));
+    }
+    else if(opName == "coveredby") {
+        if (tester.isUsePrepared()) {
+            checkResult( prepare(gA)->coveredBy(gB));
+        }
+        else {
+            checkResult( gA->coveredBy(gB) );
+        }
+    }
+    else if(opName == "getboundary") {
+        checkResult( gA->getBoundary().get() );
+    }
+    else if(opName == "getcentroid") {
+        checkResult( gA->getCentroid().get() );
+    }
+    else if(opName == "issimple") {
+        checkResult( gA->isSimple() );
+   }
+    else if(opName == "convexhull") {
+        checkResult( gA->convexHull().get() );
+    }
+    else if(opName == "buffer") {
+        using namespace operation::buffer;
+
+        std::unique_ptr<Geometry> gRes(parseGeometry(opRes, "expected"));
+        gRes->normalize();
+
+        std::unique_ptr<Geometry> gRealRes;
+        double dist = std::atof(opArg2.c_str());
+
+        BufferParameters params;
+        if(opArg3 != "") {
+            params.setQuadrantSegments(std::atoi(opArg3.c_str()));
+        }
+
+
+        BufferOp op(gA, params);
+        gRealRes = op.getResultGeometry(dist);
+
+        gRealRes->normalize();
+
+        // Validate the buffer operation
+        success = checkBufferSuccess(*gRes, *gRealRes, dist);
+
+        actual_result = printGeom(gRealRes.get());
+        expected_result = printGeom(gRes.get());
+
+        if(testValidOutput) {
+            success &= int(testValid(gRealRes.get(), "result"));
+        }
+    }
+
+    else if(opName == "buffersinglesided") {
+        using namespace operation::buffer;
+
+        std::unique_ptr<Geometry> gRes(parseGeometry(opRes, "expected"));
+        gRes->normalize();
+
+        std::unique_ptr<Geometry> gRealRes;
+        double dist = std::atof(opArg2.c_str());
+
+        BufferParameters params ;
+        params.setJoinStyle(BufferParameters::JOIN_ROUND) ;
+        if(opArg3 != "") {
+            params.setQuadrantSegments(std::atoi(opArg3.c_str()));
+        }
+
+        bool leftSide = true ;
+        if(opArg4 == "right") {
+            leftSide = false ;
+        }
+
+        BufferBuilder bufBuilder(params) ;
+        gRealRes = bufBuilder.bufferLineSingleSided(gA, dist, leftSide);
+
+        gRealRes->normalize();
+
+        // Validate the single sided buffer operation
+        success = checkSingleSidedBufferSuccess(*gRes,
+                                                *gRealRes, dist);
+
+        actual_result = printGeom(gRealRes.get());
+        expected_result = printGeom(gRes.get());
+
+        if(testValidOutput) {
+            success &= int(testValid(gRealRes.get(), "result"));
+        }
+    }
+
+    else if(opName == "buffermitredjoin") {
+        using namespace operation::buffer;
+
+        std::unique_ptr<Geometry> gRes(parseGeometry(opRes, "expected"));
+        gRes->normalize();
+
+        std::unique_ptr<Geometry> gRealRes;
+        double dist = std::atof(opArg2.c_str());
+
+        BufferParameters params;
+        params.setJoinStyle(BufferParameters::JOIN_MITRE);
+
+        if(opArg3 != "") {
+            params.setQuadrantSegments(std::atoi(opArg3.c_str()));
+        }
+
+        BufferOp op(gA, params);
+        gRealRes = op.getResultGeometry(dist);
+
+        gRealRes->normalize();
+
+        // Validate the buffer operation
+        success = checkBufferSuccess(*gRes, *gRealRes, dist);
+
+        actual_result = printGeom(gRealRes.get());
+        expected_result = printGeom(gRes.get());
+
+        if(testValidOutput) {
+            success &= int(testValid(gRealRes.get(), "result"));
+        }
+    }
+    else if(opName == "getinteriorpoint") {
+        std::unique_ptr<Geometry> res(gA->getInteriorPoint());
+        if (! res.get()) {
+            res = tester.getFactory()->createPoint();
+        }
+        checkResult( res.get() );
+    }
+    else if(opName == "iswithindistance") {
+        double dist = std::atof(opArg3.c_str());
+        checkResult( gA->isWithinDistance(gB, dist) );
+    }
+    else if(opName == "polygonize") {
+        Polygonizer plgnzr;
+        plgnzr.add(gA);
+        auto polys = plgnzr.getPolygons();
+        std::unique_ptr<Geometry> res(tester.getFactory()->createGeometryCollection(std::move(polys)));
+        checkResult( res.get() );
+    }
+    else if(opName == "linemerge") {
+        LineMerger merger;
+        merger.add(gA);
+        auto lines = merger.getMergedLineStrings();
+        std::unique_ptr<Geometry> res(tester.getFactory()->createGeometryCollection(std::move(lines)));
+        checkResult( res.get() );
+    }
+    else if(opName == "overlayareatest") {
+        std::string maxDiffOp;
+        std::stringstream p_tmp;
+        double maxDiff = 1e-6;
+        double areaDiff = areaDelta(gA, gB, maxDiffOp, maxDiff, p_tmp);
+        
+        // Debug output of actual geometries returned
+        if (areaDiff < maxDiff && false) {
+            std::cout << p_tmp.str();
+        }
+        checkResult(areaDiff < maxDiff);
+    }
+    else if(opName == "unionlength") {
+        checkResult( OverlayNGRobust::Union(gA)->getLength() );
+    }
+    else if(opName == "unionarea") {
+        checkResult( OverlayNGRobust::Union(gA)->getArea() );
+    }
+    else if(opName == "areatest") {
+        char* rest;
+        double toleratedDiff = std::strtod(opRes.c_str(), &rest);
+        int validOut = 1;
+
+        if(rest == opRes.c_str()) {
+            throw std::runtime_error("malformed testcase: missing tolerated area difference in 'areatest' op");
+        }
+
+        if(verbose > 1) {
+            std::cerr << "Running intersection for areatest" << std::endl;
+        }
+        std::unique_ptr<Geometry> gI(gA->intersection(gB));
+
+        if(testValidOutput) {
+            validOut &= int(testValid(gI.get(), "areatest intersection"));
+        }
+
+        if(verbose > 1) {
+            std::cerr << "Running difference(A,B) for areatest" << std::endl;
+        }
+
+        std::unique_ptr<Geometry> gDab(gA->difference(gB));
+
+        if(testValidOutput) {
+            validOut &= int(testValid(gI.get(), "areatest difference(a,b)"));
+        }
+
+        if(verbose > 1) {
+            std::cerr << "Running difference(B,A) for areatest" << std::endl;
+        }
+
+        std::unique_ptr<Geometry> gDba(gB->difference(gA));
+
+        if(testValidOutput) {
+            validOut &= int(testValid(gI.get(), "areatest difference(b,a)"));
+        }
+
+        if(verbose > 1) {
+            std::cerr << "Running symdifference for areatest" << std::endl;
+        }
+
+        std::unique_ptr<Geometry> gSD(gA->symDifference(gB));
+
+        if(testValidOutput) {
+            validOut &= int(testValid(gI.get(), "areatest symdifference"));
+        }
+
+        if(verbose > 1) {
+            std::cerr << "Running union for areatest" << std::endl;
+        }
+
+        std::unique_ptr<Geometry> gU(gA->Union(gB));
+
+        double areaA = gA->getArea();
+        double areaB = gB->getArea();
+        double areaI = gI->getArea();
+        double areaDab = gDab->getArea();
+        double areaDba = gDba->getArea();
+        double areaSD = gSD->getArea();
+        double areaU = gU->getArea();
+
+        double maxdiff = 0;
+        std::string maxdiffop;
+
+        // @ : symdifference
+        // - : difference
+        // + : union
+        // ^ : intersection
+
+        // A == ( A ^ B ) + ( A - B )
+        double diff = std::fabs(areaA - areaI - areaDab);
+        if(diff > maxdiff) {
+            maxdiffop = "A == ( A ^ B ) + ( A - B )";
+            maxdiff = diff;
+        }
+
+        // B == ( A ^ B ) + ( B - A )
+        diff = std::fabs(areaB - areaI - areaDba);
+        if(diff > maxdiff) {
+            maxdiffop = "B == ( A ^ B ) + ( B - A )";
+            maxdiff = diff;
+        }
+
+        //  ( A @ B ) == ( A - B ) + ( B - A )
+        diff = std::fabs(areaDab + areaDba - areaSD);
+        if(diff > maxdiff) {
+            maxdiffop = "( A @ B ) == ( A - B ) + ( B - A )";
+            maxdiff = diff;
+        }
+
+        //  ( A u B ) == ( A ^ B ) + ( A @ B )
+        diff = std::fabs(areaI + areaSD - areaU);
+        if(diff > maxdiff) {
+            maxdiffop = "( A u B ) == ( A ^ B ) + ( A @ B )";
+            maxdiff = diff;
+        }
+
+        if(maxdiff <= toleratedDiff) {
+            success = 1 && validOut;
+        }
+
+        std::stringstream p_tmp;
+        p_tmp << maxdiffop << ": " << maxdiff;
+        actual_result = p_tmp.str();
+        expected_result = opRes;
+    }
+    else if(opName == "distance") {
+        checkResult( gA->distance(gB) );
+    }
+    else if(opName == "minclearance") {
+        precision::MinimumClearance mc(gA);
+        double minclearanceO = mc.getDistance();
+        // Hack for Inf/1.7976931348623157E308 comparison
+        if(minclearanceO > 1.7976931348623157E308) {
+            minclearanceO = 1.7976931348623157E308;
+        }
+        checkResult( minclearanceO );
+    }
+    else if(opName == "minclearanceline") {
+        precision::MinimumClearance mc(gA);
+        //TODO: could use a checkResult with a tolerance?
+        checkResult( mc.getLine().get() );
+    }
+    else if (opName == "buildarea")
+    {
+        checkResult( BuildArea().build(gA).get() );
+    }
+    else if (opName == "makevalid")
+    {
+        checkResult( geos::operation::valid::MakeValid().build(gA).get() );
+    }
+    else if(opName == "simplifydp")
+    {
+        double tolerance = std::atof(opArg2.c_str());
+        checkResult( geos::simplify::DouglasPeuckerSimplifier::simplify(gA, tolerance).get() );
+    }
+    else if(opName == "simplifytp")
+    {
+        double tolerance = std::atof(opArg2.c_str());
+        checkResult( geos::simplify::TopologyPreservingSimplifier::simplify(gA, tolerance).get() );
     }
     else {
-        ++failed;
+        std::cerr << tester.testcaseRef() << " - " << opName;
+        std::cerr << ": skipped (unrecognized)." << std::endl;
     }
-
-    if((!success && verbose) || verbose > 0) {
-        printTest(!!success, expected_result, actual_result, profile);
-    }
-
-    if(test_predicates && gB && gA) {
-        runPredicates(gA, gB);
-    }
-
-}
-
-void
-XMLTester::runPredicates(const geom::Geometry* p_gA, const geom::Geometry* p_gB)
-{
-    std::cout << "\t    Equals:\tAB=" << (p_gA->equals(p_gB) ? "T" : "F") << ", BA=" << (p_gB->equals(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t  Disjoint:\tAB=" << (p_gA->disjoint(p_gB) ? "T" : "F") << ", BA=" << (p_gB->disjoint(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\tIntersects:\tAB=" << (p_gA->intersects(p_gB) ? "T" : "F") << ", BA=" << (p_gB->intersects(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t   Touches:\tAB=" << (p_gA->touches(p_gB) ? "T" : "F") << ", BA=" << (p_gB->touches(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t   Crosses:\tAB=" << (p_gA->crosses(p_gB) ? "T" : "F") << ", BA=" << (p_gB->crosses(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t    Within:\tAB=" << (p_gA->within(p_gB) ? "T" : "F") << ", BA=" << (p_gB->within(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t  Contains:\tAB=" << (p_gA->contains(p_gB) ? "T" : "F") << ", BA=" << (p_gB->contains(
-                  p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t  Overlaps:\tAB=" << (p_gA->overlaps(p_gB) ? "T" : "F") << ", BA=" << (p_gB->overlaps(
-                  p_gA) ? "T" : "F") << std::endl;
-
-    std::cout << "\t  Prepared Disjoint:\tAB=" << (prepare(p_gA)->disjoint(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->disjoint(p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\tPrepared Intersects:\tAB=" << (prepare(p_gA)->intersects(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->intersects(p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t   Prepared Touches:\tAB=" << (prepare(p_gA)->touches(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->touches(p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t   Prepared Crosses:\tAB=" << (prepare(p_gA)->crosses(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->crosses(p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t    Prepared Within:\tAB=" << (prepare(p_gA)->within(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->within(p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t  Prepared Contains:\tAB=" << (prepare(p_gA)->contains(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->contains(p_gA) ? "T" : "F") << std::endl;
-    std::cout << "\t Prepared Overlaps:\tAB=" << (prepare(p_gA)->overlaps(p_gB) ? "T" : "F") << ", BA=" << (prepare(
-                  p_gB)->overlaps(p_gA) ? "T" : "F") << std::endl;
-}
-
-XMLTester::~XMLTester()
-{
+    //-- for ops which set success local var
+    if (success > 0) isSuccess = true;
 }
 
 
@@ -2428,39 +1618,5 @@ main(int argC, char* argV[])
     }
     DeInitAllocCheck();
 #endif
-
 }
 
-/**********************************************************************
- * $Log: XMLTester.cpp,v $
- * Revision 1.38  2006/07/13 03:59:10  csavage
- * Changes to compile on VC++ - fully qualified polygon name.  Should also work on MingW, will test next.
- *
- * Revision 1.37  2006/06/19 20:48:35  strk
- * parseCase(): make sure to exit the <case> tag before returning
- *
- * Revision 1.36  2006/06/14 19:19:10  strk
- * Added support for "AreaTest" operations.
- *
- * Revision 1.35  2006/06/12 10:39:29  strk
- * don't print test file precision model if verbosity level < 2.
- *
- * Revision 1.34  2006/06/05 15:36:34  strk
- * Given OverlayOp funx code enum a name and renamed values to have a lowercase prefix. Drop all of noding headers from installed header set.
- *
- * Revision 1.33  2006/05/19 16:38:22  strk
- *         * tests/xmltester/XMLTester.cpp: report
- *         error on load of requested tests.
- *
- * Revision 1.32  2006/04/14 14:57:15  strk
- * XMLTester binary ops invoked using the new HeuristicOverlay template function.
- *
- * Revision 1.31  2006/04/07 13:26:38  strk
- * Use of unique_ptr<> to prevent confusing leaks in tester
- *
- * Revision 1.30  2006/03/22 16:01:33  strk
- * indexBintree.h header split, classes renamed to match JTS
- *
- * Revision 1.29  2006/03/17 14:56:39  strk
- * Fixed filename normalizer for sql output
- **********************************************************************/

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -309,7 +309,7 @@ XMLTester::testcaseRef()
 
 /*private*/
 void
-XMLTester::printTestSQL(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result)
+XMLTester::printTestSQL(bool success, const std::string& expected_result, const std::string& actual_result)
 {
     std::cout << "INSERT INTO \"" << normalize_filename(*curr_file) << "\" VALUES ("
                 << caseCount << ", "
@@ -347,7 +347,7 @@ void
 XMLTester::printTest(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result)
 {
     if(sqlOutput) {
-        printTestSQL(success, op, expected_result, actual_result);
+        printTestSQL(success, expected_result, actual_result);
         return;
     }
     //-- no output for quiet success

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -819,7 +819,6 @@ Test::areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& r
 
     // normalize the area delta value
     double diffScore = maxDelta / (areaA + areaB);
-
     if (diffScore > maxDiff) {
         ss << std::endl << "A" << std::endl;
         ss << *a;
@@ -837,31 +836,17 @@ Test::areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& r
         ss << *geomSD;
         ss << std::endl;
     }
-
     return diffScore;
 }
 
 void
-Test::checkResult( const std::unique_ptr<Geometry>& res ) 
+Test::checkResult( const std::unique_ptr<Geometry>& result ) 
 {
-    std::string expectedRes = opRes;
-    std::unique_ptr<Geometry> gExpectedRes(tester.parseGeometry(expectedRes, "expected"));
-    gExpectedRes->normalize();
-
-    std::unique_ptr<Geometry> gActualRes(res->clone());
-    gActualRes->normalize();
-
-    isSuccess = false;
-    //TODO: change to equalsExact, since compareTo doesn't check empty type
-    if (gExpectedRes->compareTo(gActualRes.get()) == 0) {
-        isSuccess = true;
-    }
-
-    if (testValidOutput) {
-        isSuccess &= tester.testValid(gActualRes.get(), "result");
-    }
-
-    actual_result = tester.printGeom(gActualRes.get());
+    checkResult( result, 
+    [](std::unique_ptr<Geometry>& expected, std::unique_ptr<Geometry>& actual) -> bool {
+        //TODO: change to equalsExact, since compareTo doesn't check empty type
+        return expected->compareTo(actual.get()) == 0;
+    });
 }
 
 void

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -690,9 +690,11 @@ bool
 Test::checkOverlaySuccess(Geometry const& gExpected, Geometry const& gActual)
 {
     double tol = operation::overlay::snap::GeometrySnapper::computeSizeBasedSnapTolerance(gExpected);
+    //-- BUG: this allows all empties to test equal
     if(gExpected.equals(&gActual)) {
         return 1;
     }
+    //TODO: is this needed by any tests?
     std::cerr << "Using an overlay tolerance of " << tol << std::endl;
     if(gExpected.equalsExact(&gActual, tol)) {
         return 1;
@@ -871,23 +873,14 @@ Test::checkResult( const std::unique_ptr<Geometry>& result,
     actualResultStr = tester.printGeom(gActualRes.get());
 }
 
-//TODO: fix this hack.  Only used for union now, and has a bug where empties test equal
+//TODO: remove this hack when tests are fixed.  Only used for union, and has a bug where empties test equal
 void
 Test::checkUnionResult( const std::unique_ptr<Geometry>& result ) 
 {
-    std::string sExpected = opResult;
-    std::unique_ptr<Geometry> gExpected(tester.parseGeometry(sExpected, "expected"));
-    gExpected->normalize();
-
-    std::unique_ptr<Geometry> gActual(result->clone());
-    gActual->normalize();
-
-    isSuccess = checkOverlaySuccess(*gExpected.get(), *gActual.get());
-
-    if(testValidOutput) {
-        isSuccess &= tester.testValid(gActual.get(), "result");
-    }
-    actualResultStr = tester.printGeom(gActual.get());
+    checkResult( result, 
+        [](std::unique_ptr<Geometry>& expected, std::unique_ptr<Geometry>& actual) -> bool {
+            return checkOverlaySuccess(*expected.get(), *actual.get());
+    });
 }
 
 void

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -141,11 +141,11 @@ private:
     void parse(const tinyxml2::XMLNode* node);
     void execute(Geometry* geomA, Geometry* geomB);
     void executeOp(Geometry* geomA, Geometry* geomB);
-    void checkResult( const std::unique_ptr<Geometry>& result );
-    void checkResult( const std::unique_ptr<Geometry>& result, 
-        std::function<bool( std::unique_ptr<Geometry>& expected, 
-                            std::unique_ptr<Geometry>& actual )> isMatch );
-    void checkUnionResult( const std::unique_ptr<Geometry>& result );
+    void checkResult( const Geometry& result );
+    void checkResult( const Geometry& result, 
+        std::function<bool( Geometry& expected, 
+                            Geometry& actual )> isMatch );
+    void checkUnionResult( const Geometry& result );
     void checkResult( double result );
     void checkResult( bool result );
 

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -102,7 +102,7 @@ public:
 
     bool isTestValidOutput() { return testValidOutput; }
 
-    bool isUsePrepared() { return usePrepared; }
+    bool isPrepared() { return usePrepared; }
 
     geom::GeometryFactory* getFactory() { return factory.get(); }
 
@@ -135,6 +135,9 @@ public:
 
 };
 
+/*
+  Executes a single test in a XML test file.
+*/
 class Test {
 private:
     XMLTester& tester;
@@ -148,7 +151,6 @@ private:
     std::string opSignature;
 
     //TODO: make these functions on XMLTester?
-    int verbose;
     bool testValidOutput;
 
     bool isSuccess;
@@ -174,9 +176,7 @@ public:
         isSuccess(false),
         actual_result("NONE")
     {
-        verbose = tester.isVerbose();
         testValidOutput = tester.isTestValidOutput();
-        //usePrepared = tester.isUsePrepared();
     }
     bool run(const tinyxml2::XMLNode* node, Geometry* geomA, Geometry* geomB);
 

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -164,8 +164,8 @@ private:
     void checkResult( double res );
     void checkResult( bool res );
 
-    static int checkBufferSuccess(Geometry const& gRes, Geometry const& gRealRes, double dist);
-    static int checkSingleSidedBufferSuccess(Geometry& gRes, Geometry& gRealRes, double dist);
+    static bool checkBufferSuccess(Geometry const& gRes, Geometry const& gRealRes, double dist);
+    static bool checkSingleSidedBufferSuccess(Geometry& gRes, Geometry& gRealRes, double dist);
     static double areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& rsltMaxDiffOp, double maxDiff, std::stringstream& ss);
 
 public:

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -85,7 +85,7 @@ public:
     Geometry* parseGeometry(const std::string& in, const char* label = "parsed");
     std::string printGeom(const geom::Geometry* g);
     void printTest(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result);
-    void printTestSQL(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result);
+    void printTestSQL(bool success, const std::string& expected_result, const std::string& actual_result);
     bool testValid(const geom::Geometry* g, const std::string& label);
     std::string testcaseRef();
     

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -143,7 +143,8 @@ private:
     void executeOp(Geometry* geomA, Geometry* geomB);
     void checkResult( const std::unique_ptr<Geometry>& result );
     void checkResult( const std::unique_ptr<Geometry>& result, 
-        std::function<bool(std::unique_ptr<Geometry>& expected, std::unique_ptr<Geometry>& actual)> isMatch );
+        std::function<bool( std::unique_ptr<Geometry>& expected, 
+                            std::unique_ptr<Geometry>& actual )> isMatch );
     void checkUnionResult( const std::unique_ptr<Geometry>& result );
     void checkResult( double result );
     void checkResult( bool result );

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -85,6 +85,7 @@ public:
     Geometry* parseGeometry(const std::string& in, const char* label = "parsed");
     std::string printGeom(const geom::Geometry* g);
     void printTest(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result);
+    void printTestSQL(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result);
     bool testValid(const geom::Geometry* g, const std::string& label);
     std::string testcaseRef();
     

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -161,8 +161,10 @@ private:
     void parse(const tinyxml2::XMLNode* node);
     void execute(Geometry* geomA, Geometry* geomB);
     void executeOp(Geometry* geomA, Geometry* geomB);
-    void checkResult( Geometry * res );
-    void checkUnionResult( Geometry * res );
+    void checkResult( const std::unique_ptr<Geometry>& res );
+    void checkResult( const std::unique_ptr<Geometry>& res, 
+        std::function<bool(std::unique_ptr<Geometry>& expected, std::unique_ptr<Geometry>& actual)> isMatch );
+    void checkUnionResult( const std::unique_ptr<Geometry>& res );
     void checkResult( double res );
     void checkResult( bool res );
 

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -25,19 +25,11 @@ using geos::geom::Geometry;
 class XMLTester {
 
 private:
-    enum {
-        SHOW_RUN_INFO = 1,
-        SHOW_CASE,
-        SHOW_TEST,
-        SHOW_RESULT,
-        SHOW_GEOMS,
-        SHOW_GEOMS_FULL,
-        PRED
-    };
 
     void parsePrecisionModel(const tinyxml2::XMLElement* el);
     void parseRun(const tinyxml2::XMLNode* node);
     void parseCase(const tinyxml2::XMLNode* node);
+
     void runPredicates(const geom::Geometry* a, const geom::Geometry* b);
 
     void runTest(const tinyxml2::XMLNode* node);
@@ -56,13 +48,11 @@ private:
 
     int verbose;
 
-    int failed;
-    int succeeded;
+    int failedCount;
+    int succeededCount;
     int caseCount;
     int testCount;
     int testLineNum;
-    std::string opSignature;
-
     int testFileCount;
     int totalTestCount;
 
@@ -99,6 +89,23 @@ public:
      */
     int setVerbosityLevel(int val);
 
+    void setTestOutputValidity(bool val)
+    {
+        testValidOutput = val;
+    }
+    void setTestInputValidity(bool val)
+    {
+        testValidInput = val;
+    }
+    void setSQLOutput(bool val)
+    {
+        sqlOutput = val;
+    }
+    void setHEXWKBOutput(bool val)
+    {
+        HEXWKB_output = val;
+    }
+
     int isVerbose() { return verbose; }
 
     bool isTestValidOutput() { return testValidOutput; }
@@ -107,33 +114,7 @@ public:
 
     geom::GeometryFactory* getFactory() { return factory.get(); }
 
-    int
-    getFailuresCount()
-    {
-        return failed;
-    }
-
-    void
-    testOutputValidity(bool val)
-    {
-        testValidOutput = val;
-    }
-    void
-    testInputValidity(bool val)
-    {
-        testValidInput = val;
-    }
-    void
-    setSQLOutput(bool val)
-    {
-        sqlOutput = val;
-    }
-    void
-    setHEXWKBOutput(bool val)
-    {
-        HEXWKB_output = val;
-    }
-
+    int getFailuresCount() { return failedCount;  }
 };
 
 /*

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -148,36 +148,35 @@ private:
     std::string opArg2;
     std::string opArg3;
     std::string opArg4;
-    std::string opRes;
+    std::string opResult;
     std::string opSignature;
 
     //TODO: make these functions on XMLTester?
     bool testValidOutput;
 
     bool isSuccess;
-
-    std::string actual_result;
-    std::string expected_result;
+    std::string actualResultStr;
 
     void parse(const tinyxml2::XMLNode* node);
     void execute(Geometry* geomA, Geometry* geomB);
     void executeOp(Geometry* geomA, Geometry* geomB);
-    void checkResult( const std::unique_ptr<Geometry>& res );
-    void checkResult( const std::unique_ptr<Geometry>& res, 
+    void checkResult( const std::unique_ptr<Geometry>& result );
+    void checkResult( const std::unique_ptr<Geometry>& result, 
         std::function<bool(std::unique_ptr<Geometry>& expected, std::unique_ptr<Geometry>& actual)> isMatch );
-    void checkUnionResult( const std::unique_ptr<Geometry>& res );
-    void checkResult( double res );
-    void checkResult( bool res );
+    void checkUnionResult( const std::unique_ptr<Geometry>& result );
+    void checkResult( double result );
+    void checkResult( bool result );
 
-    static bool checkBufferSuccess(Geometry const& gRes, Geometry const& gRealRes, double dist);
-    static bool checkSingleSidedBufferSuccess(Geometry& gRes, Geometry& gRealRes, double dist);
+    static bool checkBufferSuccess(Geometry const& gExpected, Geometry const& gActual, double dist);
+    static bool checkSingleSidedBufferSuccess(Geometry& gExpected, Geometry& gActual, double dist);
+    static bool checkOverlaySuccess(Geometry const& gExpected, Geometry const& gActual);
     static double areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& rsltMaxDiffOp, double maxDiff, std::stringstream& ss);
 
 public:
     Test(XMLTester& xmlTester) 
         : tester(xmlTester),
         isSuccess(false),
-        actual_result("NONE")
+        actualResultStr("NONE")
     {
         testValidOutput = tester.isTestValidOutput();
     }

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -139,7 +139,6 @@ class Test {
 private:
     XMLTester& tester;
 
-    //int success = 0; // no success by default
     std::string opName;
     std::string opArg1;
     std::string opArg2;
@@ -151,6 +150,7 @@ private:
     //TODO: make these functions on XMLTester?
     int verbose;
     bool testValidOutput;
+
     bool isSuccess;
 
     std::string actual_result;
@@ -164,22 +164,9 @@ private:
     void checkResult( double res );
     void checkResult( bool res );
 
-    // TODO: temporary delegators
-    Geometry* parseGeometry(const std::string& in, const char* label = "parsed")
-    {
-        return tester.parseGeometry(in, label);
-    }
-    std::string printGeom(const geom::Geometry* g)
-    {
-        return tester.printGeom(g);
-    }
-    bool testValid(const geom::Geometry* g, const std::string& label)
-    {
-        return tester.testValid(g, label);
-    }
-
     static int checkBufferSuccess(Geometry const& gRes, Geometry const& gRealRes, double dist);
     static int checkSingleSidedBufferSuccess(Geometry& gRes, Geometry& gRealRes, double dist);
+    static double areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& rsltMaxDiffOp, double maxDiff, std::stringstream& ss);
 
 public:
     Test(XMLTester& xmlTester) 
@@ -193,7 +180,6 @@ public:
     }
     bool run(const tinyxml2::XMLNode* node, Geometry* geomA, Geometry* geomB);
 
-    static double areaDelta(const geom::Geometry* a, const geom::Geometry* b, std::string& rsltMaxDiffOp, double maxDiff, std::stringstream& ss);
 
 };
 

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -84,7 +84,7 @@ public:
 
     Geometry* parseGeometry(const std::string& in, const char* label = "parsed");
     std::string printGeom(const geom::Geometry* g);
-    void printTest(bool success, const std::string& expected_result, const std::string& actual_result);
+    void printTest(bool success, const std::string& op, const std::string& expected_result, const std::string& actual_result);
     bool testValid(const geom::Geometry* g, const std::string& label);
     std::string testcaseRef();
     
@@ -172,10 +172,6 @@ private:
     std::string printGeom(const geom::Geometry* g)
     {
         return tester.printGeom(g);
-    }
-    void printTest(bool success, const std::string& expected, const std::string& actual)
-    {
-        tester.printTest(success, expected, actual);
     }
     bool testValid(const geom::Geometry* g, const std::string& label)
     {


### PR DESCRIPTION
Improves `XMLTester` by modularizing it using an additional `Test` class and a few lambda functions.  This allows factoring out common code to achieve DRY.

* improves maintainability
* easier to add new operations
* reduces risk of ops missing expected behaviour (e.g. swapping A and B args, test reporting)
* reduces code size (> 800 lines removed)
* adds test file line number reporting

This has also uncovered some issues with result testing (in particular, using topological rather than exact equals).  Fixing this requires fixing a few tests, so will be done in a subsequent PR.