### PR TITLE
Add Orientation Index stress test

### DIFF
--- a/benchmarks/algorithm/CMakeLists.txt
+++ b/benchmarks/algorithm/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(perf_unaryunion_segments geos)
 
 if (BUILD_BENCHMARKS)
 
+add_executable(stress_orientation OrientationIndexStressTest.cpp)
+target_link_libraries(stress_orientation geos)
+
 if (benchmark_FOUND)
     add_executable(perf_orientation OrientationIndexPerfTest.cpp
             ${PROJECT_SOURCE_DIR}/src/algorithm/CGAlgorithmsDD.cpp

--- a/benchmarks/algorithm/OrientationIndexStressTest.cpp
+++ b/benchmarks/algorithm/OrientationIndexStressTest.cpp
@@ -1,0 +1,160 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2025 Martin Davis
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+/*--------------------------------------------------------------
+Stress test for the Orientation Index implementation.
+
+Usage: stress_orientation [ -v ]
+
+A robust orientation index implementation should be consistent
+- i.e. it should produce the same result for the 3 possible 
+permutations of the input coordinates which have the same orientation:
+
+p0-p1 / p2    p1-p2 / p0    p2-p0 / p1     
+
+The robust implementation uses DoubleDouble arithmetic and a filter to improve computation time. 
+It is compared to 
+the simple floating-point orientation computation, which is not consistent.
+--------------------------------------------------------------*/
+
+#include <geos/algorithm/Orientation.h>
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/LineSegment.h>
+#include <geos/io/WKTWriter.h>
+
+using namespace geos::algorithm;
+using namespace geos::geom;
+using namespace geos::io;
+
+int
+orientationIndexFP(const Coordinate& p1, const Coordinate& p2,const Coordinate& q){
+	double dx1 = p2.x-p1.x;
+	double dy1 = p2.y-p1.y;
+	double dx2 = q.x-p2.x;
+	double dy2 = q.y-p2.y;
+	double det = dx1 * dy2 - dx2 * dy1;
+	if (det > 0.0) return 1;
+	if (det < 0.0) return-1;
+	return 0;
+}
+
+bool isVerbose = false;
+
+std::size_t failDD;
+std::size_t failFP;
+
+void parseFlag(char* arg) {
+    char flag = arg[1];
+    switch (flag) {
+    case 'v': 
+        isVerbose = true; break;
+    }
+}
+
+void parseArgs(int argc, char** argv) {
+    if (argc <= 1) return;
+    int i = 1;
+    //-- parse flags
+    while (i < argc && argv[i][0] == '-' && isalpha(argv[i][1])) {
+        parseFlag(argv[i]);
+        i++;
+    }
+}
+
+char orientSym(int orientationIndex) {
+    if (orientationIndex < 0) return '-';
+    if (orientationIndex > 0) return '+';
+    return '0';
+}
+
+void report(std::string name, int orient0, int orient1,
+    int orient2) {
+
+    std::string consistentInd = (orient0 == orient1 && orient0 == orient2) ? "  " : "<!";
+    std::cout << name << ": "
+    << orientSym(orient0) << "  "  
+    << orientSym(orient1) << "  " 
+    << orientSym(orient2) << "  "
+    << consistentInd << "  ";
+}
+
+bool isAllOrientationsEqualDD(Coordinate p0, Coordinate p1, Coordinate p2)
+{
+    int orient0 = Orientation::index(p0, p1, p2);
+    int orient1 = Orientation::index(p1, p2, p0);
+    int orient2 = Orientation::index(p2, p0, p1);
+
+    if (isVerbose) {
+        report("DD", orient0, orient1, orient2);
+    }
+
+    return orient0 == orient1 && orient0 == orient2;
+}
+
+bool isAllOrientationsEqualFP(Coordinate p0, Coordinate p1, Coordinate p2)
+{
+    int orient0 = orientationIndexFP(p0, p1, p2);
+    int orient1 = orientationIndexFP(p1, p2, p0);
+    int orient2 = orientationIndexFP(p2, p0, p1);
+    if (isVerbose) {
+        report("FP", orient0, orient1, orient2);
+    }
+    return orient0 == orient1 && orient0 == orient2;
+}
+
+Coordinate randomCoord() {
+    double x = (10.0 * random()) / RAND_MAX;
+    double y = (10.0 * random()) / RAND_MAX;
+    return Coordinate(x, y);
+}
+
+void runTest()
+{
+    Coordinate p0 = randomCoord();
+    Coordinate p1 = randomCoord();
+
+    Coordinate p2 = Coordinate(LineSegment::midPoint(p0, p1));
+
+    bool isCorrectDD = isAllOrientationsEqualDD(p0, p1, p2);
+    bool isCorrectFP = isAllOrientationsEqualFP(p0, p1, p2);
+
+    if (isVerbose) {
+        std::cout << "   " << WKTWriter::toLineString(p0, p1) << " - " << WKTWriter::toPoint(p2)
+            << std::endl;
+    }
+
+    if (! isCorrectDD) failDD++;
+    if (! isCorrectFP) failFP++;
+}
+
+int main(int argc, char** argv) {
+    if (argc > 1) {
+        parseArgs(argc, argv);
+    }
+
+    srand (static_cast <unsigned> (time(0)));
+
+    int i = 0;
+    while (true) {
+        runTest();
+        i++;
+        
+        if (i % 1000 == 0) {
+            std::cout << "Num tests: " <<  i 
+                << "  DD fail = " << failDD << " (" << (100.0 * failDD / (double) i) << "%)"
+                << "  FP fail = " << failFP << " (" << (100.0 * failFP / (double) i) << "%)"
+                << std::endl;
+        }
+    }
+}

--- a/benchmarks/algorithm/OrientationIndexStressTest.cpp
+++ b/benchmarks/algorithm/OrientationIndexStressTest.cpp
@@ -36,6 +36,8 @@ It is compared to the simple Floating-Point orientation computation, which is no
 #include <geos/geom/LineSegment.h>
 #include <geos/io/WKTWriter.h>
 
+#include <iomanip>
+
 using namespace geos::algorithm;
 using namespace geos::geom;
 using namespace geos::io;
@@ -143,7 +145,9 @@ void runTest()
     bool isCorrectFP = isConsistentFP(p0, p1, p2);
 
     if (isVerbose) {
-        std::cout << "   " << WKTWriter::toLineString(p0, p1) << " - " << WKTWriter::toPoint(p2)
+        std::cout << std::setprecision(20) << "   " 
+            << "LINESTRING ( " << p0.x << " " << p0.y << ", " << p1.x << " " << p1.y << " )"
+            << "  - " << "POINT ( " << p2.x << " " << p2.y << " )"
             << std::endl;
     }
 

--- a/benchmarks/algorithm/OrientationIndexStressTest.cpp
+++ b/benchmarks/algorithm/OrientationIndexStressTest.cpp
@@ -112,7 +112,7 @@ bool isConsistent(std::string tag, Coordinate p0, Coordinate p1, Coordinate p2,
 
 bool isConsistentDD(Coordinate p0, Coordinate p1, Coordinate p2)
 {
-    return isConsistent("FP", p0, p1, p2, 
+    return isConsistent("DD", p0, p1, p2, 
     [](Coordinate p0, Coordinate p1, Coordinate p2) -> int {
         return Orientation::index(p0, p1, p2);
     });


### PR DESCRIPTION
Adds an Orientation Index stress test, to test the consistency of the robust Orientation Index algorithm in [`CGAlgorithmsDD::orientationIndex`](https://github.com/libgeos/geos/blob/main/src/algorithm/CGAlgorithmsDD.cpp#L54).

This is a followup to the [discussion](https://github.com/libgeos/geos/pull/1184#issuecomment-2634312584) on #1184.

Orientation Index computation consistency is tested by checking:
* all 3 permutations of input points have same index 
* all 3 permutations of input points in reverse orientation have same index
* orientation index and reverse index have opposite sign, or are collinear

Two ways of generating test cases are provided:

### Decimated Diagonal
Sample output:
```
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 0 2 )
DD: +++ ---      FP: ++0 0--  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 0.10000000000000000555 1.8999999999999999112 )
DD: --- +++      FP: --0 0++  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 0.2000000000000000111 1.8000000000000000444 )
DD: +++ ---      FP: +00 00-  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 0.2999999999999999889 1.6999999999999999556 )
DD: --- +++      FP: --0 0++  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 0.4000000000000000222 1.6000000000000000888 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 0.5 1.5 )
DD: +++ ---      FP: ++0 0--  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 0.5999999999999999778 1.3999999999999999112 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 0.69999999999999995559 1.3000000000000000444 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 0.80000000000000004441 1.1999999999999999556 )
DD: --- +++      FP: --0 0++  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 0.9000000000000000222 1.1000000000000000888 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 1 1 )
DD: --- +++      FP: 0-- ++0  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 1.1000000000000000888 0.9000000000000000222 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 1.1999999999999999556 0.80000000000000004441 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 1.3000000000000000444 0.69999999999999995559 )
DD: +++ ---      FP: 0++ --0  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 1.3999999999999999112 0.5999999999999999778 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 1.5 0.5 )
DD: --- +++      FP: 0-- ++0  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 1.6000000000000000888 0.4000000000000000222 )
DD: +++ ---      FP: 00+ -00  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 1.6999999999999999556 0.2999999999999999889 )
DD: --- +++      FP: 0-- ++0  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 1.8000000000000000444 0.2000000000000000111 )
DD: +++ ---      FP: 0++ --0  <!     LINESTRING ( 2 0, 0 2 )  - POINT ( 1.8999999999999999112 0.10000000000000000555 )
DD: 000 000      FP: 000 000         LINESTRING ( 2 0, 0 2 )  - POINT ( 2 0 )
```

### Random segment midpoint
Sample output showing the **consistency** of the DD implementation, and the **inconsistency** of the FP implementation:
```
DD: 000 000      FP: 000 000         LINESTRING (1.975 9.89878, 1.22214 8.63843) - POINT (1.59857 9.2686 )
DD: +++ ---      FP: +++ ---         LINESTRING (1.97316 7.86036, 0.54432 8.52318) - POINT (1.25874 8.19177 )
DD: --- +++      FP: --- +++         LINESTRING (7.46839 7.18772, 2.2134 1.76035) - POINT (4.84089 4.47403 )
DD: --- +++      FP: --0 0++  <!     LINESTRING (7.15706 5.00496, 0.299816 1.03827) - POINT (3.72844 3.02162 )
DD: --- +++      FP: --0 0++  <!     LINESTRING (1.81436 2.57266, 9.9449 4.61921) - POINT (5.87963 3.59593 )
DD: --- +++      FP: 0-- ++0  <!     LINESTRING (0.152498 5.41789, 7.46287 6.00798) - POINT (3.80769 5.71293 )

```
The tester counts the number of failures encountered for both orientation index implementations.  For random segment midpoint test cases, the DD implementation is robust over 10M runs, while the FP implementation shows a high percentage of consistency failures:
```
Final: Num tests: 10000000  DD fail = 0 (0%)  FP fail = 2358352 (24%)
```