### PR TITLE
ci: remove workaround for ubuntu-22.04 image with clang++-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,15 +204,6 @@ jobs:
     runs-on: ${{ matrix.ci.os }}
     steps:
 
-    # Work around https://github.com/actions/runner-images/issues/8659
-    - name: 'Remove GCC 13 from runner image (workaround)'
-      if: matrix.ci.os == 'ubuntu-22.04' && matrix.ci.cxx_compiler == 'clang++-14'
-      shell: bash
-      run: |
-        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-        sudo apt-get update
-        sudo apt-get install -y --allow-downgrades libc6=2.35-* libc6-dev=2.35-* libstdc++6=12.3.0-* libgcc-s1=12.3.0-*
-
     - name: 'Install'
       run: |
         set -e


### PR DESCRIPTION
This CI workaround (bb2db233eb2d51ba1f44cfaaf5dbd39f0cb1af87) is resolved upstream.