### PR TITLE
OverlayEdge: Avoid unintended ring rotation

### DIFF
--- a/src/operation/overlayng/OverlayEdge.cpp
+++ b/src/operation/overlayng/OverlayEdge.cpp
@@ -55,7 +55,7 @@ OverlayEdge::getCoordinatesOriented() const
 void
 OverlayEdge::addCoordinates(CoordinateSequence* coords) const
 {
-    bool isFirstEdge = coords->size() > 0;
+    const bool isFirstEdge = coords->isEmpty();
     if (direction) {
         std::size_t startIndex = 1;
         if (isFirstEdge) {

--- a/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
+++ b/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
@@ -333,12 +333,10 @@ void object::test<24>()
     // https://github.com/libgeos/geos/issues/1365{
     set_test_name("M value retained on last point");
 
-    input_ = fromWKT("POLYGON ZM ((0 0 0 0, 0 1 1 1, 1 1 2 3, 1 0 4 5, 0 0 6 7))");
-    expected_ = fromWKT("POLYGON ZM ((0 1 1 1, 1 1 2 3, 1 0 4 5, 0 0 6 7, 0 1 1 1))");
-
+    input_ = fromWKT("POLYGON ZM ((0 0 6 7, 0 1 1 1, 1 1 2 3, 1 0 4 5, 0 0 6 7))");
     result_ = GEOSGeom_setPrecision(input_, 0.1, 0);
 
-    ensure(GEOSEqualsIdentical(result_, expected_));
+    ensure_geometry_equals_identical(result_, input_);
 }
 
 } // namespace tut

--- a/tests/unit/capi/GEOSMakeValidTest.cpp
+++ b/tests/unit/capi/GEOSMakeValidTest.cpp
@@ -125,7 +125,8 @@ void object::test<7>()
     ensure(input_);
 
     result_ = GEOSMakeValid(input_);
-    expected_ = fromWKT("MULTIPOLYGON ZM (((0 0 1 2, 0.5 0.5 2.5 3.5, 1 0 2 3, 0 0 1 2)), ((1 1 4 5, 0.5 0.5 2.5 3.5, 0 1 3 4, 1 1 4 5)))");
+    expected_ = fromWKT("MULTIPOLYGON ZM (((0.5 0.5 2.5 3.5, 1 0 2 3, 0 0 1 2, 0.5 0.5 2.5 3.5)), ((0.5 0.5 2.5 3.5, 0 1 3 4, 1 1 4 5, 0.5 0.5 2.5 3.5)))");
+
     ensure_geometry_equals_identical(result_, expected_);
 }
 

--- a/tests/unit/capi/GEOSSubdivideByGridTest.cpp
+++ b/tests/unit/capi/GEOSSubdivideByGridTest.cpp
@@ -50,7 +50,7 @@ void object::test<2>()
 
     result_ = GEOSSubdivideByGrid(input_, 1, 0, 5, 3, 4, 3, true);
 
-    ensure_geometry_equals_identical(expected_, result_);
+    ensure_geometry_equals(expected_, result_);
 }
 
 }


### PR DESCRIPTION
Ref: https://github.com/locationtech/jts/pull/1187 and https://github.com/OSGeo/gdal/pull/13932#issuecomment-3910567713