### PR TITLE
CoverageRingEdges.cpp: Fix include map

### DIFF
--- a/src/coverage/CoverageRingEdges.cpp
+++ b/src/coverage/CoverageRingEdges.cpp
@@ -13,6 +13,7 @@
  *
  **********************************************************************/
 
+#include <map>
 #include <unordered_map>
 
 #include <geos/coverage/CoverageBoundarySegmentFinder.h>


### PR DESCRIPTION
#include \<map\> was accidentally deleted in the previous commit, but it is referenced in several places within.  This commit restores the now-missing include.