### PR TITLE
OverlayEdgeRing: Preserve M values when closing ring

### DIFF
--- a/src/operation/overlayng/OverlayEdgeRing.cpp
+++ b/src/operation/overlayng/OverlayEdgeRing.cpp
@@ -128,7 +128,7 @@ void
 OverlayEdgeRing::closeRing(CoordinateSequence& pts)
 {
     if(pts.size() > 0) {
-        pts.add(pts.getAt(0), false);
+        pts.closeRing(false);
     }
 }
 

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -326,5 +326,20 @@ void object::test<23>()
     checkPrecision(wkt,  100000, "LINESTRING ( 700000 200000,  700000 1400000)");
 }
 
+template<>
+template<>
+void object::test<24>()
+{
+    // https://github.com/libgeos/geos/issues/1365{
+    set_test_name("M value retained on last point");
+
+    input_ = fromWKT("POLYGON ZM ((0 0 0 0, 0 1 1 1, 1 1 2 3, 1 0 4 5, 0 0 6 7))");
+    expected_ = fromWKT("POLYGON ZM ((0 1 1 1, 1 1 2 3, 1 0 4 5, 0 0 6 7, 0 1 1 1))");
+
+    result_ = GEOSGeom_setPrecision(input_, 0.1, 0);
+
+    ensure(GEOSEqualsIdentical(result_, expected_));
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Resolves https://github.com/libgeos/geos/issues/1365

Issue also discussed by @scottrhoyt in https://gist.github.com/scottrhoyt/8c7373fec25b677b9c0437bb6a4ce418#set-theoretic-operations