### PR TITLE
CircularString: even controls valid only as ABCA circumcircle

### DIFF
--- a/include/geos/algorithm/CircularArcs.h
+++ b/include/geos/algorithm/CircularArcs.h
@@ -271,6 +271,17 @@ public:
                          const geom::CoordinateXY& cb, double rb,
                          const geom::CoordinateXY& b0, const geom::CoordinateXY& b2, bool bCCW);
 
+    /// Point-reflection of hint through the circumcenter of (from, hint, to).
+    /// Null if the triple does not define a unique circle.
+    static std::optional<geom::CoordinateXY>
+    complementaryArcMid(const geom::CoordinateXY& from, const geom::CoordinateXY& hint,
+                        const geom::CoordinateXY& to);
+
+    /// Complementary-close mid of closed four-control CIRCULARSTRING(A, B, C, A).
+    /// Null unless that shape defines a circumcircle.
+    static std::optional<geom::CoordinateXY>
+    threePointCircleCloseMid(const geom::CoordinateSequence& seq);
+
 };
 }
 }

--- a/include/geos/geom/CircularString.h
+++ b/include/geos/geom/CircularString.h
@@ -23,15 +23,18 @@ namespace geom {
 
 /// A curve of circular arcs encoded as control points.
 ///
-/// A CircularString is empty or has at least 3 control points.
-/// Even length is valid only when closed (first = last).
-/// The first and third points of any arc must be different.
+/// Empty CircularStrings are valid. A non-empty string is valid when it
+/// has an odd control count of at least 3, or when it is the closed
+/// four-control form CIRCULARSTRING(A, B, C, A) that defines a circumcircle.
 class GEOS_DLL CircularString : public SimpleCurve {
 
 public:
     using SimpleCurve::SimpleCurve;
 
     friend class GeometryFactory;
+
+    /// Empty, odd count >= 3, or closed four-control circumcircle.
+    static bool isValidControlCount(const CoordinateSequence& seq);
 
     ~CircularString() override;
 
@@ -103,7 +106,6 @@ protected:
 
     CircularString* reverseImpl() const override;
 
-    /// Throws if the control-point count or per-arc endpoints are invalid.
     void validateConstruction();
 
 private:

--- a/include/geos/geom/CircularString.h
+++ b/include/geos/geom/CircularString.h
@@ -21,6 +21,11 @@
 namespace geos {
 namespace geom {
 
+/// A curve of circular arcs encoded as control points.
+///
+/// A CircularString is empty or has at least 3 control points.
+/// Even length is valid only when closed (first = last).
+/// The first and third points of any arc must be different.
 class GEOS_DLL CircularString : public SimpleCurve {
 
 public:
@@ -98,6 +103,7 @@ protected:
 
     CircularString* reverseImpl() const override;
 
+    /// Throws if the control-point count or per-arc endpoints are invalid.
     void validateConstruction();
 
 private:

--- a/include/geos/operation/valid/IsValidOp.h
+++ b/include/geos/operation/valid/IsValidOp.h
@@ -31,6 +31,7 @@ class Point;
 class MultiPoint;
 class LineString;
 class LinearRing;
+class CircularString;
 class Polygon;
 class MultiPolygon;
 class GeometryCollection;
@@ -97,6 +98,12 @@ private:
      * Almost anything goes for linestrings!
      */
     bool isValid(const geom::LineString* g);
+
+    /**
+     * Tests control-count validity of a CircularString.
+     * Empty, odd count >= 3, or closed four-control circumcircle.
+     */
+    bool isValid(const geom::CircularString* g);
 
     /**
      * Tests validity of a LinearRing.

--- a/src/algorithm/CircularArcs.cpp
+++ b/src/algorithm/CircularArcs.cpp
@@ -15,6 +15,7 @@
 #include <geos/algorithm/Angle.h>
 #include <geos/algorithm/CircularArcs.h>
 #include <geos/algorithm/Orientation.h>
+#include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/Envelope.h>
 #include <geos/geom/LineSegment.h>
 #include <geos/geom/Quadrant.h>
@@ -765,6 +766,38 @@ CircularArcs::arcIntersectionPoint(const CoordinateXY& ca, double ra,
     }
 
     return std::nullopt;
+}
+
+std::optional<CoordinateXY>
+CircularArcs::complementaryArcMid(const CoordinateXY& from, const CoordinateXY& hint,
+                                  const CoordinateXY& to)
+{
+    CoordinateXY center = getCenter(from, hint, to);
+    if (!std::isfinite(center.x) || !std::isfinite(center.y)) {
+        return std::nullopt;
+    }
+    CoordinateXY mid{2.0 * center.x - hint.x, 2.0 * center.y - hint.y};
+    if (!std::isfinite(mid.x) || !std::isfinite(mid.y)
+            || mid.equals2D(from) || mid.equals2D(to)) {
+        return std::nullopt;
+    }
+    return mid;
+}
+
+std::optional<CoordinateXY>
+CircularArcs::threePointCircleCloseMid(const CoordinateSequence& seq)
+{
+    if (seq.size() != 4) {
+        return std::nullopt;
+    }
+    const CoordinateXY& a = seq.getAt<CoordinateXY>(0);
+    const CoordinateXY& b = seq.getAt<CoordinateXY>(1);
+    const CoordinateXY& c = seq.getAt<CoordinateXY>(2);
+    const CoordinateXY& a2 = seq.getAt<CoordinateXY>(3);
+    if (!a.equals2D(a2)) {
+        return std::nullopt;
+    }
+    return complementaryArcMid(c, b, a);
 }
 
 }

--- a/src/geom/CircularString.cpp
+++ b/src/geom/CircularString.cpp
@@ -12,6 +12,7 @@
  *
  **********************************************************************/
 
+#include <geos/algorithm/CircularArcs.h>
 #include <geos/geom/CircularArc.h>
 #include <geos/geom/CircularString.h>
 #include <geos/geom/CoordinateSequence.h>
@@ -192,6 +193,22 @@ CircularString::reverseImpl() const
     return getFactory()->createCircularString(std::move(seq)).release();
 }
 
+bool
+CircularString::isValidControlCount(const CoordinateSequence& seq)
+{
+    const std::size_t n = seq.size();
+    if (n == 0) {
+        return true;
+    }
+    if (n < 3) {
+        return false;
+    }
+    if (n % 2 == 1) {
+        return true;
+    }
+    return algorithm::CircularArcs::threePointCircleCloseMid(seq).has_value();
+}
+
 void
 CircularString::validateConstruction()
 {
@@ -200,27 +217,8 @@ CircularString::validateConstruction()
         return;
     }
 
-    const std::size_t n = points->size();
-    if (n == 0) {
-        return;
-    }
-    if (n < 3) {
-        throw util::IllegalArgumentException(
-            "point array size must be 0 or at least 3");
-    }
-
-    const bool closed = points->front<CoordinateXY>().equals2D(
-                            points->back<CoordinateXY>());
-    if (n % 2 == 0 && !closed) {
-        throw util::IllegalArgumentException(
-            "even-length CircularString is valid only when closed (first = last)");
-    }
-
-    for (std::size_t i = 0; i + 2 < n; i += 2) {
-        if (points->getAt<CoordinateXY>(i).equals2D(points->getAt<CoordinateXY>(i + 2))) {
-            throw util::IllegalArgumentException(
-                "first and third points of any arc must be different");
-        }
+    if (points->size() == 1) {
+        throw util::IllegalArgumentException("point array must contain 0 or >1 elements\n");
     }
 }
 

--- a/src/geom/CircularString.cpp
+++ b/src/geom/CircularString.cpp
@@ -16,6 +16,7 @@
 #include <geos/geom/CircularString.h>
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/GeometryFactory.h>
+#include <geos/util/IllegalArgumentException.h>
 #include <geos/util/UnsupportedOperationException.h>
 
 namespace geos {
@@ -199,8 +200,27 @@ CircularString::validateConstruction()
         return;
     }
 
-    if (points->size() > 0 && (points->size() < 3 || points->size() % 2 == 0)) {
-        throw util::IllegalArgumentException("point array size must zero or be an odd number >= 3");
+    const std::size_t n = points->size();
+    if (n == 0) {
+        return;
+    }
+    if (n < 3) {
+        throw util::IllegalArgumentException(
+            "point array size must be 0 or at least 3");
+    }
+
+    const bool closed = points->front<CoordinateXY>().equals2D(
+                            points->back<CoordinateXY>());
+    if (n % 2 == 0 && !closed) {
+        throw util::IllegalArgumentException(
+            "even-length CircularString is valid only when closed (first = last)");
+    }
+
+    for (std::size_t i = 0; i + 2 < n; i += 2) {
+        if (points->getAt<CoordinateXY>(i).equals2D(points->getAt<CoordinateXY>(i + 2))) {
+            throw util::IllegalArgumentException(
+                "first and third points of any arc must be different");
+        }
     }
 }
 

--- a/src/operation/valid/IsValidOp.cpp
+++ b/src/operation/valid/IsValidOp.cpp
@@ -19,6 +19,7 @@
 #include <geos/geom/GeometryCollection.h>
 #include <geos/geom/LineString.h>
 #include <geos/geom/LinearRing.h>
+#include <geos/geom/CircularString.h>
 #include <geos/geom/Location.h>
 #include <geos/geom/MultiPoint.h>
 #include <geos/geom/MultiPolygon.h>
@@ -94,6 +95,8 @@ IsValidOp::isValidGeometry(const Geometry* g)
             return isValid(static_cast<const LinearRing*>(g));
         case GEOS_LINESTRING:
             return isValid(static_cast<const LineString*>(g));
+        case GEOS_CIRCULARSTRING:
+            return isValid(static_cast<const CircularString*>(g));
         case GEOS_POLYGON:
             return isValid(static_cast<const Polygon*>(g));
         case GEOS_MULTIPOLYGON:
@@ -102,7 +105,6 @@ IsValidOp::isValidGeometry(const Geometry* g)
             return isValid(static_cast<const GeometryCollection*>(g));
         case GEOS_GEOMETRYCOLLECTION:
             return isValid(static_cast<const GeometryCollection*>(g));
-        case GEOS_CIRCULARSTRING:
         case GEOS_COMPOUNDCURVE:
         case GEOS_CURVEPOLYGON:
         case GEOS_MULTICURVE:
@@ -151,6 +153,24 @@ IsValidOp::isValid(const LineString* g)
 
     checkTooFewPoints(g, MIN_SIZE_LINESTRING);
     if (hasInvalidError()) return false;
+
+    return true;
+}
+
+
+/* private */
+bool
+IsValidOp::isValid(const CircularString* g)
+{
+    checkCoordinatesValid(g->getCoordinatesRO());
+    if (hasInvalidError()) return false;
+
+    if (!CircularString::isValidControlCount(*g->getCoordinatesRO())) {
+        const CoordinateXY* pt = g->getCoordinate();
+        logInvalid(TopologyValidationError::eTooFewPoints,
+                   pt ? *pt : CoordinateXY());
+        return false;
+    }
 
     return true;
 }

--- a/tests/unit/geom/CircularStringTest.cpp
+++ b/tests/unit/geom/CircularStringTest.cpp
@@ -390,7 +390,7 @@ template<>
 template<>
 void object::test<15>() {
     set_test_name("liblwgeom: 10 segments per quadrant - circular");
-    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 0, 0 0)");
+    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 0.5 0.5, 1 0, 0.5 -0.5, 0 0)");
     auto ls = cs->getLinearized(CurveToLineParams::stepSizeDegrees(90.0 / 10));
     ensure_equals(ls->getNumPoints(), 41u); // PostGIS test has 40, but this is incorrect
     const auto* seq = ls->getCoordinatesRO();
@@ -533,6 +533,58 @@ void object::test<27>()
 
     // line point 5 is 30 degrees from end of the arc. Z/M interpolated from CircularString points 1 and 2
     ensure_equals_xyzm(seq->getAt<XYZM>(5), XYZM{2.5, -4.33, 6 + (30.0 - 6)*(2.0/3), 8 + (40.0 - 8)*(2.0/3)}, 1e-3);
+}
+
+template<>
+template<>
+void object::test<28>()
+{
+    set_test_name("closed four-control CIRCULARSTRING(A, B, C, A) is accepted");
+
+    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (-5 0, 0 5, 5 0, -5 0)");
+    ensure_equals(cs->getNumPoints(), 4u);
+    ensure(cs->isClosed());
+
+    auto pts = std::make_shared<CoordinateSequence>();
+    pts->add(-5.0, 0.0);
+    pts->add(0.0, 5.0);
+    pts->add(5.0, 0.0);
+    pts->add(-5.0, 0.0);
+    ensure_NO_THROW(factory_->createCircularString(pts));
+}
+
+template<>
+template<>
+void object::test<29>()
+{
+    set_test_name("open even leftover is rejected");
+
+    ensure_THROW(wktreader_.read("CIRCULARSTRING (0 0, 1 1, 2 0, 3 1)"), geos::util::GEOSException);
+}
+
+template<>
+template<>
+void object::test<30>()
+{
+    set_test_name("closed even-length CircularString is accepted");
+
+    auto cs4 = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 0, 2 0, 0 0)");
+    ensure_equals(cs4->getNumPoints(), 4u);
+    ensure(cs4->isClosed());
+
+    auto cs6 = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0, 0 0)");
+    ensure_equals(cs6->getNumPoints(), 6u);
+    ensure(cs6->isClosed());
+}
+
+template<>
+template<>
+void object::test<31>()
+{
+    set_test_name("first and third points of any arc must be different");
+
+    ensure_THROW(wktreader_.read("CIRCULARSTRING (0 0, 1 0, 0 0)"), geos::util::GEOSException);
+    ensure_THROW(wktreader_.read("CIRCULARSTRING (0 0, 1 1, 0 0, 1 -1, 2 0)"), geos::util::GEOSException);
 }
 
 }

--- a/tests/unit/geom/CircularStringTest.cpp
+++ b/tests/unit/geom/CircularStringTest.cpp
@@ -181,7 +181,7 @@ void object::test<3>()
 
     // Valid / Simple
     ensure_THROW(cs_->isSimple(), geos::util::UnsupportedOperationException);
-    ensure_THROW(cs_->isValid(), geos::util::UnsupportedOperationException);
+    ensure(cs_->isValid());
 
     // Operations
     ensure_THROW(cs_->convexHull(), geos::util::UnsupportedOperationException);
@@ -228,19 +228,23 @@ void object::test<5>()
     set_test_name("invalid number of points");
 
     auto pts = std::make_shared<CoordinateSequence>();
-    ensure_NO_THROW(factory_->createCircularString(pts));
+    auto empty = factory_->createCircularString(pts);
+    ensure(empty->isValid());
 
     pts->add(0.0, 0.0);
     ensure_THROW(factory_->createCircularString(pts), geos::util::GEOSException);
 
     pts->add(1.0, 1.0);
-    ensure_THROW(factory_->createCircularString(pts), geos::util::GEOSException);
+    auto two = factory_->createCircularString(pts);
+    ensure(!two->isValid());
 
     pts->add(2.0, 0.0);
-    ensure_NO_THROW(factory_->createCircularString(pts));
+    auto three = factory_->createCircularString(pts);
+    ensure(three->isValid());
 
     pts->add(3.0, -1.0);
-    ensure_THROW(factory_->createCircularString(pts), geos::util::GEOSException);
+    auto fourOpen = factory_->createCircularString(pts);
+    ensure(!fourOpen->isValid());
 }
 
 template<>
@@ -390,7 +394,7 @@ template<>
 template<>
 void object::test<15>() {
     set_test_name("liblwgeom: 10 segments per quadrant - circular");
-    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 0.5 0.5, 1 0, 0.5 -0.5, 0 0)");
+    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 0, 0 0)");
     auto ls = cs->getLinearized(CurveToLineParams::stepSizeDegrees(90.0 / 10));
     ensure_equals(ls->getNumPoints(), 41u); // PostGIS test has 40, but this is incorrect
     const auto* seq = ls->getCoordinatesRO();
@@ -539,52 +543,49 @@ template<>
 template<>
 void object::test<28>()
 {
-    set_test_name("closed four-control CIRCULARSTRING(A, B, C, A) is accepted");
+    set_test_name("closed four-control CIRCULARSTRING(A, B, C, A) is valid");
 
     auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (-5 0, 0 5, 5 0, -5 0)");
     ensure_equals(cs->getNumPoints(), 4u);
     ensure(cs->isClosed());
-
-    auto pts = std::make_shared<CoordinateSequence>();
-    pts->add(-5.0, 0.0);
-    pts->add(0.0, 5.0);
-    pts->add(5.0, 0.0);
-    pts->add(-5.0, 0.0);
-    ensure_NO_THROW(factory_->createCircularString(pts));
+    ensure(cs->isValid());
+    ensure(CircularString::isValidControlCount(*cs->getCoordinatesRO()));
 }
 
 template<>
 template<>
 void object::test<29>()
 {
-    set_test_name("open even leftover is rejected");
+    set_test_name("open even leftover is ingestible and invalid");
 
-    ensure_THROW(wktreader_.read("CIRCULARSTRING (0 0, 1 1, 2 0, 3 1)"), geos::util::GEOSException);
+    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 1, 2 0, 3 1)");
+    ensure(!cs->isValid());
 }
 
 template<>
 template<>
 void object::test<30>()
 {
-    set_test_name("closed even-length CircularString is accepted");
+    set_test_name("even leftover is not a four-control circumcircle");
 
-    auto cs4 = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 0, 2 0, 0 0)");
-    ensure_equals(cs4->getNumPoints(), 4u);
-    ensure(cs4->isClosed());
+    auto collinear = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 0, 2 0, 0 0)");
+    ensure(collinear->isClosed());
+    ensure(!collinear->isValid());
 
-    auto cs6 = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0, 0 0)");
-    ensure_equals(cs6->getNumPoints(), 6u);
-    ensure(cs6->isClosed());
+    auto six = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0, 0 0)");
+    ensure(six->isClosed());
+    ensure(!six->isValid());
 }
 
 template<>
 template<>
 void object::test<31>()
 {
-    set_test_name("first and third points of any arc must be different");
+    set_test_name("three-point CIRCULARSTRING(A, B, A) is ingestible");
 
-    ensure_THROW(wktreader_.read("CIRCULARSTRING (0 0, 1 0, 0 0)"), geos::util::GEOSException);
-    ensure_THROW(wktreader_.read("CIRCULARSTRING (0 0, 1 1, 0 0, 1 -1, 2 0)"), geos::util::GEOSException);
+    auto cs = wktreader_.read<CircularString>("CIRCULARSTRING (0 0, 1 0, 0 0)");
+    ensure_equals(cs->getNumPoints(), 3u);
+    ensure(cs->isValid());
 }
 
 }


### PR DESCRIPTION
## Summary

Ingest stays lenient. `isValid` is the gate:

- empty is valid
- odd control count >= 3 is valid
- even controls are valid only as closed four-control `CIRCULARSTRING(A, B, C, A)` that defines a circumcircle

Open even leftovers, closed 6-control leftover, and collinear `CIRCULARSTRING(A, B, C, A)` ingest and return `isValid() == false`.

Witness: `CIRCULARSTRING (-5 0, 0 5, 5 0, -5 0)`.

## Tests

`tests/unit/geom/CircularStringTest.cpp` pins the four-control circumcircle, rejects leftover even counts on `isValid`, and keeps `CIRCULARSTRING (0 0, 1 0, 0 0)` ingestible.