### PR TITLE
Make `GeometryFactory::addRef/dropRef` thread-safe

### DIFF
--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -33,6 +33,7 @@
 #include <vector>
 #include <memory>
 #include <cassert>
+#include <atomic>
 
 namespace geos {
 namespace geom {
@@ -522,7 +523,7 @@ private:
     PrecisionModel precisionModel;
     int SRID;
 
-    mutable int _refCount;
+    mutable std::atomic<int> _refCount;
     bool _autoDestroy;
 
     friend class Geometry;


### PR DESCRIPTION
Closes #847 

Even when using the reentrant C API, there are still potential thread safety issues when incrementing and decrementing `GeometryFactory::_refCount`. To fix this, I chose to do what `std::shared_ptr` does and make the reference count atomic.