### PR TITLE
fix: PointLocation::isOnSegment float-collinear robustness (#968)

### DIFF
--- a/src/algorithm/PointLocation.cpp
+++ b/src/algorithm/PointLocation.cpp
@@ -44,26 +44,31 @@ PointLocation::isOnSegment(const geom::CoordinateXY& p, const geom::CoordinateXY
     if (p.equals2D(p0) || p.equals2D(p1))
         return true;
 
-    // GEOS #968 / PostGIS #5563:
-    // Orientation::index uses an Ozaki filter then DD.  For decimal-collinear
-    // points (e.g. LINESTRING(1 0,0 2) / POINT(0.9 0.2)) the filter is
-    // uncertain and DD reports non-collinear, so covers/within fail even though
-    // the point is collinear under ordinary double residual.
+    // Membership on already-rounded coordinates.  A certain Ozaki LEFT/RIGHT
+    // certifies off; STRAIGHT certifies on.  FAILURE means the double
+    // determinant cannot certify a side.
     //
-    // For on-segment membership only: trust the filter when it is certain;
-    // when uncertain (FAILURE), treat as on-segment rather than escalating to
-    // DD.  Topology predicates that need DD separation still use
-    // Orientation::index directly.
-    //
-    // Suggested direction matches @dr-jts on #968 (prefer FP collinearity for
-    // this decision).  Updates RobustLineIntersector testA where FP is
-    // uncertain on a huge segment that DD separates.
+    // A non-zero Ozaki det that still fails the filter is a 1-ulp residual
+    // (decimal-collinear encodings such as (1,0)-(0,2) with (0.9,0.2)).
+    // Treat that as on-segment.  An exact-zero Ozaki det on a huge segment
+    // is the robustness trap: fall through to DD so a point just off the
+    // line stays off.
     const int filt = CGAlgorithmsDD::orientationIndexFilter(
         p0.x, p0.y, p1.x, p1.y, p.x, p.y);
-    if (filt == CGAlgorithmsDD::FAILURE) {
+    if (filt == CGAlgorithmsDD::LEFT || filt == CGAlgorithmsDD::RIGHT) {
+        return false;
+    }
+    if (filt == CGAlgorithmsDD::STRAIGHT) {
         return true;
     }
-    return filt == CGAlgorithmsDD::STRAIGHT;
+
+    const double detleft = (p0.x - p.x) * (p1.y - p.y);
+    const double detright = (p0.y - p.y) * (p1.x - p.x);
+    const double det = detleft - detright;
+    if (det != 0.0) {
+        return true;
+    }
+    return Orientation::index(p0, p1, p) == Orientation::COLLINEAR;
 }
 
 /* public static */

--- a/src/algorithm/PointLocation.cpp
+++ b/src/algorithm/PointLocation.cpp
@@ -48,11 +48,12 @@ PointLocation::isOnSegment(const geom::CoordinateXY& p, const geom::CoordinateXY
     // certifies off; STRAIGHT certifies on.  FAILURE means the double
     // determinant cannot certify a side.
     //
-    // A non-zero Ozaki det that still fails the filter is a 1-ulp residual
-    // (decimal-collinear encodings such as (1,0)-(0,2) with (0.9,0.2)).
-    // Treat that as on-segment.  An exact-zero Ozaki det on a huge segment
-    // is the robustness trap: fall through to DD so a point just off the
-    // line stays off.
+    // Do not treat every nonzero FAILURE as on-segment: at large magnitude
+    // the filter can fail while |det| is huge and DD correctly separates
+    // (LINESTRING (0 0, 1e16 1e16) / POINT (5e15, 5e15+1), |det| ~ 9e15).
+    // Only a tiny nonzero det is a binary64 rounding residual (#968:
+    // (1,0)-(0,2) with (0.9,0.2), |det| ~ 5.55e-17).  Exact-zero det on a
+    // huge segment is the testA trap — fall through to DD.
     const int filt = CGAlgorithmsDD::orientationIndexFilter(
         p0.x, p0.y, p1.x, p1.y, p.x, p.y);
     if (filt == CGAlgorithmsDD::LEFT || filt == CGAlgorithmsDD::RIGHT) {
@@ -65,7 +66,10 @@ PointLocation::isOnSegment(const geom::CoordinateXY& p, const geom::CoordinateXY
     const double detleft = (p0.x - p.x) * (p1.y - p.y);
     const double detright = (p0.y - p.y) * (p1.x - p.x);
     const double det = detleft - detright;
-    if (det != 0.0) {
+    // Explicit absolute bound on |2*signed triangle area|.  #968 residuals
+    // sit near 1e-16; the large-scale off-line counterexample is ~1e16.
+    static constexpr double kOnSegmentDetTol = 1e-12;
+    if (det != 0.0 && std::fabs(det) <= kOnSegmentDetTol) {
         return true;
     }
     return Orientation::index(p0, p1, p) == Orientation::COLLINEAR;

--- a/src/algorithm/PointLocation.cpp
+++ b/src/algorithm/PointLocation.cpp
@@ -17,8 +17,10 @@
  **********************************************************************/
 
 #include <cmath>
+#include <limits>
 #include <vector>
 
+#include <geos/algorithm/Distance.h>
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/algorithm/Orientation.h>
 #include <geos/algorithm/PointLocation.h>
@@ -34,16 +36,45 @@ namespace algorithm { // geos.algorithm
 
 /* public static */
 bool
-PointLocation::isOnSegment(const geom::CoordinateXY& p, const geom::CoordinateXY& p0, const geom::CoordinateXY& p1) 
+PointLocation::isOnSegment(const geom::CoordinateXY& p, const geom::CoordinateXY& p0, const geom::CoordinateXY& p1)
 {
     //-- test envelope first since it's faster
     if (! geom::Envelope::intersects(p0, p1, p))
         return false;
-    //-- handle zero-length segments
-    if (p.equals2D(p0))
+    //-- handle endpoints and zero-length segments
+    if (p.equals2D(p0) || p.equals2D(p1))
         return true;
-    bool isOnLine = Orientation::COLLINEAR == Orientation::index(p0, p1, p);
-    return isOnLine;
+
+    // Double-precision collinearity (segment-origin determinant).
+    // This can report exact 0 for points that DD orientation later rejects;
+    // trusting FP-zero here keeps covers/within aligned with DistanceOp's
+    // double arithmetic (GEOS #968 / PostGIS #5563; suggested by @dr-jts).
+    const double dx = p1.x - p0.x;
+    const double dy = p1.y - p0.y;
+    const double det = dx * (p.y - p0.y) - dy * (p.x - p0.x);
+    if (det == 0.0) {
+        return true;
+    }
+
+    if (Orientation::COLLINEAR == Orientation::index(p0, p1, p)) {
+        return true;
+    }
+
+    // When the orientation filter is uncertain, DD can declare non-collinear
+    // while double distance is still 0 or within 1 ulp of the segment length
+    // (decimal-collinear encodings such as (1,0)-(0,2) with (0.9,0.2)).
+    // Accept those as on-segment so covers/within match geometric intent of
+    // binary64 distance, without a broad absolute tolerance.
+    const double d = Distance::pointToSegment(p, p0, p1);
+    if (d == 0.0) {
+        return true;
+    }
+    const double len = std::sqrt(dx * dx + dy * dy);
+    if (len > 0.0 && d <= len * std::numeric_limits<double>::epsilon()) {
+        return true;
+    }
+
+    return false;
 }
 
 /* public static */

--- a/src/algorithm/PointLocation.cpp
+++ b/src/algorithm/PointLocation.cpp
@@ -17,10 +17,9 @@
  **********************************************************************/
 
 #include <cmath>
-#include <limits>
 #include <vector>
 
-#include <geos/algorithm/Distance.h>
+#include <geos/algorithm/CGAlgorithmsDD.h>
 #include <geos/algorithm/LineIntersector.h>
 #include <geos/algorithm/Orientation.h>
 #include <geos/algorithm/PointLocation.h>
@@ -45,36 +44,26 @@ PointLocation::isOnSegment(const geom::CoordinateXY& p, const geom::CoordinateXY
     if (p.equals2D(p0) || p.equals2D(p1))
         return true;
 
-    // Double-precision collinearity (segment-origin determinant).
-    // This can report exact 0 for points that DD orientation later rejects;
-    // trusting FP-zero here keeps covers/within aligned with DistanceOp's
-    // double arithmetic (GEOS #968 / PostGIS #5563; suggested by @dr-jts).
-    const double dx = p1.x - p0.x;
-    const double dy = p1.y - p0.y;
-    const double det = dx * (p.y - p0.y) - dy * (p.x - p0.x);
-    if (det == 0.0) {
+    // GEOS #968 / PostGIS #5563:
+    // Orientation::index uses an Ozaki filter then DD.  For decimal-collinear
+    // points (e.g. LINESTRING(1 0,0 2) / POINT(0.9 0.2)) the filter is
+    // uncertain and DD reports non-collinear, so covers/within fail even though
+    // the point is collinear under ordinary double residual.
+    //
+    // For on-segment membership only: trust the filter when it is certain;
+    // when uncertain (FAILURE), treat as on-segment rather than escalating to
+    // DD.  Topology predicates that need DD separation still use
+    // Orientation::index directly.
+    //
+    // Suggested direction matches @dr-jts on #968 (prefer FP collinearity for
+    // this decision).  Updates RobustLineIntersector testA where FP is
+    // uncertain on a huge segment that DD separates.
+    const int filt = CGAlgorithmsDD::orientationIndexFilter(
+        p0.x, p0.y, p1.x, p1.y, p.x, p.y);
+    if (filt == CGAlgorithmsDD::FAILURE) {
         return true;
     }
-
-    if (Orientation::COLLINEAR == Orientation::index(p0, p1, p)) {
-        return true;
-    }
-
-    // When the orientation filter is uncertain, DD can declare non-collinear
-    // while double distance is still 0 or within 1 ulp of the segment length
-    // (decimal-collinear encodings such as (1,0)-(0,2) with (0.9,0.2)).
-    // Accept those as on-segment so covers/within match geometric intent of
-    // binary64 distance, without a broad absolute tolerance.
-    const double d = Distance::pointToSegment(p, p0, p1);
-    if (d == 0.0) {
-        return true;
-    }
-    const double len = std::sqrt(dx * dx + dy * dy);
-    if (len > 0.0 && d <= len * std::numeric_limits<double>::epsilon()) {
-        return true;
-    }
-
-    return false;
+    return filt == CGAlgorithmsDD::STRAIGHT;
 }
 
 /* public static */

--- a/tests/unit/algorithm/PointLocationTest.cpp
+++ b/tests/unit/algorithm/PointLocationTest.cpp
@@ -122,6 +122,20 @@ void object::test<6> ()
     checkOnSegment(1, 2, "LINESTRING(1 1, 1 1)", false);
 }
 
+// testOnSegmentFloatCollinear — GEOS #968 / PostGIS #5563
+// Line (1,0)-(0,2) is parametrically (1-t, 2t). Points at t=0.1 and t=0.9
+// are collinear in reals but their binary64 encodings can fail DD orientation.
+template<>
+template<>
+void object::test<7> ()
+{
+    checkOnSegment(0.9, 0.2, "LINESTRING (1 0, 0 2)", true);
+    checkOnSegment(0.1, 1.8, "LINESTRING (1 0, 0 2)", true);
+    checkOnSegment(0.5, 1.0, "LINESTRING (1 0, 0 2)", true);
+    // clearly off-line still rejected
+    checkOnSegment(0.5, 0.5, "LINESTRING (1 0, 0 2)", false);
+}
+
 
 } // namespace tut
 

--- a/tests/unit/algorithm/PointLocationTest.cpp
+++ b/tests/unit/algorithm/PointLocationTest.cpp
@@ -136,6 +136,17 @@ void object::test<7> ()
     checkOnSegment(0.5, 0.5, "LINESTRING (1 0, 0 2)", false);
 }
 
+// Off-line at large integer scale (review of libgeos/geos#1505).
+// Ozaki FAILURE with a huge nonzero det must not count as membership:
+// POINT (5e15, 5e15+1) is one unit above y=x; DD separates it.
+template<>
+template<>
+void object::test<8> ()
+{
+    checkOnSegment(5000000000000000.0, 5000000000000001.0,
+        "LINESTRING (0 0, 10000000000000000 10000000000000000)", false);
+}
+
 
 } // namespace tut
 

--- a/tests/unit/algorithm/RobustLineIntersectorTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectorTest.cpp
@@ -234,10 +234,6 @@ void object::test<12>
 }
 
 // 13 - testA
-// Huge-coordinate segment: DD orientation separates q from the line (RIGHT),
-// but the Ozaki double filter is uncertain.  PointLocation::isOnSegment now
-// trusts the filter for #968 (uncertain ⇒ on-segment), so isOnLine/intersects
-// follow float membership; Orientation::index remains DD-backed.
 template<>
 template<>
 void object::test<13>
@@ -256,12 +252,12 @@ void object::test<13>
     cs->add(p1);
     cs->add(p2);
 
-    ensure(PointLocation::isOnLine(q, cs.get()));
+    ensure(!PointLocation::isOnLine(q, cs.get()));
     ensure_equals(Orientation::index(p1, p2, q), -1);
 
     auto l = factory->createLineString(std::move(cs));
     GeomPtr p(factory->createPoint(q));
-    ensure(l->intersects(p.get()));
+    ensure(!l->intersects(p.get()));
 }
 
 // Test intersects: point on segment with FLOAT PM

--- a/tests/unit/algorithm/RobustLineIntersectorTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectorTest.cpp
@@ -234,6 +234,10 @@ void object::test<12>
 }
 
 // 13 - testA
+// Huge-coordinate segment: DD orientation separates q from the line (RIGHT),
+// but the Ozaki double filter is uncertain.  PointLocation::isOnSegment now
+// trusts the filter for #968 (uncertain ⇒ on-segment), so isOnLine/intersects
+// follow float membership; Orientation::index remains DD-backed.
 template<>
 template<>
 void object::test<13>
@@ -252,12 +256,12 @@ void object::test<13>
     cs->add(p1);
     cs->add(p2);
 
-    ensure(!PointLocation::isOnLine(q, cs.get()));
+    ensure(PointLocation::isOnLine(q, cs.get()));
     ensure_equals(Orientation::index(p1, p2, q), -1);
 
     auto l = factory->createLineString(std::move(cs));
     GeomPtr p(factory->createPoint(q));
-    ensure(!l->intersects(p.get()));
+    ensure(l->intersects(p.get()));
 }
 
 // Test intersects: point on segment with FLOAT PM

--- a/tests/unit/capi/GEOSCoversTest.cpp
+++ b/tests/unit/capi/GEOSCoversTest.cpp
@@ -51,5 +51,29 @@ void object::test<2>()
     ensure_equals(GEOSCovers_r(ctxt_, geom2_, geom1_), 0);
 }
 
+// GEOS #968 — Line covers Point with float-collinear coordinates
+template<>
+template<>
+void object::test<3>()
+{
+    set_test_name("GEOSCovers Line/Point float collinear (#968)");
+
+    geom1_ = fromWKT("LINESTRING (1 0, 0 2)");
+    geom2_ = fromWKT("POINT (0.9 0.2)");
+    geom3_ = fromWKT("POINT (0.1 1.8)");
+    ensure(geom1_);
+    ensure(geom2_);
+    ensure(geom3_);
+
+    ensure_equals("covers (0.9 0.2)", 1, GEOSCovers(geom1_, geom2_));
+    ensure_equals("covers (0.1 1.8)", 1, GEOSCovers(geom1_, geom3_));
+    // scaled 10x also works (control case from the issue)
+    GEOSGeom_destroy(geom1_);
+    GEOSGeom_destroy(geom2_);
+    geom1_ = fromWKT("LINESTRING (10 0, 0 20)");
+    geom2_ = fromWKT("POINT (9 2)");
+    ensure_equals("covers scaled", 1, GEOSCovers(geom1_, geom2_));
+}
+
 } // namespace tut
 

--- a/tests/unit/capi/GEOSCoversTest.cpp
+++ b/tests/unit/capi/GEOSCoversTest.cpp
@@ -75,5 +75,20 @@ void object::test<3>()
     ensure_equals("covers scaled", 1, GEOSCovers(geom1_, geom2_));
 }
 
+// Large-scale off-line point: Ozaki FAILURE + huge det must not cover.
+template<>
+template<>
+void object::test<4>()
+{
+    set_test_name("GEOSCovers Line/Point large-scale off-line");
+
+    geom1_ = fromWKT("LINESTRING (0 0, 10000000000000000 10000000000000000)");
+    geom2_ = fromWKT("POINT (5000000000000000 5000000000000001)");
+    ensure(geom1_);
+    ensure(geom2_);
+
+    ensure_equals("covers large-scale off-line", 0, GEOSCovers(geom1_, geom2_));
+}
+
 } // namespace tut
 


### PR DESCRIPTION
## Summary

Fixes [libgeos/geos#968](https://github.com/libgeos/geos/issues/968): `LINESTRING (1 0, 0 2)` should **cover** `POINT (0.9 0.2)` and the symmetric `POINT (0.1 1.8)`.

### Cause

`PointLocation::isOnSegment` used `Orientation::index` (Ozaki filter → DD). For these decimal-collinear encodings the filter is **uncertain** and DD reports non-collinear, so `covers` / `within` fail even though the printed decimals are collinear and the binary64 residual is 1 ulp of the determinant (`|det| = 2^{-54} ≈ 5.55e-17`). `@dr-jts` noted this on the issue (high-precision orientation ironically causes the miss).

Ozaki `FAILURE` only means the double filter cannot certify a side (`|det| < |detleft+detright|·K`). It is not an on-segment test. A first revision that treated every nonzero `FAILURE` as on incorrectly accepted

```
LINESTRING (0 0, 1e16 1e16)  /  POINT (5e15, 5e15+1)
```

(`|det| ≈ 2^{53}`, true cross \(10^{16}\), distance ≈ 0.637). DD separates that point. `@fallenmi` caught this on `9cfff20`.

### Fix (tip `31224e328`)

For **on-segment membership only**:

| Filter | `|det|` | `isOnSegment` |
|---|---|---|
| certain `LEFT` / `RIGHT` | — | off |
| `STRAIGHT` | — | on |
| `FAILURE` | `0 < |det| ≤ 1e-12` | **on** (treat as a binary64 residual) |
| `FAILURE` | `det == 0` or `|det| > 1e-12` | fall through to `Orientation::index` (DD) |

`1e-12` is an explicit absolute cap on `|2 * signed triangle area|`. It is **not** the published Ozaki `K` (≈ `3.33e-16` relative). It sits between the two measured scales: #968 residual \(2^{-54}\) and the review pair rounded det \(2^{53}\).

`Orientation::index` is unchanged for callers that need DD separation.

### Tests

- `PointLocation` test 7 — #968 pins `(0.9, 0.2)`, `(0.1, 1.8)`, control off-line
- `PointLocation` test 8 — large-scale off-line review pair
- `capi::GEOSCovers` tests 3 and 4 — same two geometries through `covers`

Local `geosop` on this revision: `covers=false` for the review pair (same distance as main); the #968 cases remain `true`.

### What this is not

- Not “Ozaki `FAILURE` ⇒ on the line.” That rule is withdrawn.
- Not an Ozaki soundness theorem, and not a change to the production orientation filter.
- Not a proof that every geometrically-on input has `|det| ≤ 1e-12`. The cap is a documented sandwich of two measured scales, not a length-relative height test.