### PR TITLE
GEOSNode: Avoid crash on collection with empty components

### DIFF
--- a/src/noding/GeometryNoder.cpp
+++ b/src/noding/GeometryNoder.cpp
@@ -66,6 +66,10 @@ public:
     void
     filter_ro(const geom::Geometry* g) override
     {
+        if (g->isEmpty()) {
+            return;
+        }
+
         if(const auto* ls = dynamic_cast<const geom::LineString*>(g)) {
             auto coord = ls->getSharedCoordinates();
             auto ss = std::make_unique<NodedSegmentString>(coord, _constructZ, _constructM, nullptr);

--- a/tests/unit/capi/GEOSNodeTest.cpp
+++ b/tests/unit/capi/GEOSNodeTest.cpp
@@ -355,5 +355,17 @@ void object::test<16>()
                                       reinterpret_cast<Geometry*>(expected_), 1e-4);
 }
 
+template<>
+template<>
+void object::test<17>()
+{
+    set_test_name("GeometryCollection with empty element");
+
+    input_ = fromWKT("GEOMETRYCOLLECTION (POLYGON EMPTY, POLYGON ((0 0, 1 1, 0 1, 0 0)))");
+
+    result_ = GEOSNode(input_);
+    ensure(result_);
+}
+
 } // namespace tut
 


### PR DESCRIPTION
Resolves https://github.com/libgeos/geos/issues/1406