### PR TITLE
Extract Shared and/or Boundary Edges from Polygonal Coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 2026-xx-xx
 
 - New things:
+  - Add GEOSCoverageEdges (Paul Ramsey)
   - Add new C API functions for Hausdorff distance (GH-1352, Sven Jensen)
   - Add GEOSSubdivideByGrid (GH-1232, Dan Baston)
 

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1100,6 +1100,15 @@ extern "C" {
             handle, input);
     }
 
+    GEOSGeometry *
+    GEOSCoverageEdges(
+        const GEOSGeometry * input,
+        int edgetype)
+    {
+        return GEOSCoverageEdges_r(
+            handle, input, edgetype);
+    }
+
     Geometry*
     GEOSRemoveRepeatedPoints(
         const Geometry* g,

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -938,6 +938,13 @@ GEOSCoverageSimplifyVW_r(
     double tolerance,
     int preserveBoundary);
 
+/** \see GEOSCoverageEdges */
+extern GEOSGeometry GEOS_DLL *
+GEOSCoverageEdges_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* input,
+    int edgetype);
+
 /** \see GEOSCoverageCleanParams_create */
 extern GEOSCoverageCleanParams GEOS_DLL *
 GEOSCoverageCleanParams_create_r(
@@ -4630,8 +4637,18 @@ extern GEOSGeometry GEOS_DLL * GEOSCoverageSimplifyVW(
     int preserveBoundary);
 
 /**
-* Create a default GEOSCoverageCleanParams object for controlling
-* the way invalid polygon interactions are repaired by \ref GEOSCoverageCleanWithParams.
+ * Returns a MultiLineString representing the unique edges of a polygonal coverage.
+ *
+ * \param input a GeometryCollection or MultiPolygon representing the coverage.
+ * \param edgetype selection type: 0 = ALL, 1 = INTERIOR (shared), 2 = EXTERIOR (non-shared).
+ * \return a MultiLineString of unique edges, or NULL on error.
+ *
+ * \since 3.15
+ */
+extern GEOSGeometry GEOS_DLL *GEOSCoverageEdges(const GEOSGeometry *input, int edgetype);
+
+/**
+ * Create a default GEOSCoverageCleanParams object for controlling* the way invalid polygon interactions are repaired by \ref GEOSCoverageCleanWithParams.
 * \return A newly allocated GEOSCoverageCleanParams. NULL on exception.
 * Caller is responsible for freeing with GEOSCoverageCleanParams_destroy().
 *

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -4640,7 +4640,7 @@ extern GEOSGeometry GEOS_DLL * GEOSCoverageSimplifyVW(
  * Returns a MultiLineString representing the unique edges of a polygonal coverage.
  *
  * \param input a GeometryCollection or MultiPolygon representing the coverage.
- * \param edgetype selection type: 0 = ALL, 1 = INTERIOR (shared), 2 = EXTERIOR (non-shared).
+ * \param edgetype selection type: 0 = ALL, 1 = EXTERIOR (non-shared), 2 = INTERIOR (shared).
  * \return a MultiLineString of unique edges, or NULL on error.
  *
  * \since 3.15

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -28,6 +28,7 @@
 #include <geos/algorithm/distance/DiscreteFrechetDistance.h>
 #include <geos/algorithm/hull/ConcaveHull.h>
 #include <geos/algorithm/hull/ConcaveHullOfPolygons.h>
+#include <geos/coverage/CoverageEdges.h>
 #include <geos/coverage/CoverageCleaner.h>
 #include <geos/coverage/CoverageSimplifier.h>
 #include <geos/coverage/CoverageUnion.h>
@@ -4817,5 +4818,16 @@ extern "C" {
         return GEOSCoverageCleanWithParams_r(extHandle, input, nullptr);
     }
 
+    GEOSGeometry *
+    GEOSCoverageEdges_r(GEOSContextHandle_t extHandle,
+        const GEOSGeometry* input,
+        int edgetype)
+    {
+        using geos::coverage::CoverageEdges;
+
+        return execute(extHandle, [&]() -> Geometry* {
+            return CoverageEdges::GetEdges(input, edgetype).release();
+        });
+    }
 
 } /* extern "C" */

--- a/include/geos/coverage/CoverageEdges.h
+++ b/include/geos/coverage/CoverageEdges.h
@@ -1,0 +1,52 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2026 Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/export.h>
+#include <memory>
+#include <vector>
+
+// Forward declarations
+namespace geos {
+namespace geom {
+class Geometry;
+}
+}
+
+namespace geos {      // geos
+namespace coverage { // geos::coverage
+
+/**
+ * Utility to extract unique edges from a polygonal coverage.
+ *
+ * @author Paul Ramsey
+ *
+ */
+class GEOS_DLL CoverageEdges {
+public:
+
+    /**
+    * Returns a MultiLineString representing the unique edges of a polygonal coverage.
+    *
+    * @param coverage a GeometryCollection or MultiPolygon representing the coverage
+    * @param type selection type: 0 = ALL, 1 = INTERIOR (shared), 2 = EXTERIOR (non-shared)
+    * @return a MultiLineString of unique edges
+    */
+    static std::unique_ptr<geom::Geometry> GetEdges(const geom::Geometry* coverage, int type = 0);
+
+};
+
+} // namespace geos::coverage
+} // namespace geos

--- a/include/geos/coverage/CoverageEdges.h
+++ b/include/geos/coverage/CoverageEdges.h
@@ -40,8 +40,17 @@ public:
     /**
     * Returns a MultiLineString representing the unique edges of a polygonal coverage.
     *
+    * @param coverage a vector of polygons in the coverage
+    * @param type selection type: 0 = ALL, 1 = EXTERIOR (non-shared), 2 = INTERIOR (shared)
+    * @return a MultiLineString of unique edges
+    */
+    static std::unique_ptr<geom::Geometry> GetEdges(const std::vector<const geom::Geometry*>& coverage, int type = 0);
+
+    /**
+    * Returns a MultiLineString representing the unique edges of a polygonal coverage.
+    *
     * @param coverage a GeometryCollection or MultiPolygon representing the coverage
-    * @param type selection type: 0 = ALL, 1 = INTERIOR (shared), 2 = EXTERIOR (non-shared)
+    * @param type selection type: 0 = ALL, 1 = EXTERIOR (non-shared), 2 = INTERIOR (shared)
     * @return a MultiLineString of unique edges
     */
     static std::unique_ptr<geom::Geometry> GetEdges(const geom::Geometry* coverage, int type = 0);

--- a/src/coverage/CoverageEdges.cpp
+++ b/src/coverage/CoverageEdges.cpp
@@ -1,0 +1,61 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2026 Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/coverage/CoverageEdges.h>
+#include <geos/coverage/CoverageRingEdges.h>
+#include <geos/coverage/CoverageEdge.h>
+#include <geos/geom/Geometry.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/MultiLineString.h>
+
+namespace geos {      // geos
+namespace coverage { // geos::coverage
+
+/* public static */
+std::unique_ptr<geom::Geometry>
+CoverageEdges::GetEdges(const geom::Geometry* input, int type)
+{
+    std::vector<const geom::Geometry*> coverage;
+    if (input->getGeometryTypeId() == geom::GEOS_GEOMETRYCOLLECTION ||
+        input->getGeometryTypeId() == geom::GEOS_MULTIPOLYGON) {
+        for (std::size_t i = 0; i < input->getNumGeometries(); i++) {
+            coverage.push_back(input->getGeometryN(i));
+        }
+    }
+    else {
+        coverage.push_back(input);
+    }
+
+    CoverageRingEdges cre(coverage);
+    std::vector<CoverageEdge*> selectedEdges;
+
+    for (auto* edge : cre.getEdges()) {
+        if (type == 1) { // INTERIOR
+            if (edge->getRingCount() > 1)
+                selectedEdges.push_back(edge);
+        }
+        else if (type == 2) { // EXTERIOR
+            if (edge->getRingCount() == 1)
+                selectedEdges.push_back(edge);
+        }
+        else { // ALL (0 and default)
+            selectedEdges.push_back(edge);
+        }
+    }
+
+    return CoverageEdge::createLines(selectedEdges, input->getFactory());
+}
+
+} // namespace geos::coverage
+} // namespace geos

--- a/src/coverage/CoverageEdges.cpp
+++ b/src/coverage/CoverageEdges.cpp
@@ -18,34 +18,29 @@
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/MultiLineString.h>
+#include <geos/geom/util/PolygonExtracter.h>
 
 namespace geos {      // geos
 namespace coverage { // geos::coverage
 
 /* public static */
 std::unique_ptr<geom::Geometry>
-CoverageEdges::GetEdges(const geom::Geometry* input, int type)
+CoverageEdges::GetEdges(const std::vector<const geom::Geometry*>& coverage, int type)
 {
-    std::vector<const geom::Geometry*> coverage;
-    if (input->getGeometryTypeId() == geom::GEOS_GEOMETRYCOLLECTION ||
-        input->getGeometryTypeId() == geom::GEOS_MULTIPOLYGON) {
-        for (std::size_t i = 0; i < input->getNumGeometries(); i++) {
-            coverage.push_back(input->getGeometryN(i));
-        }
-    }
-    else {
-        coverage.push_back(input);
+    if (coverage.empty()) {
+        return nullptr;
     }
 
+    const geom::GeometryFactory* factory = coverage[0]->getFactory();
     CoverageRingEdges cre(coverage);
     std::vector<CoverageEdge*> selectedEdges;
 
     for (auto* edge : cre.getEdges()) {
-        if (type == 1) { // INTERIOR
+        if (type == 2) { // INTERIOR
             if (edge->getRingCount() > 1)
                 selectedEdges.push_back(edge);
         }
-        else if (type == 2) { // EXTERIOR
+        else if (type == 1) { // EXTERIOR
             if (edge->getRingCount() == 1)
                 selectedEdges.push_back(edge);
         }
@@ -54,8 +49,28 @@ CoverageEdges::GetEdges(const geom::Geometry* input, int type)
         }
     }
 
-    return CoverageEdge::createLines(selectedEdges, input->getFactory());
+    return CoverageEdge::createLines(selectedEdges, factory);
 }
+
+/* public static */
+std::unique_ptr<geom::Geometry>
+CoverageEdges::GetEdges(const geom::Geometry* input, int type)
+{
+    std::vector<const geom::Polygon*> polygons;
+    geom::util::PolygonExtracter::getPolygons(*input, polygons);
+
+    if (polygons.empty()) {
+        return input->getFactory()->createMultiLineString();
+    }
+
+    std::vector<const geom::Geometry*> coverage;
+    for (const auto* poly : polygons) {
+        coverage.push_back(poly);
+    }
+
+    return GetEdges(coverage, type);
+}
+
 
 } // namespace geos::coverage
 } // namespace geos

--- a/tests/unit/capi/GEOSCoverageEdgesTest.cpp
+++ b/tests/unit/capi/GEOSCoverageEdgesTest.cpp
@@ -1,0 +1,51 @@
+//
+// Test Suite for GEOSCoverageEdges CAPI function.
+
+#include <tut/tut.hpp>
+// geos
+#include <geos_c.h>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used by all tests
+struct test_geoscoverageedges_data : public capitest::utility
+ {
+    test_geoscoverageedges_data() {}
+};
+
+typedef test_group<test_geoscoverageedges_data> group;
+typedef group::object object;
+
+group test_geoscoverageedges_data("capi::GEOSCoverageEdges");
+
+
+// testTwoAdjacentInterior
+template<>
+template<>
+void object::test<1> ()
+{
+    input_ = fromWKT("GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))");
+    result_ = GEOSCoverageEdges(input_, 1);
+    expected_ = fromWKT("MULTILINESTRING ((1 6, 6 5))");
+
+    ensure_geometry_equals(result_, expected_);
+}
+
+// testTwoAdjacentExterior
+template<>
+template<>
+void object::test<2> ()
+{
+    input_ = fromWKT("GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))");
+    result_ = GEOSCoverageEdges(input_, 2);
+    expected_ = fromWKT("MULTILINESTRING ((1 6, 1 1, 9 1, 9 6, 6 5), (1 6, 1 9, 6 9, 6 5))");
+
+    ensure_geometry_equals(result_, expected_);
+}
+
+} // namespace tut

--- a/tests/unit/capi/GEOSCoverageEdgesTest.cpp
+++ b/tests/unit/capi/GEOSCoverageEdgesTest.cpp
@@ -30,7 +30,7 @@ template<>
 void object::test<1> ()
 {
     input_ = fromWKT("GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))");
-    result_ = GEOSCoverageEdges(input_, 1);
+    result_ = GEOSCoverageEdges(input_, 2); // INTERIOR
     expected_ = fromWKT("MULTILINESTRING ((1 6, 6 5))");
 
     ensure_geometry_equals(result_, expected_);
@@ -42,7 +42,7 @@ template<>
 void object::test<2> ()
 {
     input_ = fromWKT("GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))");
-    result_ = GEOSCoverageEdges(input_, 2);
+    result_ = GEOSCoverageEdges(input_, 1); // EXTERIOR
     expected_ = fromWKT("MULTILINESTRING ((1 6, 1 1, 9 1, 9 6, 6 5), (1 6, 1 9, 6 9, 6 5))");
 
     ensure_geometry_equals(result_, expected_);

--- a/tests/unit/coverage/CoverageEdgesTest.cpp
+++ b/tests/unit/coverage/CoverageEdgesTest.cpp
@@ -1,0 +1,91 @@
+//
+// Test Suite for geos::coverage::CoverageEdges class.
+
+#include <tut/tut.hpp>
+#include <utility.h>
+
+// geos
+#include <geos/coverage/CoverageEdges.h>
+#include <geos/geom/Geometry.h>
+
+using geos::coverage::CoverageEdges;
+
+namespace tut {
+//
+// Test Group
+//
+
+// Common data used by all tests
+struct test_coverageedges_data
+ {
+
+    WKTReader r;
+    WKTWriter w;
+
+    test_coverageedges_data() {
+    }
+
+    void
+    checkEdges(const std::string& wkt, int type, const std::string& wktExpected)
+    {
+        std::unique_ptr<Geometry> geom = r.read(wkt);
+        std::unique_ptr<Geometry> edgeLines = CoverageEdges::GetEdges(geom.get(), type);
+        std::unique_ptr<Geometry> expected = r.read(wktExpected);
+        ensure_equals_geometry(edgeLines.get(), expected.get());
+    }
+};
+
+
+typedef test_group<test_coverageedges_data> group;
+typedef group::object object;
+
+group test_coverageedges_data("geos::coverage::CoverageEdges");
+
+
+// testTwoAdjacentAll
+template<>
+template<>
+void object::test<1> ()
+{
+    checkEdges(
+        "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))",
+        0,
+        "MULTILINESTRING ((1 6, 1 1, 9 1, 9 6, 6 5), (1 6, 1 9, 6 9, 6 5), (1 6, 6 5))"
+    );
+}
+
+// testTwoAdjacentInterior
+template<>
+template<>
+void object::test<2> ()
+{
+    checkEdges(
+        "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))",
+        1,
+        "MULTILINESTRING ((1 6, 6 5))"
+    );
+}
+
+// testTwoAdjacentExterior
+template<>
+template<>
+void object::test<3> ()
+{
+    checkEdges(
+        "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))",
+        2,
+        "MULTILINESTRING ((1 6, 1 1, 9 1, 9 6, 6 5), (1 6, 1 9, 6 9, 6 5))"
+    );
+}
+
+// testAdjacentSquaresInterior
+template<>
+template<>
+void object::test<4> ()
+{
+    std::string wkt = "GEOMETRYCOLLECTION (POLYGON ((1 3, 2 3, 2 2, 1 2, 1 3)), POLYGON ((3 3, 3 2, 2 2, 2 3, 3 3)), POLYGON ((3 1, 2 1, 2 2, 3 2, 3 1)), POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)))";
+    checkEdges(wkt, 1,
+        "MULTILINESTRING ((1 2, 2 2), (2 1, 2 2), (2 2, 2 3), (2 2, 3 2))");
+}
+
+} // namespace tut

--- a/tests/unit/coverage/CoverageEdgesTest.cpp
+++ b/tests/unit/coverage/CoverageEdgesTest.cpp
@@ -61,7 +61,7 @@ void object::test<2> ()
 {
     checkEdges(
         "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))",
-        1,
+        2, // INTERIOR
         "MULTILINESTRING ((1 6, 6 5))"
     );
 }
@@ -73,7 +73,7 @@ void object::test<3> ()
 {
     checkEdges(
         "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 5, 9 6, 9 1, 1 1)), POLYGON ((1 9, 6 9, 6 5, 1 6, 1 9)))",
-        2,
+        1, // EXTERIOR
         "MULTILINESTRING ((1 6, 1 1, 9 1, 9 6, 6 5), (1 6, 1 9, 6 9, 6 5))"
     );
 }
@@ -84,8 +84,30 @@ template<>
 void object::test<4> ()
 {
     std::string wkt = "GEOMETRYCOLLECTION (POLYGON ((1 3, 2 3, 2 2, 1 2, 1 3)), POLYGON ((3 3, 3 2, 2 2, 2 3, 3 3)), POLYGON ((3 1, 2 1, 2 2, 3 2, 3 1)), POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)))";
-    checkEdges(wkt, 1,
+    checkEdges(wkt, 2, // INTERIOR
         "MULTILINESTRING ((1 2, 2 2), (2 1, 2 2), (2 2, 2 3), (2 2, 3 2))");
+}
+
+// testTouchingAtPointInterior
+template<>
+template<>
+void object::test<5> ()
+{
+    // Two polygons touching only at a point (1 1)
+    std::string wkt = "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)))";
+    checkEdges(wkt, 2, // INTERIOR
+        "MULTILINESTRING EMPTY");
+}
+
+// testTouchingAtPointExterior
+template<>
+template<>
+void object::test<6> ()
+{
+    // Two polygons touching only at a point (1 1)
+    std::string wkt = "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)))";
+    checkEdges(wkt, 1, // EXTERIOR
+        "MULTILINESTRING ((0 0, 0 1, 1 1, 1 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))");
 }
 
 } // namespace tut


### PR DESCRIPTION
Per issue #1413, a helper class and CAPI end point to pull the edges from a polygonal coverage. Make sure to check for a clean coverage first!