### PR TITLE
geos_c.h: Remove prototype for unimplemented GEOS_interruptThread()

### DIFF
--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -421,12 +421,6 @@ extern GEOSContextInterruptCallback GEOS_DLL *GEOSContext_setInterruptCallback_r
 extern void GEOS_DLL GEOS_interruptRequest(void);
 
 /**
-* Interrupt the current thread.
-* \since 3.14
-*/
-extern void GEOS_DLL GEOS_interruptThread(void);
-
-/**
 * Cancel a pending interruption request
 * \since 3.4
 */


### PR DESCRIPTION
Looks like this was accidentally added in #803