### PR TITLE
Added a spatial index to the overlayng polygonbuilder

### DIFF
--- a/src/operation/overlayng/PolygonBuilder.cpp
+++ b/src/operation/overlayng/PolygonBuilder.cpp
@@ -174,11 +174,12 @@ PolygonBuilder::placeFreeHoles(const std::vector<OverlayEdgeRing*>& shells, cons
         index.insert(*shell->getRingPtr()->getEnvelopeInternal(), shell);
     }
 
+    std::vector<OverlayEdgeRing*> shellListOverlaps;
     for (OverlayEdgeRing* hole : freeHoles) {
         // only place this hole if it doesn't yet have a shell
         if (hole->getShell() == nullptr) {
             // get list of overlapping shells
-            std::vector<OverlayEdgeRing*> shellListOverlaps;
+            shellListOverlaps.clear();
             index.query(*hole->getRingPtr()->getEnvelopeInternal(), shellListOverlaps);
 
             OverlayEdgeRing* shell = hole->findEdgeRingContaining(shellListOverlaps);


### PR DESCRIPTION
This PR ports [this JTS PR](https://github.com/locationtech/jts/pull/1173) to GEOS. It adds a spatial index to the polygonbuilder in overlayNG.

The proposed implementation differs from the JTS implementation, since the latter uses an HPR-tree (Hilbert-packed R-tree) as the spatial filter. The implementation of the HPR-tree has not yet been ported to GEOS, so I'm using an STR-tree here instead. Following the discussion [at the JTS PR](https://github.com/locationtech/jts/pull/1173), the adverse consequences should be insignificant.

The performance improvements are substantial. Similar to [this GEOS PR](https://github.com/libgeos/geos/pull/1353), I benchmarked the code using a difference operation between two MultiPolygons. To simulate real-world data, I used datasets taken from OSM. Specifically, I took the landmass of a region, and subtracted all its rivers and lakes. The resulting runtimes are listed in the table below.

|Region|No. points object|No. points water|Old runtime (ms)|New runtime (ms)|
|-|-|-|-|-|
|Zuid Holland|10338|244996|121|119|
|Netherlands|130042|930803|635|511|
|Spain|637196|787533|943|707|
|Germany|264483|2325827|2565|1305|
|France|653589|3353064|3928|2330|
|USA|8473315|28684522|508820|24706|

All timings have been obtained by taking the average runtime of 5 independent runs. The improvement becomes pretty significant for large objects (~20x improvement for USA), signifying that this PR removes a considerable bottleneck in the old implementation. I also verified that the two implementations produce the same results by comparing the areas of the resulting objects.