### PR TITLE
Allow GeoJSONWriter to force polygons to be counterclockwise

### DIFF
--- a/include/geos/io/GeoJSONWriter.h
+++ b/include/geos/io/GeoJSONWriter.h
@@ -95,12 +95,26 @@ public:
      */
     void setOutputDimension(uint8_t newOutputDimension);
 
+    /*
+     * Sets whether the GeoJSON should be output following counter-clockwise orientation aka Right Hand Rule defined in
+     * RFC7946. See <a href="https://tools.ietf.org/html/rfc7946#section-3.1.6">RFC 7946 Specification</a>
+     * for more context.
+     *
+     * @param newIsForceCCW true if the GeoJSON should be output following the RFC7946
+     *                      counter-clockwise orientation aka Right Hand Rule
+     */
+    void setForceCCW(bool newIsForceCCW);
+
 private:
     uint8_t defaultOutputDimension = 3;
+
+    bool isForceCCW = false;
 
     std::vector<double> convertCoordinate(const geom::Coordinate* c);
 
     std::vector<std::vector<double>> convertCoordinateSequence(const geom::CoordinateSequence* c);
+
+    std::vector<std::vector<std::vector<double>>> convertLinearRings(const geom::Polygon *poly);
 
     void encode(const geom::Geometry* g, GeoJSONType type, geos_nlohmann::ordered_json& j);
 

--- a/tests/unit/io/GeoJSONWriterTest.cpp
+++ b/tests/unit/io/GeoJSONWriterTest.cpp
@@ -453,4 +453,40 @@ void object::test<30>
     ensure_equals(result, "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[0.0,0.0]},\"properties\":{\"array\":[{\"key\":\"value_1\"},{\"key\":\"value_2\"}]}}");
 }
 
+// Test Polygon right-hand rule
+template<>
+template<>
+void object::test<31>
+()
+{
+    geojsonwriter.setForceCCW(true);
+    GeomPtr geom(wktreader.read("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Polygon\",\"coordinates\":[[[0.0,0.0],[1.0,0.0],[1.0,1.0],[0.0,1.0],[0.0,0.0]]]}");
+}
+
+// Test Polygon with hole right-hand rule
+template<>
+template<>
+void object::test<32>
+()
+{
+    geojsonwriter.setForceCCW(true);
+    GeomPtr geom(wktreader.read("POLYGON ((0 0, 0 20, 20 20, 20 0, 0 0), (1 1, 10 1, 10 10, 1 10, 1 1) )"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"Polygon\",\"coordinates\":[[[0.0,0.0],[20.0,0.0],[20.0,20.0],[0.0,20.0],[0.0,0.0]],[[1.0,1.0],[1.0,10.0],[10.0,10.0],[10.0,1.0],[1.0,1.0]]]}");
+}
+
+// Test MultiPolygon right-hand rule
+template<>
+template<>
+void object::test<33>
+()
+{
+    geojsonwriter.setForceCCW(true);
+    GeomPtr geom(wktreader.read("MULTIPOLYGON (((0 0, 0 1, 1 1, 1 0, 0 0)), ((2 2, 2 3, 3 3, 3 2, 2 2)))"));
+    std::string result = geojsonwriter.write(geom.get());
+    ensure_equals(result, "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0.0,0.0],[1.0,0.0],[1.0,1.0],[0.0,1.0],[0.0,0.0]]],[[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]]]}");
+}
+
 }


### PR DESCRIPTION
Add a `setForceCCW` function to `GeoJSONWriter`, which enables conversion of polygons to follow the RFC 7946 winding order. When `isForceCCW` is true, linear rings in Polygons and MultiPolygons follow the right-hand rule, meaning exterior rings are counterclockwise, and holes are clockwise.

See https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6

This addition to GEOS is inspired by a corresponding change in JTS, see https://github.com/locationtech/jts/pull/694