### PR TITLE
CMake: Create targets file in build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,14 @@ if(PROJECT_IS_TOP_LEVEL AND BUILD_WEBSITE)
 endif()
 
 #-----------------------------------------------------------------------------
+# Generate targets file for importing directly from GEOS build tree
+#-----------------------------------------------------------------------------
+
+export(TARGETS geos geos_c geos_cxx_flags geos_developer_cxx_flags
+       NAMESPACE GEOS::
+       FILE "geos-targets.cmake")
+
+#-----------------------------------------------------------------------------
 # Install and export targets - support 'make install' or equivalent
 #-----------------------------------------------------------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
   - Add clustering functions to C API (GH-1154, Dan Baston)
   - Ported LineDissolver (Paul Ramsey)
   - Ported CoverageCleaner (Paul Ramsey)
+  - Add "geos-targets.cmake" to build tree to allow building other software against
+    GEOS build without installing first (GH-1269, Dan Baston)
 
 - Breaking Changes:
   - Stricter WKT parsing (GH-1241, @freemine)


### PR DESCRIPTION
Analog of https://github.com/OSGeo/gdal/pull/12217

Lets one build GDAL (or anything else) by setting `GEOS_DIR` to a build tree.