### PR TITLE
DEVELOPER-NOTES.md and NEWS.md: Minor cleanup.

### DIFF
--- a/DEVELOPER-NOTES.md
+++ b/DEVELOPER-NOTES.md
@@ -10,7 +10,7 @@
 * Ideally, new algorithms are implemented in JTS and then ported to GEOS.
   * Sometimes GEOS gains new functionality; ideally this is backported to JTS
 * Performance optimizations in GEOS can backport to JTS.
-  * Short circuits, indexes, other non-language optimizations, should be ticketed in JTS when they are added to GEOS.
+  * Short circuits, indexes, and other non-language optimizations should be ticketed in JTS when they are added to GEOS.
 
 ### Follow JTS as Much as Possible
 
@@ -69,21 +69,21 @@ public:
 [Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r-resource-management).
 * [A raw pointer (a T*) is non-owning](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-ptr)
 * [A raw reference (a T&) is non-owning](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-ref)
-  
+
 ### Function Parameter calling conventions
 
-* Objects which are passed as read-only with no transfer of ownership 
+* Objects which are passed as read-only with no transfer of ownership
   should be passed as `const` [references](https://en.wikipedia.org/wiki/Reference_%28C++%29#) (e.g. `const Geometry&`).
   References are simpler and safer to use than pointers.
   * in particular, this applies to Geometry objects passed to API operations
-  (in static functions, class constructors, or initialization methods) 
+  (in static functions, class constructors, or initialization methods)
   * NOTE: many GEOS API functions use pass-by-pointer (`Geometry*`), but this is historical baggage
-  * for the common case of passing a `std::unique_ptr<Geometry> foo` the argument will be `*foo` 
+  * for the common case of passing a `std::unique_ptr<Geometry> foo` the argument will be `*foo`
 * Pass-by-pointer can be used if the argument may be NULL (this is rare for API functions)
 
 ### Avoid Many Small Heap Allocations
 
-* Heap allocations (objects created using `new`) are more expensive than stack allocations, but they can show up in batchs in JTS in places where structures are built, like index trees, or graphs.
+* Heap allocations (objects created using `new`) are more expensive than stack allocations, but they can show up in batches in JTS in places where structures are built, like index trees or graphs.
 * To both lower the overhead of heap allocations, and to manage the life-cycle of the objects, we recommend storing small objects in an appropriate "double-ended queue", like [std::deque<>](https://en.cppreference.com/w/cpp/container/deque).
 * The implementation of `edgegraph` is an example.
 
@@ -122,7 +122,7 @@ GEOS is organized into many nested namespaces to reflect the JTS package structu
 Namespace qualification of class references can be shortened
 with the `using` keyword in two different ways:
 
-In **header files**, `using` [type aliases](https://en.cppreference.com/w/cpp/language/type_alias) can be defined **inside class definitions**: 
+In **header files**, `using` [type aliases](https://en.cppreference.com/w/cpp/language/type_alias) can be defined **inside class definitions**:
 
 ```
 class OffsetCurve {

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 2025-xx-xx
 
 - New things:
-  - Add clustering functions to C API (GH-1154, Dan Baston) 
+  - Add clustering functions to C API (GH-1154, Dan Baston)
 
 - Breaking Changes:
   - Stricter WKT parsing (GH-1241, @freemine)
@@ -20,7 +20,7 @@
   - Fix overlay heuristic for GeometryCollections with empty elements (GH-1229, Martin Davis)
   - Add ring buffer hole removal heuristic (GH-1233, Martin Davis)
   - Fix buffer element erosion for negative distance and remove overlay deps (GH-1239, Martin Davis)
-  - Fix OverlayNG coordinate dimemsion handling for EMPTY geometries (GH-1258, Martin Davis)
+  - Fix OverlayNG coordinate dimension handling for EMPTY geometries (GH-1258, Martin Davis)
 
 ## Changes in 3.13.0
 2024-09-06
@@ -35,11 +35,11 @@
     - Rewrite of boolean predicates and relate matrix calculations
     - "Prepared" mode now available for all predicates and relate matrix
     - CAPI functions GEOSPreparedRelate and GEOSPreparedRelatePattern expose new functionality
-    - CAPI implementations of GEOSPreparedTouches, etc, that were previously defaulting 
+    - CAPI implementations of GEOSPreparedTouches, etc, that were previously defaulting
       into non-prepared implementations now default into the RelateNG prepared implementation
     - Prepared implementations for Intersects, Covers, still use the older implementations
     - https://lin-ear-th-inking.blogspot.com/2024/05/jts-topological-relationships-next.html
-    - https://lin-ear-th-inking.blogspot.com/2024/05/relateng-performance.html 
+    - https://lin-ear-th-inking.blogspot.com/2024/05/relateng-performance.html
 
 - Breaking Changes:
   - Zero-length linestrings (eg LINESTRING(1 1, 1 1)) are now treated as equivalent to points (POINT(1 1)) in boolean predicates
@@ -76,7 +76,7 @@
   - TopologyPreservingSimplifier: fix to remove ring endpoints safely (GH-1110, Martin Davis)
   - TopologyPreservingSimplifier: fix stack overflow on degenerate inputs (GH-1113, Dan Baston)
   - DouglasPeuckerSimplifier: fix stack overflow on NaN tolerance (GH-1114, Dan Baston)
-  - GEOSConcaveHullOfPolygons: Avoid crash on zero-area input (GH-1076, Dan Baston) 
+  - GEOSConcaveHullOfPolygons: Avoid crash on zero-area input (GH-1076, Dan Baston)
 
 ## Changes in 3.12.0
 2023-06-27


### PR DESCRIPTION
- Spelling
- Minor grammar
- A few trailing spaces removed