### PR TITLE
Fix size_t underflow in CircularString::createArcs() for empty input

### DIFF
--- a/src/geom/CircularString.cpp
+++ b/src/geom/CircularString.cpp
@@ -49,6 +49,9 @@ CircularString::clone() const
 void
 CircularString::createArcs() const
 {
+    if (points->getSize() < 3) {
+        return;
+    }
     for (std::size_t i = 0; i < points->getSize() - 2; i += 2) {
         arcs.emplace_back(*points, i);
     }

--- a/tests/unit/capi/GEOSNodeTest.cpp
+++ b/tests/unit/capi/GEOSNodeTest.cpp
@@ -355,5 +355,24 @@ void object::test<16>()
                                       reinterpret_cast<Geometry*>(expected_), 1e-4);
 }
 
+// Test empty CircularString noding (underflow regression test)
+template<>
+template<>
+void object::test<17>()
+{
+    set_test_name("empty CIRCULARSTRING does not cause underflow");
+
+    geom1_ = GEOSGeomFromWKT("CIRCULARSTRING EMPTY");
+    ensure(geom1_ != nullptr);
+
+    geom2_ = GEOSNode(geom1_);
+    ensure(geom2_ != nullptr);
+
+    wkt_ = GEOSWKTWriter_write(wktw_, geom2_);
+    std::string out(wkt_);
+
+    ensure_equals(out, "CIRCULARSTRING EMPTY");
+}
+
 } // namespace tut
 

--- a/tests/unit/geom/CircularStringTest.cpp
+++ b/tests/unit/geom/CircularStringTest.cpp
@@ -199,4 +199,19 @@ void object::test<5>()
     ensure_THROW(factory_->createCircularString(pts), geos::util::GEOSException);
 }
 
+// Test that getArcs() on empty CircularString does not cause underflow
+template<>
+template<>
+void object::test<6>()
+{
+    set_test_name("getArcs on empty CircularString");
+
+    auto cs = factory_->createCircularString(false, false);
+    ensure(cs->isEmpty());
+
+    // This should not cause size_t underflow or infinite loop
+    const auto& arcs = cs->getArcs();
+    ensure_equals(arcs.size(), 0u);
+}
+
 }


### PR DESCRIPTION
`CircularString::createArcs()` uses `points->getSize() - 2` as the loop bound. When size is 0 (valid empty CircularString), this underflows to ~2^64, causing unbounded iterations, OOB access, and potential DoS.

### Fix
Guard against insufficient points before the loop:

```cpp
void CircularString::createArcs() const
{
    if (points->getSize() < 3) {
        return;
    }
    for (std::size_t i = 0; i < points->getSize() - 2; i += 2) {
        arcs.emplace_back(*points, i);
    }
}
```

### Tests
- `CircularStringTest::test<6>`: Verifies `getArcs()` returns empty vector for empty CircularString
- `GEOSNodeTest::test<17>`: Verifies `GEOSNode` handles `CIRCULARSTRING EMPTY` without crash