### PR TITLE
Fix test_docs failure with doxygen 1.15.0.

### DIFF
--- a/include/geos/linearref/LengthIndexedLine.h
+++ b/include/geos/linearref/LengthIndexedLine.h
@@ -138,7 +138,7 @@ public:
      * slightly off the line and is equidistant from two different
      * points on the line.
      *
-     * The supplied point does not `*necessarily* have to lie precisely
+     * The supplied point does not *necessarily* have to lie precisely
      * on the line, but if it is far from the line the accuracy and
      * performance of this function is not guaranteed.
      * Use {@link #project} to compute a guaranteed result for points


### PR DESCRIPTION
The Debian package build failed with doxygen 1.15.0:
```
        Start 509: test_docs
509: Test command: /usr/bin/cmake "-D" "DOXYGEN_LOGFILE="/build/geos-3.14.1/build/doxygen/doxygen.log"" "-P" "/build/geos-3.14.1/build/doxygen/check_doxygen_errors.cmake"
509: Working Directory: /build/geos-3.14.1/build/doxygen
509: Test timeout computed to be: 1500
509: -- Doxygen issued 1849 warning(s), see /build/geos-3.14.1/build/doxygen/doxygen.log
509: CMake Error at check_doxygen_errors.cmake:44 (message):
509:   /build/geos-3.14.1/include/geos/linearref/LengthIndexedLine.h:212: warning:
509:   Reached end of file while still searching closing '`' of a verbatim block
509:   starting at line 196
509: 
509:   /build/geos-3.14.1/include/geos/linearref/LengthIndexedLine.h:212: warning:
509:   Reached end of file while still inside a (nested) comment.  Nesting level 1
509:   (possible line reference(s): 130)
509: 
509:   /build/geos-3.14.1/include/geos/linearref/LengthIndexedLine.h:152: warning:
509:   Found end of C comment inside a '`' block without matching start of the
509:   comment! Maybe the end marker for the block is missing?
509: 
509:   /build/geos-3.14.1/include/geos/linearref/LengthIndexedLine.h:135: warning:
509:   argument 'pt' of command @param is not found in the argument list of
509:   geos::linearref::LengthIndexedLine::indicesOf(const geom::Geometry
509:   *subLine) const
509: 
509:   /build/geos-3.14.1/include/geos/linearref/LengthIndexedLine.h:135: warning:
509:   argument 'minIndex' of command @param is not found in the argument list of
509:   geos::linearref::LengthIndexedLine::indicesOf(const geom::Geometry
509:   *subLine) const
509: 
509: 
503/509 Test #509: test_docs ..................................................***Failed    0.03 sec
```

Removing the unclosed backtick resolves the issue.