### PR TITLE
Polygonizer: Avoid dropped ZM on mixed-dimension inputs

### DIFF
--- a/src/operation/polygonize/EdgeRing.cpp
+++ b/src/operation/polygonize/EdgeRing.cpp
@@ -328,17 +328,29 @@ EdgeRing::getRingOwnership()
 
 /*private*/
 void
-EdgeRing::addEdge(const CoordinateSequence* coords, bool isForward,
-                  CoordinateSequence* coordList)
+EdgeRing::addEdge(const CoordinateSequence* srcCoords, bool isForward,
+                  CoordinateSequence* dstCoords)
 {
-    const std::size_t npts = coords->getSize();
+    const std::size_t npts = srcCoords->getSize();
+
+    if (!dstCoords->isEmpty() && !srcCoords->isEmpty()) {
+        // Patch Z value in last coordinate, if needed
+        if (srcCoords->hasZ() && std::isnan(dstCoords->getZ(dstCoords->size() - 1))) {
+            dstCoords->setZ(dstCoords->size() - 1, isForward ? srcCoords->getZ(0) : srcCoords->getZ(srcCoords->getSize() - 1));
+        }
+        // Patch M value in last coordinate, if needed
+        if (srcCoords->hasM() && std::isnan(dstCoords->getM(dstCoords->size() - 1))) {
+            dstCoords->setM(dstCoords->size() - 1, isForward ? srcCoords->getM(0) : srcCoords->getM(srcCoords->getSize() - 1));
+        }
+    }
+
     if(isForward) {
-        coordList->add(*coords, 0, npts - 1, false);
+        dstCoords->add(*srcCoords, 0, npts - 1, false);
     }
     else {
         for(std::size_t i = npts; i > 0; --i) {
-            coords->applyAt(i-1, [coordList](const auto& coord) {
-                coordList->add(coord, false);
+            srcCoords->applyAt(i-1, [&dstCoords](const auto& coord) {
+                dstCoords->add(coord, false);
             });
         }
     }

--- a/tests/unit/operation/polygonize/PolygonizeTest.cpp
+++ b/tests/unit/operation/polygonize/PolygonizeTest.cpp
@@ -459,5 +459,27 @@ void object::test<14>()
     doTest(input, expected, true, POLYGONS);
 }
 
+template<>
+template<>
+void object::test<15>()
+{
+    set_test_name("mixed dimension inputs");
+
+    std::vector<std::string> input{
+        "LINESTRING (0 0, 1 0)",
+        "LINESTRING Z (1 0 6, 2 2 9)",
+        "LINESTRING M (2 2 8, 0 0 7)"};
+
+    std::vector<std::string> expected{
+        "POLYGON ZM ((0 0 NaN 7, 1 0 6 NaN, 2 2 9 8, 0 0 NaN 7))",
+    };
+
+    doTest(input, expected, false, POLYGONS);
+
+    std::reverse(input.begin(), input.end());
+
+    doTest(input, expected, false, POLYGONS);
+}
+
 } // namespace tut
 

--- a/tests/unit/operation/split/GeometrySplitterTest.cpp
+++ b/tests/unit/operation/split/GeometrySplitterTest.cpp
@@ -882,6 +882,30 @@ void object::test<72>()
               "GEOMETRYCOLLECTION (LINESTRING (-11.1111111 70, -8.055555550000001 66.94444445), LINESTRING (-8.055555550000001 66.94444445, 70 -11.1111111))");
 }
 
+template<>
+template<>
+void object::test<73>()
+{
+    set_test_name("split PolygonZ with LineString");
+    // https://github.com/libgeos/geos/issues/1483
+
+    testSplit("POLYGONZ ((0 5 10, 0 10 20, 10 10 30, 10 5 20, 0 5 10))",
+              "LINESTRING(1 11, 1 5)",
+              "GEOMETRYCOLLECTION Z (POLYGON Z ((0 5 10, 0 10 20, 1 10 21, 1 5 11, 0 5 10)), POLYGON Z ((1 10 21, 10 10 30, 10 5 20, 1 5 11, 1 10 21)))");
+}
+
+template<>
+template<>
+void object::test<74>()
+{
+    set_test_name("split MultiPolygonZM with LineString");
+
+    testSplit(
+        "MULTIPOLYGON ZM (((1000000 6800000 0 0, 1000000 6800100 1 1, 1000200 6800100 2 2, 1000200 6800000 0 0, 1000000 6800000 0 0)))",
+        "LINESTRING( 1000135 6800130, 1000135 6799975)",
+        "GEOMETRYCOLLECTION ZM (POLYGON ZM ((1000000 6800000 0 0, 1000000 6800100 1 1, 1000135 6800100 1.675 1.675, 1000135 6800000 0 0, 1000000 6800000 0 0)), POLYGON ZM ((1000135 6800100 1.675 1.675, 1000200 6800100 2 2, 1000200 6800000 0 0, 1000135 6800000 0 0, 1000135 6800100 1.675 1.675)))"
+    );
+}
 
 
 }


### PR DESCRIPTION
Resolves https://github.com/libgeos/geos/issues/1483 and https://github.com/libgeos/geos/issues/1484

The fix here is largely the same as https://github.com/libgeos/geos/pull/1364 -- an unfortunate consequence of code duplication.