### PR TITLE
geosop: make floating-point exceptions optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,3 +558,10 @@ if(PROJECT_IS_TOP_LEVEL)
 
   unset(_is_multi_config_generator)
 endif()  # PROJECT_IS_TOP_LEVEL
+
+include(CheckIncludeFile)
+check_include_file(fenv.h HAVE_FENV_H)
+
+if(HAVE_FENV_H)
+    target_compile_definitions(geos_cxx_flags INTERFACE HAVE_FENV)
+endif()

--- a/util/geosop/GeosOp.cpp
+++ b/util/geosop/GeosOp.cpp
@@ -26,7 +26,9 @@
 #include <geos/io/WKBStreamReader.h>
 #include <geos/io/WKBWriter.h>
 
+#if defined(HAVE_FENV)
 #include <cfenv>
+#endif
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -394,10 +396,13 @@ void GeosOp::run(OpArguments& opArgs) {
     //------------------------
 
     try {
+#if defined(HAVE_FENV)
         std::feclearexcept(FE_ALL_EXCEPT); // clear floating-point status flags
+#endif
 
         execute(op, opArgs);
 
+#if defined(HAVE_FENV)
         // Catch everything except for FE_INEXACT, which is usually harmless
         const int fpexp = std::fetestexcept(FE_ALL_EXCEPT ^ FE_INEXACT);
         if (args.isVerbose && (fpexp != 0)) {
@@ -414,6 +419,7 @@ void GeosOp::run(OpArguments& opArgs) {
                 std::cerr << " FE_UNDERFLOW";
             std::cerr << std::endl;
         }
+#endif
     }
     catch (std::exception &e) {
         std::cerr << "Run-time exception: " << e.what() << std::endl;


### PR DESCRIPTION
commit 26292ce ("geosop: show most floating-point exceptions in verbose mode") add fenv.h dependency. Some libc implementations (uclibc-ng )may have no fenv support. So make floating-point exceptions optional and detetct fenv.h at configure stage.