### PR TITLE
CI: build container tags using docker/metadata-action

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*.*.*'
     paths-ignore:
       - 'web/**'
 
@@ -24,8 +26,17 @@ jobs:
 
     - uses: actions/checkout@v6
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v6
+      with:
+        images: ghcr.io/libgeos/geosop
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{version}}
+          type=sha
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v4
@@ -33,6 +44,9 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
 
     - name: Get Dockerfile
       run: |
@@ -42,11 +56,6 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: .
-        # platforms: linux/amd64,linux/arm64
-        platforms: linux/amd64
         push: true
-        tags: |
-            ghcr.io/libgeos/geosop:latest
-
-
-
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/tools/ci/geosop/Dockerfile
+++ b/tools/ci/geosop/Dockerfile
@@ -1,28 +1,38 @@
-FROM docker.osgeo.org/geos/build-test:alpine AS base
-ARG VERSION=47f145e
+ARG BASEIMAGE="alpine:3.23"
+ARG GEOS_VERSION
 
-WORKDIR /source
+FROM ${BASEIMAGE} AS builder
+
+RUN apk add --no-cache \
+  cmake \
+  ninja \
+  g++ \
+  gcc
+
 ADD . /source
 
-#RUN wget --quiet https://github.com/libgeos/geos/archive/${VERSION}.tar.gz --output-document - \
-#| tar xz --directory=. --strip-components=1
+ARG GEOS_VERSION
+ENV GEOS_VERSION=${GEOS_VERSION}
+RUN if [ -n "${GEOS_VERSION}" ]; then \
+    rm -rf /source && mkdir /source && \
+    wget https://github.com/libgeos/geos/archive/${GEOS_VERSION}.tar.gz \
+      --output-document - | tar xz --directory=/source --strip-components=1; \
+  fi
 
-WORKDIR /build
-RUN cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_BENCHMARKS=OFF -D BUILD_TESTING=OFF /source \
-  && make install \
-  && cp bin/geosop /usr/local/bin/geosop
+RUN cmake -S /source -B /build -G Ninja \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_LIBDIR=lib \
+    -D BUILD_BENCHMARKS=OFF \
+    -D BUILD_DOCUMENTATION=OFF \
+    -D BUILD_TESTING=OFF \
+  && cmake --build /build \
+  && cmake --install /build --prefix /install --strip
 
-WORKDIR /install/bin
-RUN cp --no-dereference /usr/local/bin/geos* . \
-  && for i in ./*; do strip -s $i 2>/dev/null || /bin/true; done
+FROM ${BASEIMAGE} AS runner
 
-WORKDIR /install/lib
-RUN cp --no-dereference /usr/local/lib*/libgeos*.so.* . \
-  && for i in ./*; do strip -s $i 2>/dev/null || /bin/true; done
-
-FROM alpine
 RUN apk add --no-cache libstdc++
-COPY --from=base /install/bin/geos* /usr/local/bin/
-COPY --from=base /install/lib/libgeos* /usr/local/lib/
+
+COPY --from=builder /install/bin/geosop /usr/local/bin/geosop
+COPY --from=builder /install/lib/libgeos.* /usr/local/lib/
 
 ENTRYPOINT ["geosop"]


### PR DESCRIPTION
This PR refactors the workflow used to build containers to use [docker/metadata-action](https://github.com/docker/metadata-action) on pushes to main (as already done) as well as for releases. It's difficult to test the refactored GitHub Action in a pull request, so it may require further attention.

Other changes refactor the Dockerfile to use alpine images for the builder, and cmake commands to install and strip executables. This removes `geos-conf` and `libgeos_c.*` files, which are not needed for running geosop.

The same Dockerfile could also be used to manually build older versions from a cli:
```bash
docker build tools/ci/geosop -t ghcr.io/libgeos/geosop:3.10.1 --build-arg GEOS_VERSION=3.10.1 --build-arg BASEIMAGE=alpine:3.13 
docker push ghcr.io/libgeos/geosop:3.10.1 ghcr.io/libgeos/geosop
```
(This older version of GEOS needs an older image to compile). This appeared to work, and I could manually push the previous older versions of geosop to the [main ghcr.io](https://github.com/libgeos/geos/pkgs/container/geosop) too.

Closes #1398