### PR TITLE
GeometrySplitter: do not split lines at self-intersection points

### DIFF
--- a/src/operation/split/GeometrySplitter.cpp
+++ b/src/operation/split/GeometrySplitter.cpp
@@ -16,6 +16,7 @@
 
 #include <geos/geom/CircularString.h>
 #include <geos/geom/CompoundCurve.h>
+#include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryCollection.h>
 #include <geos/geom/GeometryFactory.h>
@@ -289,6 +290,12 @@ GeometrySplitter::splitLinealWithEdge(const Geometry &geom, const Geometry &edge
         std::vector<std::unique_ptr<Geometry>> geoms;
         geoms.push_back(geom.clone());
         return geom.getFactory()->createGeometryCollection(std::move(geoms));
+    }
+
+    if (!geom.hasCurvedComponents() && !geom.isSimple()) {
+        auto splitPoints = geom.intersection(&edge)->getCoordinates();
+        auto splitPointsGeom = geom.getFactory()->createMultiPoint(*splitPoints);
+        return splitAtPoints(geom, *splitPointsGeom);
     }
 
     GeometryNoder noder(geom, edge);

--- a/src/operation/valid/IsSimpleOp.cpp
+++ b/src/operation/valid/IsSimpleOp.cpp
@@ -19,6 +19,7 @@
 
 #include <geos/algorithm/BoundaryNodeRule.h>
 #include <geos/algorithm/LineIntersector.h>
+#include <geos/geom/CompoundCurve.h>
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryCollection.h>
@@ -128,8 +129,13 @@ IsSimpleOp::computeSimple(const Geometry& geom)
             return isSimplePolygonal(geom);
         case GEOS_GEOMETRYCOLLECTION:
             return isSimpleGeometryCollection(geom);
-        case GEOS_CIRCULARSTRING:
         case GEOS_COMPOUNDCURVE:
+            if (!geom.hasCurvedComponents()) {
+                return isSimpleLinearGeometry(geom);
+            } else {
+                throw util::UnsupportedOperationException("Curved types not supported in IsSimpleOp.");
+            }
+        case GEOS_CIRCULARSTRING:
         case GEOS_MULTICURVE:
         case GEOS_CURVEPOLYGON:
         case GEOS_MULTISURFACE:
@@ -229,14 +235,17 @@ IsSimpleOp::removeRepeatedPts(const Geometry& geom)
 {
     std::vector<std::shared_ptr<const CoordinateSequence>> coordseqs;
     for (std::size_t i = 0, sz = geom.getNumGeometries(); i < sz; i++) {
-        const LineString* line = dynamic_cast<const LineString*>(geom.getGeometryN(i));
-        if (line) {
-            auto pts = line->getSharedCoordinates();
-            if (pts->hasRepeatedPoints()) {
-                pts = RepeatedPointRemover::removeRepeatedPoints(line->getCoordinatesRO());
+        const Curve* c = detail::down_cast<const Curve*>(geom.getGeometryN(i));
+        for (std::size_t j = 0; j < c->getNumCurves(); j++) {
+            const LineString* line = dynamic_cast<const LineString*>(c->getCurveN(j));
+            if (line) {
+                const auto& pts = line->getSharedCoordinates();
+                if (pts->hasRepeatedPoints()) {
+                    coordseqs.push_back(RepeatedPointRemover::removeRepeatedPoints(pts.get()));
+                } else {
+                    coordseqs.push_back(pts);
+                }
             }
-
-            coordseqs.push_back(pts);
         }
     }
     return coordseqs;

--- a/tests/unit/operation/split/GeometrySplitterTest.cpp
+++ b/tests/unit/operation/split/GeometrySplitterTest.cpp
@@ -691,24 +691,17 @@ void object::test<56>()
               "GEOMETRYCOLLECTION (LINESTRING (0 0, 10 0, 10 1), LINESTRING (10 1, 10 2, 6 2, 6 1), LINESTRING (6 1, 6 -1), LINESTRING (6 -1, 6 -2, 3 -2, 3 -1), LINESTRING (3 -1, 3 1), LINESTRING (3 1, 3 2, 0 2, 0 1), LINESTRING (0 1, 0 0))");
 }
 
-#if 0
 template<>
 template<>
 void object::test<57>()
 {
     set_test_name("do not split on self-intersections; QGIS test #4");
 
-    // Need to either
-    // a) do as QGIS does, and use Geometry::intersection to get intersection points, then node on those
-    // b) update GeometryNoder / SegmentIntersector classes with an ignoreSelfIntersections flag that would
-    //    ignore PathStrings with the same context.
-
     // Do not split on self-intersections - https://github.com/qgis/QGIS/issues/14070
     testSplit("LINESTRING (0 0, 10 0, 10 2, 6 2, 6 -2, 3 -2, 3 2, 0 2, 0 0)",
               "LINESTRING (0 1, 11 1, 11 -1, 0 -1)",
               "GEOMETRYCOLLECTION (LINESTRING (0 0, 10 0, 10 1), LINESTRING (10 1, 10 2, 6 2, 6 1), LINESTRING (6 1, 6 -1), LINESTRING (6 -1, 6 -2, 3 -2, 3 -1), LINESTRING (3 -1, 3 1), LINESTRING (3 1, 3 2, 0 2, 0 1), LINESTRING (0 1, 0 0))");
 }
-#endif
 
 template<>
 template<>

--- a/tests/unit/operation/valid/IsSimpleOpTest.cpp
+++ b/tests/unit/operation/valid/IsSimpleOpTest.cpp
@@ -3,6 +3,7 @@
 
 
 #include <tut/tut.hpp>
+#include <tut/tut_macros.hpp>
 #include <utility.h>
 
 // geos
@@ -47,7 +48,7 @@ struct test_issimpleop_data {
     {}
 
     void checkIsSimple(
-        std::string& wkt,
+        const std::string& wkt,
         const BoundaryNodeRule& bnRule,
         bool expectedResult)
     {
@@ -55,7 +56,7 @@ struct test_issimpleop_data {
     }
 
     void checkIsSimple(
-        std::string& wkt,
+        const std::string& wkt,
         const BoundaryNodeRule& bnRule,
         bool expectedResult,
         Coordinate expectedLocation)
@@ -233,5 +234,24 @@ void object::test<10> ()
     checkIsSimpleAll(a, BoundaryNodeRule::getBoundaryRuleMod2(), b);
 }
 
+template<>
+template<>
+void object::test<11>()
+{
+    set_test_name("CompoundCurve with linear components");
+
+    checkIsSimple( "COMPOUNDCURVE ((0 0, 10 10, 0 10), (0 10, 10 0))", BoundaryNodeRule::getBoundaryRuleMod2(), false, Coordinate(5, 5));
+}
+
+template<>
+template<>
+void object::test<12>()
+{
+    set_test_name("CompoundCurve with curved component");
+
+    auto g = reader_.read("COMPOUNDCURVE ((1 1, 0 0, -1 0), CIRCULARSTRING (-1 0, 0 1, 1 0))");
+
+    ensure_THROW(IsSimpleOp::isSimple(*g), geos::util::UnsupportedOperationException);
+}
 
 } // namespace tut


### PR DESCRIPTION
Resolves #1486 

This can be improved in a future release by removing the `isSimple` check and updating the noding machinery to optionally ignore self-intersections.