### PR TITLE
CommonBits: clean UBSAN error

### DIFF
--- a/src/precision/CommonBits.cpp
+++ b/src/precision/CommonBits.cpp
@@ -14,6 +14,7 @@
  **********************************************************************/
 
 #include <geos/precision/CommonBits.h>
+#include <limits>
 
 namespace geos {
 namespace precision { // geos.precision
@@ -71,6 +72,11 @@ CommonBits::CommonBits()
 void
 CommonBits::add(double num)
 {
+    if (num > static_cast<double>(std::numeric_limits<std::int64_t>::max())) {
+        commonBits = 0;
+        return;
+    }
+
     int64_t numBits = (int64_t) num;
     if(isFirst) {
         commonBits = numBits;


### PR DESCRIPTION
Addresses 

```
bin/test_geos_unit capi::GEOSMinimumBoundingCircle 6
===============================
  GEOS Unit Test Suite
===============================
/Users/dan/dev/libgeos/src/precision/CommonBits.cpp:74:33: runtime error: 7.77778e+300 is outside the range of representable values of type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/dan/dev/libgeos/src/precision/CommonBits.cpp:74:33
NOTICE: IllegalArgumentException: BufferOp::getResultGeometry distance must be a finite value

capi::GEOSMinimumBoundingCircle: .

tests summary: ok:1
```