### PR TITLE
Limit recursion depth in WKT/WKB/GeoJSON readers

### DIFF
--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -194,7 +194,6 @@ WKBReader::readHEX(const std::string& hex)
 void
 WKBReader::minMemSize(geom::GeometryTypeId geomType, uint64_t size) const
 {
-    uint64_t minSize = 0;
     constexpr uint64_t minCoordSize = 2 * sizeof(double);
     constexpr uint64_t minPtSize = (1+4) + minCoordSize;
     constexpr uint64_t minLineSize = (1+4+4); // empty line
@@ -202,35 +201,36 @@ WKBReader::minMemSize(geom::GeometryTypeId geomType, uint64_t size) const
     constexpr uint64_t minPolySize = (1+4+4); // empty polygon
     constexpr uint64_t minGeomSize = minLineSize;
 
+    uint64_t perElement = 0;
     switch(geomType) {
         case GEOS_LINESTRING:
         case GEOS_LINEARRING:
         case GEOS_CIRCULARSTRING:
         case GEOS_COMPOUNDCURVE:
         case GEOS_POINT:
-            minSize = size * minCoordSize;
+            perElement = minCoordSize;
             break;
         case GEOS_POLYGON:
         case GEOS_CURVEPOLYGON:
-            minSize = size * minRingSize;
+            perElement = minRingSize;
             break;
         case GEOS_MULTIPOINT:
-            minSize = size * minPtSize;
+            perElement = minPtSize;
             break;
         case GEOS_MULTILINESTRING:
         case GEOS_MULTICURVE:
-            minSize = size * minLineSize;
+            perElement = minLineSize;
             break;
         case GEOS_MULTIPOLYGON:
         case GEOS_MULTISURFACE:
-            minSize = size * minPolySize;
+            perElement = minPolySize;
             break;
         case GEOS_GEOMETRYCOLLECTION:
-            minSize = size * minGeomSize;
+            perElement = minGeomSize;
             break;
     }
 
-    if (dis.size() < minSize) {
+    if (perElement > 0 && size > dis.size() / perElement) {
         throw ParseException("Input buffer is smaller than requested object size");
     }
 }

--- a/tests/unit/io/WKBReaderTest.cpp
+++ b/tests/unit/io/WKBReaderTest.cpp
@@ -857,11 +857,27 @@ void object::test<37>
     buf.insert(buf.end(), inner.begin(), inner.end());
 
     ensure_THROW(wkbreader.read(buf.data(), buf.size()), geos::io::ParseException);
+}
 
-    // try {
-    //     wkbreader.read(buf.data(), buf.size());
-    //     fail("Expected ParseException for deeply nested WKB");
-    // } catch (const geos::util::GEOSException&) {}
+// Claimed element count larger than buffer can hold should throw ParseException
+template<>
+template<>
+void object::test<38>
+()
+{
+    set_test_name("ParseException when WKB element count exceeds buffer capacity");
+
+    // NDR GeometryCollection with numGeoms = 0x00FFFFFF in a 20-byte buffer
+    // Header: byteOrder=01, type=07000000, numGeoms=FFFFFF00 (little-endian 0x00FFFFFF)
+    std::vector<unsigned char> buf = {
+        0x01,                         // NDR byte order
+        0x07, 0x00, 0x00, 0x00,       // type: GeometryCollection
+        0xFF, 0xFF, 0xFF, 0x00,       // numGeoms: 0x00FFFFFF (little-endian)
+        0x00, 0x00, 0x00, 0x00, 0x00, // padding to make buffer 20 bytes
+        0x00, 0x00, 0x00, 0x00, 0x00
+    };
+
+    ensure_THROW(wkbreader.read(buf.data(), buf.size()), geos::io::ParseException);
 }
 
 } // namespace tut


### PR DESCRIPTION
Prevents stack overflow on malformed input