### PR TITLE
CoordinateSequence: Raise error on invalid ordinateIndex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 - Breaking Changes:
   - Stricter WKT parsing (GH-1241, @freemine)
+  - GEOSCoordSeq_setOrdinate returns an error if the sequence does not have the specified ordinate (GH-1245, Dan Baston)
 
 - Fixes/Improvements:
   - Fix ConcaveHullOfPolygons nested shell handling (GH-1169, Martin Davis)

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -547,10 +547,18 @@ CoordinateSequence::setOrdinate(std::size_t index, std::size_t ordinateIndex, do
         getAt<CoordinateXY>(index).y = value;
         break;
         case CoordinateSequence::Z:
-        getAt<Coordinate>(index).z = value;
+        {
+            if (!hasZ()) {
+                throw util::IllegalArgumentException("Coordinate type is not XYZ or XYZM");
+            }
+            getAt<Coordinate>(index).z = value;
+        }
         break;
         case CoordinateSequence::M:
         {
+            if (!hasM()) {
+                throw util::IllegalArgumentException("Coordinate type is not XYM or XYZM.");
+            }
             if (getCoordinateType() == CoordinateType::XYZM) {
                 getAt<CoordinateXYZM>(index).m = value;
             } else {

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -766,4 +766,90 @@ void object::test<21>()
     GEOS_finish_r(handle);
 }
 
+template<>
+template<>
+void object::test<22>()
+{
+    set_test_name("setOrdinate on XYZM coordinate");
+
+    cs_ = GEOSCoordSeq_create(1, 4);
+
+    ensure("setX", GEOSCoordSeq_setOrdinate(cs_, 0, 0, 1));
+    ensure("setY", GEOSCoordSeq_setOrdinate(cs_, 0, 1, 2));
+    ensure("setZ", GEOSCoordSeq_setOrdinate(cs_, 0, 2, 3));
+    ensure("setM", GEOSCoordSeq_setOrdinate(cs_, 0, 3, 4));
+
+    double x, y, z, m;
+    ensure(GEOSCoordSeq_copyToArrays(cs_, &x, &y, &z, &m));
+
+    ensure_equals("X", x, 1);
+    ensure_equals("Y", y, 2);
+    ensure_equals("Z", z, 3);
+    ensure_equals("M", m, 4);
+}
+
+template<>
+template<>
+void object::test<23>()
+{
+    set_test_name("setOrdinate on XYZ coordinate");
+
+    cs_ = GEOSCoordSeq_create(1, 3);
+
+    ensure("setX", GEOSCoordSeq_setOrdinate(cs_, 0, 0, 1));
+    ensure("setY", GEOSCoordSeq_setOrdinate(cs_, 0, 1, 2));
+    ensure("setZ", GEOSCoordSeq_setOrdinate(cs_, 0, 2, 3));
+    ensure("setM", !GEOSCoordSeq_setOrdinate(cs_, 0, 3, 4));
+
+    double x, y, z;
+    ensure(GEOSCoordSeq_copyToArrays(cs_, &x, &y, &z, nullptr));
+
+    ensure_equals("X", x, 1);
+    ensure_equals("Y", y, 2);
+    ensure_equals("Z", z, 3);
+}
+
+template<>
+template<>
+void object::test<24>()
+{
+    set_test_name("setOrdinate on XY coordinate");
+
+    cs_ = GEOSCoordSeq_create(1, 2);
+
+    ensure("setX", GEOSCoordSeq_setOrdinate(cs_, 0, 0, 1));
+    ensure("setY", GEOSCoordSeq_setOrdinate(cs_, 0, 1, 2));
+    ensure("setZ", !GEOSCoordSeq_setOrdinate(cs_, 0, 2, 3));
+    ensure("setM", !GEOSCoordSeq_setOrdinate(cs_, 0, 3, 4));
+
+    double x, y;
+    ensure(GEOSCoordSeq_copyToArrays(cs_, &x, &y, nullptr, nullptr));
+
+    ensure_equals("X", x, 1);
+    ensure_equals("Y", y, 2);
+}
+
+template<>
+template<>
+void object::test<25>()
+{
+    set_test_name("setOrdinate on XYM coordinate");
+
+    /* TODO: use GEOSCoordSeq_createWithDimensions() instead */
+    double buffer[3];
+    cs_ = GEOSCoordSeq_copyFromBuffer(buffer, 1, 0, 1);
+
+    ensure("setX", GEOSCoordSeq_setOrdinate(cs_, 0, 0, 1));
+    ensure("setY", GEOSCoordSeq_setOrdinate(cs_, 0, 1, 2));
+    ensure("setZ", !GEOSCoordSeq_setOrdinate(cs_, 0, 2, 3));
+    ensure("setM", GEOSCoordSeq_setOrdinate(cs_, 0, 3, 4));
+
+    double x, y, m;
+    ensure(GEOSCoordSeq_copyToArrays(cs_, &x, &y, nullptr, &m));
+
+    ensure_equals("X", x, 1);
+    ensure_equals("Y", y, 2);
+    ensure_equals("M", m, 4);
+}
+
 } // namespace tut


### PR DESCRIPTION
As discussed in https://github.com/libgeos/geos/issues/1244#issuecomment-2683808208

Mixed feelings about this, since the ability to set a Z value on an XY sequence without getting an error has existed since forever.