### PR TITLE
DistanceOp::distance(): make it return +inf instead of 0 if one of the geometry is empty

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -3631,8 +3631,8 @@ extern int GEOS_DLL GEOSGeomGetLength(
 * Calculate the distance between two geometries.
 * \param[in] g1 Input geometry
 * \param[in] g2 Input geometry
-* \param[out] dist Pointer to be filled in with distance result. NaN is returned
-*                  if one of the geometry is empty.
+* \param[out] dist Pointer to be filled in with distance result. Positive
+*                  infinity is returned if one of the geometry is empty.
 * \return 1 on success, 0 on exception.
 * \since 2.2
 */

--- a/src/operation/distance/DistanceOp.cpp
+++ b/src/operation/distance/DistanceOp.cpp
@@ -98,7 +98,7 @@ DistanceOp::DistanceOp(const Geometry& g0, const Geometry& g1, double tdist)
 /**
  * Report the distance between the closest points on the input geometries.
  *
- * @return the distance between the geometries, or NaN if one of them is empty.
+ * @return the distance between the geometries, or positive infinity if one of them is empty.
  */
 double
 DistanceOp::distance()
@@ -112,7 +112,7 @@ DistanceOp::distance()
         throw IllegalArgumentException("null geometries are not supported");
     }
     if(geom[0]->isEmpty() || geom[1]->isEmpty()) {
-        return std::numeric_limits<double>::quiet_NaN();
+        return std::numeric_limits<double>::infinity();
     }
     if(geom[0]->getGeometryTypeId() == GEOS_POINT && geom[1]->getGeometryTypeId() == GEOS_POINT) {
         return static_cast<const Point*>(geom[0])->getCoordinate()->distance(*static_cast<const Point*>(geom[1])->getCoordinate());

--- a/tests/unit/operation/distance/DistanceOpTest.cpp
+++ b/tests/unit/operation/distance/DistanceOpTest.cpp
@@ -228,7 +228,7 @@ void object::test<8>
 
     DistanceOp dist(g0.get(), g1.get());
 
-    ensure(std::isnan(dist.distance()));
+    ensure(std::isinf(dist.distance()));
 
     ensure(dist.nearestPoints() == nullptr);
 }
@@ -416,7 +416,7 @@ void object::test<16>
 
     DistanceOp dist(g0.get(), g1.get());
 
-    ensure(std::isnan(dist.distance()));
+    ensure(std::isinf(dist.distance()));
 
     ensure(dist.nearestPoints() == nullptr);
 }
@@ -497,7 +497,7 @@ void object::test<19>
     ensure(g1->isValid());
     ensure(g2->isValid());
 
-    ensure(std::isnan(g1->distance(g2.get())));
+    ensure(std::isinf(g1->distance(g2.get())));
 }
 
 // Test case reported in Shapely
@@ -588,8 +588,8 @@ void object::test<23>()
     auto g2 = wktreader.read("LINESTRING EMPTY");
 
     ensure(g1 != nullptr && g2 != nullptr);
-    ensure(std::isnan(g1->distance(g2.get())));
-    ensure(std::isnan(g2->distance(g1.get())));
+    ensure(std::isinf(g1->distance(g2.get())));
+    ensure(std::isinf(g2->distance(g1.get())));
 }
 
 template<>
@@ -600,8 +600,8 @@ void object::test<24>()
     auto g2 = wktreader.read("LINESTRING EMPTY");
 
     ensure(g1 != nullptr && g2 != nullptr);
-    ensure(std::isnan(g1->distance(g2.get())));
-    ensure(std::isnan(g2->distance(g1.get())));
+    ensure(std::isinf(g1->distance(g2.get())));
+    ensure(std::isinf(g2->distance(g1.get())));
 }
 
 // But ignore empty if there's a real distance?
@@ -637,8 +637,8 @@ void object::test<27>()
     auto g2 = wktreader.read("GEOMETRYCOLLECTION(POINT(1 0))");
 
     ensure(g1 != nullptr && g2 != nullptr);
-    ensure(std::isnan(g1->distance(g2.get())));
-    ensure(std::isnan(g2->distance(g1.get())));
+    ensure(std::isinf(g1->distance(g2.get())));
+    ensure(std::isinf(g2->distance(g1.get())));
 }
 
 

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -896,7 +896,10 @@ Test::checkResult( double result)
 {
     char* rest = nullptr;
     const double expectedRes = (opResult == "NaN" || opResult == "nan") ?
-        std::numeric_limits<double>::quiet_NaN() : std::strtod(opResult.c_str(), &rest);
+        std::numeric_limits<double>::quiet_NaN() :
+        (opResult == "Inf" || opResult == "inf") ?
+        std::numeric_limits<double>::infinity() :
+        std::strtod(opResult.c_str(), &rest);
     if(rest == opResult.c_str()) {
         throw std::runtime_error("malformed testcase: missing expected double value");
     }
@@ -907,6 +910,9 @@ Test::checkResult( double result)
     }
     else if (std::isnan(expectedRes)) {
         isSuccess = std::isnan(result);
+    }
+    else if( expectedRes == result ) {
+        isSuccess = true;
     }
     else {
         if (std::abs(expectedRes - result) / expectedRes < 1e-3) {

--- a/tests/xmltester/tests/general/TestDistance.xml
+++ b/tests/xmltester/tests/general/TestDistance.xml
@@ -4,8 +4,8 @@
   <desc>PeP - point to an empty point</desc>
   <a>    POINT(10 10)  </a>
   <b>    POINT EMPTY  </b>
-<test><op name="distance" arg1="A" arg2="B">    NaN   </op></test>
-<test><op name="distance" arg1="B" arg2="A">    NaN   </op></test>
+<test><op name="distance" arg1="A" arg2="B">    inf   </op></test>
+<test><op name="distance" arg1="B" arg2="A">    inf   </op></test>
 </case>
 
 <case>
@@ -36,8 +36,8 @@
   <desc>LL - line to empty line</desc>
   <a>    LINESTRING (0 0, 0 10)  </a>
   <b>    LINESTRING EMPTY  </b>
-<test><op name="distance" arg1="A" arg2="B">    NaN   </op></test>
-<test><op name="distance" arg1="B" arg2="A">    NaN   </op></test>
+<test><op name="distance" arg1="A" arg2="B">    inf   </op></test>
+<test><op name="distance" arg1="B" arg2="A">    inf   </op></test>
 </case>
 
 <case>
@@ -68,8 +68,8 @@
   <desc>PA - point to empty polygon</desc>
   <a>    POINT (240 160)  </a>
   <b>    POLYGON EMPTY  </b>
-<test><op name="distance" arg1="A" arg2="B" >    NaN   </op></test>
-<test><op name="distance" arg1="B" arg2="A" >    NaN   </op></test>
+<test><op name="distance" arg1="A" arg2="B" >    inf   </op></test>
+<test><op name="distance" arg1="B" arg2="A" >    inf   </op></test>
 </case>
 
 <case>


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/12978