### PR TITLE
SegmentNodeList: Preserve Z/M in mixed-dimension overlay

### DIFF
--- a/src/noding/SegmentNodeList.cpp
+++ b/src/noding/SegmentNodeList.cpp
@@ -280,6 +280,14 @@ SegmentNodeList::createSplitEdgePts(const SegmentNode *ei0, const SegmentNode *e
     pts->add(*edgeCoords, ei0->segmentIndex + 1, ei1->segmentIndex);
     if (useIntPt1) {
         pts->add(ei1->coord);
+    } else if (ei1->coord.equals2D(lastSegStartPt)) {
+        // Can we pick up Z/M values from ei1 that weren't present in edgeCoords?
+        if (constructZ && !edgeCoords->hasZ() && !std::isnan(ei1->coord.z)) {
+            pts->setZ(pts->size() - 1, ei1->coord.z);
+        }
+        if (constructM && !edgeCoords->hasM() && !std::isnan(ei1->coord.m)) {
+            pts->setM(pts->size() - 1, ei1->coord.m);
+        }
     }
 
     assert(pts->size() == npts);

--- a/src/operation/overlayng/OverlayUtil.cpp
+++ b/src/operation/overlayng/OverlayUtil.cpp
@@ -311,7 +311,7 @@ OverlayUtil::toLines(OverlayGraph* graph, bool isOutputEdges, const GeometryFact
       bool includeEdge = isOutputEdges || edge->isInResultArea();
       if (! includeEdge) continue;
 
-      std::shared_ptr<const CoordinateSequence> pts = edge->getCoordinatesOriented();
+      const auto& pts = edge->getCoordinatesOriented();
       std::unique_ptr<LineString> line = geomFact->createLineString(pts);
       // line->setUserData(labelForResult(edge));
       lines.push_back(std::move(line));

--- a/tests/unit/capi/GEOSNodeTest.cpp
+++ b/tests/unit/capi/GEOSNodeTest.cpp
@@ -331,7 +331,7 @@ void object::test<15>()
     result_ = GEOSNode(input_);
     ensure(result_ != nullptr);
 
-    expected_ = fromWKT("MULTILINESTRING Z ((-5 0 3, 4 3 6), (0 0 NaN, 4 3 NaN))");
+    expected_ = fromWKT("MULTILINESTRING Z ((-5 0 3, 4 3 6), (0 0 NaN, 4 3 6))");
 
     ensure_equals_exact_geometry_xyzm(reinterpret_cast<Geometry*>(result_),
                                       reinterpret_cast<Geometry*>(expected_), 1e-4);
@@ -349,7 +349,7 @@ void object::test<16>()
     result_ = GEOSNode(input_);
     ensure(result_ != nullptr);
 
-    expected_ = fromWKT("MULTICURVE Z (CIRCULARSTRING Z (-5 0 3, -1.5811388301 4.7434164903 4.5, 4 3 6), (0 0 NaN, 4 3 NaN))");
+    expected_ = fromWKT("MULTICURVE Z (CIRCULARSTRING Z (-5 0 3, -1.5811388301 4.7434164903 4.5, 4 3 6), (0 0 NaN, 4 3 6))");
 
     ensure_equals_exact_geometry_xyzm(reinterpret_cast<Geometry*>(result_),
                                       reinterpret_cast<Geometry*>(expected_), 1e-4);

--- a/tests/unit/capi/GEOSSharedPathsTest.cpp
+++ b/tests/unit/capi/GEOSSharedPathsTest.cpp
@@ -99,5 +99,40 @@ void object::test<4>()
     ensure("curved geometry not supported", result_ == nullptr);
 }
 
+template<>
+template<>
+void object::test<5>() {
+    set_test_name("Z/M values taken from first input");
+
+    geom1_ = fromWKT("LINESTRING ZM (0 1 5 4, 0 0 6 5, 1 0 7 6, 1 1 8 7)");
+    geom2_ = fromWKT("LINESTRING ZM (0 -1 3 8, 0 0 2 9, 1 0 1 10, 1 -1 0 11)");
+
+    ensure(geom1_);
+    ensure(geom2_);
+
+    result_ = GEOSSharedPaths(geom1_, geom2_);
+
+    expected_ = fromWKT("GEOMETRYCOLLECTION(MULTILINESTRING ZM ((0 0 6 5, 1 0 7 6)), MULTILINESTRING EMPTY)");
+    ensure_geometry_equals_identical(result_, expected_);
+}
+
+template<>
+template<>
+void object::test<6>() {
+    set_test_name("Z/M values taken from second input");
+
+    geom1_ = fromWKT("LINESTRING (0 1, 0 0, 1 0, 1 1)");
+    geom2_ = fromWKT("LINESTRING ZM (0 -1 3 8, 0 0 2 9, 1 0 1 10, 1 -1 0 11)");
+
+    ensure(geom1_);
+    ensure(geom2_);
+
+    result_ = GEOSSharedPaths(geom1_, geom2_);
+
+    expected_ = fromWKT("GEOMETRYCOLLECTION(MULTILINESTRING ZM ((0 0 2 9, 1 0 1 10)), MULTILINESTRING EMPTY)");
+    ensure_geometry_equals_identical(result_, expected_);
+}
+
+
 } // namespace tut
 

--- a/tests/unit/operation/overlayng/OverlayNGZTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayNGZTest.cpp
@@ -294,4 +294,26 @@ void object::test<19>()
                       "POINT M (5 5 99)");
 }
 
+template<>
+template<>
+void object::test<20>()
+{
+    set_test_name("LINESTRING / LINESTRING ZM intersection");
+
+    checkIntersection("LINESTRING (0 0, 1 0)",
+        "LINESTRING ZM (0 0 2 9, 1 0 5 7)",
+        "LINESTRING ZM (0 0 2 9, 1 0 5 7)");
+}
+
+template<>
+template<>
+void object::test<21>()
+{
+    set_test_name("LINESTRING M / LINESTRING Z intersection");
+
+    checkIntersection("LINESTRING M (0 0 9, 1 0 7)",
+        "LINESTRING Z (1 0 5, 0 0 2)",
+        "LINESTRING ZM (0 0 2 9, 1 0 5 7)");
+}
+
 } // namespace tut


### PR DESCRIPTION
Handle a case where Z and M were previously dropped.