### PR TITLE
GeometrySplitter: always raise error for point input geometry

### DIFF
--- a/src/operation/split/GeometrySplitter.cpp
+++ b/src/operation/split/GeometrySplitter.cpp
@@ -173,6 +173,10 @@ GeometrySplitter::splitAtPoints(const Geometry& geom, const Geometry& splitPoint
 std::unique_ptr<Geometry>
 GeometrySplitter::split(const Geometry &geom, const Geometry &splitGeom)
 {
+    if (geom.hasDimension(geom::Dimension::P)) {
+        throw util::IllegalArgumentException("Input geometry must be linear or polygonal.");
+    }
+
     if (geom.isEmpty() || splitGeom.isEmpty()) {
         std::vector<std::unique_ptr<Geometry>> geoms;
         geoms.push_back(geom.clone());

--- a/tests/unit/capi/GEOSSplitTest.cpp
+++ b/tests/unit/capi/GEOSSplitTest.cpp
@@ -44,8 +44,27 @@ void object::test<2>()
 {
     geom1_ = fromWKT("POINT (3 7)");
     geom2_ = fromWKT("LINESTRING (3 7, 3 8)");
+    geom3_ = fromWKT("POINT (3 7)");
 
     result_ = GEOSSplit(geom1_, geom2_); // cannot split a point geometry
+    ensure(!result_);
+
+    result_ = GEOSSplit(geom1_, geom3_); // cannot split a point geometry
+    ensure(!result_);
+}
+
+template<>
+template<>
+void object::test<3>()
+{
+    geom1_ = fromWKT("GEOMETRYCOLLECTION (POINT (3 7), LINESTRING (3 7, 3 8))");
+    geom2_ = fromWKT("LINESTRING (3 7, 3 8)");
+    geom3_ = fromWKT("POINT (3 7)");
+
+    result_ = GEOSSplit(geom1_, geom2_); // cannot split collection with a point geometry
+    ensure(!result_);
+
+    result_ = GEOSSplit(geom1_, geom3_); // cannot split collection with a point geometry
     ensure(!result_);
 }
 


### PR DESCRIPTION
Potentially addresses https://github.com/libgeos/geos/issues/1490