### PR TITLE
performance improvements to the overlayng polygon builder

### DIFF
--- a/include/geos/operation/overlayng/OverlayEdgeRing.h
+++ b/include/geos/operation/overlayng/OverlayEdgeRing.h
@@ -52,7 +52,7 @@ class GEOS_DLL OverlayEdgeRing {
     using Polygon = geos::geom::Polygon;
     using PointOnGeometryLocator = algorithm::locate::PointOnGeometryLocator;
     using IndexedPointInAreaLocator = algorithm::locate::IndexedPointInAreaLocator;
-
+    
 private:
 
     // Members
@@ -63,6 +63,7 @@ private:
     OverlayEdgeRing* shell;
     // a list of EdgeRings which are holes in this EdgeRing
     std::vector<OverlayEdgeRing*> holes;
+    std::unique_ptr<std::unordered_set<Coordinate, geom::CoordinateXY::HashCode>> coordinatesSet;
 
     // Methods
     void computeRingPts(OverlayEdge* start, CoordinateSequence& pts);
@@ -75,6 +76,7 @@ private:
     */
     const CoordinateSequence& getCoordinates();
     PointOnGeometryLocator* getLocator();
+    std::unordered_set<Coordinate, geom::CoordinateXY::HashCode>* getCoordinatesSet();
     static void closeRing(CoordinateSequence& pts);
 
 


### PR DESCRIPTION
Preface: I'm new to this, so apologies ahead of time if I'm making stupid mistakes. ;)

This PR aims to optimize the `findEdgeRingContaining` function in `OverlayEdge.cpp`.
Given a list of rings and a target ring (B), this function tries to find the smallest ring in the list that encloses B.
In order to do so, the function loops over the rings in the list (we call the resulting ring A), and selects a vertex in B that is not a vertex in A.
This PR improves over the previous version by using an efficient data structure (unordered_set) to check for membership in A (i.e., to check whether a given vertex is part of the vertices that define A).
To prevent having to construct this data structure upon every check, the new code caches it as an extra property in the OverlayEdge object.
For the first check, the time complexity of both operations is linear, but then for subsequent checks, the new time complexity is constant, compared to linear in the old version.

This code should be functionally equivalent to the old version.
Interestingly, this particular vertex check does not seem to be present in JTS, so I'm not sure why the old version differed from JTS in the first place.

I did some rough benchmarking to assess the impact of this improvement, using some data sets taken from OSM.
In all cases, I took a region's administrative area as a single MultiPolygon, and subtracted its water areas as a single MultiPolygon as well (i.e., lakes, rivers, and areas off the coast, all merged together into a single MultiPolygon).
I measured the time it took for the MultiPolygon.difference operation (so not including any io-time, etc.)
Here are the results:

| Region | Total no. vertices | Old runtime | New runtime | Data set |
|-------------|--------------------------|--------------------|--------------------|---------------------------|
| Zuid Holland | 255334 | 126 ms | 105 ms | [zuid-holland.zip](https://github.com/user-attachments/files/24311323/zuid-holland.zip) |
| Netherlands | 1060845 | 618 ms | 558 ms | [netherlands.zip](https://github.com/user-attachments/files/24311335/netherlands.zip) |
| Spain | 1424729 | 2620 ms | 913 ms | (*) |
| Germany | 2590310 | 6976 ms | 2438 ms | (*) |
| France | 4006653 | 13747 ms | 3437 ms | (*) |

(*) Data sets are rather big, so available upon request.

As expected, the speed-up becomes bigger as the dataset size increases.

PS. The resulting runtimes can still be significantly improved by adding spatial indexing to the `placeFreeHoles` function in `PolygonBuilder.cpp`. I implemented that as well (not in this PR), but I'm thinking this is more of an algorithmic change, so it should probably be incorporated into JTS first. Happy to discuss what the proper course of action is here.