### PR TITLE
SIMD vectorization of Length.cpp, runs up to 2.8x faster.

### DIFF
--- a/src/algorithm/Length.cpp
+++ b/src/algorithm/Length.cpp
@@ -36,9 +36,6 @@ Length::ofLine(const geom::CoordinateSequence* pts)
 
     double len = 0.0;
     
-    #ifdef HAVE_OPEN_SIMD
-    #pragma omp simd reduction(+:len)
-    #endif
     for(std::size_t i = 1; i < n; i++) {
         const geom::CoordinateXY& pi = pts->getAt<geom::CoordinateXY>(i);
         const geom::CoordinateXY& pi_1 = pts->getAt<geom::CoordinateXY>(i-1);
@@ -60,9 +57,6 @@ Length::ofLine(const std::vector<geom::CoordinateXY>& pts)
 
     double len = 0;
     
-    #ifdef HAVE_OPEN_SIMD
-    #pragma omp simd reduction(+:len)
-    #endif
     for(std::size_t i = 1; i < pts.size(); i++) {
         const geom::CoordinateXY& pi = pts[i];
         const geom::CoordinateXY& pi_1 = pts[i-1];


### PR DESCRIPTION
Hello,

This PR increases the speed of Length.cpp by 1.13x - 2.83x by enabling the compiler to use SIMD vector instructions with [SIMD directives](https://www.openmp.org/spec-html/5.0/openmpsu42.html). This is done safely by checking `#ifdef HAVE_OPEN_SIMD` so if the preprocessor macro HAVE_OPEN_SIMD has not been defined then the Length.cpp runs as usual.

On x86 Linux 32GiB DRAM, Intel i9 performance varied by size of line (# of points) and whether line was a CoordinateSequence or CoordinateXY vector.

`
Points |  Vector Gain |  CoordinateSequence Gain
--------------------------------------------
          10 |         -- |           --
         100 |         -- |           --
        1000 |      1.67x |        1.67x
       10,000 |      2.83x |        2.33x
      100,000 |      1.83x |        1.96x
     1,000,000 |      1.75x |        1.48x
    10,000,000 |      1.24x |        1.13x

`

The speed and throughput testing script I used:
[myLengthTest.cpp](https://github.com/user-attachments/files/23781366/myLengthTest.cpp)

I built and ran `ctest` on both the x86 Linux and an M1 Mac, passed all tests.

Thank you,
Sven

