### PR TITLE
GeometrySplitter Crash

### DIFF
--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -265,6 +265,7 @@ protected:
 
     void geometryChangedAction() override {
         envelope.setToNull();
+        flags.flagsCalculated = false;
     }
 
     int compareToSameClass(const Geometry* gc) const override;

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -150,6 +150,15 @@ GeometryCollection::setFlags() const {
         return;
     }
 
+    // Reset before accumulating, otherwise stale values (e.g. carried over
+    // by a clone) would never clear once flagsCalculated is invalidated.
+    flags.hasPoints = false;
+    flags.hasLines = false;
+    flags.hasPolygons = false;
+    flags.hasM = false;
+    flags.hasZ = false;
+    flags.hasCurves = false;
+
     for (const auto& geom : geometries) {
         flags.hasPoints |= geom->hasDimension(Dimension::P);
         flags.hasLines |= geom->hasDimension(Dimension::L);

--- a/src/operation/split/GeometrySplitter.cpp
+++ b/src/operation/split/GeometrySplitter.cpp
@@ -131,22 +131,24 @@ class RemoveCoordinateZM : public geom::CoordinateSequenceFilter {
 
 public:
 
-    void filter_rw(geom::CoordinateSequence& seq, std::size_t) override {
-        seq.setZM(false, false);
-        m_done = true;
+    void filter_rw(geom::CoordinateSequence& seq, std::size_t i) override {
+        // setZM rewrites the entire sequence, so we only need to act once
+        // per sequence (at the first coordinate).
+        if (i == 0) {
+            seq.setZM(false, false);
+        }
     }
 
     bool isDone() const override {
-        return m_done;
-    }
-
-    bool isGeometryChanged() const override {
-        // We didn't change the XY coords; no need to update the envelope.
+        // We must visit every sequence in the geometry, so never stop early.
         return false;
     }
 
-private:
-    bool m_done{false};
+    bool isGeometryChanged() const override {
+        // We dropped the Z/M dimensions, so cached dimensional flags
+        // must be recomputed.
+        return true;
+    }
 };
 
 std::unique_ptr<Geometry>

--- a/tests/unit/operation/split/GeometrySplitterTest.cpp
+++ b/tests/unit/operation/split/GeometrySplitterTest.cpp
@@ -875,11 +875,11 @@ template<>
 template<>
 void object::test<72>()
 {
-    set_test_name("split CompoundCurve with disjoint Point");
+    set_test_name("split LineString with 3D MultiLineString edge");
 
     testSplit("LINESTRING(-11.1111111 70,70 -11.1111111)",
               "MULTILINESTRING((-10 40 1,-9 41 1),(-9 41 1,-8 42 2),(-10 65 1,-9 66 1),(-9 66 1,-8 67 2),(10 40 1,11 41 1),(11 41 1,12 42 2),(10 65 1,11 66 1),(11 66 1,12 67 2),(30 40 1,31 41 1),(31 41 1,32 42 2),(30 65 1,31 66 1),(31 66 1,32 67 2),(50 40 1,51 41 1),(51 41 1,52 42 2),(50 65 1,51 66 1),(51 66 1,52 67 2))",
-              "LINESTRING(0 0, 1 1)");
+              "GEOMETRYCOLLECTION (LINESTRING (-11.1111111 70, -8.055555550000001 66.94444445), LINESTRING (-8.055555550000001 66.94444445, 70 -11.1111111))");
 }
 
 

--- a/tests/unit/operation/split/GeometrySplitterTest.cpp
+++ b/tests/unit/operation/split/GeometrySplitterTest.cpp
@@ -870,4 +870,18 @@ void object::test<71>()
               "GEOMETRYCOLLECTION(COMPOUNDCURVE ((-10 0, -5 0), CIRCULARSTRING (-5 0, 0 5, 5 0), (5 0, 10 0)))");
 }
 
+
+template<>
+template<>
+void object::test<72>()
+{
+    set_test_name("split CompoundCurve with disjoint Point");
+
+    testSplit("LINESTRING(-11.1111111 70,70 -11.1111111)",
+              "MULTILINESTRING((-10 40 1,-9 41 1),(-9 41 1,-8 42 2),(-10 65 1,-9 66 1),(-9 66 1,-8 67 2),(10 40 1,11 41 1),(11 41 1,12 42 2),(10 65 1,11 66 1),(11 66 1,12 67 2),(30 40 1,31 41 1),(31 41 1,32 42 2),(30 65 1,31 66 1),(31 66 1,32 67 2),(50 40 1,51 41 1),(51 41 1,52 42 2),(50 65 1,51 66 1),(51 66 1,52 67 2))",
+              "LINESTRING(0 0, 1 1)");
+}
+
+
+
 }


### PR DESCRIPTION
Found in the PostGIS garden tester (!) of all places, this example crashed the splitter.
```
testSplit(
  "LINESTRING(-11.1111111 70,70 -11.1111111)",
  "MULTILINESTRING((-10 40 1,-9 41 1),(-9 41 1,-8 42 2),(-10 65 1,-9 66 1),(-9 66 1,-8 67 2),(10 40 1,11 41 1),(11 41 1,12 42 2),(10 65 1,11 66 1),(11 66 1,12 67 2),(30 40 1,31 41 1),(31 41 1,32 42 2),(30 65 1,31 66 1),(31 66 1,32 67 2),(50 40 1,51 41 1),(51 41 1,52 42 2),(50 65 1,51 66 1),(51 66 1,52 67 2))",
  "GEOMETRYCOLLECTION (LINESTRING (-11.1111111 70, -8.055555550000001 66.94444445), LINESTRING (-8.055555550000001 66.94444445, 70 -11.1111111))"    
)
```