### PR TITLE
Node a set of LineString and retain reference to original inputs

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -790,6 +790,12 @@ extern "C" {
     }
 
     Geometry*
+    GEOSNodeCollection(const Geometry* input, double gridSize)
+    {
+        return GEOSNodeCollection_r(handle, input, gridSize);
+    }
+
+    Geometry*
     GEOSSplit(const Geometry* g, const Geometry* edge)
     {
         return GEOSSplit_r(handle, g, edge);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -1214,6 +1214,12 @@ extern GEOSGeometry GEOS_DLL *GEOSNode_r(
     GEOSContextHandle_t handle,
     const GEOSGeometry* g);
 
+/** \see GEOSNodeCollection */
+extern GEOSGeometry GEOS_DLL *GEOSNodeCollection_r(
+    GEOSContextHandle_t handle,
+    const GEOSGeometry* input,
+    double gridSize);
+
 /** \see GEOSSplit */
 extern GEOSGeometry GEOS_DLL *GEOSSplit_r(
     GEOSContextHandle_t handle,
@@ -5561,6 +5567,34 @@ extern GEOSGeometry GEOS_DLL * GEOSVoronoiDiagram(
 * \since 3.4
 */
 extern GEOSGeometry GEOS_DLL *GEOSNode(const GEOSGeometry* g);
+
+/**
+* Nodes a collection of linear geometries against each other,
+* returning a collection of the same size where each member has been
+* split into a MultiLineString at all interior node points.
+*
+* Unlike GEOSNode(), which collects all edges into a single flattened
+* MultiLineString, this function preserves the per-member structure of
+* the input, returning one MultiLineString per input element.
+* Linework shared between members is not dissolved.
+*
+* Input members must be linear (LineString, MultiLineString, or
+* GeometryCollection of linear types). Non-linear components are
+* ignored; their output slot will be an empty MultiLineString.
+*
+* \param input A GeometryCollection of linear geometries.
+* \param gridSize Snap-rounding grid size for robust noding of inputs
+*        with near-coincident coordinates, or 0.0 for standard noding.
+* \return A GeometryCollection of the same size as the input, with each
+*         member returned as a noded MultiLineString, or NULL on error.
+* Caller is responsible for freeing with GEOSGeom_destroy().
+* \see geos::operation::linenode::LineCollectionNoder::node
+*
+* \since 3.14
+*/
+extern GEOSGeometry GEOS_DLL *GEOSNodeCollection(
+    const GEOSGeometry* input,
+    double gridSize);
 
 
 /** Split a linear or polygonal input 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -87,6 +87,7 @@
 #include <geos/operation/grid/Grid.h>
 #include <geos/operation/grid/GridIntersection.h>
 #include <geos/operation/linemerge/LineMerger.h>
+#include <geos/operation/linenode/LineCollectionNoder.h>
 #include <geos/operation/spanning/SpanningTree.h>
 #include <geos/operation/split/GeometrySplitter.h>
 #include <geos/operation/intersection/Rectangle.h>
@@ -2039,6 +2040,33 @@ extern "C" {
             auto g3 = geos::noding::GeometryNoder::node(*g);
             g3->setSRID(g->getSRID());
             return g3.release();
+        });
+    }
+
+    Geometry*
+    GEOSNodeCollection_r(GEOSContextHandle_t extHandle,
+        const Geometry* input,
+        double gridSize)
+    {
+        using geos::operation::linenode::LineCollectionNoder;
+
+        return execute(extHandle, [&]() -> Geometry* {
+            const GeometryCollection* col =
+                dynamic_cast<const GeometryCollection*>(input);
+            if (!col) return nullptr;
+
+            std::vector<const Geometry*> geoms;
+            geoms.reserve(col->getNumGeometries());
+            for (std::size_t i = 0; i < col->getNumGeometries(); i++)
+                geoms.push_back(col->getGeometryN(i));
+
+            LineCollectionNoder lcn(geoms);
+            auto result = lcn.node(gridSize);
+
+            const GeometryFactory* gf = input->getFactory();
+            auto r = gf->createGeometryCollection(std::move(result));
+            r->setSRID(input->getSRID());
+            return r.release();
         });
     }
 

--- a/include/geos/noding/OrientedCoordinateArray.h
+++ b/include/geos/noding/OrientedCoordinateArray.h
@@ -21,6 +21,7 @@
 #include <geos/export.h>
 
 #include <cstddef>
+#include <set>
 
 // Forward declarations
 namespace geos {
@@ -107,6 +108,36 @@ operator< (const OrientedCoordinateArray& oca1,
 {
     return oca1.compareTo(oca2) < 0;
 }
+
+/** \brief
+ * Deduplicates coordinate sequences in an orientation-independent way.
+ *
+ * Tracks the set of sequences seen so far (as OrientedCoordinateArrays)
+ * and reports whether each newly offered sequence is novel. Used by
+ * noders to drop edges that are geometrically identical regardless of
+ * direction.
+ *
+ * NOTE: like OrientedCoordinateArray, this stores only pointers to the
+ * sequences offered to add(). Every sequence passed in must outlive the
+ * EdgeDeduplicator.
+ */
+class GEOS_DLL EdgeDeduplicator {
+public:
+
+    /**
+     * @param seq a coordinate sequence; must outlive this object
+     * @return true if seq was not equivalent to any previously added
+     *         sequence (and is now recorded), false if it is a duplicate
+     */
+    bool add(const geom::CoordinateSequence& seq) {
+        return m_seen.insert(OrientedCoordinateArray(seq)).second;
+    }
+
+private:
+
+    std::set<OrientedCoordinateArray> m_seen;
+
+};
 
 } // namespace geos.noding
 } // namespace geos

--- a/include/geos/operation/linenode/LineCollectionNoder.h
+++ b/include/geos/operation/linenode/LineCollectionNoder.h
@@ -1,0 +1,147 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2025 Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#pragma once
+
+#include <geos/export.h>
+#include <memory>
+#include <vector>
+
+// Forward declarations
+namespace geos {
+namespace geom {
+class Geometry;
+class GeometryFactory;
+}
+namespace noding {
+class NodedSegmentString;
+class SegmentString;
+}
+}
+
+namespace geos {
+namespace operation {
+namespace linenode {
+
+/**
+ * Nodes a collection of linear geometries against each other,
+ * returning a collection of the same size where each member has
+ * been split into a MultiLineString at all interior node points.
+ *
+ * Unlike geos::noding::GeometryNoder::node(), which collects all
+ * input edges into a single flattened MultiLineString, this class
+ * preserves the identity of each input member. Linework that is
+ * shared (or nearly shared) between members is not dissolved.
+ *
+ * Input geometries must be linear (LineString, MultiLineString, or
+ * a GeometryCollection of linear types). Non-linear components (e.g.
+ * polygon rings, points) are silently ignored; their output slot
+ * will contain an empty MultiLineString.
+ *
+ * When gridSize == 0.0 (default), standard IteratedNoder is used.
+ * When gridSize > 0.0, SnapRoundingNoder is used instead, providing
+ * robust output for inputs with near-coincident coordinates
+ * (see https://github.com/libgeos/geos/issues/877).
+ * Values <= 0.0 all use IteratedNoder.
+ *
+ * Usage:
+ * @code
+ *   std::vector<const Geometry*> lines = { ... };
+ *   auto noded = LineCollectionNoder::node(lines);        // standard noding
+ *   auto noded = LineCollectionNoder::node(lines, 1.0);   // snap-rounding
+ * @endcode
+ *
+ * @author Paul Ramsey
+ */
+class GEOS_DLL LineCollectionNoder {
+
+    using Geometry = geos::geom::Geometry;
+    using GeometryFactory = geos::geom::GeometryFactory;
+    using NodedSegmentString = geos::noding::NodedSegmentString;
+    using SegmentString = geos::noding::SegmentString;
+
+public:
+
+    /**
+     * Creates a new LineCollectionNoder for the given collection of
+     * linear geometries.
+     *
+     * @param collection input geometries; caller retains ownership.
+     *   The vector must outlive this object.
+     */
+    LineCollectionNoder(const std::vector<const Geometry*>& collection);
+
+    /**
+     * Nodes a collection of linear geometries (vector of raw const pointers).
+     *
+     * @param collection vector of linear geometries
+     * @param gridSize snap-rounding grid size, or 0.0 for standard noding
+     * @return one noded MultiLineString per input element, in the same order
+     */
+    static std::vector<std::unique_ptr<Geometry>> node(
+        std::vector<const Geometry*>& collection,
+        double gridSize = 0.0);
+
+    /**
+     * Nodes a collection of linear geometries (vector of unique_ptr).
+     *
+     * @param collection vector of owning pointers to linear geometries
+     * @param gridSize snap-rounding grid size, or 0.0 for standard noding
+     * @return one noded MultiLineString per input element, in the same order
+     */
+    static std::vector<std::unique_ptr<Geometry>> node(
+        const std::vector<std::unique_ptr<Geometry>>& collection,
+        double gridSize = 0.0);
+
+    /**
+     * Computes the noded collection.
+     *
+     * @param gridSize snap-rounding grid size, or 0.0 for standard noding
+     * @return one noded MultiLineString per input element, in the same order
+     */
+    std::vector<std::unique_ptr<Geometry>> node(double gridSize = 0.0);
+
+    // Noncopyable
+    LineCollectionNoder(const LineCollectionNoder&) = delete;
+    LineCollectionNoder& operator=(const LineCollectionNoder&) = delete;
+
+private:
+
+    const std::vector<const Geometry*>& m_input;
+    const GeometryFactory* m_geomFactory;
+
+    /**
+     * Extracts NodedSegmentStrings from the linear components of g
+     * (LineString only, not LinearRing/polygon rings), tagging each
+     * with reinterpret_cast<const void*>(static_cast<uintptr_t>(index)).
+     */
+    static void extractSegments(
+        const Geometry& g,
+        std::size_t index,
+        std::vector<std::unique_ptr<NodedSegmentString>>& segments);
+
+    /**
+     * Builds a MultiLineString from the noded sub-segments that carry
+     * the given source index tag. Deduplicates via OrientedCoordinateArray
+     * (same logic as GeometryNoder::toGeometry).
+     */
+    std::unique_ptr<Geometry> buildResult(
+        const std::vector<std::unique_ptr<SegmentString>>& nodedSegs,
+        std::size_t index) const;
+
+};
+
+} // geos::operation::linenode
+} // geos::operation
+} // geos

--- a/src/noding/GeometryNoder.cpp
+++ b/src/noding/GeometryNoder.cpp
@@ -316,7 +316,7 @@ GeometryNoder::toGeometry(std::vector<std::unique_ptr<PathString>>& nodedEdges) 
 {
     const geom::GeometryFactory* geomFact = argGeom1->getFactory();
 
-    std::set< OrientedCoordinateArray > ocas;
+    EdgeDeduplicator dedup;
 
     std::vector<PathString*> pathsToKeep;
 
@@ -327,11 +327,8 @@ GeometryNoder::toGeometry(std::vector<std::unique_ptr<PathString>>& nodedEdges) 
             continue;
         }
 
-        const auto& coords = path->getCoordinates();
-        OrientedCoordinateArray oca1(*coords);
-
         // Check if an equivalent edge is known
-        if(ocas.insert(oca1).second) {
+        if(dedup.add(*path->getCoordinates())) {
             pathsToKeep.push_back(path.get());
         }
     }

--- a/src/operation/linenode/LineCollectionNoder.cpp
+++ b/src/operation/linenode/LineCollectionNoder.cpp
@@ -40,7 +40,7 @@ using geos::geom::PrecisionModel;
 using geos::noding::IteratedNoder;
 using geos::noding::NodedSegmentString;
 using geos::noding::Noder;
-using geos::noding::OrientedCoordinateArray;
+using geos::noding::EdgeDeduplicator;
 using geos::noding::SegmentString;
 using geos::noding::snapround::SnapRoundingNoder;
 
@@ -108,14 +108,13 @@ LineCollectionNoder::buildResult(
 {
     const void* tag = reinterpret_cast<const void*>(static_cast<uintptr_t>(index));
 
-    std::set<OrientedCoordinateArray> seen;
+    EdgeDeduplicator dedup;
     std::vector<std::unique_ptr<Geometry>> lines;
 
     for (const auto& ss : nodedSegs) {
         if (ss->getData() != tag) continue;
         const auto& coords = ss->getCoordinates();
-        OrientedCoordinateArray oca(*coords);
-        if (seen.insert(oca).second) {
+        if (dedup.add(*coords)) {
             lines.push_back(m_geomFactory->createLineString(coords));
         }
     }

--- a/src/operation/linenode/LineCollectionNoder.cpp
+++ b/src/operation/linenode/LineCollectionNoder.cpp
@@ -1,0 +1,203 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2025 Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+#include <geos/operation/linenode/LineCollectionNoder.h>
+
+#include <geos/geom/Geometry.h>
+#include <geos/geom/GeometryComponentFilter.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/LinearRing.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/PrecisionModel.h>
+#include <geos/noding/IteratedNoder.h>
+#include <geos/noding/NodedSegmentString.h>
+#include <geos/noding/Noder.h>
+#include <geos/noding/OrientedCoordinateArray.h>
+#include <geos/noding/SegmentString.h>
+#include <geos/noding/snapround/SnapRoundingNoder.h>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+using geos::geom::Geometry;
+using geos::geom::GeometryComponentFilter;
+using geos::geom::GeometryFactory;
+using geos::geom::LinearRing;
+using geos::geom::LineString;
+using geos::geom::PrecisionModel;
+using geos::noding::IteratedNoder;
+using geos::noding::NodedSegmentString;
+using geos::noding::Noder;
+using geos::noding::OrientedCoordinateArray;
+using geos::noding::SegmentString;
+using geos::noding::snapround::SnapRoundingNoder;
+
+namespace geos {
+namespace operation {
+namespace linenode {
+
+namespace {
+
+class LineStringExtractor : public GeometryComponentFilter {
+public:
+    LineStringExtractor(std::size_t p_index,
+                        std::vector<std::unique_ptr<NodedSegmentString>>& p_segs)
+        : m_index(p_index)
+        , m_segs(p_segs)
+    {}
+
+    void filter_ro(const Geometry* g) override
+    {
+        // Skip polygon rings — only standalone LineStrings
+        if (dynamic_cast<const LinearRing*>(g)) return;
+        const auto* ls = dynamic_cast<const LineString*>(g);
+        if (!ls || ls->isEmpty()) return;
+
+        auto coords = ls->getSharedCoordinates();
+        auto nss = std::make_unique<NodedSegmentString>(
+            coords,
+            ls->hasZ(),
+            ls->hasM(),
+            reinterpret_cast<const void*>(static_cast<uintptr_t>(m_index)));
+        m_segs.push_back(std::move(nss));
+    }
+
+private:
+    std::size_t m_index;
+    std::vector<std::unique_ptr<NodedSegmentString>>& m_segs;
+};
+
+} // anonymous namespace
+
+
+LineCollectionNoder::LineCollectionNoder(const std::vector<const Geometry*>& collection)
+    : m_input(collection)
+    , m_geomFactory(collection.empty() ? nullptr : collection[0]->getFactory())
+{}
+
+
+/* static */
+void
+LineCollectionNoder::extractSegments(
+    const Geometry& g,
+    std::size_t index,
+    std::vector<std::unique_ptr<NodedSegmentString>>& segments)
+{
+    LineStringExtractor ex(index, segments);
+    g.apply_ro(&ex);
+}
+
+
+/* private */
+std::unique_ptr<Geometry>
+LineCollectionNoder::buildResult(
+    const std::vector<std::unique_ptr<SegmentString>>& nodedSegs,
+    std::size_t index) const
+{
+    const void* tag = reinterpret_cast<const void*>(static_cast<uintptr_t>(index));
+
+    std::set<OrientedCoordinateArray> seen;
+    std::vector<std::unique_ptr<Geometry>> lines;
+
+    for (const auto& ss : nodedSegs) {
+        if (ss->getData() != tag) continue;
+        const auto& coords = ss->getCoordinates();
+        OrientedCoordinateArray oca(*coords);
+        if (seen.insert(oca).second) {
+            lines.push_back(m_geomFactory->createLineString(coords));
+        }
+    }
+
+    return m_geomFactory->createMultiLineString(std::move(lines));
+}
+
+
+/* public */
+std::vector<std::unique_ptr<Geometry>>
+LineCollectionNoder::node(double gridSize)
+{
+    const std::size_t n = m_input.size();
+    std::vector<std::unique_ptr<Geometry>> result;
+    result.reserve(n);
+
+    if (n == 0) return result;
+
+    // Extract all LinearString segments from all inputs, tagged with source index
+    std::vector<std::unique_ptr<NodedSegmentString>> segments;
+    for (std::size_t i = 0; i < n; ++i) {
+        extractSegments(*m_input[i], i, segments);
+    }
+
+    if (segments.empty()) {
+        for (std::size_t i = 0; i < n; ++i)
+            result.push_back(m_geomFactory->createMultiLineString());
+        return result;
+    }
+
+    // Build raw pointer vector for noder API
+    std::vector<SegmentString*> rawSegs;
+    rawSegs.reserve(segments.size());
+    for (auto& ss : segments)
+        rawSegs.push_back(ss.get());
+
+    // Select noder based on gridSize
+    std::unique_ptr<PrecisionModel> pm;
+    std::unique_ptr<Noder> noder;
+    if (gridSize > 0.0) {
+        pm = std::make_unique<PrecisionModel>(1.0 / gridSize);
+        noder = std::make_unique<SnapRoundingNoder>(pm.get());
+    } else {
+        noder = std::make_unique<IteratedNoder>(m_geomFactory->getPrecisionModel());
+    }
+
+    noder->computeNodes(rawSegs);
+    auto nodedSegs = noder->getNodedSubstrings();
+
+    // Build one noded MultiLineString per input geometry
+    for (std::size_t i = 0; i < n; ++i)
+        result.push_back(buildResult(nodedSegs, i));
+
+    return result;
+}
+
+
+/* static */
+std::vector<std::unique_ptr<Geometry>>
+LineCollectionNoder::node(
+    std::vector<const Geometry*>& collection,
+    double gridSize)
+{
+    LineCollectionNoder lcn(collection);
+    return lcn.node(gridSize);
+}
+
+
+/* static */
+std::vector<std::unique_ptr<Geometry>>
+LineCollectionNoder::node(
+    const std::vector<std::unique_ptr<Geometry>>& collection,
+    double gridSize)
+{
+    std::vector<const Geometry*> raw;
+    raw.reserve(collection.size());
+    for (const auto& g : collection)
+        raw.push_back(g.get());
+    LineCollectionNoder lcn(raw);
+    return lcn.node(gridSize);
+}
+
+} // geos::operation::linenode
+} // geos::operation
+} // geos

--- a/tests/unit/capi/GEOSNodeCollectionTest.cpp
+++ b/tests/unit/capi/GEOSNodeCollectionTest.cpp
@@ -1,0 +1,176 @@
+// Test Suite for C-API GEOSNodeCollection
+
+#include <tut/tut.hpp>
+#include <geos_c.h>
+
+#include "capi_test_utils.h"
+
+namespace tut {
+
+struct test_capigeosnode_collection_data : public capitest::utility {};
+
+typedef test_group<test_capigeosnode_collection_data> group;
+typedef group::object object;
+group test_capigeosnode_collection_group("capi::GEOSNodeCollection");
+
+// Basic: two crossing lines produce two noded MultiLineStrings
+template<> template<> void object::test<1>()
+{
+    set_test_name("two crossing linestrings");
+    input_ = fromWKT("GEOMETRYCOLLECTION (LINESTRING (0 0, 10 10), LINESTRING (0 10, 10 0))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    ensure_equals(GEOSGeomTypeId(result_), GEOS_GEOMETRYCOLLECTION);
+    ensure_equals(GEOSGetNumGeometries(result_), 2);
+    ensure_equals(GEOSGetNumGeometries(GEOSGetGeometryN(result_, 0)), 2);
+    ensure_equals(GEOSGetNumGeometries(GEOSGetGeometryN(result_, 1)), 2);
+}
+
+// Issue 877: near-duplicate rings fail with IteratedNoder; snap-rounding fixes it
+template<> template<> void object::test<2>()
+{
+    set_test_name("issue 877 near-duplicate rings with snap-rounding");
+    input_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "LINESTRING (125635 6696, 131951 6376, 132163 474.0000000000043, 128381 1569.9999999999986, 125635 6696),"
+        "LINESTRING (125635 6696, 131951 6376, 132163 474, 128381 1570, 125635 6696))");
+    result_ = GEOSNodeCollection(input_, 1.0);
+    ensure("snap-rounding succeeds", result_ != nullptr);
+    ensure_equals("count preserved", GEOSGetNumGeometries(result_), 2);
+}
+
+// Non-collection input returns NULL
+template<> template<> void object::test<3>()
+{
+    set_test_name("non-collection input returns NULL");
+    input_ = fromWKT("LINESTRING (0 0, 1 1)");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure("non-collection returns NULL", result_ == nullptr);
+}
+
+// Non-intersecting: count preserved, each member stays as single-segment MultiLineString
+template<> template<> void object::test<4>()
+{
+    set_test_name("non-intersecting: count preserved");
+    input_ = fromWKT("GEOMETRYCOLLECTION (LINESTRING (0 0, 5 5), LINESTRING (10 0, 15 5))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    ensure_equals(GEOSGetNumGeometries(result_), 2);
+    ensure_equals(GEOSGetNumGeometries(GEOSGetGeometryN(result_, 0)), 1);
+    ensure_equals(GEOSGetNumGeometries(GEOSGetGeometryN(result_, 1)), 1);
+}
+
+// SRID is preserved on the output collection
+template<> template<> void object::test<5>()
+{
+    set_test_name("SRID preservation");
+    input_ = fromWKT("GEOMETRYCOLLECTION (LINESTRING (0 0, 10 10), LINESTRING (0 10, 10 0))");
+    GEOSSetSRID(input_, 4326);
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    ensure_equals("SRID preserved", GEOSGetSRID(result_), GEOSGetSRID(input_));
+}
+
+// Z interpolation: new node points get Z averaged from both intersecting lines
+template<> template<> void object::test<6>()
+{
+    set_test_name("Z averaged at new node points from both intersecting lines");
+    // Line 0: Z 0->1 at t=0.5 -> 0.5; Line 1: Z 5->10 at t=0.5 -> 7.5; avg=4.0
+    input_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "LINESTRING Z (0 0 0, 1 1 1),"
+        "LINESTRING Z (0 1 5, 1 0 10))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    expected_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "MULTILINESTRING Z ((0 0 0, 0.5 0.5 4), (0.5 0.5 4, 1 1 1)),"
+        "MULTILINESTRING Z ((0 1 5, 0.5 0.5 4), (0.5 0.5 4, 1 0 10)))");
+    GEOSNormalize(result_);
+    GEOSNormalize(expected_);
+    ensure_geometry_equals(result_, expected_);
+}
+
+// M interpolation: new node points get M averaged from both intersecting lines
+template<> template<> void object::test<7>()
+{
+    set_test_name("M averaged at new node points from both intersecting lines");
+    // Line 0: M 0->1 at t=0.5 -> 0.5; Line 1: M 5->10 at t=0.5 -> 7.5; avg=4.0
+    input_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "LINESTRING M (0 0 0, 1 1 1),"
+        "LINESTRING M (0 1 5, 1 0 10))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    expected_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "MULTILINESTRING M ((0 0 0, 0.5 0.5 4), (0.5 0.5 4, 1 1 1)),"
+        "MULTILINESTRING M ((0 1 5, 0.5 0.5 4), (0.5 0.5 4, 1 0 10)))");
+    GEOSNormalize(result_);
+    GEOSNormalize(expected_);
+    ensure_geometry_equals(result_, expected_);
+}
+
+// gridSize < 0: treated as 0, does not crash
+template<> template<> void object::test<8>()
+{
+    set_test_name("gridSize < 0 treated as standard noding");
+    input_ = fromWKT("GEOMETRYCOLLECTION (LINESTRING (0 0, 10 10), LINESTRING (0 10, 10 0))");
+    result_ = GEOSNodeCollection(input_, -1.0);
+    ensure("negative gridSize does not crash", result_ != nullptr);
+    ensure_equals("count preserved", GEOSGetNumGeometries(result_), 2);
+}
+
+// Empty GEOMETRYCOLLECTION: returns empty collection, not NULL
+template<> template<> void object::test<9>()
+{
+    set_test_name("empty collection");
+    input_ = fromWKT("GEOMETRYCOLLECTION EMPTY");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure("empty collection returns non-NULL", result_ != nullptr);
+    ensure_equals("result has 0 members", GEOSGetNumGeometries(result_), 0);
+}
+
+// Identical members: both preserved, not dissolved
+template<> template<> void object::test<10>()
+{
+    set_test_name("identical members each preserved separately");
+    input_ = fromWKT("GEOMETRYCOLLECTION (LINESTRING (0 0, 10 0), LINESTRING (0 0, 10 0))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    ensure_equals("count preserved", GEOSGetNumGeometries(result_), 2);
+    ensure("member 0 non-empty", !GEOSisEmpty(GEOSGetGeometryN(result_, 0)));
+    ensure("member 1 non-empty", !GEOSisEmpty(GEOSGetGeometryN(result_, 1)));
+}
+
+// Non-linear (POLYGON) member produces empty MultiLineString in its output slot
+template<> template<> void object::test<11>()
+{
+    set_test_name("polygon member yields empty output slot");
+    input_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)),"
+        "LINESTRING (5 -5, 5 15))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    ensure_equals("count preserved", GEOSGetNumGeometries(result_), 2);
+    ensure("polygon slot is empty", GEOSisEmpty(GEOSGetGeometryN(result_, 0)));
+    ensure("line slot is non-empty", !GEOSisEmpty(GEOSGetGeometryN(result_, 1)));
+}
+
+// Nested GEOMETRYCOLLECTION member: all linear components extracted
+template<> template<> void object::test<12>()
+{
+    set_test_name("nested GEOMETRYCOLLECTION member");
+    input_ = fromWKT(
+        "GEOMETRYCOLLECTION ("
+        "GEOMETRYCOLLECTION (LINESTRING (0 0, 10 0), LINESTRING (0 5, 10 5)),"
+        "LINESTRING (5 -1, 5 10))");
+    result_ = GEOSNodeCollection(input_, 0.0);
+    ensure(result_ != nullptr);
+    ensure_equals("count preserved", GEOSGetNumGeometries(result_), 2);
+    ensure_equals("nested member has 4 segments",
+        GEOSGetNumGeometries(GEOSGetGeometryN(result_, 0)), 4);
+}
+
+} // namespace tut

--- a/tests/unit/operation/linenode/LineCollectionNoderTest.cpp
+++ b/tests/unit/operation/linenode/LineCollectionNoderTest.cpp
@@ -42,7 +42,7 @@ struct test_linecollectionnoder_data {
 
 typedef test_group<test_linecollectionnoder_data> group;
 typedef group::object object;
-group test_linecollectionnoder_group("operation::linenode::LineCollectionNoder");
+group test_linecollectionnoder_group("geos::operation::linenode::LineCollectionNoder");
 
 // Two crossing linestrings: each split at the crossing point
 template<> template<> void object::test<1>()

--- a/tests/unit/operation/linenode/LineCollectionNoderTest.cpp
+++ b/tests/unit/operation/linenode/LineCollectionNoderTest.cpp
@@ -1,0 +1,229 @@
+// Test Suite for geos::operation::linenode::LineCollectionNoder
+
+#include <tut/tut.hpp>
+#include <geos/operation/linenode/LineCollectionNoder.h>
+#include <geos/geom/Geometry.h>
+#include <geos/io/WKTReader.h>
+
+#include "utility.h"
+
+using geos::geom::Geometry;
+using geos::io::WKTReader;
+using geos::operation::linenode::LineCollectionNoder;
+
+namespace tut {
+
+struct test_linecollectionnoder_data {
+    WKTReader r;
+
+    std::vector<std::unique_ptr<Geometry>> readArray(
+        std::initializer_list<const char*> wkts)
+    {
+        std::vector<std::unique_ptr<Geometry>> v;
+        for (const char* wkt : wkts)
+            v.push_back(r.read(wkt));
+        return v;
+    }
+
+    void checkResult(
+        const std::vector<std::unique_ptr<Geometry>>& input,
+        std::initializer_list<const char*> expectedWkts,
+        double gridSize = 0.0)
+    {
+        auto actual = LineCollectionNoder::node(input, gridSize);
+        std::vector<const char*> exp(expectedWkts);
+        ensure_equals("result count", actual.size(), exp.size());
+        for (std::size_t i = 0; i < exp.size(); i++) {
+            auto e = r.read(exp[i]);
+            ensure_equals_exact_geometry_xyzm(actual[i].get(), e.get(), 1e-9);
+        }
+    }
+};
+
+typedef test_group<test_linecollectionnoder_data> group;
+typedef group::object object;
+group test_linecollectionnoder_group("operation::linenode::LineCollectionNoder");
+
+// Two crossing linestrings: each split at the crossing point
+template<> template<> void object::test<1>()
+{
+    set_test_name("two crossing linestrings");
+    checkResult(
+        readArray({"LINESTRING (0 0, 10 10)", "LINESTRING (0 10, 10 0)"}),
+        {"MULTILINESTRING ((0 0, 5 5), (5 5, 10 10))",
+         "MULTILINESTRING ((0 10, 5 5), (5 5, 10 0))"});
+}
+
+// Non-intersecting: each becomes a single-segment MultiLineString
+template<> template<> void object::test<2>()
+{
+    set_test_name("non-intersecting: each kept as single segment");
+    checkResult(
+        readArray({"LINESTRING (0 0, 5 5)", "LINESTRING (10 0, 15 5)"}),
+        {"MULTILINESTRING ((0 0, 5 5))", "MULTILINESTRING ((10 0, 15 5))"});
+}
+
+// Three-way: three lines that all cross at (5,5)
+template<> template<> void object::test<3>()
+{
+    set_test_name("three linestrings intersecting pairwise");
+    checkResult(
+        readArray({
+            "LINESTRING (0 5, 10 5)",
+            "LINESTRING (5 0, 5 10)",
+            "LINESTRING (0 0, 10 10)"}),
+        {"MULTILINESTRING ((0 5, 5 5), (5 5, 10 5))",
+         "MULTILINESTRING ((5 0, 5 5), (5 5, 5 10))",
+         "MULTILINESTRING ((0 0, 5 5), (5 5, 10 10))"});
+}
+
+// Issue 877: near-duplicate rings — snap-rounding converges where IteratedNoder would not
+template<> template<> void object::test<4>()
+{
+    set_test_name("issue 877 near-duplicate rings with snap-rounding");
+    auto input = readArray({
+        "LINESTRING (125635 6696, 131951 6376, 132163 474.0000000000043, 128381 1569.9999999999986, 125635 6696)",
+        "LINESTRING (125635 6696, 131951 6376, 132163 474, 128381 1570, 125635 6696)"
+    });
+    auto actual = LineCollectionNoder::node(input, 1.0);
+    ensure_equals("count preserved", actual.size(), std::size_t(2));
+    ensure("member 0 non-empty", !actual[0]->isEmpty());
+    ensure("member 1 non-empty", !actual[1]->isEmpty());
+}
+
+// MULTILINESTRING member: all component LineStrings extracted and noded as a unit
+template<> template<> void object::test<5>()
+{
+    set_test_name("MULTILINESTRING member is noded as a unit");
+    checkResult(
+        readArray({
+            "MULTILINESTRING ((0 0, 10 10), (0 10, 10 0))",
+            "LINESTRING (5 -1, 5 11)"}),
+        {"MULTILINESTRING ((0 0, 5 5), (5 5, 10 10), (0 10, 5 5), (5 5, 10 0))",
+         "MULTILINESTRING ((5 -1, 5 5), (5 5, 5 11))"});
+}
+
+// Identical members: both preserved independently, linework not dissolved
+template<> template<> void object::test<6>()
+{
+    set_test_name("identical members each keep their own linework");
+    checkResult(
+        readArray({
+            "LINESTRING (0 0, 10 0)",
+            "LINESTRING (0 0, 10 0)"}),
+        {"MULTILINESTRING ((0 0, 10 0))",
+         "MULTILINESTRING ((0 0, 10 0))"});
+}
+
+// Duplicate segments within same member: deduplication removes the second copy
+template<> template<> void object::test<7>()
+{
+    set_test_name("duplicate segments within one member are deduplicated");
+    auto input = readArray({
+        "MULTILINESTRING ((0 0, 10 0), (0 0, 10 0))",
+        "LINESTRING (5 -5, 5 5)"
+    });
+    auto actual = LineCollectionNoder::node(input);
+    ensure_equals("count preserved", actual.size(), std::size_t(2));
+    ensure_equals("member 0 deduplicated to 2 segments",
+        (int)actual[0]->getNumGeometries(), 2);
+}
+
+// Empty member: produces an empty MultiLineString in the corresponding output slot
+template<> template<> void object::test<8>()
+{
+    set_test_name("empty member produces empty output slot");
+    auto input = readArray({
+        "LINESTRING EMPTY",
+        "LINESTRING (0 0, 10 0)"
+    });
+    auto actual = LineCollectionNoder::node(input);
+    ensure_equals("count preserved", actual.size(), std::size_t(2));
+    ensure("member 0 output is empty", actual[0]->isEmpty());
+    ensure("member 1 output is non-empty", !actual[1]->isEmpty());
+}
+
+// Empty collection: returns an empty result vector
+template<> template<> void object::test<9>()
+{
+    set_test_name("empty collection returns empty result");
+    std::vector<const Geometry*> empty;
+    auto actual = LineCollectionNoder::node(empty);
+    ensure_equals("empty result", actual.size(), std::size_t(0));
+}
+
+// Non-linear member (POLYGON): no LineString components, output slot is empty
+template<> template<> void object::test<10>()
+{
+    set_test_name("polygon member yields empty output slot");
+    auto input = readArray({
+        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+        "LINESTRING (5 -5, 5 15)"
+    });
+    auto actual = LineCollectionNoder::node(input);
+    ensure_equals("count preserved", actual.size(), std::size_t(2));
+    ensure("polygon member output is empty", actual[0]->isEmpty());
+}
+
+// Nested GEOMETRYCOLLECTION member: all linear components extracted
+template<> template<> void object::test<11>()
+{
+    set_test_name("nested GEOMETRYCOLLECTION member");
+    checkResult(
+        readArray({
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 10 0), LINESTRING (0 5, 10 5))",
+            "LINESTRING (5 -1, 5 10)"}),
+        {"MULTILINESTRING ((0 0, 5 0), (5 0, 10 0), (0 5, 5 5), (5 5, 10 5))",
+         "MULTILINESTRING ((5 -1, 5 0), (5 0, 5 5), (5 5, 5 10))"});
+}
+
+// gridSize < 0: treated as 0 (uses IteratedNoder), does not crash
+template<> template<> void object::test<12>()
+{
+    set_test_name("gridSize < 0 falls back to standard noding");
+    auto input = readArray({"LINESTRING (0 0, 10 10)", "LINESTRING (0 10, 10 0)"});
+    auto actual = LineCollectionNoder::node(input, -1.0);
+    ensure_equals("count preserved", actual.size(), std::size_t(2));
+    ensure_equals("member 0 split at crossing", (int)actual[0]->getNumGeometries(), 2);
+}
+
+// Z propagation: new node point gets Z averaged from both lines' interpolated values
+template<> template<> void object::test<13>()
+{
+    set_test_name("Z values averaged at new node points from both intersecting lines");
+    // Line 0: Z 0->1 at t=0.5 -> zp=0.5; Line 1: Z 5->10 at t=0.5 -> zq=7.5; avg=4.0
+    checkResult(
+        readArray({
+            "LINESTRING Z (0 0 0, 1 1 1)",
+            "LINESTRING Z (0 1 5, 1 0 10)"}),
+        {"MULTILINESTRING Z ((0 0 0, 0.5 0.5 4), (0.5 0.5 4, 1 1 1))",
+         "MULTILINESTRING Z ((0 1 5, 0.5 0.5 4), (0.5 0.5 4, 1 0 10))"});
+}
+
+// M propagation: new node point gets M averaged from both lines' interpolated values
+template<> template<> void object::test<14>()
+{
+    set_test_name("M values averaged at new node points from both intersecting lines");
+    // Line 0: M 0->1 at t=0.5 -> mp=0.5; Line 1: M 5->10 at t=0.5 -> mq=7.5; avg=4.0
+    checkResult(
+        readArray({
+            "LINESTRING M (0 0 0, 1 1 1)",
+            "LINESTRING M (0 1 5, 1 0 10)"}),
+        {"MULTILINESTRING M ((0 0 0, 0.5 0.5 4), (0.5 0.5 4, 1 1 1))",
+         "MULTILINESTRING M ((0 1 5, 0.5 0.5 4), (0.5 0.5 4, 1 0 10))"});
+}
+
+// ZM propagation: both Z and M averaged at new node points
+template<> template<> void object::test<15>()
+{
+    set_test_name("ZM values averaged at new node points from both intersecting lines");
+    // Line 0 at t=0.5: Z=0.5 M=150; Line 1 at t=0.5: Z=75 M=7.5; avg Z=37.75 M=78.75
+    checkResult(
+        readArray({
+            "LINESTRING ZM (0 0 0 100, 1 1 1 200)",
+            "LINESTRING ZM (0 1 50 5, 1 0 100 10)"}),
+        {"MULTILINESTRING ZM ((0 0 0 100, 0.5 0.5 37.75 78.75), (0.5 0.5 37.75 78.75, 1 1 1 200))",
+         "MULTILINESTRING ZM ((0 1 50 5, 0.5 0.5 37.75 78.75), (0.5 0.5 37.75 78.75, 1 0 100 10))"});
+}
+
+} // namespace tut


### PR DESCRIPTION
This feature is in support of the idea of an [ST_NodeWin()](https://trac.osgeo.org/postgis/ticket/5377) PostGIS feature, that would allow a table of LineString to be noded while retaining the associated attributes. Would look like 
```
SELECT ST_NodeWin(geom) AS noded_geom, foo, bar, baz 
FROM mygeomtable
```
Along the same lines as the ST_CoverageSimplify() implementation, providing 1:1 input/output guarantee.

This code is from my friend Claude. This PR is to make the changes reviewable by me (human) and also to get any other feedback that can improve this work.