### PR TITLE
GeometrySplitter: Return input CompoundCurve when split line is disjoint

### DIFF
--- a/src/operation/split/GeometrySplitter.cpp
+++ b/src/operation/split/GeometrySplitter.cpp
@@ -289,11 +289,17 @@ GeometrySplitter::splitLinealWithEdge(const Geometry &geom, const Geometry &edge
     noder.setOnlyFirstGeomEdges(true);
     noder.setPreserveCompoundCurves(true);
 
-    auto nodedMLS = noder.getNoded();
+    auto noded = noder.getNoded();
 
-    auto nodedGC = geom.getFactory()->createGeometryCollection(detail::down_cast<GeometryCollection*>(nodedMLS.get())->releaseGeometries());
+    // Already a collection type? Convert to a generic GeometryCollection and return.
+    if (auto* coll = dynamic_cast<GeometryCollection*>(noded.get())) {
+        return geom.getFactory()->createGeometryCollection(coll->releaseGeometries());
+    }
 
-    return nodedGC;
+    // Promote single-part geometries to a collection type
+    std::vector<std::unique_ptr<Geometry>> geoms;
+    geoms.push_back(std::move(noded));
+    return geom.getFactory()->createGeometryCollection(std::move(geoms));
 }
 
 static std::unique_ptr<Point>

--- a/tests/unit/operation/split/GeometrySplitterTest.cpp
+++ b/tests/unit/operation/split/GeometrySplitterTest.cpp
@@ -848,4 +848,26 @@ void object::test<69>()
         "GEOMETRYCOLLECTION (LINESTRING (-10 0, -8 0), LINESTRING (-8 0, -5 0), COMPOUNDCURVE (CIRCULARSTRING (-5 0, 0 5, 5 0), (5 0, 8 0)), LINESTRING (8 0, 10 0), CIRCULARSTRING (10 0, 15 -5, 20 0))");
 }
 
+template<>
+template<>
+void object::test<70>()
+{
+    set_test_name("split CompoundCurve with disjoint LineString");
+
+    testSplit("COMPOUNDCURVE ((-10 0, -5 0), CIRCULARSTRING (-5 0, 0 5, 5 0), (5 0, 10 0))",
+              "LINESTRING (0 0, 0 4)",
+              "GEOMETRYCOLLECTION(COMPOUNDCURVE ((-10 0, -5 0), CIRCULARSTRING (-5 0, 0 5, 5 0), (5 0, 10 0)))");
+}
+
+template<>
+template<>
+void object::test<71>()
+{
+    set_test_name("split CompoundCurve with disjoint Point");
+
+    testSplit("COMPOUNDCURVE ((-10 0, -5 0), CIRCULARSTRING (-5 0, 0 5, 5 0), (5 0, 10 0))",
+              "POINT (0 0)",
+              "GEOMETRYCOLLECTION(COMPOUNDCURVE ((-10 0, -5 0), CIRCULARSTRING (-5 0, 0 5, 5 0), (5 0, 10 0)))");
+}
+
 }


### PR DESCRIPTION
Resolves https://github.com/libgeos/geos/issues/1456