### PR TITLE
Node collinear overlaps when snapping tolerance is zero

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 2027-xx-xx
 
 - Fixes/Improvements:
+  - Fix CoverageCleaner merging adjacent polygons when snapping is disabled
   -
 
 ## Changes in 3.15.0

--- a/src/noding/snap/SnappingIntersectionAdder.cpp
+++ b/src/noding/snap/SnappingIntersectionAdder.cpp
@@ -60,16 +60,19 @@ SnappingIntersectionAdder::processIntersections(SegmentString* seg0, std::size_t
     if (!isAdjacent(seg0, segIndex0, seg1, segIndex1)) {
         li.computeIntersection(p00, p01, p10, p11);
         /**
-         * Process single point intersections only.
-         * Two-point (collinear) ones are handled by the near-vertex code
+         * With a positive tolerance, two-point (collinear) intersections
+         * are handled by the near-vertex code.  At zero tolerance that
+         * code does not add nodes, so process both overlap endpoints here.
          */
-        if (li.hasIntersection() && li.getIntersectionNum() == 1) {
+        if (li.hasIntersection() && (li.getIntersectionNum() == 1 || snapTolerance == 0)) {
+            for (std::size_t i = 0; i < li.getIntersectionNum(); ++i) {
 
-            const auto& intPt = li.getIntersection(0);
-            const auto& snapPt = snapPointIndex.snap(intPt);
+                const auto& intPt = li.getIntersection(i);
+                const auto& snapPt = snapPointIndex.snap(intPt);
 
-            static_cast<NodedSegmentString*>(seg0)->addIntersection(snapPt, segIndex0);
-            static_cast<NodedSegmentString*>(seg1)->addIntersection(snapPt, segIndex1);
+                static_cast<NodedSegmentString*>(seg0)->addIntersection(snapPt, segIndex0);
+                static_cast<NodedSegmentString*>(seg1)->addIntersection(snapPt, segIndex1);
+            }
         }
     }
 

--- a/tests/unit/coverage/CoverageCleanerTest.cpp
+++ b/tests/unit/coverage/CoverageCleanerTest.cpp
@@ -463,4 +463,47 @@ void object::test<20> ()
 
 
 
+// An extra vertex on a shared edge must be noded even with snapping disabled.
+template<>
+template<>
+void object::test<21>()
+{
+    auto input = readArray({
+        "POLYGON ((1 0, 1 1, 1 3, 4 0, 1 0))",
+        "POLYGON ((0 4, 1 3, 1 0, 0 4))"
+    });
+    auto expected = readArray({
+        "POLYGON ((1 0, 1 1, 1 3, 4 0, 1 0))",
+        "POLYGON ((0 4, 1 3, 1 1, 1 0, 0 4))"
+    });
+    auto cov = toArray(input);
+    auto expectedArr = toArray(expected);
+    for (const auto* g : cov) {
+        ensure("valid input polygon", g->isValid());
+    }
+    ensure("input edges need matching", !CoverageValidator::isValid(cov));
+    for (int order = 0; order < 2; ++order) {
+        for (int strategy : {CoverageCleaner::MERGE_LONGEST_BORDER,
+                             CoverageCleaner::MERGE_MAX_AREA,
+                             CoverageCleaner::MERGE_MIN_AREA,
+                             CoverageCleaner::MERGE_MIN_INDEX}) {
+            for (double tolerance : {0.0, -1.0}) {
+                CoverageCleaner cleaner(cov);
+                cleaner.setSnappingDistance(tolerance);
+                cleaner.setGapMaximumWidth(0);
+                cleaner.setOverlapMergeStrategy(strategy);
+                cleaner.clean();
+                ensure("no overlaps", cleaner.getOverlaps().empty());
+                ensure("no merged gaps", cleaner.getMergedGaps().empty());
+                auto result = cleaner.getResult();
+                auto actual = toArray(result);
+                checkValidCoverage(actual, 0);
+                checkEqual(expectedArr, actual);
+            }
+        }
+        std::swap(cov[0], cov[1]);
+        std::swap(expectedArr[0], expectedArr[1]);
+    }
+}
+
 } // namespace tut

--- a/tests/unit/noding/snap/SnappingNoderTest.cpp
+++ b/tests/unit/noding/snap/SnappingNoderTest.cpp
@@ -151,4 +151,34 @@ void object::test<7> ()
 
 
 
+// Zero tolerance must still node the endpoints of collinear overlaps.
+template<>
+template<>
+void object::test<8>()
+{
+    std::string expected = "MULTILINESTRING ((1 0, 1 1), (1 1, 1 3), (1 3, 1 1), (1 1, 1 0))";
+    checkRounding("LINESTRING (1 0, 1 1, 1 3)",
+                  "LINESTRING (1 3, 1 0)", 0, expected);
+}
+
+// Both endpoints of a contained segment must split the containing segment.
+template<>
+template<>
+void object::test<9>()
+{
+    std::string expected = "MULTILINESTRING ((0 0, 1 1), (1 1, 3 3), (3 3, 4 4), (3 3, 1 1))";
+    checkRounding("LINESTRING (0 0, 4 4)",
+                  "LINESTRING (3 3, 1 1)", 0, expected);
+}
+
+// Zero tolerance must not snap nearby, non-intersecting linework.
+template<>
+template<>
+void object::test<10>()
+{
+    std::string expected = "MULTILINESTRING ((0 0, 4 0), (1 0.000000001, 3 0.000000001))";
+    checkRounding("LINESTRING (0 0, 4 0)",
+                  "LINESTRING (1 0.000000001, 3 0.000000001)", 0, expected);
+}
+
 } // namespace tut


### PR DESCRIPTION
Fixes #1525

`SnappingIntersectionAdder` delegates collinear overlaps to near-vertex processing, which requires `distance < snapTolerance`. At zero tolerance, this skips even exact intersections. When adjacent polygons have differently segmented shared edges, CoverageCleaner can consequently polygonize across that boundary and assign both polygons to one input.

Process both overlap endpoints returned by the line intersector when the tolerance is zero. Positive-tolerance noding retains its existing behavior. No tolerance is introduced and the fix does not move the collinear endpoints.

## Validation

- The coverage regression checks preservation of each polygon, matched edges, valid output coverage, and no reported overlaps or merged gaps. It covers both input orders, all four overlap strategies, and zero versus automatic snapping.
- Noder regressions check an unmatched shared-edge vertex and a contained diagonal segment, with output noding validation. Both fail before the fix.
- Nearby non-intersecting lines remain unchanged at zero tolerance.
- The coverage regression fails before the fix, returning areas 6 and 0 instead of 4.5 and 1.5.
- All 535 configured CTest tests pass in a Release build on arm64 macOS with AppleClang.
