### PR TITLE
Detect overlay location inversions near collapsed ring edges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 2027-xx-xx
 
 - Fixes/Improvements:
-  -
+  - Detect overlay location inversions near collapsed edges of nearly collinear rings
 
 ## Changes in 3.15.0
 2026-09-01

--- a/include/geos/operation/overlayng/OverlayLabeller.h
+++ b/include/geos/operation/overlayng/OverlayLabeller.h
@@ -81,6 +81,13 @@ private:
     * but may be more efficient and accurate to do it here.)
     */
     void labelCollapsedEdges();
+
+    /**
+    * Verifies a propagated (non-boundary) edge location for a geometry
+    * against the original input geometry, at a point in the interior of
+    * the edge.  Throws TopologyException on a mismatch.
+    */
+    void checkEdgeLocation(OverlayEdge* edge, uint8_t geomIndex) const;
     static void labelCollapsedEdge(OverlayEdge* edge, uint8_t geomIndex);
 
     /**
@@ -170,6 +177,17 @@ public:
     * Computes the topological labelling for the edges in the graph->
     */
     void computeLabelling();
+
+    /**
+    * Checks for inconsistent propagated locations at nodes incident on
+    * collapsed edges, by sampling non-boundary edges in the input areas.
+    * This is a heuristic for detecting topology inversions introduced by
+    * floating-point noding, not a complete validation of the labelling.
+    * Must only be used for unsnapped linear overlay: snapping and precision
+    * reduction can legitimately change locations relative to the inputs.
+    * Throws TopologyException on a mismatch so robust overlay can retry.
+    */
+    void checkCollapseNodeLocations() const;
 
     /**
     * Scans around a node CCW, propagating the side labels

--- a/src/operation/overlayng/OverlayLabeller.cpp
+++ b/src/operation/overlayng/OverlayLabeller.cpp
@@ -22,6 +22,7 @@
 #include <geos/util/Assert.h>
 #include <geos/util/TopologyException.h>
 
+#include <cmath>
 #include <sstream>
 
 
@@ -50,6 +51,86 @@ OverlayLabeller::computeLabelling()
     labelConnectedLinearEdges();
 
     labelDisconnectedEdges();
+}
+
+/*public*/
+void
+OverlayLabeller::checkCollapseNodeLocations() const
+{
+    const auto nodes = graph->getNodeEdges();
+    for (OverlayEdge* nodeEdge : nodes) {
+        for (uint8_t geomIndex = 0; geomIndex < 2; geomIndex++) {
+            if (! inputGeometry->isArea(geomIndex))
+                continue;
+            //-- limit this heuristic to nodes where noding has collapsed an edge
+            bool hasCollapse = false;
+            OverlayEdge* e = nodeEdge;
+            do {
+                if (e->getLabel()->isCollapse(geomIndex)) {
+                    hasCollapse = true;
+                    break;
+                }
+                e = e->oNextOE();
+            } while (e != nodeEdge);
+            if (! hasCollapse)
+                continue;
+            e = nodeEdge;
+            do {
+                checkEdgeLocation(e, geomIndex);
+                e = e->oNextOE();
+            } while (e != nodeEdge);
+        }
+    }
+}
+
+/*private*/
+void
+OverlayLabeller::checkEdgeLocation(OverlayEdge* edge, uint8_t geomIndex) const
+{
+    const OverlayLabel* label = edge->getLabel();
+    //-- boundary edges carry their own (ring-derived) locations
+    if (label->isBoundary(geomIndex) || edge->isCurved())
+        return;
+    //-- a collapsed edge lies on degenerate geometry, where a point-in-area
+    //-- test is itself unreliable, so its location is not checkable
+    if (label->isCollapse(geomIndex))
+        return;
+    Location lineLoc = label->getLineLocation(geomIndex);
+    if (lineLoc != Location::INTERIOR && lineLoc != Location::EXTERIOR)
+        return;
+    /**
+    * The edge endpoints are noded points, which may lie exactly on
+    * degenerate elements of the geometry, so the location is checked at a
+    * sample point on the longest segment. This reduces sensitivity to
+    * rounding near a node, but is not a complete test of edge location.
+    */
+    const CoordinateSequence* pts = edge->getCoordinatesRO();
+    double lenMax = 0.0;
+    CoordinateXY mid = edge->orig();
+    for (std::size_t i = 0; i + 1 < pts->size(); i++) {
+        const CoordinateXY& p0 = pts->getAt<CoordinateXY>(i);
+        const CoordinateXY& p1 = pts->getAt<CoordinateXY>(i + 1);
+        double len = p0.distance(p1);
+        // Halve first to avoid overflowing the sum of large ordinates.
+        CoordinateXY candidate(p0.x / 2 + p1.x / 2, p0.y / 2 + p1.y / 2);
+        if (len > lenMax && std::isfinite(candidate.x) && std::isfinite(candidate.y)
+                && !candidate.equals2D(p0) && !candidate.equals2D(p1)) {
+            lenMax = len;
+            mid = candidate;
+        }
+    }
+    if (lenMax == 0.0)
+        return;
+    Location locActual = inputGeometry->locatePointInArea(geomIndex, mid);
+    //-- a point on the geometry boundary decides nothing
+    if (locActual == Location::BOUNDARY || locActual == Location::NONE)
+        return;
+    if (locActual != lineLoc) {
+        std::stringstream ss;
+        ss << "collapse location conflict at ";
+        ss << mid.toString();
+        throw util::TopologyException(ss.str());
+    }
 }
 
 

--- a/src/operation/overlayng/OverlayNG.cpp
+++ b/src/operation/overlayng/OverlayNG.cpp
@@ -290,6 +290,14 @@ OverlayNG::labelGraph(OverlayGraph* graph)
 {
     OverlayLabeller labeller(graph, &inputGeom);
     labeller.computeLabelling();
+    // Validate against the original inputs only for default floating noding.
+    // A supplied noder may snap even when the precision model is floating.
+    // Curved edges require a different sampling strategy.
+    if (OverlayUtil::isFloating(pm) && noder == nullptr
+            && !inputGeom.getGeometry(0)->hasCurvedComponents()
+            && (inputGeom.isSingle() || !inputGeom.getGeometry(1)->hasCurvedComponents())) {
+        labeller.checkCollapseNodeLocations();
+    }
     labeller.markResultAreaEdges(opCode);
     labeller.unmarkDuplicateEdgesFromResultArea();
 }

--- a/tests/unit/operation/overlayng/OverlayNGRobustTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayNGRobustTest.cpp
@@ -14,6 +14,8 @@
 // geos
 #include <geos/operation/overlayng/OverlayNGRobust.h>
 #include <geos/operation/overlayng/OverlayNG.h>
+#include <geos/noding/snap/SnappingNoder.h>
+#include <geos/util/TopologyException.h>
 
 // std
 #include <memory>
@@ -184,5 +186,45 @@ void object::test<3> ()
 }
 
 #endif
+
+// A nearly collinear triangular hole has nonzero area, but its two
+// crossings with A round to one node and invert the remaining triangle.
+template<>
+template<>
+void object::test<5> ()
+{
+    auto a = r.read("POLYGON ((379.694383 3423, 382 3423, 382 3428, 379.694383 3428, 379.694383 3423))");
+    auto b = r.read("POLYGON ((380 3428.3, 382 3429, 388 3422, 377 3422, 378 3427, 380 3428.3), (379.153701 3427.199712952367, 380.736005 3427.1997128766443, 379.777158 3427.199712922531, 379.153701 3427.199712952367))");
+    ensure("valid A", a->isValid());
+    ensure("valid B", b->isValid());
+
+    for (bool reverse : {false, true}) {
+        const Geometry* g0 = reverse ? b.get() : a.get();
+        const Geometry* g1 = reverse ? a.get() : b.get();
+        for (int op : {OverlayNG::INTERSECTION, OverlayNG::DIFFERENCE}) {
+            // Floating overlay must report the inconsistency to its caller.
+            bool caught = false;
+            try {
+                OverlayNG::overlay(g0, g1, op);
+            }
+            catch (const geos::util::TopologyException&) {
+                caught = true;
+            }
+            ensure("floating overlay must detect inversion", caught);
+
+            double expectedArea = op == OverlayNG::INTERSECTION ? a->getArea()
+                : (reverse ? b->getArea() - a->getArea() : 0.0);
+            auto result = OverlayNGRobust::Overlay(g0, g1, op);
+            ensure("valid robust result", result->isValid());
+            ensure_equals("robust result area", result->getArea(), expectedArea, 1e-9);
+
+            // Exercise the first retry strategy explicitly as well.
+            geos::noding::snap::SnappingNoder noder(1e-8);
+            auto snapped = OverlayNG::overlay(g0, g1, op, &noder);
+            ensure("valid snapped result", snapped->isValid());
+            ensure_equals("snapped result area", snapped->getArea(), expectedArea, 1e-9);
+        }
+    }
+}
 
 } // namespace tut

--- a/tests/unit/operation/overlayng/OverlayNGSnappingNoderTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayNGSnappingNoderTest.cpp
@@ -7,6 +7,7 @@
 // geos
 #include <geos/operation/overlayng/OverlayNG.h>
 #include <geos/noding/snap/SnappingNoder.h>
+#include <geos/noding/snapround/SnapRoundingNoder.h>
 #include <geos/noding/ValidatingNoder.h>
 
 // std
@@ -108,5 +109,24 @@ void object::test<5> ()
     testOverlay(a, b, exp, OverlayNG::UNION, 0.1);
 }
 
+
+// A supplied noder can reduce precision even with a floating overlay PM.
+// Checking only the overlay precision model would reject this valid result.
+template<>
+template<>
+void object::test<6>()
+{
+    auto a = r.read("POLYGON ((8 3.6, 6 4, 1.83 2.28, 8 3.6))");
+    auto b = r.read("POLYGON ((-10 -10, 20 -10, 20 20, -10 20, -10 -10), (0.3 1.5, 5 3.4, 1 1, 0.3 1.5))");
+    auto expected = r.read("MULTIPOLYGON (((5 3, 6 4, 8 4, 5 3)), ((2 2, 4 3, 3 2, 2 2)))");
+    PrecisionModel pm(1);
+    for (bool reverse : {false, true}) {
+        geos::noding::snapround::SnapRoundingNoder snapNoder(&pm);
+        geos::noding::ValidatingNoder validNoder(snapNoder);
+        auto result = OverlayNG::overlay(reverse ? b.get() : a.get(),
+            reverse ? a.get() : b.get(), OverlayNG::INTERSECTION, &validNoder);
+        ensure_equals_geometry(expected.get(), result.get());
+    }
+}
 
 } // namespace tut

--- a/tests/unit/operation/overlayng/OverlayNGTest.cpp
+++ b/tests/unit/operation/overlayng/OverlayNGTest.cpp
@@ -856,4 +856,20 @@ void object::test<65>()
     testOverlay(a, a, a, OverlayNG::INTERSECTION, 0);
 }
 
+// Precision reduction may legitimately change an edge's location relative
+// to the original hole. Do not apply floating location checks here.
+template<>
+template<>
+void object::test<66>()
+{
+    std::string a = "POLYGON ((8 3.6, 6 4, 1.83 2.28, 8 3.6))";
+    std::string b = "POLYGON ((-10 -10, 20 -10, 20 20, -10 20, -10 -10), (0.3 1.5, 5 3.4, 1 1, 0.3 1.5))";
+    std::string expected = "MULTIPOLYGON (((5 3, 6 4, 8 4, 5 3)), ((2 2, 4 3, 3 2, 2 2)))";
+    ensure("valid A", r.read(a)->isValid());
+    ensure("valid B", r.read(b)->isValid());
+    testOverlay(a, b, expected, OverlayNG::INTERSECTION, 1);
+    testOverlay(b, a, expected, OverlayNG::INTERSECTION, 1);
+    testOverlay(a, b, "POLYGON EMPTY", OverlayNG::DIFFERENCE, 1);
+}
+
 } // namespace tut


### PR DESCRIPTION
Fixes #1523 

Floating-point noding can merge two crossings of a nearly collinear triangular hole into one node, reversing the winding of the remaining triangle. Side-location propagation can then assign self-consistent but incorrect labels without raising an exception. In the reported example, intersection returns a tiny sliver instead of almost all of A, while difference retains almost all of A.

This change adds a targeted consistency check after labelling. At nodes incident on collapsed edges, it samples eligible non-boundary edges and compares their propagated locations against the original input areas. A mismatch raises TopologyException so OverlayNGRobust can retry using its existing snapping strategies.

The check applies only to default floating-point noding for linear inputs. Fixed precision and caller-supplied noders are excluded because snapping can legitimately change locations relative to the original geometry. Curved inputs are also excluded. This is a heuristic for detecting collapse-adjacent inversions, not a complete validation of overlay topology.

## Validation

- Regression coverage checks input validity, detection by floating overlay, and valid robust results with the expected intersection and difference areas in both argument orders.
- Explicit snapping of the reported example produces the expected areas.
- Fixed-precision and caller-supplied snap-rounding tests cover cases that an unconditional location check would incorrectly reject.
- The inversion test fails without the fix; both precision-reduction tests fail with the earlier unconditional check.
- All 535 configured CTest tests pass in a Release build on arm64 macOS with AppleClang.