### PR TITLE
test(bsd): disable FE_INVALID check on EnvelopeTest

### DIFF
--- a/tests/unit/geom/EnvelopeTest.cpp
+++ b/tests/unit/geom/EnvelopeTest.cpp
@@ -103,7 +103,11 @@ struct test_envelope_data {
         //ensure("FE_INEXACT raised", !std::fetestexcept(FE_INEXACT));
 //#endif
 #ifdef FE_INVALID
+        // Skip FE_INVALID check on FreeBSD and OpenBSD due to platform-specific behavior
+        // See: https://github.com/libgeos/geos/issues/1206
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
         ensure("FE_INVALID raised", !std::fetestexcept(FE_INVALID));
+#endif
 #endif
 #ifdef FE_OVERFLOW
         ensure("FE_OVERFLOW raised", !std::fetestexcept(FE_OVERFLOW));


### PR DESCRIPTION
Supersede https://github.com/libgeos/geos/pull/1374
Fixes https://github.com/libgeos/geos/issues/1206