### PR TITLE
MakeValid: process envelope-connected components of a MultiPolygon independently

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,12 @@
   - Add progress reporting to GEOSCoverageSimplify, GEOSUnaryUnion (GH-1466, Even Rouault / Dan Baston)
 
 - Fixes/Improvements:
+  - MakeValid groups MultiPolygon parts into envelope-connected components and
+    processes each independently, so a single invalid part no longer forces all
+    parts through the whole-geometry polygonal algorithm (GH-1504, Artem Kulyk).
+    Components made entirely of valid parts are passed through unchanged,
+    keeping their original coordinates, including Z and M values, instead of
+    being rebuilt by overlay.
   - Buffer of Linestring includes spurious hole (GH-1217, Moritz Kirmse)
   - Preserve M values in GEOSInterpolate (GH-1390, Dan Baston)
   - Preserve M values in GEOSLineMerge (GH-1364, Dan Baston)

--- a/benchmarks/operation/CMakeLists.txt
+++ b/benchmarks/operation/CMakeLists.txt
@@ -11,6 +11,13 @@
 add_subdirectory(buffer)
 add_subdirectory(predicate)
 
+add_executable(perf_makevalid MakeValidPerfTest.cpp)
+target_include_directories(perf_makevalid PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>)
+target_link_libraries(perf_makevalid PRIVATE geos geos_cxx_flags)
+
 if (benchmark_FOUND)
     add_executable(perf_distance DistancePerfTest.cpp)
     target_include_directories(perf_distance PUBLIC

--- a/benchmarks/operation/MakeValidPerfTest.cpp
+++ b/benchmarks/operation/MakeValidPerfTest.cpp
@@ -1,0 +1,289 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2026 GEOS contributors
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Benchmark for MakeValid on MultiPolygon inputs (issue #1504).
+ *
+ * Reproduces the scenario where a MultiPolygon containing a single
+ * invalid part costs up to ~55x the equivalent GeometryCollection,
+ * because all parts are dragged through boundary noding, unique-point
+ * extraction and BuildArea/symdiff.
+ *
+ * Cases (run one per process for clean peak-RSS readings):
+ *   grid <n>      n*n valid unit squares spaced 2 apart + 1 far bowtie
+ *                 (the issue #1504 scenario; envelope-disjoint components)
+ *   chain <n>     n corner-touching squares (one envelope-connected
+ *                 component) + 1 bowtie far away (a second component)
+ *   overlap <n>   n overlapping squares (single connected component,
+ *                 adversarial: cannot be split)
+ *   bigbowtie <n> ~n small valid polygons + one huge invalid bowtie with
+ *                 ~n vertices (mimics issue #1504 real data shape)
+ *
+ * An optional 4th argument "coll" runs the same parts as a
+ * GeometryCollection, which MakeValid processes member-wise; it provides
+ * a reference for the best achievable per-part cost.
+ *
+ * Timing uses geos::util::Profile like the other GEOS benchmarks. Peak RSS
+ * uses getrusage where available (POSIX); ru_maxrss is bytes on macOS and
+ * KiB on Linux/BSD, which is normalized below. On platforms without
+ * getrusage (e.g. Windows) peak RSS is reported as unavailable.
+ *
+ * Usage: perf_makevalid <grid|chain|overlap|bigbowtie> [n] [reps] [coll]
+ **********************************************************************/
+
+#include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateSequence.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/Polygon.h>
+#include <geos/geom/MultiPolygon.h>
+#include <geos/geom/GeometryCollection.h>
+#include <geos/operation/valid/MakeValid.h>
+#include <geos/profiler.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+// getrusage is not available on Windows; report peak RSS as unavailable.
+#else
+#include <sys/resource.h>
+#endif
+
+using namespace geos::geom;
+using namespace geos::operation::valid;
+
+namespace {
+
+std::unique_ptr<Geometry> coll_geom;
+
+// Peak resident set size in bytes; 0 when the platform offers no way to
+// measure it. ru_maxrss is bytes on macOS and KiB on Linux/BSD.
+long
+peakRSS()
+{
+#if defined(_WIN32)
+    return 0;
+#else
+    struct rusage ru;
+    getrusage(RUSAGE_SELF, &ru);
+#if defined(__APPLE__)
+    return static_cast<long>(ru.ru_maxrss);
+#else
+    return static_cast<long>(ru.ru_maxrss) * 1024;
+#endif
+#endif
+}
+
+std::unique_ptr<Polygon>
+square(const GeometryFactory* gf, double x, double y, double side = 1.0)
+{
+    auto cs = std::make_unique<CoordinateSequence>();
+    cs->add(x, y);
+    cs->add(x + side, y);
+    cs->add(x + side, y + side);
+    cs->add(x, y + side);
+    cs->add(x, y);
+    auto ring = gf->createLinearRing(std::move(cs));
+    return gf->createPolygon(std::move(ring));
+}
+
+// Self-intersecting "bowtie" polygon (invalid), optionally with many
+// vertices (zig-zagging between two diagonals so the ring crosses itself).
+std::unique_ptr<Polygon>
+bowtie(const GeometryFactory* gf, double x, double y, std::size_t nverts)
+{
+    auto cs = std::make_unique<CoordinateSequence>();
+    cs->add(x, y);
+    cs->add(x + 1, y + 1);
+    if (nverts > 5) {
+        // Insert extra vertices along both crossing diagonals,
+        // zig-zagging between them to inflate vertex count.
+        std::size_t nseg = (nverts - 5) / 4;
+        for (std::size_t i = 1; i <= nseg; i++) {
+            double t = static_cast<double>(i) / static_cast<double>(nseg + 1);
+            cs->add(x + t * 2.0, y + 1.0);      // intermediate wiggle
+            cs->add(x + t * 2.0, y);            //   on segment 1
+            cs->add(x + t * 2.0, y + 1.0 - t);  // and on the diagonal
+        }
+    }
+    cs->add(x + 1, y);
+    cs->add(x, y + 1);
+    cs->add(x, y);
+    auto ring = gf->createLinearRing(std::move(cs));
+    return gf->createPolygon(std::move(ring));
+}
+
+struct Fixture {
+    std::unique_ptr<Geometry> multipolygon;
+    std::string name;
+};
+
+// n*n disjoint unit squares spaced 2 apart, plus one bowtie far away.
+Fixture
+makeGrid(std::size_t n)
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    std::vector<std::unique_ptr<Geometry>> polys;
+    polys.reserve(n * n + 1);
+    for (std::size_t i = 0; i < n; i++) {
+        for (std::size_t j = 0; j < n; j++) {
+            polys.push_back(square(gf, 2.0 * static_cast<double>(i),
+                                   2.0 * static_cast<double>(j)));
+        }
+    }
+    polys.push_back(bowtie(gf, -10.0, -10.0, 5));
+
+    auto mp = gf->createMultiPolygon(std::move(polys));
+    return {std::move(mp), "grid"};
+}
+
+// n corner-touching squares (diagonal chain: all one envelope-connected
+// component), plus one bowtie far away (second component).
+Fixture
+makeChain(std::size_t n)
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    std::vector<std::unique_ptr<Geometry>> polys;
+    polys.reserve(n + 1);
+    for (std::size_t i = 0; i < n; i++) {
+        double d = static_cast<double>(i);
+        polys.push_back(square(gf, d, d));
+    }
+    polys.push_back(bowtie(gf, -10.0, -10.0, 5));
+    auto mp = gf->createMultiPolygon(std::move(polys));
+    return {std::move(mp), "chain"};
+}
+
+// n overlapping squares (every square intersects the next: a single
+// envelope-connected component that cannot be split).
+Fixture
+makeOverlap(std::size_t n)
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    std::vector<std::unique_ptr<Geometry>> polys;
+    polys.reserve(n);
+    for (std::size_t i = 0; i < n; i++) {
+        double d = 0.5 * static_cast<double>(i);
+        polys.push_back(square(gf, d, d));
+    }
+    auto mp = gf->createMultiPolygon(std::move(polys));
+    return {std::move(mp), "overlap"};
+}
+
+// n small valid polygons + one huge invalid bowtie with ~n vertices
+// (shape of the real data in issue #1504).
+Fixture
+makeBigBowtie(std::size_t n)
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    std::vector<std::unique_ptr<Geometry>> polys;
+    polys.reserve(n + 1);
+    std::size_t side = static_cast<std::size_t>(
+        std::sqrt(static_cast<double>(n)));
+    for (std::size_t i = 0; i < side * side; i++) {
+        polys.push_back(square(gf, 2.0 * static_cast<double>(i % side),
+                               2.0 * static_cast<double>(i / side)));
+    }
+    polys.push_back(bowtie(gf, -10.0, -10.0, n));
+    auto mp = gf->createMultiPolygon(std::move(polys));
+    return {std::move(mp), "bigbowtie"};
+}
+
+void
+runCase(const Fixture& fix, bool useCollection, std::size_t reps)
+{
+    const Geometry* g = fix.multipolygon.get();
+    std::string kind = "MULTIPOLYGON";
+    if (useCollection) {
+        // Same parts as a GeometryCollection: per-member processing.
+        auto gf = fix.multipolygon->getFactory();
+        std::vector<std::unique_ptr<Geometry>> parts;
+        parts.reserve(fix.multipolygon->getNumGeometries());
+        for (std::size_t i = 0; i < fix.multipolygon->getNumGeometries(); i++) {
+            parts.push_back(fix.multipolygon->getGeometryN(i)->clone());
+        }
+        coll_geom = gf->createGeometryCollection(std::move(parts));
+        g = coll_geom.get();
+        kind = "GEOMCOLLECTION";
+    }
+
+    MakeValid mv;
+    geos::util::Profile profile("makevalid");
+    std::unique_ptr<Geometry> result;
+    for (std::size_t i = 0; i < reps; i++) {
+        profile.start();
+        result = mv.build(g);
+        profile.stop();
+        if (result->getGeometryTypeId() == GEOS_GEOMETRYCOLLECTION
+            && result->getNumGeometries() == 0) {
+            std::cerr << "unexpected empty result\n";
+            std::exit(1);
+        }
+    }
+
+    std::cout << fix.name
+              << " n=" << fix.multipolygon->getNumGeometries()
+              << " verts=" << g->getNumPoints()
+              << " " << kind
+              << " result_type=" << result->getGeometryType()
+              << " valid=" << (result->isValid() ? "yes" : "NO")
+              << " time=" << profile.getAvg() / 1e6 << "s";
+
+    long rss = peakRSS();
+    if (rss > 0) {
+        std::cout << " peakRSS=" << static_cast<double>(rss) / (1024.0 * 1024.0) << "MB";
+    } else {
+        std::cout << " peakRSS=unavailable";
+    }
+    std::cout << std::endl;
+}
+
+} // namespace
+
+int
+main(int argc, char** argv)
+{
+    if (argc < 2) {
+        std::cerr << "usage: perf_makevalid <grid|chain|overlap|bigbowtie>"
+                     " [n] [reps] [coll]\n";
+        return 1;
+    }
+    std::string cs = argv[1];
+    std::size_t n = argc > 2 ? std::strtoul(argv[2], nullptr, 10) : 80;
+    std::size_t reps = argc > 3 ? std::strtoul(argv[3], nullptr, 10) : 1;
+    bool useCollection = argc > 4 && std::string(argv[4]) == "coll";
+
+    Fixture fix = [&, cs]() -> Fixture {
+        if (cs == "grid") {
+            return makeGrid(n);
+        }
+        if (cs == "chain") {
+            return makeChain(n);
+        }
+        if (cs == "overlap") {
+            return makeOverlap(n);
+        }
+        if (cs == "bigbowtie") {
+            return makeBigBowtie(n);
+        }
+        std::cerr << "unknown case: " << cs << "\n";
+        std::exit(1);
+    }();
+
+    runCase(fix, useCollection, reps);
+    return 0;
+}

--- a/benchmarks/operation/MakeValidPerfTest.cpp
+++ b/benchmarks/operation/MakeValidPerfTest.cpp
@@ -28,6 +28,11 @@
  *                 adversarial: cannot be split)
  *   bigbowtie <n> ~n small valid polygons + one huge invalid bowtie with
  *                 ~n vertices (mimics issue #1504 real data shape)
+ *   sentinel <n>  n valid unit squares at Y=0 spaced 2 apart + 1 invalid
+ *                 bowtie spanning the whole row at Y=100 (long-X,
+ *                 Y-disjoint). Clustering must expire by maxX; a minX
+ *                 prefix window is N(N+1)/2 envelope tests. To confirm
+ *                 linear scaling run n=16000 / 32000 / 64000.
  *
  * An optional 4th argument "coll" runs the same parts as a
  * GeometryCollection, which MakeValid processes member-wise; it provides
@@ -38,7 +43,7 @@
  * KiB on Linux/BSD, which is normalized below. On platforms without
  * getrusage (e.g. Windows) peak RSS is reported as unavailable.
  *
- * Usage: perf_makevalid <grid|chain|overlap|bigbowtie> [n] [reps] [coll]
+ * Usage: perf_makevalid <grid|chain|overlap|bigbowtie|sentinel> [n] [reps] [coll]
  **********************************************************************/
 
 #include <geos/geom/Coordinate.h>
@@ -203,6 +208,31 @@ makeBigBowtie(std::size_t n)
     return {std::move(mp), "bigbowtie"};
 }
 
+// n disjoint unit squares at Y=0 spaced 2 apart, plus one invalid bowtie
+// spanning the whole row at Y=100 (long X, Y-disjoint). Expiry must be
+// by maxX; a minX-prefix active window compares every pair.
+Fixture
+makeSentinel(std::size_t n)
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    std::vector<std::unique_ptr<Geometry>> polys;
+    polys.reserve(n + 1);
+    for (std::size_t i = 0; i < n; i++) {
+        polys.push_back(square(gf, 2.0 * static_cast<double>(i), 0.0));
+    }
+    double span = n == 0 ? 1.0 : 2.0 * static_cast<double>(n) - 1.0;
+    auto cs = std::make_unique<CoordinateSequence>();
+    cs->add(0.0, 100.0);
+    cs->add(span, 101.0);
+    cs->add(span, 100.0);
+    cs->add(0.0, 101.0);
+    cs->add(0.0, 100.0);
+    auto ring = gf->createLinearRing(std::move(cs));
+    polys.push_back(gf->createPolygon(std::move(ring)));
+    auto mp = gf->createMultiPolygon(std::move(polys));
+    return {std::move(mp), "sentinel"};
+}
+
 void
 runCase(const Fixture& fix, bool useCollection, std::size_t reps)
 {
@@ -258,7 +288,7 @@ int
 main(int argc, char** argv)
 {
     if (argc < 2) {
-        std::cerr << "usage: perf_makevalid <grid|chain|overlap|bigbowtie>"
+        std::cerr << "usage: perf_makevalid <grid|chain|overlap|bigbowtie|sentinel>"
                      " [n] [reps] [coll]\n";
         return 1;
     }
@@ -279,6 +309,9 @@ main(int argc, char** argv)
         }
         if (cs == "bigbowtie") {
             return makeBigBowtie(n);
+        }
+        if (cs == "sentinel") {
+            return makeSentinel(n);
         }
         std::cerr << "unknown case: " << cs << "\n";
         std::exit(1);

--- a/include/geos/operation/valid/MakeValid.h
+++ b/include/geos/operation/valid/MakeValid.h
@@ -51,6 +51,12 @@ namespace valid { // geos::operation::valid
  * In case of full or partial dimensional collapses, the output geometry may be a collection of lower-to-equal dimension geometries or a geometry of lower dimension.
  *
  * Single polygons may become multi-geometries in case of self-intersections.
+ *
+ * For MultiPolygons, parts whose envelopes are disjoint cannot interact
+ * topologically. Parts are grouped into envelope-connected components and
+ * each component is made valid independently, with valid components passed
+ * through unchanged. Already-valid parts therefore keep their original
+ * coordinates (including Z and M values) rather than being rebuilt by overlay.
  */
 class GEOS_DLL MakeValid {
 

--- a/src/operation/valid/MakeValid.cpp
+++ b/src/operation/valid/MakeValid.cpp
@@ -26,14 +26,16 @@
 #include <geos/operation/overlayng/OverlayNGRobust.h>
 #include <geos/operation/polygonize/BuildArea.h>
 #include <geos/operation/union/UnaryUnionOp.h>
+#include <geos/geom/Envelope.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/GeometryCollection.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/LineString.h>
-#include <geos/geom/Point.h>
-#include <geos/geom/Polygon.h>
 #include <geos/geom/MultiLineString.h>
 #include <geos/geom/MultiPolygon.h>
+#include <geos/geom/Point.h>
+#include <geos/geom/Polygon.h>
+#include <geos/operation/cluster/UnionFind.h>
 #include <geos/util/Interrupt.h>
 #include <geos/util/UniqueCoordinateArrayFilter.h>
 #include <geos/util/UnsupportedOperationException.h>
@@ -42,6 +44,7 @@
 // std
 #include <cassert>
 #include <algorithm>
+#include <cmath>
 #include <utility>
 #include <vector>
 
@@ -303,6 +306,248 @@ static std::unique_ptr<geom::Geometry> MakeValidCollection(const geom::GeometryC
     return coll->getFactory()->createGeometryCollection(std::move(validGeoms));
 }
 
+namespace {
+
+bool
+isNonInteractingEnv(const geom::Envelope& env)
+{
+    return env.isNull() ||
+           ! (std::isfinite(env.getMinX()) && std::isfinite(env.getMaxX()) &&
+              std::isfinite(env.getMinY()) && std::isfinite(env.getMaxY()));
+}
+
+/*
+ * Partition the polygons of a MultiPolygon into groups whose envelopes
+ * are connected (envelopes intersecting, touching included).
+ *
+ * Polygons whose envelope is empty or not finite cannot interact with any
+ * other polygon, so they are excluded from the sweep and returned as
+ * single-element groups. This also keeps the sort comparator away from
+ * envelopes without well-defined ordinates.
+ *
+ * Only polygons in different groups may be processed independently:
+ * polygons sharing an envelope may still touch or overlap and must be
+ * made valid together.
+ */
+std::vector<std::vector<std::size_t>>
+envelopeConnectedComponents(const geom::MultiPolygon* mp)
+{
+    std::size_t n = mp->getNumGeometries();
+    cluster::UnionFind sets(n);
+
+    std::vector<const geom::Envelope*> envs(n);
+    for(std::size_t i = 0; i < n; i++) {
+        envs[i] = mp->getGeometryN(i)->getEnvelopeInternal();
+    }
+
+    // Sweep polygons sorted by envelope minimum X, maintaining the subset
+    // whose envelopes extend at or beyond the current minimum X. Only items
+    // in that window can intersect the current one. The number of envelope
+    // tests is proportional to the number of intersecting pairs, so the
+    // sweep is fast when parts are spatially separated and degrades
+    // quadratically when very many envelopes overlap.
+    //
+    // A spatial-index clustering such as operation::cluster::
+    // EnvelopeIntersectsClusterFinder would also be correct, but for the
+    // many tiny disjoint envelopes this operation is aimed at it builds
+    // and queries an STRtree and materializes (and sorts) every candidate
+    // hit per part, while the sweep below only ever looks at the active
+    // window. Non-finite envelopes must be excluded either way, which is
+    // done up front so the sort never sees them.
+    std::vector<std::size_t> order;
+    order.reserve(n);
+    for(std::size_t i = 0; i < n; i++) {
+        if(!isNonInteractingEnv(*envs[i])) {
+            order.push_back(i);
+        }
+    }
+
+    std::sort(order.begin(), order.end(),
+              [&envs](std::size_t a, std::size_t b)
+    {
+        if(envs[a]->getMinX() != envs[b]->getMinX()) {
+            return envs[a]->getMinX() < envs[b]->getMinX();
+        }
+        return envs[a]->getMinY() < envs[b]->getMinY();
+    });
+
+    std::size_t lo = 0; // first still-active item in order
+    for(std::size_t hi = 0; hi < order.size(); hi++) {
+        std::size_t i = order[hi];
+        while(lo < hi && envs[order[lo]]->getMaxX() < envs[i]->getMinX()) {
+            lo++;
+        }
+        for(std::size_t k = lo; k < hi; k++) {
+            std::size_t j = order[k];
+            if(envs[i]->intersects(envs[j])) {
+                sets.join(i, j);
+            }
+        }
+    }
+
+    // Group indices by cluster root, preserving polygon order within groups
+    // and ordering groups by first appearance.
+    std::vector<std::size_t> groupId(n, n); // n = "unassigned"
+    std::vector<std::vector<std::size_t>> components;
+    for(std::size_t i = 0; i < n; i++) {
+        std::size_t root = sets.find(i);
+        if(groupId[root] == n) {
+            groupId[root] = components.size();
+            components.emplace_back();
+        }
+        components[groupId[root]].push_back(i);
+    }
+
+    return components;
+}
+
+/*
+ * Move g into one of the result buckets by dimension, flattening
+ * multi-geometries and collections. Ownership of g is consumed, and
+ * children of multi-geometries are moved out via releaseGeometries()
+ * rather than cloned. Empty elements are dropped; MakeValidPoly never
+ * emits them.
+ */
+void
+collectResult(std::unique_ptr<geom::Geometry> g,
+              std::vector<std::unique_ptr<geom::Polygon>>& areas,
+              std::vector<std::unique_ptr<geom::LineString>>& cutEdges,
+              std::vector<std::unique_ptr<geom::Point>>& collapsePoints)
+{
+    if(! g || g->isEmpty()) {
+        return;
+    }
+
+    switch(g->getGeometryTypeId()) {
+        case GEOS_POLYGON: {
+            areas.emplace_back(static_cast<geom::Polygon*>(g.release()));
+            break;
+        }
+        case GEOS_MULTIPOLYGON:
+        case GEOS_MULTILINESTRING:
+        case GEOS_MULTIPOINT:
+        case GEOS_GEOMETRYCOLLECTION: {
+            // All collection types: move the children out and classify
+            // each one. Children of MultiPolygon/MultiLineString/
+            // MultiPoint are exactly Polygon/LineString/Point.
+            auto coll = detail::down_cast<geom::GeometryCollection*>(g.get());
+            auto elems = coll->releaseGeometries();
+            for(auto& e : elems) {
+                collectResult(std::move(e), areas, cutEdges, collapsePoints);
+            }
+            break;
+        }
+        case GEOS_LINESTRING: {
+            cutEdges.emplace_back(static_cast<geom::LineString*>(g.release()));
+            break;
+        }
+        case GEOS_POINT: {
+            collapsePoints.emplace_back(static_cast<geom::Point*>(g.release()));
+            break;
+        }
+        default: {
+            throw util::UnsupportedOperationException();
+        }
+    }
+}
+
+/*
+ * Make valid a MultiPolygon whose polygons fall into several
+ * envelope-connected components.
+ *
+ * Polygons from different components have disjoint envelopes, so they
+ * cannot interact: each component is made valid independently, a valid
+ * component being returned as-is by the usual fast path.
+ *
+ * The per-component results are then merged back into the same
+ * area/cut-edges/collapse-points structure MakeValidPoly would have
+ * returned for the whole MultiPolygon.
+ */
+std::unique_ptr<geom::Geometry>
+MakeValidMultiPolygonComponents(const geom::MultiPolygon* mp,
+                                std::vector<std::vector<std::size_t>>& components)
+{
+    const GeometryFactory* factory = mp->getFactory();
+
+    std::vector<std::unique_ptr<geom::Polygon>> areas;
+    std::vector<std::unique_ptr<geom::LineString>> cutEdges;
+    std::vector<std::unique_ptr<geom::Point>> collapsePoints;
+
+    for(const auto& component : components) {
+        GEOS_CHECK_FOR_INTERRUPTS();
+
+        if(component.size() == 1) {
+            // Single polygon: read it directly from the input. A valid
+            // polygon still needs a clone for the result, but an invalid
+            // one can be handed to MakeValidPoly through a const pointer
+            // without copying it first.
+            const geom::Geometry* src = mp->getGeometryN(component[0]);
+            assert(src->getGeometryTypeId() == GEOS_POLYGON);
+
+            IsValidOp ivo(src);
+            if(ivo.getValidationError() == nullptr) {
+                collectResult(src->clone(), areas, cutEdges, collapsePoints);
+            } else {
+                collectResult(MakeValidPoly(src), areas, cutEdges, collapsePoints);
+            }
+        } else {
+            // Several interacting polygons must be made valid together;
+            // they are moved into an owned MultiPolygon for that.
+            std::vector<std::unique_ptr<geom::Polygon>> polys;
+            polys.reserve(component.size());
+            for(std::size_t idx : component) {
+                polys.push_back(detail::down_cast<const geom::Polygon*>(
+                    mp->getGeometryN(idx))->clone());
+            }
+            auto part = factory->createMultiPolygon(std::move(polys));
+
+            // Valid components pass through unchanged, invalid ones go
+            // through the polygonal MakeValid algorithm.
+            IsValidOp ivo(part.get());
+            if(ivo.getValidationError() == nullptr) {
+                collectResult(std::move(part), areas, cutEdges, collapsePoints);
+            } else {
+                collectResult(MakeValidPoly(part.get()),
+                              areas, cutEdges, collapsePoints);
+            }
+        }
+    }
+
+    std::vector<std::unique_ptr<Geometry>> vgeoms(3);
+    unsigned int nvgeoms = 0;
+
+    if(! areas.empty()) {
+        if(areas.size() == 1) {
+            vgeoms[nvgeoms++] = std::move(areas[0]);
+        } else {
+            vgeoms[nvgeoms++] = factory->createMultiPolygon(std::move(areas));
+        }
+    }
+    if(! cutEdges.empty()) {
+        if(cutEdges.size() == 1) {
+            vgeoms[nvgeoms++] = std::move(cutEdges[0]);
+        } else {
+            vgeoms[nvgeoms++] = factory->createMultiLineString(std::move(cutEdges));
+        }
+    }
+    if(! collapsePoints.empty()) {
+        if(collapsePoints.size() == 1) {
+            vgeoms[nvgeoms++] = std::move(collapsePoints[0]);
+        } else {
+            vgeoms[nvgeoms++] = factory->createMultiPoint(std::move(collapsePoints));
+        }
+    }
+
+    if(nvgeoms == 1) {
+        return std::move(vgeoms[0]);
+    }
+
+    vgeoms.resize(nvgeoms);
+    return factory->createGeometryCollection(std::move(vgeoms));
+}
+
+} // namespace
+
 /** Return a valid version of the input geometry. */
 std::unique_ptr<geom::Geometry> MakeValid::build(const geom::Geometry* geom)
 {
@@ -321,9 +566,17 @@ std::unique_ptr<geom::Geometry> MakeValid::build(const geom::Geometry* geom)
         auto mls = detail::down_cast<const MultiLineString*>(geom);
         return MakeValidMultiLine(mls);
     }
-    if( typeId == GEOS_POLYGON ||
-        typeId == GEOS_MULTIPOLYGON ) {
+    if( typeId == GEOS_POLYGON ) {
         return MakeValidPoly(geom);
+    }
+    if( typeId == GEOS_MULTIPOLYGON ) {
+        auto mp = detail::down_cast<const MultiPolygon*>(geom);
+        auto components = envelopeConnectedComponents(mp);
+        if( components.size() == 1 ) {
+            // All polygons potentially interact: process as a whole.
+            return MakeValidPoly(geom);
+        }
+        return MakeValidMultiPolygonComponents(mp, components);
     }
     if( typeId == GEOS_GEOMETRYCOLLECTION ) {
         auto coll = detail::down_cast<const GeometryCollection*>(geom);

--- a/src/operation/valid/MakeValid.cpp
+++ b/src/operation/valid/MakeValid.cpp
@@ -340,19 +340,20 @@ envelopeConnectedComponents(const geom::MultiPolygon* mp)
         envs[i] = mp->getGeometryN(i)->getEnvelopeInternal();
     }
 
-    // Sweep polygons sorted by envelope minimum X, maintaining the subset
-    // whose envelopes extend at or beyond the current minimum X. Only items
-    // in that window can intersect the current one. The number of envelope
-    // tests is proportional to the number of intersecting pairs, so the
-    // sweep is fast when parts are spatially separated and degrades
-    // quadratically when very many envelopes overlap.
+    // Sweep polygons sorted by envelope minimum X, keeping an active set of
+    // envelopes that still extend to the current minimum X. Expiry is by
+    // maxX, independently of position in the minX-sorted order: a long-span
+    // envelope must not pin expired neighbors in the window. Only the X-live
+    // set can intersect the current polygon, so the number of envelope tests
+    // is proportional to true X-overlapping pairs (fast when parts are
+    // spatially separated; quadratic when very many envelopes overlap).
     //
     // A spatial-index clustering such as operation::cluster::
     // EnvelopeIntersectsClusterFinder would also be correct, but for the
     // many tiny disjoint envelopes this operation is aimed at it builds
     // and queries an STRtree and materializes (and sorts) every candidate
-    // hit per part, while the sweep below only ever looks at the active
-    // window. Non-finite envelopes must be excluded either way, which is
+    // hit per part, while the sweep below only ever looks at the X-live
+    // set. Non-finite envelopes must be excluded either way, which is
     // done up front so the sort never sees them.
     std::vector<std::size_t> order;
     order.reserve(n);
@@ -371,18 +372,26 @@ envelopeConnectedComponents(const geom::MultiPolygon* mp)
         return envs[a]->getMinY() < envs[b]->getMinY();
     });
 
-    std::size_t lo = 0; // first still-active item in order
+    std::vector<std::size_t> active;
+    active.reserve(order.size());
     for(std::size_t hi = 0; hi < order.size(); hi++) {
         std::size_t i = order[hi];
-        while(lo < hi && envs[order[lo]]->getMaxX() < envs[i]->getMinX()) {
-            lo++;
+        const double minX = envs[i]->getMinX();
+        // Drop envelopes whose maxX is strictly left of the current minX.
+        // Touching (maxX == minX) stays, matching Envelope::intersects.
+        std::size_t w = 0;
+        for(std::size_t k = 0; k < active.size(); k++) {
+            if(envs[active[k]]->getMaxX() >= minX) {
+                active[w++] = active[k];
+            }
         }
-        for(std::size_t k = lo; k < hi; k++) {
-            std::size_t j = order[k];
+        active.resize(w);
+        for(std::size_t j : active) {
             if(envs[i]->intersects(envs[j])) {
                 sets.join(i, j);
             }
         }
+        active.push_back(i);
     }
 
     // Group indices by cluster root, preserving polygon order within groups

--- a/tests/unit/operation/valid/MakeValidTest.cpp
+++ b/tests/unit/operation/valid/MakeValidTest.cpp
@@ -694,4 +694,53 @@ void object::test<20>()
     ensure("the valid part should keep its M values", sawM);
 }
 
+// A long-X, Y-disjoint invalid sentinel must not pull envelope-disjoint
+// valid squares into the same component. The squares stay pass-through
+// clones; the bowtie is repaired on its own. (Complexity of the sweep
+// for this shape is covered by perf_makevalid sentinel.)
+template<>
+template<>
+void object::test<21>()
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    geos::io::WKTReader reader(gf);
+    MakeValid mv;
+
+    std::vector<std::unique_ptr<Geometry>> parts;
+    // Invalid bowtie spanning X=[0, 20] at Y=100, Y-disjoint from the squares.
+    parts.push_back(reader.read(
+        "POLYGON ((0 100, 20 101, 20 100, 0 101, 0 100))"));
+
+    std::vector<std::unique_ptr<Geometry>> squares;
+    for(double x = 0; x <= 16; x += 4) {
+        auto cs = std::make_unique<CoordinateSequence>();
+        cs->add(x, 0.0);
+        cs->add(x + 1, 0.0);
+        cs->add(x + 1, 1.0);
+        cs->add(x, 1.0);
+        cs->add(x, 0.0);
+        squares.push_back(gf->createPolygon(gf->createLinearRing(std::move(cs))));
+        parts.push_back(squares.back()->clone());
+    }
+    auto mp = gf->createMultiPolygon(std::move(parts));
+
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals(result->getGeometryTypeId(), GEOS_MULTIPOLYGON);
+    // Five valid squares kept as-is, plus two bowtie lobes.
+    ensure_equals(result->getNumGeometries(), std::size_t(7));
+    for(const auto& sq : squares) {
+        bool found = false;
+        for(std::size_t i = 0; i < result->getNumGeometries(); i++) {
+            if(result->getGeometryN(i)->equalsExact(sq.get())) {
+                found = true;
+                break;
+            }
+        }
+        ensure("each valid square must come out with identical coordinates",
+               found);
+    }
+}
+
 } // namespace tut

--- a/tests/unit/operation/valid/MakeValidTest.cpp
+++ b/tests/unit/operation/valid/MakeValidTest.cpp
@@ -5,12 +5,19 @@
 #include <geos/geom/CoordinateSequence.h>
 #include <geos/geom/Polygon.h>
 #include <geos/geom/GeometryFactory.h>
+#include <geos/geom/GeometryCollection.h>
+#include <geos/geom/MultiPolygon.h>
 #include <geos/operation/valid/MakeValid.h>
+#include <geos/operation/overlayng/OverlayNG.h>
+#include <geos/operation/overlayng/OverlayNGRobust.h>
 #include <geos/io/WKBReader.h>
 #include <geos/io/WKTReader.h>
 #include <geos/io/WKTWriter.h>
 #include <geos/util.h>
 
+#include <algorithm>
+#include <limits>
+#include <random>
 #include <utility.h>
 
 using namespace geos::geom;
@@ -29,6 +36,101 @@ typedef test_group<test_makevalid_data> group;
 typedef group::object object;
 
 group test_makevalid_group("geos::operation::valid::MakeValid");
+
+// Split a geometry into per-dimension geometry lists. Overlay operations
+// refuse mixed-dimension inputs, so equivalence checks are done per
+// dimension (area/line/point).
+void
+splitByDimension(const Geometry* g,
+                 std::vector<const Geometry*>& polys,
+                 std::vector<const Geometry*>& lines,
+                 std::vector<const Geometry*>& points)
+{
+    switch(g->getGeometryTypeId()) {
+        case GEOS_GEOMETRYCOLLECTION:
+            for(std::size_t i = 0; i < g->getNumGeometries(); i++) {
+                splitByDimension(g->getGeometryN(i), polys, lines, points);
+            }
+            break;
+        case GEOS_POLYGON:
+        case GEOS_MULTIPOLYGON: polys.push_back(g); break;
+        case GEOS_LINESTRING:
+        case GEOS_MULTILINESTRING: lines.push_back(g); break;
+        case GEOS_POINT:
+        case GEOS_MULTIPOINT: points.push_back(g); break;
+        default: break;
+    }
+}
+
+bool
+hasEmptyElement(const Geometry* g)
+{
+    if(g->isEmpty()) {
+        return true;
+    }
+    if(g->getNumGeometries() > 1 ||
+       g->getGeometryTypeId() == GEOS_GEOMETRYCOLLECTION) {
+        for(std::size_t i = 0; i < g->getNumGeometries(); i++) {
+            if(hasEmptyElement(g->getGeometryN(i))) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Build a unit square polygon with lower-left corner (x, y).
+static std::unique_ptr<Polygon>
+makeSquare(const GeometryFactory* gf, double x, double y)
+{
+    auto cs = std::make_unique<CoordinateSequence>();
+    cs->add(x, y);
+    cs->add(x + 1, y);
+    cs->add(x + 1, y + 1);
+    cs->add(x, y + 1);
+    cs->add(x, y);
+    return gf->createPolygon(gf->createLinearRing(std::move(cs)));
+}
+
+// Check that two geometries cover the same area/line/point sets, by
+// asserting their per-dimension symmetric differences are empty.
+void
+ensureTopologicallyEqual(const Geometry* lhs, const Geometry* rhs,
+                         const std::string& context)
+{
+    std::vector<const Geometry*> lp, ll, ln, rp, rl, rn;
+    splitByDimension(lhs, lp, ll, ln);
+    splitByDimension(rhs, rp, rl, rn);
+    const char* dimName[] = {"area", "line", "point"};
+    std::vector<const Geometry*>* ldims[] = {&lp, &ll, &ln};
+    std::vector<const Geometry*>* rdims[] = {&rp, &rl, &rn};
+    using geos::operation::overlayng::OverlayNG;
+    using geos::operation::overlayng::OverlayNGRobust;
+    for(std::size_t d = 0; d < 3; d++) {
+        bool lEmpty = ldims[d]->empty();
+        bool rEmpty = rdims[d]->empty();
+        if(lEmpty != rEmpty) {
+            std::string what = context + ": " + dimName[d] + " present in one input only";
+            fail(what);
+        }
+        if(lEmpty) {
+            continue;
+        }
+        std::vector<std::unique_ptr<Geometry>> lgeoms;
+        std::vector<std::unique_ptr<Geometry>> rgeoms;
+        for(const Geometry* g : *ldims[d]) {
+            lgeoms.push_back(g->clone());
+        }
+        for(const Geometry* g : *rdims[d]) {
+            rgeoms.push_back(g->clone());
+        }
+        auto lg = lhs->getFactory()->buildGeometry(std::move(lgeoms));
+        auto rg = rhs->getFactory()->buildGeometry(std::move(rgeoms));
+        auto symdif = OverlayNGRobust::Overlay(lg.get(), rg.get(), OverlayNG::SYMDIFFERENCE);
+        ensure(context + ": " + dimName[d] + " symmetric difference not empty",
+               symdif->isEmpty());
+    }
+}
 
 //
 // Test Cases
@@ -138,5 +240,458 @@ void object::test<4>()
                            "92115.51207431706 463462.2069374289,92127.546 463452.075))");
 }
 
+// MultiPolygon with disjoint valid parts and one invalid (self-intersecting)
+// part: the valid parts must not be dragged through the polygonal
+// re-building algorithm and must come out with identical coordinates.
+// https://github.com/libgeos/geos/issues/1504
+template<>
+template<>
+void object::test<5>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((10 10, 11 10, 11 11, 10 11, 10 10)),"
+        " ((20 20, 21 21, 21 20, 20 21, 20 20)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    // Valid parts kept as-is (exact clone, ring orientation included),
+    // invalid part split into its two lobes, all packaged as a single
+    // MultiPolygon of areas in input order.
+    auto expected = reader.read(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((10 10, 11 10, 11 11, 10 11, 10 10)),"
+        " ((20.5 20.5, 20 20, 20 21, 20.5 20.5)), ((20.5 20.5, 21 21, 21 20, 20.5 20.5)))");
+    ensure(result->equalsExact(expected.get()));
+}
+
+// A MultiPolygon whose parts all share envelopes is one connected
+// component and takes the unmodified whole-geometry path.
+template<>
+template<>
+void object::test<6>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((1 0, 2 0, 2 1, 1 1, 1 0)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    // Shared edge becomes a cut edge, exactly as before the optimization.
+    ensure_equals_geometry(result.get(),
+        "GEOMETRYCOLLECTION (POLYGON ((1 0, 0 0, 0 1, 1 1, 2 1, 2 0, 1 0)),"
+        " LINESTRING (1 0, 1 1))");
+}
+
+// Bowties touching at a single point interact and are processed together.
+template<>
+template<>
+void object::test<7>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 1, 1 0, 0 1, 0 0)), ((1 1, 2 2, 2 1, 1 2, 1 1)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals_geometry(result.get(),
+        "MULTIPOLYGON (((0.5 0.5, 0 0, 0 1, 0.5 0.5)), ((0.5 0.5, 1 1, 1 0, 0.5 0.5)),"
+        " ((1.5 1.5, 1 1, 1 2, 1.5 1.5)), ((1.5 1.5, 2 2, 2 1, 1.5 1.5)))");
+}
+
+// Bowties whose lobes cross each other interact and are processed together.
+template<>
+template<>
+void object::test<8>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 1, 1 0, 0 1, 0 0)), ((-0.5 0.25, 0.5 1.25, 0.5 0.25, -0.5 1.25, -0.5 0.25)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals_geometry(result.get(),
+        "MULTIPOLYGON (((0.375 0.375, 0 0, 0 0.75, 0.375 0.375)), ((0 0.75, 0 1, 0.125 0.875, 0 0.75)),"
+        " ((0.125 0.875, 0.5 1.25, 0.5 0.5, 0.125 0.875)), ((0.5 0.5, 0.5 0.25, 0.375 0.375, 0.5 0.5)),"
+        " ((0.5 0.5, 1 1, 1 0, 0.5 0.5)), ((0 0.75, -0.5 0.25, -0.5 1.25, 0 0.75)))");
+}
+
+// Empty elements propagate through, as in the whole-geometry path.
+template<>
+template<>
+void object::test<9>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read("MULTIPOLYGON (EMPTY, ((10 10, 11 11, 11 10, 10 10)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure(hasEmptyElement(result.get()));
+    ensure_equals_geometry(result.get(),
+        "MULTIPOLYGON (EMPTY, ((10 10, 11 11, 11 10, 10 10)))");
+}
+
+// Empty MultiPolygon and fully-collapsed parts.
+template<>
+template<>
+void object::test<10>()
+{
+    geos::io::WKTReader reader;
+    auto mpEmpty = reader.read("MULTIPOLYGON (EMPTY)");
+    MakeValid mv;
+    auto resultEmpty = mv.build(mpEmpty.get());
+    ensure(resultEmpty->isValid());
+    ensure_equals_geometry(resultEmpty.get(), "MULTIPOLYGON (EMPTY)");
+
+    auto mpCollapsed = reader.read(
+        "MULTIPOLYGON (((0 0, 1 1, 2 2, 1 1, 0 0)), ((10 10, 11 11, 11 10, 10 10)))");
+    auto resultCollapsed = mv.build(mpCollapsed.get());
+    ensure(resultCollapsed->isValid());
+    ensure_equals_geometry(resultCollapsed.get(),
+        "GEOMETRYCOLLECTION (POLYGON ((10 10, 11 11, 11 10, 10 10)),"
+        " LINESTRING (0 0, 1 1, 2 2))");
+}
+
+// Nested shells interact (envelopes overlap) and are processed together.
+template<>
+template<>
+void object::test<11>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 10 0, 10 10, 0 10, 0 0)), ((2 2, 4 2, 4 4, 2 4, 2 2)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals_geometry(result.get(),
+        "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 2, 4 2, 4 4, 2 4, 2 2))");
+}
+
+// Z values are interpolated in the invalid part; a valid part without Z
+// is returned unchanged (dimension included), matching the documented
+// fast path for already-valid geometries.
+// NOTE: the whole-geometry algorithm used to smear interpolated Z values
+// onto the valid parts of mixed-dimension inputs; per-component
+// processing preserves each part's own coordinates instead.
+template<>
+template<>
+void object::test<12>()
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    // 2D square (valid) + Z bowtie (invalid), envelope-disjoint
+    auto cs = std::make_unique<CoordinateSequence>(5u, 3u);
+    cs->setAt(Coordinate(0, 0, 1), 0);
+    cs->setAt(Coordinate(1, 1, 2), 1);
+    cs->setAt(Coordinate(1, 0, 3), 2);
+    cs->setAt(Coordinate(0, 1, 4), 3);
+    cs->setAt(Coordinate(0, 0, 1), 4);
+    auto bowtieZ = gf->createPolygon(gf->createLinearRing(std::move(cs)));
+
+    std::vector<std::unique_ptr<Geometry>> parts;
+    parts.push_back(makeSquare(gf, 10, 10));
+    parts.push_back(std::move(bowtieZ));
+    auto mp = gf->createMultiPolygon(std::move(parts));
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals(result->getGeometryTypeId(), GEOS_MULTIPOLYGON);
+    ensure_equals(result->getNumGeometries(), std::size_t(3));
+    bool saw2D = false;
+    bool sawZ = false;
+    for(std::size_t i = 0; i < result->getNumGeometries(); i++) {
+        const Polygon* p = static_cast<const Polygon*>(result->getGeometryN(i));
+        if(p->getCoordinateDimension() == 2) {
+            saw2D = true;
+        } else {
+            sawZ = true;
+        }
+    }
+    ensure("the valid non-Z part should keep its 2D coordinates", saw2D);
+    ensure("the invalid Z part should keep interpolated Z", sawZ);
+    ensure_equals("area of square + bowtie lobes is preserved",
+                  result->getArea(), 1.5, 1e-9);
+}
+
+// Already-valid MultiPolygon is returned as an exact clone (fast path).
+template<>
+template<>
+void object::test<13>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((1 1, 2 1, 2 2, 1 2, 1 1)))");
+    mp->setSRID(4326);
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->equalsExact(mp.get()));
+    ensure_equals(result->getSRID(), 4326);
+}
+
+// SRID carried by the geometry factory is preserved when invalid parts
+// force per-component processing.
+template<>
+template<>
+void object::test<14>()
+{
+    auto gf = GeometryFactory::create(nullptr, 26910);
+    geos::io::WKTReader reader(gf.get());
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((10 10, 11 11, 11 10, 10 11, 10 10)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals(result->getSRID(), 26910);
+}
+
+// Differential test: for polygons with pairwise disjoint envelopes the
+// MultiPolygon result must cover the same area/line/point sets as the
+// equivalent GeometryCollection, which MakeValid processes member-wise.
+template<>
+template<>
+void object::test<15>()
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    MakeValid mv;
+
+    auto square = [gf](double x, double y) {
+        auto cs = std::make_unique<CoordinateSequence>();
+        cs->add(x, y);
+        cs->add(x + 1, y);
+        cs->add(x + 1, y + 1);
+        cs->add(x, y + 1);
+        cs->add(x, y);
+        return gf->createPolygon(gf->createLinearRing(std::move(cs)));
+    };
+    // self-intersecting bowtie
+    auto bowtie = [gf](double x, double y) {
+        auto cs = std::make_unique<CoordinateSequence>();
+        cs->add(x, y);
+        cs->add(x + 1, y + 1);
+        cs->add(x + 1, y);
+        cs->add(x, y + 1);
+        cs->add(x, y);
+        return gf->createPolygon(gf->createLinearRing(std::move(cs)));
+    };
+    // polygon with an outward self-touching spike
+    auto spiked = [gf](double x, double y) {
+        auto cs = std::make_unique<CoordinateSequence>();
+        cs->add(x, y);
+        cs->add(x + 2, y);
+        cs->add(x + 2, y + 2);
+        cs->add(x + 1, y - 1);
+        cs->add(x, y + 2);
+        cs->add(x, y);
+        return gf->createPolygon(gf->createLinearRing(std::move(cs)));
+    };
+
+    for(unsigned seed = 1; seed <= 8; seed++) {
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<double> jitter(0.0, 0.9);
+        std::uniform_real_distribution<double> pick(0.0, 1.0);
+
+        std::vector<std::unique_ptr<Geometry>> parts;
+        for(int i = 0; i < 12; i++) {
+            for(int j = 0; j < 12; j++) {
+                double x = 4.0 * i + jitter(rng);
+                double y = 4.0 * j + jitter(rng);
+                double p = pick(rng);
+                if(p < 0.10) {
+                    parts.push_back(bowtie(x, y));
+                } else if(p < 0.15) {
+                    parts.push_back(spiked(x, y));
+                } else {
+                    parts.push_back(square(x, y));
+                }
+            }
+        }
+        for(int k = 0; k < 3; k++) {
+            parts.push_back(bowtie(-20.0 - 2.0 * k, -20.0 - 2.0 * k));
+        }
+        std::shuffle(parts.begin(), parts.end(), rng);
+
+        std::vector<std::unique_ptr<Geometry>> gcParts;
+        gcParts.reserve(parts.size());
+        for(const auto& p : parts) {
+            gcParts.push_back(p->clone());
+        }
+
+        auto mp = gf->createMultiPolygon(std::move(parts));
+        auto gc = gf->createGeometryCollection(std::move(gcParts));
+
+        auto resMP = mv.build(mp.get());
+        auto resGC = mv.build(gc.get());
+        ensure("multipolygon result is valid", resMP->isValid());
+        ensure("collection result is valid", resGC->isValid());
+        ensureTopologicallyEqual(resMP.get(), resGC.get(),
+                                 "seed " + std::to_string(seed));
+    }
+}
+
+// A component made of several interacting polygons is dissolved together,
+// while independent components are processed separately and merged into
+// the same area/cut-edges structure the whole-geometry algorithm returns.
+template<>
+template<>
+void object::test<16>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((0.5 0, 1.5 0, 1.5 1, 0.5 1, 0.5 0)),"
+        " ((20 20, 21 21, 21 20, 20 21, 20 20)), ((40 40, 41 40, 41 41, 40 41, 40 40)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals_geometry(result.get(),
+        "GEOMETRYCOLLECTION (MULTIPOLYGON (((0.5 0, 0 0, 0 1, 0.5 1, 1 1, 1.5 1, 1.5 0, 1 0, 0.5 0)),"
+        " ((20.5 20.5, 20 20, 20 21, 20.5 20.5)), ((20.5 20.5, 21 21, 21 20, 20.5 20.5)),"
+        " ((40 40, 40 41, 41 41, 41 40, 40 40))),"
+        " MULTILINESTRING ((1 0, 1 1), (0.5 1, 0.5 0)))");
+}
+
+// Empty polygons have no usable envelope; they must not disturb the
+// component sweep and propagate only when the fast path clones them.
+template<>
+template<>
+void object::test<17>()
+{
+    geos::io::WKTReader reader;
+    // empty polygon + overlapping squares: invalid, reaches the
+    // per-component path with a null-envelope part present
+    auto mp = reader.read(
+        "MULTIPOLYGON (EMPTY, ((0 0, 1 0, 1 1, 0 1, 0 0)),"
+        " ((0.5 0, 1.5 0, 1.5 1, 0.5 1, 0.5 0)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    // Same output the whole-geometry algorithm produces: the empty element
+    // contributes nothing and is not present in the result.
+    ensure(!hasEmptyElement(result.get()));
+    ensure_equals_geometry(result.get(),
+        "GEOMETRYCOLLECTION (POLYGON ((0.5 0, 0 0, 0 1, 0.5 1, 1 1, 1.5 1, 1.5 0, 1 0, 0.5 0)),"
+        " MULTILINESTRING ((1 0, 1 1), (0.5 1, 0.5 0)))");
+}
+
+// An empty part and envelope-disjoint invalid parts: the empty part goes
+// through the component sweep (its envelope is unusable) and contributes
+// nothing to the result, exactly as the whole-geometry algorithm behaves.
+template<>
+template<>
+void object::test<18>()
+{
+    geos::io::WKTReader reader;
+    auto mp = reader.read(
+        "MULTIPOLYGON (EMPTY, ((10 10, 11 11, 11 10, 10 11, 10 10)),"
+        " ((40 40, 41 40, 41 41, 40 41, 40 40)))");
+
+    MakeValid mv;
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure(!hasEmptyElement(result.get()));
+    ensure_equals_geometry(result.get(),
+        "MULTIPOLYGON (((10.5 10.5, 10 10, 10 11, 10.5 10.5)),"
+        " ((10.5 10.5, 11 11, 11 10, 10.5 10.5)),"
+        " ((40 40, 40 41, 41 41, 41 40, 40 40)))");
+}
+
+// Non-finite envelopes (Inf/NaN ordinates) are excluded from the
+// component sweep before the sort; grouping must never read their
+// ordinates. The non-finite linework itself is rejected by the overlay
+// algorithm exactly as it is by the whole-geometry path.
+template<>
+template<>
+void object::test<19>()
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    geos::io::WKTReader reader(gf);
+    MakeValid mv;
+
+    auto cs = std::make_unique<CoordinateSequence>();
+    const double inf = std::numeric_limits<double>::infinity();
+    cs->add(inf, 0.0);
+    cs->add(1.0, 0.0);
+    cs->add(1.0, 1.0);
+    cs->add(inf, 1.0);
+    cs->add(inf, 0.0);
+    auto infPoly = gf->createPolygon(gf->createLinearRing(std::move(cs)));
+    auto square = reader.read("POLYGON ((10 10, 11 10, 11 11, 10 11, 10 10))");
+
+    std::vector<std::unique_ptr<Geometry>> parts;
+    parts.push_back(std::move(infPoly));
+    parts.push_back(std::move(square));
+    auto mp = gf->createMultiPolygon(std::move(parts));
+
+    bool threw = false;
+    try {
+        mv.build(mp.get());
+    } catch(const geos::util::IllegalArgumentException&) {
+        threw = true;
+    }
+    ensure("non-finite linework must fail the same way the"
+           " whole-geometry algorithm does", threw);
+}
+
+// M values of valid parts survive the pass-through like Z values do.
+template<>
+template<>
+void object::test<20>()
+{
+    auto gf = GeometryFactory::getDefaultInstance();
+    geos::io::WKTReader reader(gf);
+    MakeValid mv;
+
+    // valid square with Z and M, envelope-disjoint from an invalid bowtie
+    auto cs = std::make_unique<CoordinateSequence>(5u, 4u);
+    cs->setAt(Coordinate(10, 10), 0);
+    cs->setAt(Coordinate(11, 10), 1);
+    cs->setAt(Coordinate(11, 11), 2);
+    cs->setAt(Coordinate(10, 11), 3);
+    cs->setAt(Coordinate(10, 10), 4);
+    for(std::size_t i = 0; i < 5; i++) {
+        cs->setZ(i, 5.0);
+        cs->setM(i, 7.0);
+    }
+
+    std::vector<std::unique_ptr<Geometry>> parts;
+    parts.push_back(gf->createPolygon(gf->createLinearRing(std::move(cs))));
+    parts.push_back(reader.read("POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))"));
+    auto mp = gf->createMultiPolygon(std::move(parts));
+
+    auto result = mv.build(mp.get());
+
+    ensure(result->isValid());
+    ensure_equals(result->getGeometryTypeId(), GEOS_MULTIPOLYGON);
+    bool sawM = false;
+    for(std::size_t i = 0; i < result->getNumGeometries(); i++) {
+        const auto* p = static_cast<const Polygon*>(result->getGeometryN(i));
+        const auto* seq = p->getExteriorRing()->getCoordinatesRO();
+        if(seq->getM(0) == 7.0) {
+            sawM = true;
+            ensure_equals("Z kept alongside M", seq->getZ(0), 5.0);
+        }
+    }
+    ensure("the valid part should keep its M values", sawM);
+}
 
 } // namespace tut


### PR DESCRIPTION
# MakeValid: process envelope-connected components of a MultiPolygon independently

Fixes #1504

## Problem

`MakeValid::build` sends an entire MultiPolygon containing even one invalid part
through `MakeValidPoly`, so every part is dragged through boundary noding,
`extractUniquePoints`, and the BuildArea/symdiff loop — even parts that cannot
possibly interact with the invalid one. For parts with disjoint envelopes this
costs up to ~55x the equivalent GeometryCollection, which processes members
independently (measured in GH-1504). The real-world case reported there
(88,997 parts / 20.7M vertices with one self-intersecting ring) takes >55
minutes instead of seconds.

## Algorithm

For invalid MultiPolygons, the parts are partitioned into envelope-connected
components (union-find over a sorted x-sweep of the part envelopes; envelopes
that intersect — touching included — share a component). Polygons in different
components have disjoint envelopes and therefore cannot interact topologically,
so the split is exact:

* A MultiPolygon forming a **single** component takes the untouched
  whole-geometry path — connected/overlapping/nested cases behave exactly as
  before.
* With **several** components, each is made valid independently: a component
  made entirely of valid parts is passed through (the existing `IsValidOp`
  fast path), a component with an invalid part goes through `MakeValidPoly`.
* Per-component results are merged back into the same
  area/cut-edges/collapse-points structure `MakeValidPoly` would have returned
  for the whole MultiPolygon.

Correctness: each component's result is enclosed within the envelopes of its
own parts, and component envelopes are pairwise disjoint, so merged results
are disjoint and topologically equal to the whole-geometry result. Envelopes
that are null or non-finite are excluded from the sweep before sorting (they
would otherwise trip `Envelope` accessor asserts in debug builds), and their
linework still fails in the overlay exactly as the whole-geometry path does.

## Behavior changes

* Components made entirely of valid parts are now passed through unchanged
  (the documented fast path for already-valid geometries) instead of being
  rebuilt by overlay: they keep their original coordinates, including Z and M
  values, and their original ring orientation.
* Consequently, output element order follows the input/component order for
  pass-through parts; overlay-rebuilt pieces may still come out in any order.
  (Previously *everything* was rebuilt and could be reordered.)
* Non-finite linework (Inf/NaN coordinates) still fails with the same
  `IllegalArgumentException` as the whole-geometry algorithm.

## Performance

`perf_makevalid` (added under `benchmarks/operation/`, reproduces the GH-1504
synthetic grid + one bowtie), interleaved A/B against unmodified main,
Release build, medians:

| case | parts | before | after | speedup | peak RSS before → after |
|---|---|---|---|---|---|
| disjoint grid | 401 | 0.036 s | 0.0015 s | ~24x | 10 → 4 MB |
| disjoint grid | 1,601 | 0.155 s | 0.005 s | ~30x | 30 → 7 MB |
| disjoint grid | 6,401 | 0.78 s | 0.017 s | ~46x | 105 → 14 MB |
| disjoint grid | 14,401 | 4.0 s | 0.034–0.066 s | ~60x | 218 → 27 MB |
| disjoint grid | 88,805 | 15.4 s | 0.24–0.32 s | ~50–60x | 851 → 118 MB |
| corner-touching chain + bowtie | 1,201 | 0.20 s | 0.003 s | ~60x | 29 → 6 MB |
| overlapping chain (single component, cannot split) | 4,000 | ~1.1 s | ~1.0 s | parity | 135 → 134 MB |
| many valid parts + one huge (50k-vertex) bowtie | 49,730 | ~21 s | ~7 s | ~3x | 644 → 232 MB |

The equivalent GeometryCollection reference path runs at ~0.029 s for 14,401
parts; the optimized MultiPolygon path lands within ~2x of it while keeping
MultiPolygon semantics.

## Testing

* 13 new/extended unit tests in `tests/unit/operation/valid/MakeValidTest.cpp`:
  deterministic edge cases (disjoint + invalid, touching/crossing bowties,
  shared edges, nested shells, duplicates, collapses, empty parts, Z/M and
  mixed-dimension parts, SRID handling), a randomized MultiPolygon vs
  equivalent-GeometryCollection equivalence invariant (fixed seeds), and
  non-finite envelope handling.
* Differential testing against unmodified main: 36-case harness (deterministic
  edge cases + seeded randomized grids + overlap clusters), comparing results
  per dimension by symmetric-difference emptiness — 36/36 topologically
  equivalent, 18/36 byte-identical (the rest differ only in element order /
  ring orientation of pass-through parts, as described above).
* Full test suite: 535/535 passing. Debug-build (asserts enabled) verified for
  the empty/null-envelope cases.
