### PR TITLE
Add CMake check for std::filesystem availability

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,6 +14,35 @@ file(GLOB_RECURSE _sources ${CMAKE_CURRENT_LIST_DIR}/*.cpp CONFIGURE_DEPEND)
 add_executable(test_geos_unit ${_sources})
 unset(_sources)
 
+# test that std::filesystem header actually is there and works
+if(NOT CMAKE_REQUIRED_QUIET)
+  # CMake 3.17+ use CHECK_START/CHECK_PASS/CHECK_FAIL
+  message(STATUS "Checking if compiler supports std::filesystem")
+endif()
+set(_filename "${CMAKE_CURRENT_BINARY_DIR}/has_filesystem.cpp")
+write_file(${_filename} "\
+#include <filesystem>
+int main() {
+  std::filesystem::path pth {\"../\"};
+  return 0;
+}")
+try_compile(HAVE_STD_FILESYSTEM "${CMAKE_BINARY_DIR}/temp" "${_filename}")
+file(REMOVE "${_filename}")
+unset(_filename)
+if(HAVE_STD_FILESYSTEM)
+  if(NOT CMAKE_REQUIRED_QUIET)
+    # CMake 3.17+ use CHECK_START/CHECK_PASS/CHECK_FAIL
+    message(STATUS "Checking if compiler supports std::filesystem - yes")
+  endif()
+  target_compile_definitions(test_geos_unit PRIVATE HAVE_STD_FILESYSTEM)
+else()
+  if(NOT CMAKE_REQUIRED_QUIET)
+    # CMake 3.17+ use CHECK_START/CHECK_PASS/CHECK_FAIL
+    message(STATUS "Checking if compiler supports std::filesystem - no")
+  endif()
+  target_compile_definitions(test_geos_unit PRIVATE HAVE_STD_FILESYSTEM=0)
+endif()
+
 find_package(Threads)
 
 target_link_libraries(test_geos_unit PRIVATE geos geos_c Threads::Threads)

--- a/tests/unit/utility.h
+++ b/tests/unit/utility.h
@@ -33,11 +33,13 @@
 #include <fstream>
 #include <sstream>
 
+#ifndef HAVE_STD_FILESYSTEM
 #if defined(__GNUC__) && !defined(__clang__)
 #define HAVE_STD_FILESYSTEM (__GNUC__ > 8)
 #else
 #define HAVE_STD_FILESYSTEM 1
 #endif
+#endif /* ifndef HAVE_STD_FILESYSTEM */
 #if HAVE_STD_FILESYSTEM
 #include <filesystem>
 #endif


### PR DESCRIPTION
With c++17 or later, `std::filesystem` should normally be enabled, unless the compiler can't compile it.
Setting (e.g.) `-DCMAKE_CXX_STANDARD=11` will disable use of `std::filesystem`.

Not tested with conda-forge/osx_64 to check [this behaviour](https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk), but hopefully it gets caught.

Closes #1299