### PR TITLE
Fix intersection computation of slightly overlapping polygons

### DIFF
--- a/src/edgegraph/HalfEdge.cpp
+++ b/src/edgegraph/HalfEdge.cpp
@@ -179,6 +179,8 @@ HalfEdge::findLowest() const
 int
 HalfEdge::compareAngularDirection(const HalfEdge* e) const
 {
+    assert(orig().equals2D(e->orig()));
+
     // same vector
     if (directionPt().equals2D(e->directionPt()))
         return 0;
@@ -267,5 +269,3 @@ HalfEdge::toStringNode(const HalfEdge* he, std::ostream& os)
 
 } // namespace geos.edgegraph
 } // namespace geos
-
-

--- a/src/edgegraph/HalfEdge.cpp
+++ b/src/edgegraph/HalfEdge.cpp
@@ -179,17 +179,12 @@ HalfEdge::findLowest() const
 int
 HalfEdge::compareAngularDirection(const HalfEdge* e) const
 {
-    double dx = directionX();
-    double dy = directionY();
-    double dx2 = e->directionX();
-    double dy2 = e->directionY();
-
     // same vector
-    if (dx == dx2 && dy == dy2)
+    if (directionPt().equals2D(e->directionPt()))
         return 0;
 
-    int quadrant = geom::Quadrant::quadrant(dx, dy);
-    int quadrant2 = geom::Quadrant::quadrant(dx2, dy2);
+    int quadrant = geom::Quadrant::quadrant(directionX(), directionY());
+    int quadrant2 = geom::Quadrant::quadrant(e->directionX(), e->directionY());
 
     /**
     * If the direction vectors are in different quadrants,

--- a/src/geomgraph/EdgeEnd.cpp
+++ b/src/geomgraph/EdgeEnd.cpp
@@ -160,7 +160,7 @@ int
 EdgeEnd::compareDirection(const EdgeEnd* e) const
 {
     assert(e);
-    if(dx == e->dx && dy == e->dy) {
+    if(p1.equals2D(e->p1)) {
         return 0;
     }
 

--- a/src/geomgraph/EdgeEnd.cpp
+++ b/src/geomgraph/EdgeEnd.cpp
@@ -160,6 +160,8 @@ int
 EdgeEnd::compareDirection(const EdgeEnd* e) const
 {
     assert(e);
+    assert(p0.equals2D(e->p0));
+
     if(p1.equals2D(e->p1)) {
         return 0;
     }
@@ -215,4 +217,3 @@ operator<< (std::ostream& os, const EdgeEnd& ee)
 
 } // namespace geos.geomgraph
 } // namespace geos
-

--- a/tests/unit/edgegraph/EdgeGraphTest.cpp
+++ b/tests/unit/edgegraph/EdgeGraphTest.cpp
@@ -170,6 +170,25 @@ void object::test<5> ()
     checkNextPrev(*graph);
 }
 
+// testSimilarEdgesDirection
+template<>
+template<>
+void object::test<6> ()
+{
+    EdgeGraph graph;
+    HalfEdge* e1 = addEdge(graph, 1, 1, 0, 0.5);
+    addEdge(graph, 1, 1, 0, 0.49999999999999994);
+    addEdge(graph, 1, 1, 0, 1);
+
+    HalfEdge* eUpper = findEdge(graph, 1, 1, 0, 0.5);
+    HalfEdge* eLower = findEdge(graph, 1, 1, 0, 0.49999999999999994);
+    ensure("edges with distinct direction points must not compare equal", eUpper->compareTo(eLower) != 0);
+    ensure("edge comparison must be antisymmetric", eUpper->compareTo(eLower) == -eLower->compareTo(eUpper));
+
+    checkNodeValid(e1);
+    checkNextPrev(graph);
+}
+
 
 
 } // namespace tut

--- a/tests/unit/operation/overlayng/OverlayNGRobustTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayNGRobustTest.cpp
@@ -61,6 +61,17 @@ struct test_overlayngrobust_data {
         ensure_NO_THROW( OverlayNGRobust::Overlay(geom_a.get(), geom_b.get(), opCode) );
     }
 
+    void
+    checkOverlaySymmetricArea(const std::string& a, const std::string& b, int opCode, double expectedArea)
+    {
+        std::unique_ptr<Geometry> geom_a = r.read(a);
+        std::unique_ptr<Geometry> geom_b = r.read(b);
+        double areaAB = OverlayNGRobust::Overlay(geom_a.get(), geom_b.get(), opCode)->getArea();
+        double areaBA = OverlayNGRobust::Overlay(geom_b.get(), geom_a.get(), opCode)->getArea();
+        ensure_equals("overlay is not commutative", areaAB, areaBA, 1e-12);
+        ensure_equals("unexpected overlay area", areaAB, expectedArea, 1e-12);
+    }
+
     std::unique_ptr<Geometry>
     double2geom(const std::vector<double>& x, const std::vector<double>& y)
     {
@@ -109,7 +120,26 @@ void object::test<2> ()
     checkOverlaySuccess(a, b, OverlayNG::INTERSECTION);
 }
 
+// 2026-08-05 Intersection of polygons isn't commutative (https://github.com/libgeos/geos/issues/1405)
+template<>
+template<>
+void object::test<3> ()
+{
+    set_test_name("Intersection of triangles with an extremely similar edge");
+    const std::string a = "POLYGON ((1 1, 0 0.5, 0 0, 1 1))";
+    const std::string b = "POLYGON ((1 1, 0 0.49999999999999994, 0 1, 1 1))";
+    checkOverlaySymmetricArea(a, b, OverlayNG::INTERSECTION, 0.0);
+}
 
+template<>
+template<>
+void object::test<4> ()
+{
+    set_test_name("Union of triangles with an extremely similar edge");
+    const std::string a = "POLYGON ((1 1, 0 0.5, 0 0, 1 1))";
+    const std::string b = "POLYGON ((1 1, 0 0.49999999999999994, 0 1, 1 1))";
+    checkOverlaySymmetricArea(a, b, OverlayNG::UNION, 0.5);
+}
 
 #if 0
 /**


### PR DESCRIPTION
**Problem**: The polygon intersection computation doesn't work well when two polygons ~almost share an edge~ overlap very slightly. One of the symptoms is that intersection operation isn't commutative (as described in #1405)

**Content**: This PR consists of two commits: one adding a trivial not-working example (a unit test), two a proposed fix using `equals2D` instead of trivial independent coord-by-coord comparison. What i propose is to actually compare the dst point instead of float comparison of subtraction. That, should the points be very close, can produce 0 even for non-equivalent edges due to float arithmetics.

---

**Example description**: Below I enclose the problem description. It's similar to #1405 but, I believe, more straightforward and debuggable.
- Polygon A: 	`POLYGON ((1 1, 0 0.5, 0 0, 1 1))`  - a triangle with area 0.25
- Polygon B:   `POLYGON ((1 1, 0 0.49999999999999994, 0 1, 1 1))` - another triangle with area (almost) 0.25 which shares a common vertex `1 1` and a tiny overlap close to one of the edges with A ~and almost shares a second vertex `0 0.49999999999999994` with A (`0 0.5`)~
- ~Apart from point `(1 1)` these polygons don't share any point. Their intersection is a single point and the intersection area is mathematically `0`. Their union area is (almost) `0.5`~
- The intersection of these polygons a tiny neighborhood of edge `(1 1) -> (0 0.5)` with area close to `0`
- Prior this PR, the intersection area of these polygons was `0.25` as well as the union area. The newly proposed unit tests demonstrate this fact.
- With the second commit applied, the behavior is fixed

**Example visualization**: I used dbeaver with postgis only for the visualization purposes. I know this postgis isn't up-to-date and linked geos is only `3.13.1`, however, the same behavior is replicated directly in the tests. 
`postgis_full_version()`  

```
: POSTGIS="3.6.4 94d984b" [EXTENSION] PGSQL="180" GEOS="3.13.1-CAPI-1.19.2" SFCGAL="SFCGAL 2.0.0, CGAL 6.0, BOOST 1.83.0" PROJ="9.6.0 NETWORK_ENABLED=OFF URL_ENDPOINT=https://cdn.proj.org USER_WRITABLE_DIRECTORY=/var/lib/postgresql/.local/share/proj DATABASE_PATH=/usr/share/proj/proj.db" (compiled against PROJ 9.6.0) LIBXML="2.9.14" LIBJSON="0.18" LIBPROTOBUF="1.5.1" WAGYU="0.5.0 (Internal)" TOPOLOGY
```
<img width="1784" height="1029" alt="image" src="https://github.com/user-attachments/assets/6c1b0590-95d8-414c-9056-51320cf925ab" />

The source sql in case anybody would like to replicate:
```sql
with cte as (
select
	'POLYGON ((1 1, 0 0.5, 0 0, 1 1))'::geometry as a,
    'POLYGON ((1 1, 0 0.49999999999999994, 0 1, 1 1))'::geometry as b
)
select
    a,
    b,
	st_area(a) as area_a,
	st_area(b) as area_b,
	st_area(st_intersection(a, b)) as area_ab,
	st_area(st_intersection(b, a)) as area_ba,
	postgis_full_version() as postgis_version
from cte
```
---

**Disclaimer**: while I found out about the problem myself and basically crafted the examples, I admit using a LLM for some hints and coding assistence. In case it's not allowed feel free to close the PR, however, please consider the revealed/described bug. I believe the code sheds some light to it.

---

Closes #1405