### PR TITLE
GeometryFactory::buildGeometry: use MultiCurve, MultiSurface for linear CompoundCurves, CurvePolygons

### DIFF
--- a/include/geos/geom/CircularString.h
+++ b/include/geos/geom/CircularString.h
@@ -45,6 +45,11 @@ public:
         return true;
     }
 
+    bool hasCurvedTypes() const override
+    {
+        return true;
+    }
+
     bool isCurved() const override {
         return true;
     }

--- a/include/geos/geom/CompoundCurve.h
+++ b/include/geos/geom/CompoundCurve.h
@@ -85,6 +85,10 @@ public:
 
     bool hasCurvedComponents() const override;
 
+    bool hasCurvedTypes() const override {
+        return true;
+    }
+
     bool hasM() const override;
 
     bool hasZ() const override;

--- a/include/geos/geom/CurvePolygon.h
+++ b/include/geos/geom/CurvePolygon.h
@@ -44,6 +44,10 @@ public:
 
     bool hasCurvedComponents() const override;
 
+    bool hasCurvedTypes() const override {
+        return true;
+    }
+
     void normalize() override;
 
 protected:

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -313,8 +313,12 @@ public:
     /// Return a string representation of this Geometry type
     virtual std::string getGeometryType() const = 0; //Abstract
 
-    /// Returns whether the Geometry contains curved components
+    /// Returns whether the Geometry contains arcs
     virtual bool hasCurvedComponents() const;
+
+    /// Returns whether the Geometry contains curved geometry types,
+    /// regardless of whether they actually contain any arcs.
+    virtual bool hasCurvedTypes() const;
 
     /// Return an integer representation of this Geometry type
     virtual GeometryTypeId getGeometryTypeId() const = 0; //Abstract

--- a/include/geos/geom/MultiCurve.h
+++ b/include/geos/geom/MultiCurve.h
@@ -55,6 +55,10 @@ public:
         return std::unique_ptr<MultiLineString>(getLinearizedImpl(params));
     }
 
+    bool hasCurvedTypes() const override {
+        return true;
+    }
+
     bool hasDimension(Dimension::DimensionType d) const override
     {
         return d == Dimension::L;

--- a/include/geos/geom/MultiSurface.h
+++ b/include/geos/geom/MultiSurface.h
@@ -53,6 +53,10 @@ public:
         return std::unique_ptr<MultiPolygon>(getLinearizedImpl(params));
     }
 
+    bool hasCurvedTypes() const override {
+        return true;
+    }
+
     bool hasDimension(Dimension::DimensionType d) const override
     {
         return d == Dimension::A;

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -806,6 +806,11 @@ Geometry::hasCurvedComponents() const {
     return false;
 }
 
+bool
+Geometry::hasCurvedTypes() const {
+    return false;
+}
+
 } // namespace geos::geom
 } // namespace geos
 

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -897,11 +897,11 @@ GeometryTypeId commonType(const T& geoms) {
         return geoms[0]->getGeometryTypeId();
     }
 
-    bool hasCurvedComponents = geoms[0]->hasCurvedComponents();
+    bool curvedType = geoms[0]->hasCurvedTypes();
 
     const Dimension::DimensionType dim = geoms[0]->getDimension();
     for (std::size_t i = 1; i < geoms.size(); i++) {
-        hasCurvedComponents |= geoms[i]->hasCurvedComponents();
+        curvedType |= geoms[i]->hasCurvedTypes();
 
         if (geoms[i]->getDimension() != dim) {
             return GEOS_GEOMETRYCOLLECTION;
@@ -913,9 +913,9 @@ GeometryTypeId commonType(const T& geoms) {
         case GEOS_COMPOUNDCURVE:
         case GEOS_CIRCULARSTRING: return GEOS_MULTICURVE;
         case GEOS_LINEARRING:
-        case GEOS_LINESTRING: return hasCurvedComponents ? GEOS_MULTICURVE : GEOS_MULTILINESTRING;
+        case GEOS_LINESTRING: return curvedType ? GEOS_MULTICURVE : GEOS_MULTILINESTRING;
         case GEOS_CURVEPOLYGON: return GEOS_MULTISURFACE;
-        case GEOS_POLYGON: return hasCurvedComponents ? GEOS_MULTISURFACE : GEOS_MULTIPOLYGON;
+        case GEOS_POLYGON: return curvedType ? GEOS_MULTISURFACE : GEOS_MULTIPOLYGON;
         default: return GEOS_GEOMETRYCOLLECTION;
     }
 }
@@ -1020,7 +1020,7 @@ GeometryFactory::buildGeometry(const std::vector<const Geometry*>& fromGeoms) co
         return fromGeoms[0]->clone();
     }
 
-    auto resultType = commonType(fromGeoms);
+    const auto resultType = commonType(fromGeoms);
 
     switch(resultType) {
         case GEOS_MULTIPOINT: return createMultiPoint(fromGeoms);

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -1129,6 +1129,17 @@ void object::test<34>
         ensure_equals(factory_->buildGeometry(std::move(geoms))->getGeometryTypeId(), geos::geom::GEOS_MULTICURVE);
     }
 
+    // MultiCurve (2)
+    {
+        std::vector<std::unique_ptr<Geometry>> geoms;
+        geoms.push_back(reader_.read("LINESTRING (3 3, 4 4)"));
+        geoms.push_back(reader_.read("COMPOUNDCURVE((0 0, 1 1, 2 0))"));
+
+        auto g = factory_->buildGeometry(std::move(geoms));
+        ensure_equals(g->getGeometryTypeId(), geos::geom::GEOS_MULTICURVE);
+        ensure_equals(g->getNumGeometries(), 2u);
+    }
+
     // MultiLineString
     {
         std::vector<std::unique_ptr<Geometry>> geoms;
@@ -1150,6 +1161,14 @@ void object::test<34>
         std::vector<std::unique_ptr<Geometry>> geoms;
         geoms.push_back(poly->clone());
         geoms.push_back(curvepoly->clone());
+        ensure_equals(factory_->buildGeometry(std::move(geoms))->getGeometryTypeId(), geos::geom::GEOS_MULTISURFACE);
+    }
+
+    // MultiSurface (2)
+    {
+        std::vector<std::unique_ptr<Geometry>> geoms;
+        geoms.push_back(poly->clone());
+        geoms.push_back(reader_.read("CURVEPOLYGON ((100 100, 200 100, 200 200, 100 100))"));
         ensure_equals(factory_->buildGeometry(std::move(geoms))->getGeometryTypeId(), geos::geom::GEOS_MULTISURFACE);
     }
 }


### PR DESCRIPTION
The `Geometry::hasCurvedComponents` method doesn't do what we want here, since it returns false for a linear CompoundCurve or CurvePolygon.