### PR TITLE
Add CI support for building and testing Geos on Windows ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,15 @@ jobs:
 
   windows-msvc-msbuild:
     name: Windows (MSVC MSBuild)
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
+  
     steps:
     - name: 'Check Out'
       uses: actions/checkout@v4
@@ -339,6 +347,7 @@ jobs:
         cmake --version
         cmake ^
           -G "Visual Studio 17 2022" ^
+          -A ${{ matrix.arch }} ^
           -D CMAKE_BUILD_TYPE=Debug ^
           -D CMAKE_CXX_STANDARD=17 ^
           -D BUILD_SHARED_LIBS=ON ^
@@ -362,6 +371,9 @@ jobs:
         - os: windows-2025
           cxxstd: 20
           arch: x64
+        - os: windows-11-arm
+          cxxstd: 20
+          arch: arm64
 
     runs-on: ${{ matrix.ci.os }}
     steps:
@@ -619,3 +631,4 @@ jobs:
         cmake --build build -j $(nproc)
         build/capi_read
         test ! -f build/geos/bin/test_geos_unit || { echo "Error: GEOS tests were built" 1>&2 ; exit 1; }
+  


### PR DESCRIPTION
**PR Description:**
* The PR adds CI support for building and testing Geos on Windows ARM64

**Changes Proposed:**
* Added Windows ARM64 build configurations in the workflow file[workflows/ci.yml].