### PR TITLE
geosop: add bufferSingleSided operation

### DIFF
--- a/util/geosop/GeometryOp.cpp
+++ b/util/geosop/GeometryOp.cpp
@@ -325,6 +325,16 @@ std::vector<GeometryOpCreator> opRegistry {
         return new Result( g3.release() );
     });
     }},
+{"bufferSingleSided", [](std::string name) { return GeometryOp::create(name,
+    catConst,
+    "compute the buffer of geometry by a distance with the single-sided option",
+    [](const Geometry& geom, double d) {
+        geos::operation::buffer::BufferParameters param;
+        param.setSingleSided( true );
+        std::unique_ptr<Geometry> g3 = geos::operation::buffer::BufferOp::bufferOp(&geom, d, param);
+        return new Result( g3.release() );
+    });
+    }},
 {"offsetCurve", [](std::string name) { return GeometryOp::create(name,
     catConst,
     "compute the offset curve of geometry by a distance",


### PR DESCRIPTION
Add geosop operation "bufferSingleSided" to enable the parameter [`setSingleSided( true )`](https://libgeos.org/doxygen/classgeos_1_1operation_1_1buffer_1_1BufferOp.html#aaa8c47fc49faef0cafeb3865d8785f31).

For example: `geosop -a "LineString(0 0, 0 1, 1 1, 0 0)" bufferSingleSided 0.2`
