### PR TITLE
Add new CAPI functions for Hausdorff distance

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -318,9 +318,9 @@ extern "C" {
     }
 
     int
-    GEOSHausdorffDistanceWithPoints(const Geometry* g1, const Geometry* g2, double* dist, double* pt1_x, double* pt1_y, double* pt2_x, double* pt2_y)
+    GEOSHausdorffDistanceWithPoints(const Geometry* g1, const Geometry* g2, double* dist, double* p1x, double* p1y, double* p2x, double* p2y)
     {
-        return GEOSHausdorffDistanceWithPoints_r(handle, g1, g2, dist, pt1_x, pt1_y, pt2_x, pt2_y);
+        return GEOSHausdorffDistanceWithPoints_r(handle, g1, g2, dist, p1x, p1y, p2x, p2y);
     }
 
     int
@@ -330,9 +330,9 @@ extern "C" {
     }
 
     int
-    GEOSHausdorffDistanceDensifyWithPoints(const Geometry* g1, const Geometry* g2, double densifyFrac, double* dist, double* pt1_x, double* pt1_y, double* pt2_x, double* pt2_y)
+    GEOSHausdorffDistanceDensifyWithPoints(const Geometry* g1, const Geometry* g2, double densifyFrac, double* dist, double* p1x, double* p1y, double* p2x, double* p2y)
     {
-        return GEOSHausdorffDistanceDensifyWithPoints_r(handle, g1, g2, densifyFrac, dist, pt1_x, pt1_y, pt2_x, pt2_y); 
+        return GEOSHausdorffDistanceDensifyWithPoints_r(handle, g1, g2, densifyFrac, dist, p1x, p1y, p2x, p2y);
     }
 
     int

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1960,8 +1960,8 @@ extern int GEOS_DLL GEOSHausdorffDistanceWithPoints_r(
     const GEOSGeometry *g1,
     const GEOSGeometry *g2,
     double *dist,
-    double *pt1_x, double *pt1_y,
-    double *pt2_x, double *pt2_y);
+    double *p1x, double *p1y,
+    double *p2x, double *p2y);
 
 /** \see GEOSHausdorffDistanceDensify */
 extern int GEOS_DLL GEOSHausdorffDistanceDensify_r(
@@ -1976,8 +1976,8 @@ extern int GEOS_DLL GEOSHausdorffDistanceDensifyWithPoints_r(
     const GEOSGeometry *g1,
     const GEOSGeometry *g2,
     double densifyFrac, double* dist,
-    double *pt1_x, double *pt1_y,
-    double *pt2_x, double *pt2_y);
+    double *p1x, double *p1y,
+    double *p2x, double *p2y);
 
 /** \see GEOSFrechetDistance */
 extern int GEOS_DLL GEOSFrechetDistance_r(
@@ -3729,19 +3729,20 @@ extern int GEOS_DLL GEOSHausdorffDistance(
 * \param[in] g1 Input geometry
 * \param[in] g2 Input geometry
 * \param[out] dist Pointer to be filled in with distance result
-* \param[out] pt1_x X coordinate of point on g1
-* \param[out] pt1_y Y coordinate of point on g1
-* \param[out] pt2_x X coordinate of point on g2
-* \param[out] pt2_y Y coordinate of point on g2
+* \param[out] p1x X coordinate of point on g1
+* \param[out] p1y Y coordinate of point on g1
+* \param[out] p2x X coordinate of point on g2
+* \param[out] p2y Y coordinate of point on g2
 * \return 1 on success, 0 on exception.
 * \see geos::algorithm::distance::DiscreteHausdorffDistance
+* \since 3.15
 */
 extern int GEOS_DLL GEOSHausdorffDistanceWithPoints(
     const GEOSGeometry *g1,
     const GEOSGeometry *g2,
     double *dist,
-    double *pt1_x, double *pt1_y,
-    double *pt2_x, double *pt2_y);
+    double *p1x, double *p1y,
+    double *p2x, double *p2y);
 
 
 
@@ -3776,21 +3777,21 @@ extern int GEOS_DLL GEOSHausdorffDistanceDensify(
  * \param[in] densifyFrac The largest % of the overall line length that
  * any given two point segment should be.
  * \param[out] dist Pointer to be filled in with distance result
- * \param[out] pt1_x X coordinate of point on g1
- * \param[out] pt1_y Y coordinate of point on g1
- * \param[out] pt2_x X coordinate of point on g2
- * \param[out] pt2_y Y coordinate of point on g2
+ * \param[out] p1x X coordinate of point on g1
+ * \param[out] p1y Y coordinate of point on g1
+ * \param[out] p2x X coordinate of point on g2
+ * \param[out] p2y Y coordinate of point on g2
  * \return 1 on success, 0 on exception.
  * \see goes::algorithm::distance::DiscreteHausdorffDistance
- * \since 3.2
+ * \since 3.15
  */
 extern int GEOS_DLL GEOSHausdorffDistanceDensifyWithPoints(
     const GEOSGeometry *g1,
     const GEOSGeometry *g2,
     double densifyFrac,
     double *dist,
-    double* pt1_x, double* pt1_y,
-    double* pt2_x, double* pt2_y);
+    double* p1x, double* p1y,
+    double* p2x, double* p2y);
 
 /**
 * Calculate the

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -971,11 +971,17 @@ extern "C" {
     int
     GEOSHausdorffDistanceWithPoints_r(GEOSContextHandle_t extHandle,
         const Geometry* g1, const Geometry* g2,
-        double* dist, double* pt1_x, double* pt1_y,
-    	double* pt2_x, double* pt2_y)
+        double* dist, double* p1x, double* p1y,
+    	double* p2x, double* p2y)
     {
         return execute(extHandle, 0, [&]() {
-            *dist = DiscreteHausdorffDistance::distanceWithPoints(*g1, *g2, pt1_x, pt1_y, pt2_x, pt2_y);
+            DiscreteHausdorffDistance dhd(*g1, *g2);
+            *dist = dhd.distance();
+            const auto& pts = dhd.getCoordinates();
+            *p1x = pts[0].x;
+            *p1y = pts[0].y;
+            *p2x = pts[1].x;
+            *p2y = pts[1].y;
             return 1;
         });
     }
@@ -992,12 +998,19 @@ extern "C" {
 
     int
     GEOSHausdorffDistanceDensifyWithPoints_r(GEOSContextHandle_t extHandle, const Geometry* g1, const Geometry* g2,
-		                   double densifyFrac, double* dist, double* pt1_x, double* pt1_y, double* pt2_x, double* pt2_y)
+		                   double densifyFrac, double* dist, double* p1x, double* p1y, double* p2x, double* p2y)
     {
         return execute(extHandle, 0, [&]() {
-	   *dist = DiscreteHausdorffDistance::distanceDensifyWithPoints(*g1, *g2, densifyFrac, pt1_x, pt1_y, pt2_x, pt2_y);
-	   return 1;
-	});
+            DiscreteHausdorffDistance dhd(*g1, *g2);
+            dhd.setDensifyFraction(densifyFrac);
+            *dist = dhd.distance();
+            const auto& pts = dhd.getCoordinates();
+            *p1x = pts[0].x;
+            *p1y = pts[0].y;
+            *p2x = pts[1].x;
+            *p2y = pts[1].y;
+            return 1;
+        });
     }
 
     int

--- a/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
+++ b/include/geos/algorithm/distance/DiscreteHausdorffDistance.h
@@ -93,20 +93,10 @@ public:
 
     static double distance(const geom::Geometry& g0,
                            const geom::Geometry& g1);
-    
-    static double distanceWithPoints(const geom::Geometry& g0,
-		    		     const geom::Geometry& g1,
-				     double *pt1_x, double *pt1_y,
-   				     double *pt2_x, double *pt2_y);
 
     static double distance(const geom::Geometry& g0,
                            const geom::Geometry& g1, double densifyFrac);
    
-    static double distanceDensifyWithPoints(const geom::Geometry& g0,
-		       			    const geom::Geometry& g1, double densifrFrac,
-					    double *pt1_x, double *pt1_y,
-					    double *pt2_x, double *pt2_y);
-	    
     DiscreteHausdorffDistance(const geom::Geometry& p_g0,
                               const geom::Geometry& p_g1)
         :
@@ -140,7 +130,7 @@ public:
         return ptDist.getDistance();
     }
 
-    const std::array<geom::CoordinateXY, 2>
+    const std::array<geom::CoordinateXY, 2>&
     getCoordinates() const
     {
         return ptDist.getCoordinates();

--- a/src/algorithm/distance/DiscreteHausdorffDistance.cpp
+++ b/src/algorithm/distance/DiscreteHausdorffDistance.cpp
@@ -68,28 +68,6 @@ DiscreteHausdorffDistance::distance(const geom::Geometry& g0,
     return dist.distance();
 }
 
-/*static public*/
-/*populate double pointers with points used in computation and return distance*/
-double
-DiscreteHausdorffDistance::distanceWithPoints(const geom::Geometry& g0,
-				    const geom::Geometry& g1,
-				    double *pt1_x, double *pt1_y,
-				    double *pt2_x, double *pt2_y)
-{
-    DiscreteHausdorffDistance dist(g0, g1);
-    double distance = dist.distance();
-    const std::array<CoordinateXY, 2>& points = dist.getCoordinates();
-
-    *pt1_x = points[0].x;
-    *pt1_y = points[0].y;
-    *pt2_x = points[1].x;
-    *pt2_y = points[1].y;
-
-    return distance;
-}
-
-
-
 /* static public */
 double
 DiscreteHausdorffDistance::distance(const geom::Geometry& g0,
@@ -102,28 +80,7 @@ DiscreteHausdorffDistance::distance(const geom::Geometry& g0,
 }
 
 
-/* static public */
-double DiscreteHausdorffDistance::distanceDensifyWithPoints(const geom::Geometry& g0,
-							    const geom::Geometry& g1,
-							    double densifyFrac,
-							    double *pt1_x, double *pt1_y,
-							    double *pt2_x, double *pt2_y)
-{
-    DiscreteHausdorffDistance dist(g0, g1);
-    dist.setDensifyFraction(densifyFrac);
-    double distance = dist.distance();
-    const std::array<CoordinateXY, 2>& points = dist.getCoordinates();
-
-    *pt1_x = points[0].x;
-    *pt1_y = points[0].y;
-    *pt2_x = points[1].x;
-    *pt2_y = points[1].y;
-
-    return distance;
-}
-
 /* public */
-
 void DiscreteHausdorffDistance::setDensifyFraction(double dFrac)
 {
     // !(dFrac > 0) written that way to catch NaN

--- a/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
@@ -64,32 +64,6 @@ struct test_DiscreteHausdorffDistance_data {
 
     void
     runTest(const std::string& wkt1, const std::string& wkt2,
-	    double expectedDistance, std::array<CoordinateXY, 2> expectedPoints)
-    {
-        GeomPtr g1(reader.read(wkt1));
-	GeomPtr g2(reader.read(wkt2));
-        
-	double pt1_x;
-	double pt1_y;
-	double pt2_x;
-	double pt2_y;
-
-	double distance = DiscreteHausdorffDistance::distanceWithPoints(*g1, *g2, &pt1_x, &pt1_y, &pt2_x, &pt2_y);
-        
-	double diff = std::fabs(distance - expectedDistance);
-	double diffPt1_x = std::fabs(pt1_x - expectedPoints[0].x);
-	double diffPt1_y = std::fabs(pt1_y - expectedPoints[0].y);
-	double diffPt2_x = std::fabs(pt2_x - expectedPoints[1].x);
-	double diffPt2_y = std::fabs(pt2_y - expectedPoints[1].y);
-	ensure(diff <= TOLERANCE);
-	ensure(diffPt1_x <= TOLERANCE);
-	ensure(diffPt1_y <= TOLERANCE);
-	ensure(diffPt2_x <= TOLERANCE);
-	ensure(diffPt2_y <= TOLERANCE);
-    }
-
-    void
-    runTest(const std::string& wkt1, const std::string& wkt2,
             double densifyFactor, double expectedDistance)
     {
         GeomPtr g1(reader.read(wkt1));
@@ -101,34 +75,6 @@ struct test_DiscreteHausdorffDistance_data {
         // std::cerr << "expectedDistance:" << expectedDistance << " actual distance:" << distance << std::endl;
         ensure(diff <= TOLERANCE);
     }
-    void
-    runTest(const std::string& wkt1, const std::string& wkt2,
-	    double densifyFactor, double expectedDistance, std::array<CoordinateXY, 2> expectedPoints)
-    {
-        GeomPtr g1(reader.read(wkt1));
-	GeomPtr g2(reader.read(wkt2));
-
-	double pt1_x;
-	double pt1_y;
-	double pt2_x;
-	double pt2_y;
-
-	double distance = DiscreteHausdorffDistance::distanceDensifyWithPoints(*g1, *g2, densifyFactor, &pt1_x, &pt1_y, &pt2_x, &pt2_y);
-        
-	double distanceDiff = std::fabs(distance - expectedDistance);
-	double diffPt1_x = std::fabs(pt1_x - expectedPoints[0].x);
-	double diffPt1_y = std::fabs(pt1_y - expectedPoints[0].y);
-	double diffPt2_x = std::fabs(pt2_x - expectedPoints[1].x);
-	double diffPt2_y = std::fabs(pt2_y - expectedPoints[1].y);
-
-	ensure(distanceDiff <= TOLERANCE);
-	ensure(diffPt1_x <= TOLERANCE);
-	ensure(diffPt1_y <= TOLERANCE);
-        ensure(diffPt2_x <= TOLERANCE);
-	ensure(diffPt2_y <= TOLERANCE);
-    }
-
-
 
     PrecisionModel pm;
     GeometryFactory::Ptr gf;
@@ -287,20 +233,5 @@ void object::test<8>
             2.8284271247461903);
 }
 
-// Test 9 - Hausdorff with points
-// see https://github.com/libgeos/geos/issues/1327
-template<>
-template<>
-void object::test<9>
-()
-{	
-  const std::array<CoordinateXY, 2> expectedPoints = {
-    CoordinateXY(1.0, 1.0),
-    CoordinateXY(-5.0, 0.0)
-  };
-  runTest("LINEARRING (1 1, 1 2, 5 1, 1 1)", "LINEARRING (0 0, -5 0, 0 -1, 0 0)", 6.082763, expectedPoints);
-  //Densify of 0.001
-  runTest("LINEARRING (1 1, 1 2, 5 1, 1 1)", "LINEARRING (0 0, -5 0, 0 -1, 0 0)", 0.001,  6.082763, expectedPoints);
-}
-
 } // namespace tut
+

--- a/tests/unit/capi/GEOSHausdorffDistanceTest.cpp
+++ b/tests/unit/capi/GEOSHausdorffDistanceTest.cpp
@@ -72,4 +72,45 @@ void object::test<3>()
     ensure_equals("curved geometry not supported", GEOSHausdorffDistance(geom2_, geom1_, &dist), 0);
 }
 
+template<>
+template<>
+void object::test<4>()
+{
+    set_test_name("GEOSHausdorffDistanceWithPoints");
+
+    geom1_ = fromWKT("LINEARRING (1 1, 1 2, 5 1, 1 1)");
+    geom2_ = fromWKT("LINEARRING (0 0, -5 0, 0 -1, 0 0)");
+
+    double dist;
+    double p1x, p1y, p2x, p2y;
+    ensure_equals(GEOSHausdorffDistanceWithPoints(geom1_, geom2_, &dist, &p1x, &p1y, &p2x, &p2y), 1);
+
+    ensure_equals("dist", dist, 6.082763, 1e-5);
+    ensure_equals(p1x, 1);
+    ensure_equals(p1y, 1);
+    ensure_equals(p2x, -5);
+    ensure_equals(p2y, 0);
+}
+
+template<>
+template<>
+void object::test<5>()
+{
+    set_test_name("GEOSHausdorffDistanceDensifyWithPoints");
+
+    constexpr double densifyFrac = 0.001;
+    geom1_ = fromWKT("LINEARRING (1 1, 1 2, 5 1, 1 1)");
+    geom2_ = fromWKT("LINEARRING (0 0, -5 0, 0 -1, 0 0)");
+
+    double dist;
+    double p1x, p1y, p2x, p2y;
+    ensure_equals(GEOSHausdorffDistanceDensifyWithPoints(geom1_, geom2_, densifyFrac, &dist, &p1x, &p1y, &p2x, &p2y), 1);
+
+    ensure_equals("dist", dist, 6.082763, 1e-5);
+    ensure_equals(p1x, 1);
+    ensure_equals(p1y, 1);
+    ensure_equals(p2x, -5);
+    ensure_equals(p2y, 0);
+}
+
 } // namespace tut


### PR DESCRIPTION
Regarding this issue #1327

Introduce two new CAPI functions:
- GEOSHausdorffDistanceWithPoints
- GEOSHausdorffDistanceDensifyWithPoints

These functions take four additional double pointers (pt1_x, pt1_y, pt2_x, pt2_y) and fill them with the coordinates used in the Hausdorff distance calculation via getCoordinates().

Also add a unit test verifying the new function behavior.