### PR TITLE
Fix GEOS benchmarking on Windows

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,10 +1,64 @@
-## Benchmarks
+## Building
 
-A variety of programs to execute various kinds of tests, 
-including benchmarks, stability and robustness tests.
+Building the benchmark tests must be enabled using:
 
-### Building
+```bash
+cmake -DBUILD_BENCHMARKS=ON ..
+```
 
-Building the benchmark tests must be enabled using 
+Geos uses Google Benchmarks for validating performance of Geos library. It can be built using the following ways:
 
-    cmake -DBUILD_BENCHMARKS=ON ..
+### Linux
+
+Install via package manager:
+
+```bash
+# Debian/Ubuntu
+sudo apt install libbenchmark-dev
+
+# Fedora
+sudo dnf install google-benchmark-devel
+```
+
+Then build:
+
+```bash
+mkdir build && cd build
+cmake -DBUILD_BENCHMARKS=ON ..
+make -j$(nproc)
+```
+
+### Windows (MSYS2)
+
+Install Google Benchmark via pacman:
+
+```bash
+# MINGW64
+pacman -S mingw-w64-x86_64-benchmark
+
+# UCRT64
+pacman -S mingw-w64-ucrt-x86_64-benchmark
+
+# CLANG64
+pacman -S mingw-w64-clang-x86_64-benchmark
+
+# CLANGARM64
+pacman -S mingw-w64-clang-aarch64-benchmark
+```
+
+Then build:
+
+```bash
+mkdir build && cd build
+cmake -G "MinGW Makefiles" -DBUILD_BENCHMARKS=ON ..
+mingw32-make -j$(nproc)
+```
+
+### Windows (MSVC / vcpkg)
+
+```bash
+vcpkg install benchmark:x64-windows
+mkdir build && cd build
+cmake -DBUILD_BENCHMARKS=ON -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake ..
+cmake --build . --config Release
+```

--- a/benchmarks/algorithm/CMakeLists.txt
+++ b/benchmarks/algorithm/CMakeLists.txt
@@ -29,7 +29,7 @@ if (benchmark_FOUND)
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
             $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_link_libraries(perf_orientation PRIVATE
-            benchmark::benchmark geos_cxx_flags)
+            benchmark::benchmark geos)
 
     add_executable(perf_line_intersector LineIntersectorPerfTest.cpp)
     target_include_directories(perf_line_intersector PUBLIC

--- a/benchmarks/algorithm/OrientationIndexStressTest.cpp
+++ b/benchmarks/algorithm/OrientationIndexStressTest.cpp
@@ -43,6 +43,11 @@ Two kinds of test generators are provided:
 
 #include <iomanip>
 
+// MSVC does not provide POSIX random(), Use rand() for compatibility
+#ifdef _MSC_VER
+#define random rand
+#endif
+
 using namespace geos::algorithm;
 using namespace geos::geom;
 using namespace geos::io;

--- a/include/geos/index/intervalrtree/IntervalRTreeLeafNode.h
+++ b/include/geos/index/intervalrtree/IntervalRTreeLeafNode.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <geos/export.h>
 #include <geos/index/intervalrtree/IntervalRTreeNode.h> // inherited
 
 
@@ -30,7 +31,7 @@ namespace geos {
 namespace index {
 namespace intervalrtree {
 
-class IntervalRTreeLeafNode : public IntervalRTreeNode {
+class GEOS_DLL IntervalRTreeLeafNode : public IntervalRTreeNode {
 private:
     /// externally owned
     void* item;

--- a/include/geos/index/intervalrtree/SortedPackedIntervalRTree.h
+++ b/include/geos/index/intervalrtree/SortedPackedIntervalRTree.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <geos/export.h>
 #include <geos/index/intervalrtree/IntervalRTreeNode.h>
 #include <geos/index/intervalrtree/IntervalRTreeBranchNode.h>
 #include <geos/index/intervalrtree/IntervalRTreeLeafNode.h>
@@ -48,7 +49,7 @@ namespace intervalrtree {
  * @author Martin Davis
  *
  */
-class SortedPackedIntervalRTree {
+class GEOS_DLL SortedPackedIntervalRTree { 
 private:
     std::vector<IntervalRTreeLeafNode> leaves;
     std::vector<IntervalRTreeBranchNode> branches;


### PR DESCRIPTION
PR Description:
* This PR fixes compilation issues that prevented building benchmarks on Windows with the MSVC compiler.
 
Changes Proposed:
* Link perf_orientation target against geos library instead of geos_cxx_flags. The previous setup only linked compiler flags, causing linker errors due to missing CoordinateXY::getNull() function.
* Replace POSIX random() with standard C rand(), since MSVC does not provide random().
* Add GEOS_DLL export to IntervalRTreeLeafNode and SortedPackedIntervalRTree classes to ensure these symbols are exported in geos.dll on Windows. This fixes linker errors when building perf_spatial_index target.