### PR TITLE
Add dependabot to help maintain GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Add dependabot to help check GitHub Actions on a monthly schedule. Full docs [here](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference).

This is a follow-up from #1392. This configuration is currently identical to [gdal](https://github.com/OSGeo/gdal/blob/master/.github/dependabot.yml) and [PROJ](https://github.com/OSGeo/PROJ/blob/master/.github/dependabot.yml) projects.