### PR TITLE
Add GEOSCoordSeq_hasZ and GEOSCoordSeq_hasM

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1135,6 +1135,18 @@ extern "C" {
         return GEOSCoordSeq_copyToArrays_r(handle, s, x, y, z, m);
     }
 
+    char
+    GEOSCoordSeq_hasZ(CoordinateSequence* s)
+    {
+        return GEOSCoordSeq_hasZ_r(handle, s);
+    }
+
+    char
+    GEOSCoordSeq_hasM(CoordinateSequence* s)
+    {
+        return GEOSCoordSeq_hasM_r(handle, s);
+    }
+
     int
     GEOSCoordSeq_setOrdinate(CoordinateSequence* s, unsigned int idx, unsigned int dim, double val)
     {

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -495,6 +495,16 @@ extern void GEOS_DLL GEOSCoordSeq_destroy_r(
     GEOSContextHandle_t handle,
     GEOSCoordSequence* s);
 
+/** \see GEOSCoordSeq_hasZ */
+extern char GEOS_DLL GEOSCoordSeq_hasZ_r(
+    GEOSContextHandle_t handle,
+    GEOSCoordSequence* s);
+
+/** \see GEOSCoordSeq_hasM */
+extern char GEOS_DLL GEOSCoordSeq_hasM_r(
+    GEOSContextHandle_t handle,
+    GEOSCoordSequence* s);
+
 /** \see GEOSCoordSeq_setX */
 extern int GEOS_DLL GEOSCoordSeq_setX_r(
     GEOSContextHandle_t handle,
@@ -2345,6 +2355,24 @@ extern GEOSCoordSequence GEOS_DLL *GEOSCoordSeq_clone(const GEOSCoordSequence* s
 * \since 2.2
 */
 extern void GEOS_DLL GEOSCoordSeq_destroy(GEOSCoordSequence* s);
+
+/**
+* Tests whether the input coordinate sequence has Z coordinates.
+* \param s the coordinate sequence to test
+* \return 1 on true, 0 on false, 2 on exception
+*
+* \since 3.14
+*/
+extern char GEOS_DLL GEOSCoordSeq_hasZ(GEOSCoordSequence* s);
+
+/**
+* Tests whether the input coordinate sequence has M coordinates.
+* \param s the coordinate sequence to test
+* \return 1 on true, 0 on false, 2 on exception
+*
+* \since 3.14
+*/
+extern char GEOS_DLL GEOSCoordSeq_hasM(GEOSCoordSequence* s);
 
 /**
 * Set X ordinate values in a coordinate sequence.

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2849,6 +2849,22 @@ extern "C" {
         });
     }
 
+    char
+    GEOSCoordSeq_hasZ_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs)
+    {
+        return execute(extHandle, 2, [&]() {
+            return cs->hasZ();
+        });
+    }
+
+    char
+    GEOSCoordSeq_hasM_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs)
+    {
+        return execute(extHandle, 2, [&]() {
+            return cs->hasM();
+        });
+    }
+
     int
     GEOSCoordSeq_setOrdinate_r(GEOSContextHandle_t extHandle, CoordinateSequence* cs,
                                unsigned int idx, unsigned int dim, double val)

--- a/src/geom/CoordinateSequence.cpp
+++ b/src/geom/CoordinateSequence.cpp
@@ -68,8 +68,13 @@ CoordinateSequence::CoordinateSequence(std::size_t sz, bool hasz, bool hasm, boo
 }
 
 CoordinateSequence::CoordinateSequence(std::size_t sz, std::size_t dim) :
+#ifdef GEOS_COORDSEQ_PADZ
     m_vect(sz * std::max(static_cast<std::uint8_t>(dim), static_cast<std::uint8_t>(3))),
     m_stride(std::max(static_cast<std::uint8_t>(dim), static_cast<std::uint8_t>(3))),
+#else
+    m_vect(sz * static_cast<std::uint8_t>(dim)),
+    m_stride(static_cast<std::uint8_t>(dim)),
+#endif
     m_hasdim(dim > 0),
     m_hasz(dim >= 3),
     m_hasm(dim == 4)

--- a/tests/unit/capi/GEOSCoordSeqTest.cpp
+++ b/tests/unit/capi/GEOSCoordSeqTest.cpp
@@ -881,4 +881,52 @@ void object::test<27>()
     ensure_equals(m, 4);
 }
 
+template<>
+template<>
+void object::test<28>()
+{
+    set_test_name("hasZ, hasM, getCoordinateType on XY sequence");
+
+    cs_ = GEOSCoordSeq_createWithDimensions(2, 0, 0);
+
+    ensure_not("hasZ", GEOSCoordSeq_hasZ(cs_));
+    ensure_not("hasM", GEOSCoordSeq_hasM(cs_));
+}
+
+template<>
+template<>
+void object::test<29>()
+{
+    set_test_name("hasZ, hasM, getCoordinateType on XYZ sequence");
+
+    cs_ = GEOSCoordSeq_createWithDimensions(2, 1, 0);
+
+    ensure("hasZ", GEOSCoordSeq_hasZ(cs_));
+    ensure_not("hasM", GEOSCoordSeq_hasM(cs_));
+}
+
+template<>
+template<>
+void object::test<30>()
+{
+    set_test_name("hasZ, hasM, getCoordinateType on XYM sequence");
+
+    cs_ = GEOSCoordSeq_createWithDimensions(2, 0, 1);
+
+    ensure_not("hasZ", GEOSCoordSeq_hasZ(cs_));
+    ensure("hasM", GEOSCoordSeq_hasM(cs_));
+}
+
+template<>
+template<>
+void object::test<31>()
+{
+    set_test_name("hasZ, hasM, getCoordinateType on XYZM sequence");
+
+    cs_ = GEOSCoordSeq_createWithDimensions(2, 1, 1);
+
+    ensure("hasZ", GEOSCoordSeq_hasZ(cs_));
+    ensure("hasM", GEOSCoordSeq_hasM(cs_));
+}
+
 } // namespace tut


### PR DESCRIPTION
Also contains a missing `GEOS_COORDSEQ_PADZ` case in one of the CoordSequence constructor.